### PR TITLE
Resolve conflict between GNU cp and git cherry-pick alias

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -23,8 +23,8 @@ alias gba='git branch -a'
 compdef _git gba=git-branch
 alias gcount='git shortlog -sn'
 compdef gcount=git
-alias gcp='git cherry-pick'
-compdef _git gcp=git-cherry-pick
+alias gchp='git cherry-pick'
+compdef _git gchp=git-cherry-pick
 alias glg='git log --stat --max-count=5'
 compdef _git glg=git-log
 alias glgg='git log --graph --max-count=5'


### PR DESCRIPTION
If GNU coreutils are installed as `gmv`, `gcp`, etc. via Homebrew, and `cp` is aliased to
`gcp` as is Homebrew's wont, then the tab completion for `cp` will fail oddly when the
git plugin is enabled, since zsh is completing for `git cherry-pick` but executing
`gcp`.

Being as I use `cp` much more frequently than `git cherry-pick`, I'd propose either the
cherry-pick alias be changed to `gchp` (this pull request), or removed from the plugin
and handled per-user under `/custom`.
