### PR TITLE
Do not use url-quote-magic when it is not available

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -1,6 +1,7 @@
 ## smart urls
-autoload -U url-quote-magic
-zle -N self-insert url-quote-magic
+if [ -f "/usr/share/zsh/functions/Zle/url-quote-magic" ] ; then
+    autoload -U url-quote-magic && zle -N self-insert url-quote-magic
+fi
 
 ## file rename magick
 bindkey "^[m" copy-prev-shell-word


### PR DESCRIPTION
My university terminal threw errors on every keystroke (and did not work) after i installed oh-my-zsh. It turned out that their old version of zsh did not include url-quote-magic, and this caused the errors. This commit fixes the problem by checking if the function definition file is where it is expected to be. I am not sure if this is the best way to do solve this.
