### PR TITLE
Update to fino.zsh-theme

### DIFF
--- a/themes/fino.zsh-theme
+++ b/themes/fino.zsh-theme
@@ -21,22 +21,21 @@ function box_name {
     [ -f ~/.box-name ] && cat ~/.box-name || hostname -s
 }
 
-local rvm_ruby=''
+local ruby_env=''
 if which rvm-prompt &> /dev/null; then
-  rvm_ruby='‹$(rvm-prompt i v g)›%{$reset_color%}'
+  ruby_env=' ‹$(rvm-prompt i v g)›%{$reset_color%}'
 else
   if which rbenv &> /dev/null; then
-    rvm_ruby='‹$(rbenv version | sed -e "s/ (set.*$//")›%{$reset_color%}'
+    ruby_env=' ‹$(rbenv version-name)›%{$reset_color%}'
   fi
 fi
 
 local current_dir='${PWD/#$HOME/~}'
 local git_info='$(git_prompt_info)'
 local prompt_char='$(prompt_char)'
-local rbenv_version='$(rbenv version-name)'
 
 
-PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}${current_dir}%{$reset_color%}${git_info} %{$FG[239]%}using%{$FG[243]%} ‹${rbenv_version}›%{$reset_color%}
+PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}${current_dir}%{$reset_color%}${git_info} %{$FG[239]%}using%{$FG[243]%}${ruby_env}
 ╰─${prompt_char} "
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$FG[239]%}on%{$reset_color%} %{$fg[255]%}"


### PR DESCRIPTION
- Switch from RVM to rbenv
- Fix bug where prompt character didn't actually reflect whether you were in a git repository or not

Update: I merged in the dual rvm/rbenv support by @sbfaulkner and then cleaned up the rbenv support a little bit.
