### PR TITLE
upgrade script requires ZSH environment variable to be set

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -1,7 +1,7 @@
 # Check for updates on initial load...
 if [ "$DISABLE_AUTO_UPDATE" != "true" ]
 then
-  /usr/bin/env zsh $ZSH/tools/check_for_upgrade.sh
+  /usr/bin/env ZSH=$ZSH zsh $ZSH/tools/check_for_upgrade.sh
 fi
 
 # Initializes Oh My Zsh


### PR DESCRIPTION
The template .zshrc does not export ZSH, and it is also not passed down to the upgrade script.

This results in the following error:

```
[Oh My Zsh] Would you like to check for updates?
Type Y to update oh-my-zsh: y
/bin/sh: /tools/upgrade.sh: No such file or directory
```

Explicitly passing ZSH down to the upgrade script fixes this.
