### PR TITLE
More reusable rvm_prompt_info in lib/rvm.zsh

### DIFF
--- a/lib/rvm.zsh
+++ b/lib/rvm.zsh
@@ -1,7 +1,5 @@
 # get the name of the branch we are on
 function rvm_prompt_info() {
   ruby_version=$(~/.rvm/bin/rvm-prompt 2> /dev/null) || return
-  echo "($ruby_version)"
+  echo "$ruby_version"
 }
-
-


### PR DESCRIPTION
By removing the wrapping parens this function can be reused and the output more easily customized by the consumer.

For example, in my prompt, want to combine my RVM + Git info like:

machine-name: ~/path/here [ruby-1.9.2-p290@my_project | master]

However, the existing wrapping parenthesis force me to either roll my own, or strip the parens before outputting the info to the prompt.
