### PR TITLE
Source RVM script in RVM plugin

### DIFF
--- a/plugins/rvm/rvm.plugin.zsh
+++ b/plugins/rvm/rvm.plugin.zsh
@@ -1,8 +1,10 @@
+[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm"
+
 alias rubies='rvm list rubies'
 alias gemsets='rvm gemset list'
 
-local ruby18='ruby-1.8.7-p334'
-local ruby19='ruby-1.9.2-p180'
+local ruby18='ruby-1.8.7'
+local ruby19='ruby-1.9.2'
 
 function rb18 {
 	if [ -z "$1" ]; then


### PR DESCRIPTION
A lot of instructions on how to get started with oh-my-zsh mention having to source the RVM script at the end of .zshrc, or somewhere similar. It should be as easy as adding the RVM plugin.
