### PR TITLE
Add key bindings for gnome-terminal on Fedora

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -14,9 +14,14 @@ bindkey '^[[B' down-line-or-search
 
 bindkey "^[[H" beginning-of-line
 bindkey "^[[1~" beginning-of-line
+bindkey "^[OH" beginning-of-line
 bindkey "^[[F"  end-of-line
 bindkey "^[[4~" end-of-line
+bindkey "^[OF" end-of-line
 bindkey ' ' magic-space    # also do history expansion on space
+
+bindkey "^[[1;5C" forward-word
+bindkey "^[[1;5D" backward-word
 
 bindkey '^[[Z' reverse-menu-complete
 


### PR DESCRIPTION
Some key bindings are missing :
- Home/end keys send differents codes
- forward-word/backward-word (ctrl+left/right) like bash
