### PR TITLE
Allow user to disable update prompt

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -8,6 +8,12 @@ function _update_zsh_update() {
   echo "LAST_EPOCH=$(_current_epoch)" > ~/.zsh-update
 }
 
+function _upgrade_zsh() {
+  /usr/bin/env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
+  # update the zsh file
+  _update_zsh_update
+}
+
 if [ -f ~/.zsh-update ]
 then
   . ~/.zsh-update
@@ -19,17 +25,21 @@ then
   epoch_diff=$(($(_current_epoch) - $LAST_EPOCH))
   if [ $epoch_diff -gt 6 ]
   then
-    echo "[Oh My Zsh] Would you like to check for updates?"
-    echo "Type Y to update oh-my-zsh: \c"
-    read line
-    if [ "$line" = Y ] || [ "$line" = y ]
+    if [ "$DISABLE_UPDATE_PROMPT" = "true" ]
     then
-      /usr/bin/env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
-      # update the zsh file
-      _update_zsh_update
+      _upgrade_zsh
+    else
+      echo "[Oh My Zsh] Would you like to check for updates?"
+      echo "Type Y to update oh-my-zsh: \c"
+      read line
+      if [ "$line" = Y ] || [ "$line" = y ]
+      then
+        _upgrade_zsh
+      fi
     fi
   fi
 else
   # create the zsh file
   _update_zsh_update
 fi
+


### PR DESCRIPTION
I added an option, $DISABLE_UPDATE_PROMPT, which is checked for in "check_for_upgrade.sh" that will skip asking the user to confirm the update and just go ahead and do it if it's time to check for updates again.
