### PR TITLE
Refactor window and table title change depending on context

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -1,26 +1,3 @@
-## fixme, i duplicated this in xterms - oops
-function title {
-  if [[ $TERM == "screen" ]]; then
-    # Use these two for GNU Screen:
-    print -nR $'\033k'$1$'\033'\\\
-
-    print -nR $'\033]0;'$2$'\a'
-  elif [[ ($TERM =~ "^xterm") ]] || [[ ($TERM == "rxvt") ]]; then
-    # Use this one instead for XTerms:
-    print -nR $'\033]0;'$*$'\a'
-  fi
-}
-
-function precmd {
-  title zsh "$PWD"
-}
-
-function preexec {
-  emulate -L zsh
-  local -a cmd; cmd=(${(z)1})
-  title $cmd[1]:t "$cmd[2,-1]"
-}
-
 function zsh_stats() {
   history | awk '{print $2}' | sort | uniq -c | sort -rn | head
 }

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -1,21 +1,26 @@
-case "$TERM" in
-  xterm*|rxvt*)
-    preexec () {
-      print -Pn "\e]0;%n@%m: $1\a"  # xterm
-    }
-    precmd () {
-      print -Pn "\e]0;%n@%m: %~\a"  # xterm
-    }
-    ;;
-  screen*)
-    preexec () {
-      local CMD=${1[(wr)^(*=*|sudo|ssh|-*)]}
-      echo -ne "\ek$CMD\e\\"
-      print -Pn "\e]0;%n@%m: $1\a"  # xterm
-    }
-    precmd () {
-      echo -ne "\ekzsh\e\\"
-      print -Pn "\e]0;%n@%m: %~\a"  # xterm
-    }
-    ;;
-esac
+#usage: title short_tab_title looooooooooooooooooooooggggggg_windows_title
+#http://www.faqs.org/docs/Linux-mini/Xterm-Title.html#ss3.1
+#Fully support screen, iterm, and probably most modern xterm and rxvt
+#Limited support for Apple Terminal (Terminal can't set window or tab separately)
+function title {
+  if [[ "$TERM" == "screen" ]]; then 
+    print -Pn "\ek$1\e\\" #set screen hardstatus, usually truncated at 20 chars
+  elif [[ ($TERM =~ "^xterm") ]] || [[ ($TERM == "rxvt") ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+    print -Pn "\e]2;$2\a" #set window name
+    print -Pn "\e]1;$1\a" #set icon (=tab) name (will override window name on broken terminal)
+  fi
+}
+
+ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD
+ZSH_THEME_TERM_TITLE_IDLE="%n@%m: %~"
+
+#Appears when you have the prompt
+function precmd {
+  title $ZSH_THEME_TERM_TAB_TITLE_IDLE $ZSH_THEME_TERM_TITLE_IDLE
+}
+
+#Appears at the beginning of (and during) of command execution
+function preexec {
+  local CMD=${1[(wr)^(*=*|sudo|ssh|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
+  title "$CMD" "%100>...>$2%<<"
+}


### PR DESCRIPTION
There is currently some mess in the lib/functions.zsh lib/termsupport.zsh with duplication/dead code when it comes to handle window/tab title.

Moreover this is was not customizable through theme, had not so clever default, and was not exploiting modern terminal feature (= not Apple Terminal) like iTerm.

There was even a FIX ME so I fixed it, clean/improved the code and mitigate existing default.

Now on a terminal like iTerm you will have a different value for the tab and the windows, potentially customizable via theme and with default that make the information actually fit in a tab.

Thank you very much for oh-my-zsh, you are probably the main reason for my switch to zsh :)
