### PR TITLE
Add growl command for iTerm/iTerm2

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -55,3 +55,12 @@ end do_submenu
 do_submenu("iTerm", "Shell", "New Tab")
 EOF
 }
+
+# Send a notification to growl from iTerm or iterm2
+#
+#  usage: growl "Notification Text"
+#
+# You can use \n and \t to add newlines and tabs
+# respectively.  Or add \a to make it beep
+growl() { print -n '\e]9;'${@}'\007' }
+


### PR DESCRIPTION
usage:

```
  growl "Notification Text"
```

You can use \n and \t to add newlines and tabs respectively, or add \a to make it beep.  I find this useful to let me know when a long command, such as a compile completes...

 make ; growl "Make finished\a"
