### PR TITLE
Fixed missing modified status detection in git.zsh

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -26,6 +26,10 @@ git_prompt_status() {
   fi
   if $(echo "$INDEX" | grep '^ M ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+  elif $(echo "$INDEX" | grep '^AM ' &> /dev/null); then
+    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+  elif $(echo "$INDEX" | grep '^ T ' &> /dev/null); then
+    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
   fi
   if $(echo "$INDEX" | grep '^R  ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_RENAMED$STATUS"


### PR DESCRIPTION
Two issues are fixed in _lib/git.zsh_.
- When you add a newly created file to the index then modify it, oh-my-zsh doesn't detect the status as modified.
- When modifying the type of a file, oh-my-zsh does not detect the file as modified.

Is it not better to combine regular expressions either with `grep -E` or `grep -P` instead of having so many if statements?
