### PR TITLE
Introduce DISABLE_AUTO_TITLE option

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -16,11 +16,15 @@ ZSH_THEME_TERM_TITLE_IDLE="%n@%m: %~"
 
 #Appears when you have the prompt
 function precmd {
-  title $ZSH_THEME_TERM_TAB_TITLE_IDLE $ZSH_THEME_TERM_TITLE_IDLE
+  if [ "$DISABLE_AUTO_TITLE" != "true" ]; then
+    title $ZSH_THEME_TERM_TAB_TITLE_IDLE $ZSH_THEME_TERM_TITLE_IDLE
+  fi
 }
 
 #Appears at the beginning of (and during) of command execution
 function preexec {
-  local CMD=${1[(wr)^(*=*|sudo|ssh|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
-  title "$CMD" "%100>...>$2%<<"
+  if [ "$DISABLE_AUTO_TITLE" != "true" ]; then
+    local CMD=${1[(wr)^(*=*|sudo|ssh|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
+    title "$CMD" "%100>...>$2%<<"
+  fi
 }

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -14,6 +14,9 @@ export ZSH_THEME="robbyrussell"
 # Uncomment following line if you want to disable colors in ls
 # export DISABLE_LS_COLORS="true"
 
+# Uncomment following line if you want to disable autosetting terminal title.
+# export DISABLE_AUTO_TITLE="true"
+
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Example format: plugins=(rails git textmate ruby lighthouse)
 plugins=(git)


### PR DESCRIPTION
Simple toggle option for those us who don't want titles to be automatically set. I tend to have task-oriented windows that I manually name and I want that name to stick over time.

This supersedes my older (now closed) pull request (https://github.com/robbyrussell/oh-my-zsh/pull/199) for the same functionality.
