### PR TITLE
Load paths in background

### DIFF
--- a/lib/background.zsh
+++ b/lib/background.zsh
@@ -1,0 +1,7 @@
+# Appends to path arra in background to reduce load timey
+# example
+# path_push /usr/local
+function bg_source() {
+  source $1 
+}
+

--- a/lib/path.zsh
+++ b/lib/path.zsh
@@ -1,0 +1,11 @@
+# Appends to path arra in background to reduce load timey
+# example
+# path_push /usr/local
+function path_push() {
+  export PATH=$PATH:$1 &>/dev/null
+}
+
+# Prepends to path array in background to reduce load time
+function path_unshift() {
+  export PATH=$1:$PATH &>/dev/null
+}


### PR DESCRIPTION
I've been able to reduce zsh loading time by putting some stuff in background.
So I moved from more than 2 seconds the 0.40 seconds

So here is my ~/.zshrc

```
typeset -F SECONDS
start=$SECONDS
# Path to your oh-my-zsh configuration.
ZSH=$HOME/.oh-my-zsh

ZSH_THEME="robbyrussell"
DISABLE_AUTO_UPDATE="true"
plugins=(git osx lol macports node npm vi-mode taskwarrior)
source $ZSH/oh-my-zsh.sh
bg_source ~/.oh-my-zsh/history-substring-search.zsh

path_unshift /opt/local/bin:/opt/local/sbin
path_push /opt/local/lib/postgresql83/bin/:/usr/local/bin/
path_push /Applications/calibre.app/Contents/MacOS:/Applications/VLC.app/Contents/MacOS

[[ -s "$HOME/.rvm/scripts/rvm" ]] && bg_source "$HOME/.rvm/scripts/rvm" # This loads RVM into a shell session.
[[ -s "$PWD/.rvmrc" ]] && bg_source "$PWD/.rvmrc" # This loads RVMRC


# measure how long it takes to load
print Load time: $(( $SECONDS-$start )) seconds

```
