### PR TITLE
Fixed folder naming for mysql-macports plugin and improved start/stop scr

### DIFF
--- a/plugins/mysql-macports/mysql-macports.plugin.zsh
+++ b/plugins/mysql-macports/mysql-macports.plugin.zsh
@@ -1,0 +1,8 @@
+# commands to control local mysql-server installation
+# paths are for osx installation via macports
+
+alias mysqlstart='sudo /opt/local/share/mysql5/mysql/mysql.server start'
+alias mysqlstop='sudo /opt/local/share/mysql5/mysql/mysql.server stop'
+alias mysqlrestart='sudo /opt/local/share/mysql5/mysql/mysql.server restart'
+
+alias mysqlstatus='mysqladmin5 -u root -p ping'

--- a/plugins/mysql/mysql-macports.plugin.zsh
+++ b/plugins/mysql/mysql-macports.plugin.zsh
@@ -1,6 +1,0 @@
-# commands to control local mysql-server installation
-# paths are for osx installtion via macports
-
-alias mysqlstart='sudo /opt/local/bin/mysqld_safe5'
-alias mysqlstop='/opt/local/bin/mysqladmin5 -u root -p shutdown'
-alias mysqlstatus='mysqladmin5 -u root -p ping'


### PR DESCRIPTION
Fixed folder naming for mysql-macports plugin and improved start/stop scripts.
- Plugin was not loaded because plugin folder name and file name did not match
- Using the mysql launchd wrappers provided by macports to start/stop/restart MySQL instead of calling the mysql binary directly
