### PR TITLE
Fix git prompt

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -5,7 +5,7 @@ function git_prompt_info() {
 }
 
 parse_git_dirty () {
-  if [[ -n $(git status -s 2> /dev/null) ]]; then
+  if [[ $(git status 2> /dev/null | tail -n1) != "nothing to commit (working directory clean)" ]]; then
     echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
   else
     echo "$ZSH_THEME_GIT_PROMPT_CLEAN"


### PR DESCRIPTION
git_parse_dirty broke at some point (didn't really notice when, but probably related to an upgrade)

This fixes it for me. Not sure the best way to test/vet it for others though.
