### PR TITLE
added alias for apt-cache search to deb plugin

### DIFF
--- a/plugins/deb/deb.plugin.zsh
+++ b/plugins/deb/deb.plugin.zsh
@@ -9,4 +9,5 @@ alias ar="sudo apt-get remove --purge && \
 		sudo apt-get autoremove --purge"	# remove package
 alias ap="apt-cache policy"				# apt policy
 alias av="apt-cache show"				# show package info
+alias acs="apt-cache search"                            # search package
 alias ac="sudo apt-get clean && sudo apt-get autoclean" # clean apt cache


### PR DESCRIPTION
I added an alias for apt-cache search, because I use it a lot. Maybe someone else find this useful.
