### PR TITLE
Add ability to override current themes from the custom directory

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -31,14 +31,18 @@ for config_file ($ZSH/custom/*.zsh) source $config_file
 # Check for updates on initial load...
 if [ "$ZSH_THEME" = "random" ]
 then
-  themes=($ZSH/themes/*zsh-theme)
+  themes=($ZSH/themes/*zsh-theme $ZSH/custom/themes/*zsh-theme)
   N=${#themes[@]}
   ((N=(RANDOM%N)+1))
   RANDOM_THEME=${themes[$N]}
   source "$RANDOM_THEME"
   echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
 else
-  source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+  if [ -f $ZSH/custom/themes/$ZSH_THEME.zsh-theme ]; then
+    source $ZSH/custom/themes/$ZSH_THEME.zsh-theme
+  elif [ -f $ZSH/themes/$ZSH_THEME.zsh-theme ]; then
+    source $ZSH/themes/$ZSH_THEME.zsh-theme
+  fi
 fi
 
 


### PR DESCRIPTION
Inspired by the ability to override plugins, i'm proposing a similar way to override themes from the custom directory.

Example:

```
themes
| foo.zsh-theme
```

Use modified `foo` theme:

```
custom
| themes
  | foo.zsh-theme
```
