### PR TITLE
Use a custom version of a theme if the user has it

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -45,7 +45,12 @@ then
 else
   if [ ! "$ZSH_THEME" = ""  ]
   then
-    source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+    if [ -f "$ZSH/custom/$ZSH_THEME.zsh-theme" ]
+    then
+      source "$ZSH/custom/$ZSH_THEME.zsh-theme"
+    else
+      source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+    fi
   fi
 fi
 


### PR DESCRIPTION
If the user has the `$ZSH_THEME` in the `$ZSH/custom` folder use it instead of the theme in the `$ZSH/themes` folder, thus she can tweak a theme to suit her needs.
