### PR TITLE
Support for $(current_branch) on git_parse_ahead()

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -15,7 +15,7 @@ parse_git_dirty() {
 
 # Checks if there are commits ahead from remote
 function git_prompt_ahead() {
-  if $(echo "$(git log origin/master..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
+  if $(echo "$(git log origin/$(current_branch)..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
     echo "$ZSH_THEME_GIT_PROMPT_AHEAD"
   fi
 }


### PR DESCRIPTION
Changes method git_parse_ahead() on git.zsh lib file. Before this
change it checked directly against origin/master branch. Now it
uses $(current_branch) to check for not pushed changes against
the current remote branch.
