### PR TITLE
Add missing flag to unrar

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -52,7 +52,7 @@ function extract() {
       *.tar.xz) tar xvJf $1;;
       *.tar.lzma) tar --lzma -xvf $1;;
       *.bz2) bunzip $1;;
-      *.rar) unrar $1;;
+      *.rar) unrar x $1;;
       *.gz) gunzip $1;;
       *.tar) tar xvf $1;;
       *.tbz2) tar xvjf $1;;


### PR DESCRIPTION
Hi!

the `extract` function in `lib/functions.zsh` has one small bug: the `unrar` program expects `x` as a flag for extraction.

it's in the commit :)
