### PR TITLE
add git stash indicator into git prompt

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -1,7 +1,7 @@
 # get the name of the branch we are on
 function git_prompt_info() {
   ref=$(git symbolic-ref HEAD 2> /dev/null) || return
-  echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+  echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$(parse_git_stash)$ZSH_THEME_GIT_PROMPT_SUFFIX"
 }
 
 # Checks if working tree is dirty
@@ -10,6 +10,15 @@ parse_git_dirty() {
     echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
   else
     echo "$ZSH_THEME_GIT_PROMPT_CLEAN"
+  fi
+}
+
+# Checks if working tree has stash
+parse_git_stash() {
+  if [[ -n $(git stash list 2> /dev/null) ]]; then
+    echo "$ZSH_THEME_GIT_PROMPT_STASH"
+  else
+    echo "$ZSH_THEME_GIT_PROMPT_NOSTASH"
   fi
 }
 

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -30,6 +30,8 @@ ZSH_THEME_GIT_PROMPT_PREFIX="git:("         # Prefix at the very beginning of th
 ZSH_THEME_GIT_PROMPT_SUFFIX=")"             # At the very end of the prompt
 ZSH_THEME_GIT_PROMPT_DIRTY="*"              # Text to display if the branch is dirty
 ZSH_THEME_GIT_PROMPT_CLEAN=""               # Text to display if the branch is clean
+ZSH_THEME_GIT_PROMPT_STASH="#"              # Text to display if stash exists
+ZSH_THEME_GIT_PROMPT_NOSTASH=""             # Text to display if no stash exists
 
 # Setup the prompt with pretty colors
 setopt prompt_subst


### PR DESCRIPTION
Stash is a temporary place holder which will be forgotten easily if you're doing several things at the same time. Adding a indicator can help to remind about its' existent.
