### PR TITLE
Hyphenated commands are deprecated/don't work

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -9,7 +9,7 @@ alias gup='git fetch && git rebase'
 compdef _git gup=git-fetch
 alias gp='git push'
 compdef _git gp=git-push
-gdv() { git-diff -w "$@" | view - }
+gdv() { git diff -w "$@" | view - }
 compdef _git gdv=git-diff
 alias gc='git commit -v'
 compdef _git gc=git-commit


### PR DESCRIPTION
Hyphenated git commands were deprecated 5 years ago, and are non-functional on the Ubuntu git packages unless you add something to your $PATH.

http://www.kernel.org/pub/software/scm/git/docs/RelNotes-1.6.0.txt
