### PR TITLE
Fix for Vim’s Dumb Terminal

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -1,4 +1,5 @@
 # fixme - the load process here seems a bit bizarre
+[[ "$TERM" == "dumb" ]] && return
 
 unsetopt menu_complete   # do not autoselect the first completion entry
 unsetopt flowcontrol

--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -1,6 +1,4 @@
-#
-# Color grep results
-# Examples: http://rubyurl.com/ZXv
-#
-export GREP_OPTIONS='--color=auto'
-export GREP_COLOR='1;32'
+if [[ "$DISABLE_COLOR" != "true" ]]; then
+    [[ -z "$GREP_OPTIONS" ]] && export GREP_OPTIONS='--color=auto'
+    [[ -z "$GREP_COLOR" ]] && export GREP_COLOR='1;32'
+fi

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -9,5 +9,5 @@ bindkey "^[m" copy-prev-shell-word
 setopt long_list_jobs
 
 ## pager
-export PAGER=less
-export LC_CTYPE=en_US.UTF-8
+[[ -z "$PAGER" ]] && export PAGER=less
+[[ -z "$LC_CTYPE" ]] && export LC_CTYPE=en_US.UTF-8

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -1,3 +1,5 @@
+[[ "$TERM" == "dumb" ]] && return
+
 #usage: title short_tab_title looooooooooooooooooooooggggggg_windows_title
 #http://www.faqs.org/docs/Linux-mini/Xterm-Title.html#ss3.1
 #Fully support screen, iterm, and probably most modern xterm and rxvt

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -1,10 +1,9 @@
 # ls colors
 autoload colors; colors;
-export LSCOLORS="Gxfxcxdxbxegedabagacad"
-#export LS_COLORS
+[[ -z "$LSCOLORS" ]] && export LSCOLORS="Gxfxcxdxbxegedabagacad"
 
 # Enable ls colors
-if [ "$DISABLE_LS_COLORS" != "true" ]
+if [ "$DISABLE_COLOR" != "true" ]
 then
   # Find the option for using colors in ls, depending on the version: Linux or BSD
   ls --color -d . &>/dev/null 2>&1 && alias ls='ls --color=tty' || alias ls='ls -G'

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -1,5 +1,10 @@
 # Initializes Oh My Zsh
 
+# Disable colors on dumb terminals
+if [ "$TERM" = "dumb" ]; then
+  DISABLE_COLOR="true"
+fi
+
 # add a function path
 fpath=($ZSH/functions $fpath)
 
@@ -7,15 +12,15 @@ fpath=($ZSH/functions $fpath)
 # TIP: Add files you don't want in git to .gitignore
 for config_file ($ZSH/lib/*.zsh) source $config_file
 
-# Load all of your custom configurations from custom/
-for config_file ($ZSH/custom/*.zsh) source $config_file
-
 # Load all of the plugins that were defined in ~/.zshrc
 plugin=${plugin:=()}
 for plugin ($plugins) source $ZSH/plugins/$plugin/$plugin.plugin.zsh
 
 # Load the theme
 source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+
+# Load all of your custom configurations from custom/
+for config_file ($ZSH/custom/*.zsh) source $config_file
 
 # Check for updates on initial load...
 if [ "$DISABLE_AUTO_UPDATE" = "true" ]

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -12,7 +12,7 @@ export ZSH_THEME="robbyrussell"
 # export DISABLE_AUTO_UPDATE="true"
 
 # Uncomment following line if you want to disable colors in ls
-# export DISABLE_LS_COLORS="true"
+# export DISABLE_COLOR="true"
 
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Example format: plugins=(rails git textmate ruby lighthouse)

--- a/themes/sorin.zsh-theme
+++ b/themes/sorin.zsh-theme
@@ -2,12 +2,12 @@
 #          FILE:  sorin.zsh-theme
 #   DESCRIPTION:  oh-my-zsh theme file.
 #        AUTHOR:  Sorin Ionescu (sorin.ionescu@gmail.com)
-#       VERSION:  1.0.2
+#       VERSION:  1.0.3
 #    SCREENSHOT:  http://i.imgur.com/aipDQ.png
 # ------------------------------------------------------------------------------
 
 
-if [[ "$TERM" != "dumb" ]] && [[ "$DISABLE_LS_COLORS" != "true" ]]; then
+if [[ "$DISABLE_COLOR" != "true" ]]; then
   MODE_INDICATOR="%{$fg_bold[red]%}❮%{$reset_color%}%{$fg[red]%}❮❮%{$reset_color%}"
   local return_status="%{$fg[red]%}%(?..⏎)%{$reset_color%}"
   


### PR DESCRIPTION
Do not override environmental variables declared in _.zshenv_ or in _/custom/_.

Don't do this.

```
export LSCOLORS="Gxfxcxdxbxegedabagacad"
```

Always do this.

```
[[ -z "$LSCOLORS" ]] && export LSCOLORS=“Gxfxcxdxbxegedabagacad”
```

Other changes when a dumb terminal is detected:
1. Disables colours.
2. Loads /custom/ last to disable plugin colouring.
3. Disables custom completion styles. Though, It would be best to turn completion off completely.
4. Disables term support.

![Vim Screen Shot](http://i.imgur.com/bbTuA.png)
