### PR TITLE
Vi mode plugin

### DIFF
--- a/plugins/vi-mode.plugin.zsh
+++ b/plugins/vi-mode.plugin.zsh
@@ -1,0 +1,22 @@
+function zle-line-init zle-keymap-select {
+  zle reset-prompt
+}
+
+zle -N zle-line-init
+zle -N zle-keymap-select
+
+bindkey -v
+
+# if mode indicator wasn't setup by theme, define default
+if [[ "$MODE_INDICATOR" == "" ]]; then
+  MODE_INDICATOR="%{$fg_bold[red]%}<%{$fg[red]%}<<%{$reset_color%}"
+fi
+
+function vi_mode_prompt_info() {
+  echo "${${KEYMAP/vicmd/$MODE_INDICATOR}/(main|viins)/}"
+}
+
+# define right prompt, if it wasn't defined by a theme
+if [[ "$RPS1" == "" && "$RPROMPT" == "" ]]; then
+  RPS1='$(vi_mode_prompt_info)'
+fi


### PR DESCRIPTION
This plugin implements vi-mode command line editation:
- it sets vi-mode so hitting &lt;esc&gt; switches to _normal_ mode, where hjkl and friends work
- it setups the prompt, so that anytime you switch to _normal_ mode a visual indicator appears, and if you switch back to _insert_ mode, the indicator dissapears. Technically, this is implemented as a prompt reset.

The visual indicator is customizable from a theme by setting a `MODE_INDICATOR` variable. Additionally, this plugin provides `vi_mode_prompt_info()` function, which should be used from PROMPT variables. I like this indicator placed on the right side of the prompt, so if the plugin detects that the right prompt is not set, it sets the default one. I used this approach in favor of modifying all existing themes to support vi-mode prompt.

This screenshot shows the default _normal_ mode indicator.
![vi-mode in action](http://img267.imageshack.us/img267/96/vimode.png)
