### PR TITLE
New prompt methods on Git lib file

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -4,7 +4,8 @@ function git_prompt_info() {
   echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
 }
 
-parse_git_dirty () {
+# Checks if working tree is dirty
+parse_git_dirty() {
   if [[ -n $(git status -s 2> /dev/null) ]]; then
     echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
   else
@@ -12,7 +13,24 @@ parse_git_dirty () {
   fi
 }
 
-# get the status of the working tree
+# Checks if there are commits ahead from remote
+function git_prompt_ahead() {
+  if $(echo "$(git log origin/master..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
+    echo "$ZSH_THEME_GIT_PROMPT_AHEAD"
+  fi
+}
+
+# Formats prompt string for current git commit short SHA
+function git_prompt_short_sha() {
+  SHA=$(git rev-parse --short HEAD 2> /dev/null) && echo "$ZSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$ZSH_THEME_GIT_PROMPT_SHA_AFTER"
+}
+
+# Formats prompt string for current git commit long SHA
+function git_prompt_long_sha() {
+  SHA=$(git rev-parse HEAD 2> /dev/null) && echo "$ZSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$ZSH_THEME_GIT_PROMPT_SHA_AFTER"
+}
+
+# Get the status of the working tree
 git_prompt_status() {
   INDEX=$(git status --porcelain 2> /dev/null)
   STATUS=""


### PR DESCRIPTION
Modifies the Git lib file (lib/git.zsh), adding three new prompt
methods:
- git_prompt_ahead(): Shows the content of the custom var
  $ZSH_THEME_GIT_PROMPT_AHEAD if the local repository has
  commits ahead from the remote origin repository
- git_prompt_short_sha(): Shows last commit SHA hash in short
  mode wrapped between the content of the custom vars
  $ZSH_THEME_GIT_PROMPT_SHA_BEFORE and
  $ZSH_THEME_GIT_PROMPT_SHA_AFTER
- git_prompt_long_sha(): Shows last commit SHA hash in long
  mode wrapped between the content of the custom vars
  $ZSH_THEME_GIT_PROMPT_SHA_BEFORE and
  $ZSH_THEME_GIT_PROMPT_SHA_AFTER
