### PR TITLE
Fixed theme chooser on systes that install it in different location than /bin

### DIFF
--- a/tools/theme_chooser.sh
+++ b/tools/theme_chooser.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Zsh Theme Chooser by fox (fox91 at anche dot no)
 # This program is free software. It comes without any warranty, to


### PR DESCRIPTION
The current implementation expects ZSH to be installed on /bin/zsh when at least on my system it is in /usr/bin/zsh so this fix should make it work fine on all systems
