### PR TITLE
Minor corrections to deletion detection in git_prompt_status

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -52,7 +52,9 @@ git_prompt_status() {
   if $(echo "$INDEX" | grep '^R  ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_RENAMED$STATUS"
   fi
-  if $(echo "$INDEX" | grep '^D ' &> /dev/null); then
+  if $(echo "$INDEX" | grep '^ D ' &> /dev/null); then
+    STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
+  elif $(echo "$INDEX" | grep '^AD ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
   fi
   if $(echo "$INDEX" | grep '^UU ' &> /dev/null); then


### PR DESCRIPTION
There's actually a space in front of 'D' on `git status`, and the 'AD' status should be detected.  Thanks for an awesome project!
