### PR TITLE
Bind left/right arrows to cursor backward/forward

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -12,6 +12,10 @@ bindkey "^[[6~" down-line-or-history
 bindkey '^[[A' up-line-or-search
 bindkey '^[[B' down-line-or-search
 
+# left/right arrow keys to move cursor backward/forward
+bindkey '^[[C' forward-char
+bindkey '^[[D' backward-char
+
 bindkey "^[[H" beginning-of-line
 bindkey "^[[1~" beginning-of-line
 bindkey "^[[F"  end-of-line


### PR DESCRIPTION
I guess this is the expected key binding for shell prompt: left/right arrow keys for moving cursor backward/forward.
