### PR TITLE
Fixed(?) RVM gem list helper

### DIFF
--- a/plugins/rvm/rvm.plugin.zsh
+++ b/plugins/rvm/rvm.plugin.zsh
@@ -36,9 +36,9 @@ function gems {
 	local current_ruby=`rvm-prompt i v p`
 	local current_gemset=`rvm-prompt g`
 
-	gem list $@ | sed \
-		-Ee "s/\([0-9\.]+( .+)?\)/$fg[blue]&$reset_color/g" \
-		-Ee "s|$(echo $rvm_path)|$fg[magenta]\$rvm_path$reset_color|g" \
-		-Ee "s/$current_ruby@global/$fg[yellow]&$reset_color/g" \
-		-Ee "s/$current_ruby$current_gemset$/$fg[green]&$reset_color/g"
+	gem list $@ | sed -E \
+		-e "s/\([0-9\.]+( .+)?\)/$fg[blue]&$reset_color/g" \
+		-e "s|$(echo $rvm_path)|$fg[magenta]\$rvm_path$reset_color|g" \
+		-e "s/$current_ruby@global/$fg[yellow]&$reset_color/g" \
+		-e "s/$current_ruby$current_gemset$/$fg[green]&$reset_color/g"
 }


### PR DESCRIPTION
Using the `gems` command from the RVM plugin on Ubuntu 11.04 was not working correctly&mdash;all it would do was show the GNU `sed` help output. Some playing around showed that the repeated `-E` option was causing that to happen, so removing all `-E`s after the first one returned what appears to be the correct output. I don't remember this same problem occurring on my Mac (latest 10.6, `zsh` from `brew`), and I don't have it with me to test this or to see if the output is the same as what it's supposed to be originally, but this does at least fix the radically unexpected behavior when using GNU `sed` in Ubuntu 11.04.
