### PR TITLE
github plugin: only alias git=hub if `hub --version` works.

### DIFF
--- a/plugins/github/github.plugin.zsh
+++ b/plugins/github/github.plugin.zsh
@@ -1,7 +1,17 @@
 # Setup hub function for git, if it is available; http://github.com/defunkt/hub
 if [ "$commands[(I)hub]" ] && [ "$commands[(I)ruby]" ]; then
     # eval `hub alias -s zsh`
-    function git(){hub "$@"}
+    function git(){
+        if ! (( $+_has_working_hub  )); then
+            hub --version &> /dev/null
+            _has_working_hub=$(($? == 0))
+        fi
+        if (( $_has_working_hub )) ; then
+            hub "$@"
+        else
+            command git "$@"
+        fi
+    }
 fi
 
 # Functions #################################################################


### PR DESCRIPTION
`hub` is crashing for me on a old CentOS setup with
"undefined method `shelljoin'".

On first use of the `git` function it is now checked if
`hub --version` returns successfully.
