### PR TITLE
Add the --format tag to knife list commands

### DIFF
--- a/plugins/knife/_knife
+++ b/plugins/knife/_knife
@@ -138,27 +138,27 @@ _knife_options3() {
 
 # The chef_x_remote functions use knife to get a list of objects of type x on the server
 _chef_roles_remote() {
- (knife role list | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
+ (knife role list --format json | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
 }
 
 _chef_clients_remote() {
- (knife client list | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
+ (knife client list --format json | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
 }
 
 _chef_nodes_remote() {
- (knife node list | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
+ (knife node list --format json | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
 }
 
 _chef_cookbooks_remote() {
- (knife cookbook list | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
+ (knife cookbook list --format json | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
 }
 
 _chef_sitecookbooks_remote() {
- (knife cookbook site list | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
+ (knife cookbook site list --format json | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
 }
 
 _chef_data_bags_remote() {
- (knife data bag list | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
+ (knife data bag list --format json | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
 }
 
 # The chef_x_local functions use the knife config to find the paths of relevant objects x to be uploaded to the server


### PR DESCRIPTION
This commit adds the --format tag to all of the autocompletion functions. The default format changed from json to a "human readable" format as of version 0.10.  This change should be backward compatible.  Alternatively, these commands could be simplified by using the new default human readable format.
