### PR TITLE
Fix ssh autocompletion to ignore port info from known_hosts files

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -32,7 +32,7 @@ zstyle ':completion:*:cd:*' tag-order local-directories directory-stack path-dir
 cdpath=(.)
 
 # use /etc/hosts and known_hosts for hostname completion
-[ -r ~/.ssh/known_hosts ] && _ssh_hosts=(${${${${(f)"$(<$HOME/.ssh/known_hosts)"}:#[\|]*}%%\ *}%%,*}) || _ssh_hosts=()
+[ -r ~/.ssh/known_hosts ] && _ssh_hosts=(${${${${${${(f)"$(<$HOME/.ssh/known_hosts)"}:#[\|]*}%%\ *}%%,*}##\[}%%]:*}) || _ssh_hosts=()
 [ -r /etc/hosts ] && : ${(A)_etc_hosts:=${(s: :)${(ps:\t:)${${(f)~~"$(</etc/hosts)"}%%\#*}##[:blank:]#[^[:blank:]]#}}} || _etc_hosts=()
 hosts=(
   "$_ssh_hosts[@]"


### PR DESCRIPTION
The completion improvement I did gets rid of the annoying markup created by ssh when using non-standard ports to ssh into servers.
It removes the "[]:" from around the host, which is actually what you need when looking for completion.
