### PR TITLE
Osx terminal title

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -6,8 +6,8 @@ function title {
   if [[ "$TERM" == "screen" ]]; then 
     print -Pn "\ek$1\e\\" #set screen hardstatus, usually truncated at 20 chars
   elif [[ ($TERM =~ "^xterm") ]] || [[ ($TERM == "rxvt") ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
-    print -Pn "\e]2;$2\a" #set window name
     print -Pn "\e]1;$1\a" #set icon (=tab) name (will override window name on broken terminal)
+    print -Pn "\e]2;$2\a" #set window name
   fi
 }
 


### PR DESCRIPTION
Refactor didn't work on OSX terminal.  Tab title setting appeared to wipe out window title setting.  Reordering to have window title set after tab appears to resolve the issue on OSX terminal, and should continue to work elsewhere, although frankly I could never get the tab title setting working in iTerm in either order.
