### PR TITLE
Fixed an issue where the SVN plugin would mark a folder as being dirty when there was an svn:external set.

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -28,7 +28,7 @@ function svn_get_rev_nr {
 
 function svn_dirty_choose {
     if [ in_svn ]; then
-        s=$(svn status 2>/dev/null)
+        s=$(svn status|grep -E '^\s*[ACDIM!?L]' 2>/dev/null)
         if [ $s ]; then 
             echo $1
         else 


### PR DESCRIPTION
When an svn:external is set on a folder, running svn status will always return a line something like...

<pre>
X       Application

Performing status on external item at 'Application'
</pre>


passing in the -q option removes the 'X   Application' line but not the 'Preforming...' line. The patch adds a grep after the output of 'svn status' that should only match genuine changes to the repo.
