### PR TITLE
Fix all the long standing open bugs related to window/tab title bar

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -3,6 +3,7 @@
 #Fully support screen, iterm, and probably most modern xterm and rxvt
 #Limited support for Apple Terminal (Terminal can't set window or tab separately)
 function title {
+  [ "$DISABLE_AUTO_TITLE" != "true" ] || return
   if [[ $TERM =~ "^screen" ]]; then 
     print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
   elif [[ ($TERM =~ "^xterm") ]] || [[ ($TERM == "rxvt") ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
@@ -16,17 +17,13 @@ ZSH_THEME_TERM_TITLE_IDLE="%n@%m: %~"
 
 #Appears when you have the prompt
 function precmd {
-  if [ "$DISABLE_AUTO_TITLE" != "true" ]; then
-    title $ZSH_THEME_TERM_TAB_TITLE_IDLE $ZSH_THEME_TERM_TITLE_IDLE
-  fi
+  title $ZSH_THEME_TERM_TAB_TITLE_IDLE $ZSH_THEME_TERM_TITLE_IDLE
 }
 
 #Appears at the beginning of (and during) of command execution
 function preexec {
-  if [ "$DISABLE_AUTO_TITLE" != "true" ]; then
-    emulate -L zsh
-    setopt extended_glob
-    local CMD=${1[(wr)^(*=*|sudo|ssh|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
-    title "$CMD" "%100>...>$2%<<"
-  fi
+  emulate -L zsh
+  setopt extended_glob
+  local CMD=${1[(wr)^(*=*|sudo|ssh|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
+  title "$CMD" "%100>...>$2%<<"
 }


### PR DESCRIPTION
- Lack of escaping was creating serious issue on Apple Terminal in case of complexe string with ] ; ...
- Some zsh flavor or configuration don't has extended_glob option activated which was causing command title to be blank
- A small refactoring of a recent change related to DISABLE_AUTO_TITLE

This is bugfix / aesthetic only so pretty harmless, it closes #45 #52 #57 #58 #86
