### PR TITLE
optimization for "user is root" check in prompt themes

### DIFF
--- a/themes/afowler.zsh-theme
+++ b/themes/afowler.zsh-theme
@@ -1,4 +1,4 @@
-if [ "$(whoami)" = "root" ]; then CARETCOLOR="red"; else CARETCOLOR="blue"; fi
+if [ $UID -eq 0 ]; then CARETCOLOR="red"; else CARETCOLOR="blue"; fi
 
 local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 

--- a/themes/arrow.zsh-theme
+++ b/themes/arrow.zsh-theme
@@ -1,4 +1,4 @@
-if [ "$(whoami)" = "root" ]; then NCOLOR="red"; else NCOLOR="yellow"; fi
+if [ $UID -eq 0 ]; then NCOLOR="red"; else NCOLOR="yellow"; fi
 
 PROMPT='%{$fg[$NCOLOR]%}%c ➤ %{$reset_color%}'
 RPROMPT='%{$fg[$NCOLOR]%}%p $(git_prompt_info)%{$reset_color%}'

--- a/themes/clean.zsh-theme
+++ b/themes/clean.zsh-theme
@@ -1,4 +1,4 @@
-if [ "$(whoami)" = "root" ]; then NCOLOR="red"; else NCOLOR="white"; fi
+if [ $UID -eq 0 ]; then NCOLOR="red"; else NCOLOR="white"; fi
 
 PROMPT='%{$fg[$NCOLOR]%}%B%n%b%{$reset_color%}:%{$fg[blue]%}%B%c/%b%{$reset_color%} $(git_prompt_info)%(!.#.$) '
 RPROMPT='[%*]'

--- a/themes/dst.zsh-theme
+++ b/themes/dst.zsh-theme
@@ -5,7 +5,7 @@ ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[red]%}!"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 
 function prompt_char {
-	if [ "$(whoami)" = "root" ]; then echo "%{$fg[red]%}#%{$reset_color%}"; else echo $; fi
+	if [ $UID -eq 0 ]; then echo "%{$fg[red]%}#%{$reset_color%}"; else echo $; fi
 }
 
 PROMPT='%(?, ,%{$fg[red]%}FAIL%{$reset_color%}

--- a/themes/jreese.zsh-theme
+++ b/themes/jreese.zsh-theme
@@ -1,6 +1,6 @@
 # ZSH Theme - Preview: http://dl.dropbox.com/u/1552408/Screenshots/2010-04-08-oh-my-zsh.png
 
-if [ "$(whoami)" = "root" ]; then NCOLOR="red"; else NCOLOR="green"; fi
+if [ $UID -eq 0 ]; then NCOLOR="red"; else NCOLOR="green"; fi
 local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 
 PROMPT='%{$fg[$NCOLOR]%}%n%{$fg[green]%}@%m%{$reset_color%} %~ \

--- a/themes/philips.zsh-theme
+++ b/themes/philips.zsh-theme
@@ -1,4 +1,4 @@
-if [ "$(whoami)" = "root" ]; then NCOLOR="red"; else NCOLOR="green"; fi
+if [ $UID -eq 0 ]; then NCOLOR="red"; else NCOLOR="green"; fi
 
 PROMPT='%{$fg[$NCOLOR]%}%B%n%b%{$reset_color%}:%{$fg[blue]%}%B%c/%b%{$reset_color%} $(git_prompt_info)%(!.#.$) '
 RPROMPT='[%*]'

--- a/themes/pmcgee.zsh-theme
+++ b/themes/pmcgee.zsh-theme
@@ -1,4 +1,4 @@
-if [ "$(whoami)" = "root" ]; then NCOLOR="red"; else NCOLOR="green"; fi
+if [ $UID -eq 0 ]; then NCOLOR="red"; else NCOLOR="green"; fi
 
 PROMPT='
 %{$fg[$NCOLOR]%}%B%n@%m%b%{$reset_color%} %{$fg[white]%}%B${PWD/#$HOME/~}%b%{$reset_color%}


### PR DESCRIPTION
This commit uses `$UID` instead of running `whoami` in a subshell.
