### PR TITLE
Relax pattern matching on TERM. Closes #320.

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -4,9 +4,9 @@
 #Limited support for Apple Terminal (Terminal can't set window or tab separately)
 function title {
   [ "$DISABLE_AUTO_TITLE" != "true" ] || return
-  if [[ $TERM =~ "^screen" ]]; then 
+  if [[ "$TERM" == screen* ]]; then 
     print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
-  elif [[ ($TERM =~ "^xterm") ]] || [[ ($TERM == "rxvt") ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+  elif [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
     print -Pn "\e]2;$2:q\a" #set window name
     print -Pn "\e]1;$1:q\a" #set icon (=tab) name (will override window name on broken terminal)
   fi


### PR DESCRIPTION
Small update of the patterns to match TERM in order to update window/tab title.

This was not matching rvxt-256 or screen-256 this now does.

This fixes #320
