### PR TITLE
Added RVM gemset version to dallas theme

### DIFF
--- a/themes/dallas.zsh-theme
+++ b/themes/dallas.zsh-theme
@@ -3,7 +3,7 @@
 # Grab the current date (%D) and time (%T) wrapped in {}: {%D %T}
 DALLAS_CURRENT_TIME_="%{$fg[white]%}{%{$fg[yellow]%}%D %T%{$fg[white]%}}%{$reset_color%}"
 # Grab the current version of ruby in use (via RVM): [ruby-1.8.7]
-DALLAS_CURRENT_RUBY_="%{$fg[white]%}[%{$fg[magenta]%}\$(~/.rvm/bin/rvm-prompt i v)%{$fg[white]%}]%{$reset_color%}"
+DALLAS_CURRENT_RUBY_="%{$fg[white]%}[%{$fg[magenta]%}\$(~/.rvm/bin/rvm-prompt i v g)%{$fg[white]%}]%{$reset_color%}"
 # Grab the current machine name: muscato
 DALLAS_CURRENT_MACH_="%{$fg[green]%}%m%{$fg[white]%}:%{$reset_color%}"
 # Grab the current filepath, use shortcuts: ~/Desktop


### PR DESCRIPTION
I just added the RVM gemset version to dallas theme. Now instead of showing always

10-09-16 9:46}[ruby-1.8.7]Tecnologia-01:~/Code/xpto/xpto-project flores%

It shows the current gemset:

10-09-16 9:46}[ruby-1.8.7@rails3]Tecnologia-01:~/Code/xpto/xpto-project flores%
