### PR TITLE
Don't break when there are no files in "custom"

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -23,7 +23,7 @@ for plugin ($plugins); do
 done
 
 # Load all of your custom configurations from custom/
-for config_file ($ZSH/custom/*.zsh) source $config_file
+for config_file ($(find $ZSH/custom -iname \*.zsh)) source $config_file
 
 # Load the theme
 # Check for updates on initial load...


### PR DESCRIPTION
Oh-my-zsh currently breaks if the "custom" directory is empty.  This fixes that problem, but maybe there's a better way than invoking "find"?

Context: for tidiness, I've removed the custom/example.zsh script from my fork of oh-my-zsh.  I don't like simply deleting the file after a fresh clone, because that results in the file appearing as "deleted" in git-status from then on.  Hence the empty "custom" directory after a fresh clone :)
