### PR TITLE
Plugin override capability

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -48,7 +48,8 @@ the "refcard":http://www.bash2zsh.com/zsh_refcard/refcard.pdf is pretty tasty fo
 h3. Customization
 
 If you want to override any of the default behavior, just add a new file (ending in @.zsh@) into the @custom/@ directory.
-If you have many functions which go good together you can put them as a *.plugin.zsh file in the @plugin/@ directory and then enable this plugin.
+If you have many functions which go good together you can put them as a *.plugin.zsh file in the @custom/plugins/@ directory and then enable this plugin.
+If you would like to override the functionality of a plugin distributed with oh-my-zsh, create a plugin of the same name in the @custom/plugins/@ directory and it will be loaded instead of the one in @plugins/@.
 
 h3. Uninstalling
 

--- a/custom/plugins/example/example.plugin.zsh
+++ b/custom/plugins/example/example.plugin.zsh
@@ -1,0 +1,2 @@
+# Add your own custom plugins in the custom/plugins directory. Plugins placed
+# here will override ones with the same name in the main plugins directory.

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -12,7 +12,13 @@ for config_file ($ZSH/custom/*.zsh) source $config_file
 
 # Load all of the plugins that were defined in ~/.zshrc
 plugin=${plugin:=()}
-for plugin ($plugins) source $ZSH/plugins/$plugin/$plugin.plugin.zsh
+for plugin ($plugins) 
+  # First check in the custom/ directory.
+  if [ -d $ZSH/custom/plugins/$plugin ]; then
+    source $ZSH/custom/plugins/$plugin/$plugin.plugin.zsh;
+  else
+    source $ZSH/plugins/$plugin/$plugin.plugin.zsh;
+  fi
 
 # Check for updates on initial load...
 if [ "$DISABLE_AUTO_UPDATE" = "true" ]


### PR DESCRIPTION
I added the ability to override plugins in the `plugins` directory with ones in the `custom/plugins` directory. I think all custom plugins should live in the `custom/plugins` directory even if they don't override core ones, just to keep custom code separate from the library.

What do you think?
