### PR TITLE
[speedup] remove rvm compinit call

### DIFF
--- a/plugins/rvm/rvm.plugin.zsh
+++ b/plugins/rvm/rvm.plugin.zsh
@@ -1,7 +1,3 @@
-fpath=($ZSH/plugins/rvm $fpath)
-autoload -U compinit
-compinit -i
-
 alias rubies='rvm list rubies'
 alias gemsets='rvm gemset list'
 


### PR DESCRIPTION
Since @sorin-ionescu [confirmed](https://github.com/robbyrussell/oh-my-zsh/pull/366#issuecomment-1259170) what I thought in #353 improving omz loading, here is that small pull request.
