### PR TITLE
Postponing sourcing of the theme until after local customizations

### DIFF
--- a/lib/appearance.zsh
+++ b/lib/appearance.zsh
@@ -34,5 +34,3 @@ ZSH_THEME_GIT_PROMPT_CLEAN=""               # Text to display if the branch is c
 # Setup the prompt with pretty colors
 setopt prompt_subst
 
-# Load the theme
-source "$ZSH/themes/$ZSH_THEME.zsh-theme"

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -14,6 +14,9 @@ for config_file ($ZSH/custom/*.zsh) source $config_file
 plugin=${plugin:=()}
 for plugin ($plugins) source $ZSH/plugins/$plugin/$plugin.plugin.zsh
 
+# Load the theme
+source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+
 # Check for updates on initial load...
 if [ "$DISABLE_AUTO_UPDATE" = "true" ]
 then


### PR DESCRIPTION
I sent you an email about this earlier. I'm pretty new to git / github -- and zsh as well, but my intention here was to simply postpone the sourcing of the theme until after all libs and local customizations have been performed.

To facilitate this I migrated it out of the lib/appearance.zsh and into oh-my-zsh.sh before you check for auto-update.

I'm re-submitting this because I didn't realize I was cluttering up the branch with additional unrelated changes.
