### PR TITLE
Display red dots during completion process (disabled by default)

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -59,7 +59,7 @@ zstyle ':completion:*:*:*:users' ignored-patterns \
 # ... unless we really want to.
 zstyle '*' single-ignored show
 
-if [ "x$COMPLETION_WAITING_DOTS" = "xtrue" ]; then
+if [ "$DISABLE_COMPLETION_WAITING_DOTS" != "true" ]; then
   expand-or-complete-with-dots() {
     echo -n "\e[31m......\e[0m"
     zle expand-or-complete

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -19,8 +19,8 @@ ZSH_THEME="robbyrussell"
 # Uncomment following line if you want to disable autosetting terminal title.
 # DISABLE_AUTO_TITLE="true"
 
-# Uncomment following line if you want red dots to be displayed while waiting for completion
-# COMPLETION_WAITING_DOTS="true"
+# Uncomment following line if you want disable red dots displayed while waiting for completion
+# DISABLE_COMPLETION_WAITING_DOTS="true"
 
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Example format: plugins=(rails git textmate ruby lighthouse)


### PR DESCRIPTION
It allows to see completion is in progress, usually preventing the bad reflex of hitting tab key again when completion is slow.
