### PR TITLE
Fix is_svn function check in SVN plugin

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -1,5 +1,5 @@
 function svn_prompt_info {
-    if [ in_svn ]; then
+    if [ $(in_svn) ]; then
         echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_PREFIX\
 $ZSH_THEME_REPO_NAME_COLOR$(svn_get_repo_name)$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR$(svn_dirty)$ZSH_PROMPT_BASE_COLOR"
     fi
@@ -13,7 +13,7 @@ function in_svn() {
 }
 
 function svn_get_repo_name {
-    if [ in_svn ]; then
+    if [ $(in_svn) ]; then
         svn info | sed -n 's/Repository\ Root:\ .*\///p' | read SVN_ROOT
     
         svn info | sed -n "s/URL:\ .*$SVN_ROOT\///p" | sed "s/\/.*$//"
@@ -21,13 +21,13 @@ function svn_get_repo_name {
 }
 
 function svn_get_rev_nr {
-    if [ in_svn ]; then
+    if [ $(in_svn) ]; then
         svn info 2> /dev/null | sed -n s/Revision:\ //p
     fi
 }
 
 function svn_dirty_choose {
-    if [ in_svn ]; then
+    if [ $(in_svn) ]; then
         s=$(svn status|grep -E '^\s*[ACDIM!?L]' 2>/dev/null)
         if [ $s ]; then 
             echo $1


### PR DESCRIPTION
The SVN Plugin's current 'if' statements don't properly evaluate - they always return true.
This commit fixes that problem.
