### PR TITLE
Fix to Random Theme Selection

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -31,7 +31,7 @@ if [ "$ZSH_THEME" = "random" ]
 then
   themes=($ZSH/themes/*zsh-theme)
   N=${#themes[@]}
-  ((N=RANDOM%N))
+  ((N=(RANDOM%N)+1))
   RANDOM_THEME=${themes[$N]}
   source "$RANDOM_THEME"
   echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."


### PR DESCRIPTION
- themes array is 1-based
- theme files names are located in indicies 1 through N inclusive
- this resolves an issue where you would occasionally see: "no such
  file or directory. Random theme '' loaded..."
