### PR TITLE
dieter theme: make linux and OSX hostname consistant

### DIFF
--- a/themes/dieter.zsh-theme
+++ b/themes/dieter.zsh-theme
@@ -21,7 +21,7 @@ local user="%(!.%{$fg[blue]%}.%{$fg[blue]%})%n%{$reset_color%}"
 
 # Hostname part.  compressed and colorcoded per host_repr array
 # if not found, regular hostname in default color
-local host="@${host_repr[$(hostname)]:-$(hostname)}%{$reset_color%}"
+local host="@${host_repr[$(hostname -s)]:-$(hostname -s)}%{$reset_color%}"
 
 # Compacted $PWD
 local pwd="%{$fg[blue]%}%c%{$reset_color%}"


### PR DESCRIPTION
replace $(hostname) with $(hostname -s) so that the behavior is consistant across Linux and OSX
