### PR TITLE
$ZSH not set when checking for upgrades

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -35,10 +35,12 @@ cdpath=(.)
 [ -r /etc/ssh/ssh_known_hosts ] && _global_ssh_hosts=(${${${${(f)"$(</etc/ssh/ssh_known_hosts)"}:#[\|]*}%%\ *}%%,*}) || _ssh_hosts=()
 [ -r ~/.ssh/known_hosts ] && _ssh_hosts=(${${${${(f)"$(<$HOME/.ssh/known_hosts)"}:#[\|]*}%%\ *}%%,*}) || _ssh_hosts=()
 [ -r /etc/hosts ] && : ${(A)_etc_hosts:=${(s: :)${(ps:\t:)${${(f)~~"$(</etc/hosts)"}%%\#*}##[:blank:]#[^[:blank:]]#}}} || _etc_hosts=()
+[ -r ~/.ssh/config ] &&      _ssh_config_hosts=(${(s: :)${(ps:\t:)${(f)"$(<$HOME/.ssh/config|grep 'Host')"}#Host}#Hostname}) || _ssh_config_hosts=()
 hosts=(
   "$_global_ssh_hosts[@]"
   "$_ssh_hosts[@]"
   "$_etc_hosts[@]"
+  "$_ssh_config_hosts[@]"
   "$HOST"
   localhost
 )


### PR DESCRIPTION
For some unknown reason I'm unable to check for upgrades of omz on an OS X system and an Arch VM (although another Arch install is fine). I was able to track it down to the $ZSH variable not being passed on with the env call.

This simple passes the ZSH var along with the call to the check_for_upgrade.sh file so that it will be set correctly. I'm unsure as to why this only effects some of my installs, but it should be safe for default usage.

If there's another reason why $ZSH might not be set after the call just let me know :)
