### PR TITLE
Fix edit-command-line binding

### DIFF
--- a/lib/edit-command-line.zsh
+++ b/lib/edit-command-line.zsh
@@ -1,3 +1,0 @@
-autoload -U edit-command-line
-zle -N edit-command-line
-bindkey '\C-x\C-e' edit-command-line

--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -26,6 +26,11 @@ bindkey "^[[3~" delete-char
 bindkey "^[3;5~" delete-char
 bindkey "\e[3~" delete-char
 
+# Edit the current command line in $EDITOR
+autoload -U edit-command-line
+zle -N edit-command-line
+bindkey '\C-x\C-e' edit-command-line
+
 # consider emacs keybindings:
 
 #bindkey -e  ## emacs key bindings


### PR DESCRIPTION
This binding doesn't work when the edit-command-line.zsh file is loaded
after the key-bindings.zsh file because 'bindkey -e' in key-bindings.zsh
resets the binding. Moving the bindings to the key-bindings.zsh file
and removing edit-command-line.zsh.

edit-command-line.zsh was introduced recently, #479 14 days ago
