### PR TITLE
C-x C-e to edit current command in $EDITOR

### DIFF
--- a/lib/edit-command-line.zsh
+++ b/lib/edit-command-line.zsh
@@ -1,0 +1,3 @@
+autoload -U edit-command-line
+zle -N edit-command-line
+bindkey '\C-x\C-e' edit-command-line


### PR DESCRIPTION
Enabled the awesome edit-command-line with standard keybindings

Added C-x C-e to open the editor with the current command. Bash has this by default, and is really a killer feature -- just needs to be enabled in zsh. I put it in lib because I believe it is one of those things that does not get in the way, but is really good to have out of the box. I certainly could make it a plugin, if there are strong opinions about it.

Thanks to Craig Bosma and his blog post about this: http://distrustsimplicity.net/articles/zsh-command-editing
