### PR TITLE
Add support for OS X Lion's restore windows after quit

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -101,7 +101,7 @@ function trash() {
   IFS=$temp_ifs
 }
 
-if [[ $TERM_PROGRAM == "Apple Terminal" ]] && [[ -z "$INSIDE_EMACS" ]] {
+if [[ $TERM_PROGRAM == "Apple_Terminal" ]] && [[ -z "$INSIDE_EMACS" ]]; then
   autoload -U add-zsh-hook
 
   function lion_resume_chpwd {
@@ -114,4 +114,4 @@ if [[ $TERM_PROGRAM == "Apple Terminal" ]] && [[ -z "$INSIDE_EMACS" ]] {
   }
 
    add-zsh-hook chpwd lion_resume_chpwd
-}
+fi


### PR DESCRIPTION
By default, Lion's Terminal.app will re-open all windows after quitting and
restarting the app, but only in bash using a chpwd hook found in /etc/bashrc.
See also http://superuser.com/questions/313650/resume-zsh-terminal-os-x-lion
