### PR TITLE
Compleat - Completion for Human Beings Plugin

### DIFF
--- a/plugins/compleat/compleat.plugin.zsh
+++ b/plugins/compleat/compleat.plugin.zsh
@@ -1,0 +1,22 @@
+# ------------------------------------------------------------------------------
+#          FILE:  compleat.plugin.zsh
+#   DESCRIPTION:  oh-my-zsh plugin file.
+#        AUTHOR:  Sorin Ionescu (sorin.ionescu@gmail.com)
+#       VERSION:  1.0.0
+# ------------------------------------------------------------------------------
+
+
+if (( ${+commands[compleat]} )); then
+  local prefix="${commands[compleat]:h:h}"
+  local setup="${prefix}/share/compleat-1.0/compleat_setup" 
+
+  if [[ -f "$setup" ]]; then
+    if ! bashcompinit >/dev/null 2>&1; then
+      autoload -U bashcompinit
+      bashcompinit -i
+    fi
+
+    source "$setup" 
+  fi
+fi
+


### PR DESCRIPTION
While everyone likes completions, nobody likes writing completions because, whether it is BASH or ZSH, the syntax is obnoxious and error prone. 

I have been using [Compleat](https://github.com/mbrubeck/compleat) for more than a year. It allows one to write completions with a syntax similar to a man page. See this [blog post](http://limpet.net/mbrubeck/2009/10/30/compleat.html) for more information.

I'm hoping that by merging this plugin, the project gets more exposure, and someone who knows [Haskell](http://www.haskell.org) can pick it up since there has not been a commit in quite a while.

Here is an example completion for my [attach](https://github.com/sorin-ionescu/attach) session manager script for [dtach](http://dtach.sourceforge.net/).

```
attach [(--help|-h) | (--list|-l) | (--sockets|-L) | (--version|-v)];
attach <opts> <session>;
attach <opts> <command>; 
session = !attach -l;
opts = [(--session|-s) <session> | (--char|-c) <char> | (--redraw|-r) <modes> | (--detached|-d) | (--no-detach|-D) | (--no-suspend|-Z)] ...;
modes = (none | ctrl_l | winch);
command = !echo $PATH | tr ':' "\n" | xargs -I '{}' find '{}' \( -type f -o -type l \) -perm '++x' 2>/dev/null | awk -F '/' '{ print $NF }' | sort -u | uniq
```
