### PR TITLE
fixes for ant plugin. tested on mac.

### DIFF
--- a/plugins/ant/ant.plugin.zsh
+++ b/plugins/ant/ant.plugin.zsh
@@ -2,14 +2,14 @@ stat -f%m . > /dev/null 2>&1
 if [ "$?" = 0 ]; then
 	stat_cmd=(stat -f%m)
 else
-	stat_cmd=(stat -L --format=%y)
+	stat_cmd=(stat -L --format=%Y)
 fi
 
 _ant_does_target_list_need_generating () {
   if [ ! -f .ant_targets ]; then return 0;
   else
-    accurate=$($stat_cmd -f%m .ant_targets)
-    changed=$($stat_cmd -f%m build.xml)
+    accurate=$($stat_cmd .ant_targets)
+    changed=$($stat_cmd build.xml)
     return $(expr $accurate '>=' $changed)
   fi
 }


### PR DESCRIPTION
-f%m was getting called twice in the stat_cmd
corrected format of stat command from y to Y.

/brian
