### PR TITLE
Fix completion for bundled commands using the bundler plugin

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -33,5 +33,10 @@ _run-with-bundler() {
 
 ## Main program
 for cmd in $bundled_commands; do
-  alias $cmd="_run-with-bundler $cmd"
+  eval "function bundled_$cmd () { _run-with-bundler $cmd \$@}"
+  alias $cmd=bundled_$cmd
+
+  if which _$cmd > /dev/null 2>&1; then
+        compdef _$cmd bundled_$cmd
+  fi
 done


### PR DESCRIPTION
When using a bundled command (like inside a rails folder), the completion does not work anymore for commands like rake.

I've changed the implementation so that it uses a wrapper function instead of directly an alias. This seems to fix the problem nicely.
