### PR TITLE
Ant plugin: stat command doesn't work under linux

### DIFF
--- a/plugins/ant/ant.plugin.zsh
+++ b/plugins/ant/ant.plugin.zsh
@@ -1,8 +1,15 @@
+stat -f%m . > /dev/null 2>&1
+if [ "$?" = 0 ]; then
+	stat_cmd=(stat -f%m)
+else
+	stat_cmd=(stat -L --format=%y)
+fi
+
 _ant_does_target_list_need_generating () {
   if [ ! -f .ant_targets ]; then return 0;
   else
-    accurate=$(stat -f%m .ant_targets)
-    changed=$(stat -f%m build.xml)
+    accurate=$($stat_cmd -f%m .ant_targets)
+    changed=$($stat_cmd -f%m build.xml)
     return $(expr $accurate '>=' $changed)
   fi
 }


### PR DESCRIPTION
The stat command for linux has different command line switches than the mac version. Because of this, the ant plugin doesn't work properly. I have patched this in s similar way than this issue was fixed: https://github.com/robbyrussell/oh-my-zsh/issues/19
