### PR TITLE
Add zsh_reload which provides src function, this function will source .zshrc and rebuilds cache

### DIFF
--- a/plugins/zsh_reload/zsh_reload.plugin.zsh
+++ b/plugins/zsh_reload/zsh_reload.plugin.zsh
@@ -1,0 +1,13 @@
+zsh_cache=$HOME/.zsh_cache
+mkdir -p $zsh_cache
+
+# reload zshrc
+function src()
+{
+  autoload -U compinit zrecompile
+  compinit -d $zsh_cache/zcomp-$HOST
+  for f in $HOME/.zshrc $zsh_cache/zcomp-$HOST; do
+    zrecompile -p $f && rm -f $f.zwc.old
+  done
+  source ~/.zshrc
+}


### PR DESCRIPTION
Like the title says, this pull request provides a `src` function which will source .zshrc and rebuilds cache
