### PR TITLE
Make the delete key work correctly, instead of outputting a ~

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -25,6 +25,7 @@ bindkey '^[[Z' reverse-menu-complete
 # Make the delete key (or Fn + Delete on the Mac) work instead of outputting a ~
 bindkey "^[[3~" delete-char
 bindkey "^[3;5~" delete-char
+bindkey "\e[3~" delete-char
 
 # consider emacs keybindings:
 


### PR DESCRIPTION
What the title says, taken from http://www.gnegg.ch/2004/10/delete-key-in-zsh/
