### PR TITLE
Make git_prompt_info on Gentoo theme yellow

### DIFF
--- a/themes/gentoo.zsh-theme
+++ b/themes/gentoo.zsh-theme
@@ -1,4 +1,4 @@
-PROMPT='%(!.%{$fg_bold[red]%}.%{$fg_bold[green]%}%n@)%m %{$fg_bold[blue]%}%(!.%1~.%~) $(git_prompt_info)%#%{$reset_color%} '
+PROMPT='%(!.%{$fg_bold[red]%}.%{$fg_bold[green]%}%n@)%m %{$fg_bold[blue]%}%(!.%1~.%~) %{$fg_bold[yellow]%}$(git_prompt_info)%{$fg_bold[blue]%}%#%{$reset_color%} '
 
 ZSH_THEME_GIT_PROMPT_PREFIX="("
 ZSH_THEME_GIT_PROMPT_SUFFIX=") "


### PR DESCRIPTION
The git_prompt_info on the current gentoo theme is blue which blends in with the path.

A more visually appealing configuration is to have the git branch displayed in yellow.
