### PR TITLE
Fix bug introduced in pull request #395 which impacts users who DISABLE_AUTO_UPDATE

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -1,8 +1,6 @@
 # Check for updates on initial load...
-if [ "$DISABLE_AUTO_UPDATE" = "true" ]
+if [ "$DISABLE_AUTO_UPDATE" != "true" ]
 then
-  return
-else
   /usr/bin/env zsh $ZSH/tools/check_for_upgrade.sh
 fi
 


### PR DESCRIPTION
```
#395 broke oh-my-zsh for users who disable check-for-updates
```

sourcing oh-my-zsh.zsh will return immediately without doing anything if DISABLE_AUTO_UPDATE is set to "true". This fixes that.
