### PR TITLE
Add new smh-theme, based on dst + RVM info

### DIFF
--- a/themes/smh.zsh-theme
+++ b/themes/smh.zsh-theme
@@ -8,15 +8,15 @@ function smh_rvm_info {
   echo "%{$fg[magenta]%}$(rvm_prompt_info)%{$reset_color%}"
 }
 
-function root_warning {
-  if [ $UID -eq 0 ]; then echo "%{$fg[red]%}☠%{$reset_color%} "; fi
+function prompt_char {
+  if [ $UID -eq 0 ]; then echo "%{$fg[red]%}☠%{$reset_color%}"; else echo $; fi
 }
 
 # Save a smiley to a local variable if the last command exited with success.
 local smiley="%(?,%{$fg[green]%}☺%{$reset_color%},%{$fg[red]%}☹%{$reset_color%})"
 
 PROMPT='
-$(root_warning)%{$fg[yellow]%}%m%{$reset_color%}: %{$fg_bold[blue]%}%~%{$reset_color%} [$(smh_rvm_info)$(git_prompt_info)]
+%{$fg[yellow]%}%m%{$reset_color%}: %{$fg_bold[blue]%}%~%{$reset_color%} [$(smh_rvm_info)$(git_prompt_info)]
 %_${smiley} $(prompt_char) '
 
 RPROMPT='%{$fg[green]%}[%*]%{$reset_color%}'


### PR DESCRIPTION
example prompt:
machine-name: ~/current/path [ruby-1.9.2-p290@foobar|master]
$                                                             [10:15:32]

An example can be seen here: https://skitch.com/stevenharman/fpuee/oh-my-zsh-prompt

(note: this exact formatting is dependent on my change in Pull Request 526 [https://github.com/robbyrussell/oh-my-zsh/pull/526 ].)
