### PR TITLE
Added svn plugin

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -1,0 +1,42 @@
+function svn_prompt_info {
+    if [[ -d .svn ]]; then
+        echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_PREFIX\
+$ZSH_THEME_REPO_NAME_COLOR$(svn_get_repo_name)$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR$(svn_dirty)$ZSH_PROMPT_BASE_COLOR"
+    fi
+}
+
+
+function in_svn() {
+    if [[ -d .svn ]]; then
+        echo 1
+    fi
+}
+
+function svn_get_repo_name {
+    if [ is_svn ]; then
+        svn info | sed -n 's/Repository\ Root:\ .*\///p' | read SVN_ROOT
+    
+        svn info | sed -n "s/URL:\ .*$SVN_ROOT\///p" | sed "s/\/.*$//"
+    fi
+}
+
+function svn_get_rev_nr {
+    if [ is_svn ]; then
+        svn info 2> /dev/null | sed -n s/Revision:\ //p
+    fi
+}
+
+function svn_dirty_choose {
+    if [ is_svn ]; then
+        s=$(svn status 2>/dev/null)
+        if [ $s ]; then 
+            echo $1
+        else 
+            echo $2
+        fi
+    fi
+}
+
+function svn_dirty {
+    svn_dirty_choose $ZSH_THEME_SVN_PROMPT_DIRTY $ZSH_THEME_SVN_PROMPT_CLEAN
+}

--- a/themes/robbyrussell-with-svn.zsh-theme
+++ b/themes/robbyrussell-with-svn.zsh-theme
@@ -1,0 +1,18 @@
+# the svn plugin has to be activated for this to work.
+
+PROMPT='%{$fg_bold[red]%}➜ %{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%}$(svn_prompt_info)%{$reset_color%}'
+
+ZSH_THEME_GIT_PROMPT_PREFIX="git:(%{$fg[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%})%{$fg[yellow]%} ✗ %{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%}) "
+
+
+
+ZSH_PROMPT_BASE_COLOR="%{$fg_bold[blue]%}"
+ZSH_THEME_REPO_NAME_COLOR="%{$fg_bold[yellow]%}"
+
+ZSH_THEME_SVN_PROMPT_PREFIX="svn:("
+ZSH_THEME_SVN_PROMPT_SUFFIX=")"
+ZSH_THEME_SVN_PROMPT_DIRTY="%{$fg[red]%} ✘ %{$reset_color%}"
+ZSH_THEME_SVN_PROMPT_CLEAN=" "


### PR DESCRIPTION
Hi,

I really like how the prompt displays git info whenever you're in a repo, so I added the equivalent functionality for subversion with a new plugin : When the cwd is under version control, the prompt (when using the robbyrussell-with-svn theme) will display the repo name a. It's a little slower than the git prompt, but still acceptable.

regards,
Robin
