### PR TITLE
Change default zshrc to export $ZSH (as required by check_for_upgrade.sh). 

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -1,5 +1,5 @@
 # Path to your oh-my-zsh configuration.
-ZSH=$HOME/.oh-my-zsh
+export ZSH=$HOME/.oh-my-zsh
 
 # Set name of the theme to load.
 # Look in ~/.oh-my-zsh/themes/


### PR DESCRIPTION
I find that tools/check_for_upgrade.sh can’t find tools/upgrade.sh unless I export $ZSH in my zshrc. This commit just changes the zshrc template to export $ZSH. 

I’m using an up-to-date version of the master branch of oh-my-zsh on zsh 4.3.9 (i386-apple-darwin10.0). The error text I see when I don’t export $ZSH is: 

[Oh My Zsh] Would you like to check for updates?
Type Y to update oh-my-zsh: y
/bin/sh: /tools/upgrade.sh: No such file or directory
