### PR TITLE
Fixed inconsistent casing in history.zsh

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -3,14 +3,11 @@ HISTFILE=$HOME/.zsh_history
 HISTSIZE=10000
 SAVEHIST=10000
 
-setopt hist_ignore_dups # ignore duplication command history list
-setopt share_history # share command history data
-
-setopt hist_verify
-setopt inc_append_history
-setopt extended_history
-setopt hist_expire_dups_first
-setopt hist_ignore_space
-
+setopt HIST_VERIFY
+setopt HIST_EXPIRE_DUPS_FIRST
+setopt HIST_IGNORE_SPACE
+setopt HIST_IGNORE_DUPS
 setopt SHARE_HISTORY
 setopt APPEND_HISTORY
+setopt EXTENDED_HISTORY
+setopt INC_APPEND_HISTORY


### PR DESCRIPTION
The inconsistent casing was confusing me as I read the man page to see what each option does; so, I fixed it.
