### PR TITLE
fix title() to not match any $TERM

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -5,7 +5,7 @@ function title {
     print -nR $'\033k'$1$'\033'\\\
 
     print -nR $'\033]0;'$2$'\a'
-  elif [[ $TERM =~ "^xterm" || $TERM == "rxvt" ]]; then
+  elif [[ ($TERM =~ "^xterm") ]] || [[ ($TERM == "rxvt") ]]; then
     # Use this one instead for XTerms:
     print -nR $'\033]0;'$*$'\a'
   fi


### PR DESCRIPTION
On my linux virtual terminals, where TERM="linux", I was getting
annoying output that was messing up my prompt.

It turns out the title function was always matching on the elif
statement for xterm/rxvt no matter what and the linux vt doesn't know
what to do with the title special control sequence and thus was printing
out garbage. 

Chagelog contains full details.

Thanks!

Brandon
