### PR TITLE
Replace "git-diff" with "git diff" in the git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -9,7 +9,7 @@ alias gup='git fetch && git rebase'
 compdef _git gup=git-fetch
 alias gp='git push'
 compdef _git gp=git-push
-gdv() { git-diff -w "$@" | view - }
+gdv() { git diff -w "$@" | view - }
 compdef _git gdv=git-diff
 alias gc='git commit -v'
 compdef _git gc=git-commit


### PR DESCRIPTION
"git-diff" doesn't seem to exist in newer version of git. Replacing it with "git diff" fixes the problem.
