### PR TITLE
Option for setting a different path to your custom files and plugins

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -21,17 +21,24 @@ for plugin ($plugins) fpath=($ZSH/plugins/$plugin $fpath)
 autoload -U compinit
 compinit -i
 
+# Set ZSH_CUSTOM to the path where your custom config files
+# and plugins exists, or else we will use the default custom/
+if [ "$ZSH_CUSTOM" = ""  ]
+then
+    ZSH_CUSTOM="$ZSH/custom"
+fi
+
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do
-  if [ -f $ZSH/custom/plugins/$plugin/$plugin.plugin.zsh ]; then
-    source $ZSH/custom/plugins/$plugin/$plugin.plugin.zsh
+  if [ -f $ZSH_CUSTOM/plugins/$plugin/$plugin.plugin.zsh ]; then
+    source $ZSH_CUSTOM/plugins/$plugin/$plugin.plugin.zsh
   elif [ -f $ZSH/plugins/$plugin/$plugin.plugin.zsh ]; then
     source $ZSH/plugins/$plugin/$plugin.plugin.zsh
   fi
 done
 
 # Load all of your custom configurations from custom/
-for config_file ($ZSH/custom/*.zsh) source $config_file
+for config_file ($ZSH_CUSTOM/*.zsh) source $config_file
 
 # Load the theme
 if [ "$ZSH_THEME" = "random" ]


### PR DESCRIPTION
just set ZSH_CUSTOM in your .zshrc

if not set oh-my-zsh.sh will use the default custom dir in the repository

I use this because i have oh-my-zsh as a submodule in my private toolbox, og i would like to commit
my custom files to my toolbox outside of oh-my-zsh

What do you guys think?
