### PR TITLE
Untitled

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -24,6 +24,8 @@ function precmd {
 #Appears at the beginning of (and during) of command execution
 function preexec {
   if [ "$DISABLE_AUTO_TITLE" != "true" ]; then
+    emulate -L zsh
+    setopt extended_glob
     local CMD=${1[(wr)^(*=*|sudo|ssh|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
     title "$CMD" "%100>...>$2%<<"
   fi


### PR DESCRIPTION
Reset zsh options in termsupports preexec function to enable extended_glob.

Per discussion on commit 52df85440ee8ead8f17d3aa3e1fedf187162313c, this mostly resolves the concerns raised in commit d4ea399b04ef57dd31097eadc316305d1e42a194
