### PR TITLE
Extend upgrade script to be useful to people maintaining forks

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,6 +1,19 @@
 current_path=`pwd`
 echo "Upgrading Oh My Zsh"
-( cd $ZSH && git pull origin master )
+
+git_branches=`git remote -v`
+default_origin=`echo $git_branches | egrep 'origin\s+https://github.com/robbyrussell/oh-my-zsh\.git'`
+upgrade_cmd="git pull origin master"
+if [ "N$default_origin" = "N" ]; then
+	upstream_branch=`echo $git_branches | egrep 'upstream\s+https://github.com/robbyrussell/oh-my-zsh\.git'`
+	if [ "N$upstream_branch" = "N" ]; then
+		upgrade_cmd="git remote add upstream https://github.com/robbyrussell/oh-my-zsh/; git fetch upstream; git merge upstream/master"
+	else
+		upgrade_cmd="git fetch upstream; git merge upstream/master"
+	fi
+fi
+
+( cd $ZSH && eval "$upgrade_cmd" )
 echo '         __                                     __  '
 echo '  ____  / /_     ____ ___  __  __   ____  _____/ /_ '
 echo ' / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \ '


### PR DESCRIPTION
This change only modifies the upgrade.sh script to see if the origin is still left at robby's repo. If it isn't, it detects if an "upstream" remote is already created, and if not adds it. One way or another, the upgrade.sh script now merges the latest upstream code.*

(*well, hopefull)
