### PR TITLE
Fixies auto update (2nd try)

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -25,10 +25,11 @@ then
     if [ "$line" = Y ] || [ "$line" = y ]
     then
       /bin/sh $ZSH/tools/upgrade.sh
+      # update the zsh file
+      _update_zsh_update
     fi
   fi
+else
+  # create the zsh file
+  _update_zsh_update
 fi
-
-# update the zsh file
-_update_zsh_update
-


### PR DESCRIPTION
Like other users previously said, LAST_EPOCH counter is autoupdating everyday, so it can never reach a diff of 6 days. There's already a pull request here https://github.com/robbyrussell/oh-my-zsh/pull/222 , but doesn't work if the zsh-update file doesn't exists.
This should fix it.
