### PR TITLE
add alias for `bundle package` to the bundler plugin

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -2,6 +2,7 @@ alias be="bundle exec"
 alias bi="bundle install"
 alias bl="bundle list"
 alias bu="bundle update"
+alias bp="bundle package"
 
 # The following is based on https://github.com/gma/bundler-exec
 


### PR DESCRIPTION
Pretty simple patch to add alias for `bundle package` to the bundler plugin.
