### PR TITLE
port of __git_ps1 that comes with git's bash_completion

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -26,6 +26,59 @@ function current_branch() {
   echo ${ref#refs/heads/}
 }
 
+# __git_ps1 accepts 0 or 1 arguments (i.e., format string)
+# returns text to add to bash PS1 prompt (includes branch name)
+function __git_ps1 () {
+  local g="$(git rev-parse --git-dir 2>/dev/null)"
+  if [ -n "$g" ]; then
+    local r
+    local b
+    if [ -d "$g/rebase-apply" ]
+    then
+      if test -f "$g/rebase-apply/rebasing"
+      then
+        r="|REBASE"
+      elif test -f "$g/rebase-apply/applying"
+      then
+        r="|AM"
+      else
+        r="|AM/REBASE"
+      fi
+      b="$(git symbolic-ref HEAD 2>/dev/null)"
+    elif [ -f "$g/rebase-merge/interactive" ]
+    then
+      r="|REBASE-i"
+      b="$(cat "$g/rebase-merge/head-name")"
+    elif [ -d "$g/rebase-merge" ]
+    then
+      r="|REBASE-m"
+      b="$(cat "$g/rebase-merge/head-name")"
+    elif [ -f "$g/MERGE_HEAD" ]
+    then
+      r="|MERGING"
+      b="$(git symbolic-ref HEAD 2>/dev/null)"
+    else
+      if [ -f "$g/BISECT_LOG" ]
+      then
+        r="|BISECTING"
+      fi
+      if ! b="$(git symbolic-ref HEAD 2>/dev/null)"
+      then
+        if ! b="$(git describe --exact-match HEAD 2>/dev/null)"
+        then
+          b="$(cut -c1-7 "$g/HEAD")..."
+        fi
+      fi
+    fi
+
+    if [ -n "${1-}" ]; then
+      printf "$1" "${b##refs/heads/}$r"
+    else
+      printf " (%s)" "${b##refs/heads/}$r"
+    fi
+  fi
+}
+
 # these aliases take advangate of the previous function
 alias ggpull='git pull origin $(current_branch)'
 alias ggpush='git push origin $(current_branch)'

--- a/themes/gozilla.zsh-theme
+++ b/themes/gozilla.zsh-theme
@@ -1,4 +1,4 @@
-PROMPT='%{$fg_bold[red]%}➜ %{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%} % %{$reset_color%}'
+PROMPT='%{$fg_bold[red]%}➜ %{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(__git_ps1)%{$fg_bold[blue]%} % %{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="("
 ZSH_THEME_GIT_PROMPT_SUFFIX=")"


### PR DESCRIPTION
Hi,

I've added port of `__git_ps1` function that comes with git's bash_completion. It's basically smarter version of  already existing `current_branch` function. In contrast to `current_branch` `__git_ps1` can does things like:

(bb8f98d...)                         <- if you checkout non branched commit
(master|REBASE)              <- if on rebase of your master are run into confilct 
(master|MERGING)           <- if on merge you got a merge-conflict
