### PR TITLE
use /home/ryan/d/.oh-my-zsh instead of ~/.oh-my-zsh for cache

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -44,7 +44,7 @@ zstyle ':completion:*:hosts' hosts $hosts
 
 # Use caching so that commands like apt and dpkg complete are useable
 zstyle ':completion::complete:*' use-cache 1
-zstyle ':completion::complete:*' cache-path ~/.oh-my-zsh/cache/
+zstyle ':completion::complete:*' cache-path $ZSH/cache/
 
 # Don't complete uninteresting users
 zstyle ':completion:*:*:*:users' ignored-patterns \


### PR DESCRIPTION
I keep my oh-my-zsh in my dropbox folder and the cache folder should not wander outside of the $ZSH env variable I have set.
