### PR TITLE
Multiline prompt in vi mode

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -1,8 +1,7 @@
-function zle-line-init zle-keymap-select {
+function zle-keymap-select {
   zle reset-prompt
 }
 
-zle -N zle-line-init
 zle -N zle-keymap-select
 
 bindkey -v


### PR DESCRIPTION
This fixes the problem raised by issue #387, wherein activating the vi-mode plugin causes history lines to be overwritten if PROMPT contains multiple lines. The vi-mode plugin currently sets both `zle-line-init` and `zle-keymap-select` as triggers for `zle reset-prompt`, causing the prompt to be drawn twice each time the user is prompted for a command. In normal circumstances, this is not an issue, as the second redraws over the first. But when the prompt contains newline characters, this seems to mess up zsh's internal knowledge of how many lines upward it should move before attempting the next `zle reset-prompt`, overwriting the last N lines of the previous command's output, where N is the number of newlines in the prompt. After much fiddling, I figured out that the definition of `zle-line-init` is actually unnecessary, and simply removing it fixes the bug.

Note that for this to work correctly, your `PROMPT` definition should not use any special escaping for newlines. If the newline characters are surrounded by `%{` and `%}`, you will see additional lines added when entering and leaving vi insert mode. So don't do that.

-- Riley
