### PR TITLE
Minor fix for the github plugin: check for `ruby`.

### DIFF
--- a/plugins/github/github.plugin.zsh
+++ b/plugins/github/github.plugin.zsh
@@ -1,6 +1,5 @@
-# hub alias from defunkt
-# https://github.com/defunkt/hub
-if [ "$commands[(I)hub]" ]; then
+# Setup hub function for git, if it is available; http://github.com/defunkt/hub
+if [ "$commands[(I)hub]" ] && [ "$commands[(I)ruby]" ]; then
     # eval `hub alias -s zsh`
     function git(){hub "$@"}
 fi


### PR DESCRIPTION
I've run into the issue where a stripped down container had no Ruby
installed, which caused `hub` to fail.

Therefore I've added an extra check to verify that `ruby` is in the
commands list before setting up this alias/function.
