### PR TITLE
Fix rvm_prompt_info to support multi-user installs

### DIFF
--- a/lib/rvm.zsh
+++ b/lib/rvm.zsh
@@ -1,6 +1,6 @@
 # get the name of the branch we are on
 function rvm_prompt_info() {
-  ruby_version=$(~/.rvm/bin/rvm-prompt 2> /dev/null) || return
+  ruby_version=$($rvm_bin_path/rvm-prompt 2> /dev/null) || return
   echo "($ruby_version)"
 }
 


### PR DESCRIPTION
The current rvm.sh file assumes that rvm is installed per user. I changed the path to rvm-prompt to use the environment variable rvm_bin_path instead which should cover single and multi-user installs
