### PR TITLE
Paths with spaces in upgrade script

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -9,4 +9,4 @@ echo "\033[0;32m"'\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/  '"\033[0m
 echo "\033[0;32m"'                        /____/                       '"\033[0m"
 echo "\033[0;34mHooray! Oh My Zsh has been updated and/or is at the current version.\033[0m"
 echo "\033[0;34mTo keep up on the latest, be sure to follow Oh My Zsh on twitter: \033[1mhttp://twitter.com/ohmyzsh\033[0m"
-cd $current_path
+cd "$current_path"


### PR DESCRIPTION
I added some quotes to deal with paths that have spaces in them. Currently, the script throws an error.
