### PR TITLE
Load all plugins from each plugin folder.

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -12,7 +12,7 @@ for config_file ($ZSH/custom/*.zsh) source $config_file
 
 # Load all of the plugins that were defined in ~/.zshrc
 plugin=${plugin:=()}
-for plugin ($plugins) source $ZSH/plugins/$plugin/$plugin.plugin.zsh
+for plugin ($plugins) for plugin_file ($ZSH/plugins/$plugin/*.plugin.zsh) source $plugin_file
 
 # Check for updates on initial load...
 if [ "$DISABLE_AUTO_UPDATE" = "true" ]


### PR DESCRIPTION
Now `oh-my-zsh` only load `$ZSH/plugins/foo/foo.plugin.zsh` when initializing.

It could be better if loading all `*.plugin.zsh` in `$ZSH/plugins/foo/`, IMO. 

For example, in this way, I can put my `git-flow.plugin.zsh` into `$ZSH/plugins/git/` without creating a `$ZSH/plugins/git-flow/` folder.
