### PR TITLE
Escape prompt expansion control characters before setting title in preexec.

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -25,5 +25,8 @@ function preexec {
   emulate -L zsh
   setopt extended_glob
   local CMD=${1[(wr)^(*=*|sudo|ssh|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
-  title "$CMD" "%100>...>$2%<<"
+  local psvar
+  psvar[1]="$CMD"
+  psvar[2]="$2"
+  title "%1v" "%100>...>%2v%<<"
 }


### PR DESCRIPTION
The arguments passed to precmd that are used to set the title ($2 and $CMD) were not properly being escaped for prompt expansion. Fixes issue #150.
