### PR TITLE
Add support for autojump installed with MacPorts

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -1,3 +1,6 @@
-if [ -f `brew --prefix`/etc/autojump ]; then
+if hash brew &> /dev/null && [ -f `brew --prefix`/etc/autojump ]; then
   . `brew --prefix`/etc/autojump
+elif [ -f /opt/local/etc/profile.d/autojump.sh ]; then
+  export FPATH="$FPATH:/opt/local/share/zsh/site-functions/"
+  . /opt/local/etc/profile.d/autojump.sh
 fi


### PR DESCRIPTION
- Use hash command to suppress an error message when Homebrew is not installed
- Newly added part comes from https://trac.macports.org/browser/trunk/dports/sysutils/autojump/Portfile
