### PR TITLE
Updated risto theme and a tweak to lib/rvm.zsh

### DIFF
--- a/lib/rvm.zsh
+++ b/lib/rvm.zsh
@@ -1,7 +1,7 @@
 # get the name of the branch we are on
 function rvm_prompt_info() {
   ruby_version=$(~/.rvm/bin/rvm-prompt 2> /dev/null) || return
-  echo "($ruby_version)"
+  echo "$ruby_version"
 }
 
 

--- a/themes/risto.zsh-theme
+++ b/themes/risto.zsh-theme
@@ -3,7 +3,7 @@
 # Requires the svn plugin
 #
 PROMPT='%{$fg[green]%}%n@%m:%{$fg[blue]%}%2~ $(svn_prompt_info)$(git_prompt_info)%{$reset_color%}%(!.#.%%) '
-RPROMPT='%{$fg_bold[red]%}$(rvm-prompt)%{$reset_color%}%'
+RPROMPT='%{$fg_bold[red]%}$(rvm_prompt_info)%{$reset_color%}%'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[red]%}‹"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$fg[red]%}›%{$reset_color%}"


### PR DESCRIPTION
I have fixed the risto theme, updated the documentation and switched to using the rvm_prompt_info function that id defined in rvm.vim.

As a result, I wound up removing the parenthesis that were hardcoded around the rvm prompt, which better matches git_prompt and svn_prompt.
