### PR TITLE
ggpull tweak to update the current branch's remote tracking branch

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -50,9 +50,9 @@ function current_branch() {
 }
 
 # these aliases take advantage of the previous function
-alias ggpull='git pull origin $(current_branch)'
+alias ggpull='git pull origin refs/heads/$(current_branch):refs/remotes/origin/$(current_branch)'
 compdef ggpull=git
 alias ggpush='git push origin $(current_branch)'
 compdef ggpush=git
-alias ggpnp='git pull origin $(current_branch) && git push origin $(current_branch)'
+alias ggpnp='git pull origin refs/heads/$(current_branch):refs/remotes/origin/$(current_branch) && git push origin $(current_branch)'
 compdef ggpnp=git


### PR DESCRIPTION
I noticed if I used ggpull on my branch 'dev', my remote tracking branch 'origin/dev' was not getting updated, even though my 'dev' branch was.  Here's a symptom of the problem shown by example.  I'll update my dev branch pulling down 5 commits, then switch away and back to my branch.

```
mreishus on mreishus-VirtualBox in /tmp/sp2 (58m|dev)
± ggpull
remote: Counting objects: 17, done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 9 (delta 7), reused 7 (delta 5)
Unpacking objects: 100% (9/9), done.
From github.com:foo/bar
 * branch            dev        -> FETCH_HEAD
Updating 123456..abcdef
Fast-forward
 foo/bar/baz |    8 +++++
 1 file changed, 8 insertions(+), 0 deletions(-)

mreishus on mreishus-VirtualBox in /tmp/sp2 (1m|dev)
± git checkout master
Switched to branch 'master'

mreishus on mreishus-VirtualBox in /tmp/sp2 (58m|master)
± git checkout dev
Switched to branch 'dev'
Your branch is ahead of 'origin/dev' by 5 commits.   <------- This message
```

Now I'm actually in sync with my github dev branch, but git is telling me that I'm ahead of origin/dev by 5 commits.  This would make me think that I had 5 commits I hadn't pushed out to github, but this isn't true - it's rather that ggpull updated my "dev" branch but didn't update my remote tracking branch "origin/dev".

My fix is to use git fetch to update the remote tracking branch in addition to the pull.
