### PR TITLE
Upgrade before init

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -1,3 +1,11 @@
+# Check for updates on initial load...
+if [ "$DISABLE_AUTO_UPDATE" = "true" ]
+then
+  return
+else
+  /usr/bin/env zsh $ZSH/tools/check_for_upgrade.sh
+fi
+
 # Initializes Oh My Zsh
 
 # add a function path
@@ -28,7 +36,6 @@ done
 for config_file ($ZSH/custom/*.zsh) source $config_file
 
 # Load the theme
-# Check for updates on initial load...
 if [ "$ZSH_THEME" = "random" ]
 then
   themes=($ZSH/themes/*zsh-theme)
@@ -41,11 +48,3 @@ else
   source "$ZSH/themes/$ZSH_THEME.zsh-theme"
 fi
 
-
-# Check for updates on initial load...
-if [ "$DISABLE_AUTO_UPDATE" = "true" ]
-then
-  return
-else
-  /usr/bin/env zsh $ZSH/tools/check_for_upgrade.sh
-fi

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -8,6 +8,5 @@ echo "\033[0;32m"'/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / / '"\033[0m
 echo "\033[0;32m"'\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/  '"\033[0m"
 echo "\033[0;32m"'                        /____/                       '"\033[0m"
 echo "\033[0;34mHooray! Oh My Zsh has been updated and/or is at the current version.\033[0m"
-echo "\033[0;34mAny new updates will be reflected when you start your next terminal session.\033[0m"
 echo "\033[0;34mTo keep up on the latest, be sure to follow Oh My Zsh on twitter: \033[1mhttp://twitter.com/ohmyzsh\033[0m"
 cd $current_path


### PR DESCRIPTION
No reload needed unless oh-my-zsh.sh has been modified, which would be 95% of cases.

It could also be possible to make oh-my-zsh script just a minimal bootstrap script, calling two subscript upgrade then init (that would just be the current omz.sh except for upgrade), to ensure 100%.

I don't think the upgrade scripts relies on anything from omz that is not loaded yet doing this, but maybe I'm wrong?
