### PR TITLE
ignore certificate check fail

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -8,7 +8,7 @@ h2. Setup
 
 h3. The automatic installer... (do you trust me?)
 
-@wget https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | sh@
+@wget --no-check-certificate https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | sh@
 
 h3. The manual way
 


### PR DESCRIPTION
this fork fixes the wget command used in the wiki to ignore the certificate check fail

```
WARNING: certificate common name “*.github.com” doesn’t match requested host name “github.com”.
```
