### PR TITLE
set fpath correctly for custom plugins

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -13,6 +13,12 @@ fpath=($ZSH/functions $ZSH/completions $fpath)
 # TIP: Add files you don't want in git to .gitignore
 for config_file ($ZSH/lib/*.zsh) source $config_file
 
+# Set ZSH_CUSTOM to the path where your custom config files
+# and plugins exists, or else we will use the default custom/
+if [[ -z "$ZSH_CUSTOM" ]]; then
+    ZSH_CUSTOM="$ZSH/custom"
+fi
+
 # Add all defined plugins to fpath. This must be done
 # before running compinit.
 plugin=${plugin:=()}
@@ -28,12 +34,6 @@ done
 autoload -U compinit
 compinit -i
 
-# Set ZSH_CUSTOM to the path where your custom config files
-# and plugins exists, or else we will use the default custom/
-if [ "$ZSH_CUSTOM" = ""  ]
-then
-    ZSH_CUSTOM="$ZSH/custom"
-fi
 
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do


### PR DESCRIPTION
Custom plugins weren't being added to the fpath correctly.

This is try 2 at this.  The previous was issue #705.
