### PR TITLE
Improvements to the tm command in the TextMate plugin

### DIFF
--- a/plugins/textmate/textmate.plugin.zsh
+++ b/plugins/textmate/textmate.plugin.zsh
@@ -6,7 +6,16 @@ alias etts='mate app config lib db public script spec test vendor/plugins vendor
 # Edit Ruby app in TextMate
 alias mr='mate CHANGELOG app config db lib public script spec test'
 
+# If the tm command is called without an argument, open TextMate in the current directory
+# If tm is passed a directory, cd to it and open it in TextMate
+# If tm is passed a file, open it in TextMate
 function tm() {
-  cd $1
-  mate $1
+	if [[ -z $1 ]]; then
+		mate .
+	else
+		mate $1
+		if [[ -d $1 ]]; then
+			cd $1
+		fi
+	fi
 }


### PR DESCRIPTION
I've committed a simple improvement for the "tm" command created by the TextMate plugin. Right now, the tm command must be passed a directory, and it attempts to cd into the directory and open it in TextMate. However, the order of operations is wrong, so it doesn't actually work (at least not very well).

I've improved the tm command to:
- Open the current directory in TextMate when it's passed no arguments; so typing tm by itself will just open up TextMate with all of the files in the current directory in the project drawer
- Open a single file when passed a filename; so typing "tm ~/.zshrc" will open your .zshrc in TextMate
- Open a directory in TextMate and cd in to it when passed a directory - the original intention of the command

Hope this helps everyone else as much as it's helped my workflow!
