### PR TITLE
Pathrc - plugin to manage paths

### DIFF
--- a/plugins/pathrc/pathrc.plugin.zsh
+++ b/plugins/pathrc/pathrc.plugin.zsh
@@ -1,0 +1,27 @@
+# If there is no PATHRC already set, default to ~/.pathrc
+if [ -z "$PATHRC" ]; then
+    PATHRC=$HOME/.pathrc
+fi
+
+# Similarly, MANPATHRC defaults to ~/.manpath
+if [ -z "$MANPATHRC" ]; then
+    MANPATHRC=$HOME/.manpathrc
+fi
+
+# Set the PATH
+if [ -f $PATHRC ]; then
+    path=()
+    typeset -U path
+    for dir in $(<$PATHRC); do 
+        path+=($dir)
+    done 
+fi 
+
+# Set the MANPATH
+if [ -f $MANPATHRC ]; then
+    manpath=()
+    typeset -U manpath
+    for dir in $(<$MANPATHRC); do
+        manpath+=($dir)
+    done 
+fi


### PR DESCRIPTION
_Adding mechanism for managing paths in a plugin._
- User creates a file (by default ~/.pathrc) which lists one directory per line, all of the directories which should make up his path. The file to use can be overridden with the PATHRC variable.
- User creates a file (by default ~/.manpathrc) which lists one directory per line, all of the directories which should make up his manpath. The file to use can be overridden with the MANPATHRC variable.
- Could easily be extended to handle things like pythonpath, and other similar environment variables.
