### PR TITLE
Make Shift+Tab move backwards in the menu

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -20,6 +20,7 @@ bindkey "^[[F"  end-of-line
 bindkey "^[[4~" end-of-line
 bindkey ' ' magic-space    # also do history expansion on space
 
+bindkey '^[[Z' reverse-menu-complete
 
 # consider emacs keybindings:
 


### PR DESCRIPTION
This was once requested in issue #29, which is now closed.
The key binding which made it work
    bindkey '^[^I' reverse-menu-complete
is now commented with a note: # consider emacs keybindings

I don't think this keybinding is particularly emacsy and I have no idea why it ended up commented, but considering that &lt;tab&gt; moves forward in the menus, it only seems logical that &lt;shift-tab&gt; should move backwards.
