### PR TITLE
Added start/stop aliases for Apache 2 installation via macports.

### DIFF
--- a/plugins/apache2-macports/apache2-macports.plugin.zsh
+++ b/plugins/apache2-macports/apache2-macports.plugin.zsh
@@ -1,0 +1,6 @@
+# commands to control local apache2 server installation
+# paths are for osx installation via macports
+
+alias apache2start='sudo /opt/local/etc/LaunchDaemons/org.macports.apache2/apache2.wrapper start'
+alias apache2stop='sudo /opt/local/etc/LaunchDaemons/org.macports.apache2/apache2.wrapper stop'
+alias apache2restart='sudo /opt/local/etc/LaunchDaemons/org.macports.apache2/apache2.wrapper restart'


### PR DESCRIPTION
Using the launchd scripts provided by macports to start/stop/restart macports Apache 2 installation.
