### PR TITLE
Directory listing aliases and removal of mcd

### DIFF
--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -16,8 +16,9 @@ alias history='fc -l 1'
 
 # List direcory contents
 alias lsa='ls -lah'
-alias l='ls -la'
+alias l='ls -lA1'
 alias ll='ls -l'
+alias la='ls -lA'
 alias sl=ls # often screw this up
 
 alias afind='ack-grep -il'

--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -37,8 +37,3 @@ cd () {
 alias md='mkdir -p'
 alias rd=rmdir
 alias d='dirs -v'
-
-# mkdir & cd to it
-function mcd() { 
-  mkdir -p "$1" && cd "$1"; 
-}


### PR DESCRIPTION
Modify directory listing aliases to make more sense. Remove conflicting helper
function (mcd conflicts with mtools).

Rebased and reopened. Used to be #369
