### PR TITLE
Bundler plugin

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -1,0 +1,3 @@
+alias be="bundle exec"
+alias bi="bundle install"
+alias bu="bundle update"


### PR DESCRIPTION
I've added a plugin file with aliases for bundler.  The main useful one is "be" for "bundle exec".  The others are marginally useful, but I figured I'd include them anyway.
