### PR TITLE
Use the -delete option instead of -exec rm -rf \{\} \;. 

### DIFF
--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -2,4 +2,4 @@
 alias pyfind='find . -name "*.py"'
 
 # Remove python compiled byte-code
-alias pyclean='find . -type f -name "*.py[co]" -exec rm -f \{\} \;'
+alias pyclean='find . -type f -name "*.py[co]" -delete'


### PR DESCRIPTION
The 'find' command has a -delete option for deleting files, so doing:

$ find <blah> -exec rm -f {} \;

...can be simplified to:

$ find <blah> -delete.

Woohoo, simplicity!
