### PR TITLE
Changes to simplify in_svn handling

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -1,19 +1,18 @@
 function svn_prompt_info {
-    if [ $(in_svn) ]; then
+    if $(in_svn); then
         echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_PREFIX\
 $ZSH_THEME_REPO_NAME_COLOR$(svn_get_repo_name)$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR$(svn_dirty)$ZSH_PROMPT_BASE_COLOR"
     fi
 }
 
 
+# Return true if a .svn directory exists in the current directory
 function in_svn() {
-    if [[ -d .svn ]]; then
-        echo 1
-    fi
+    [[ -d .svn ]]
 }
 
 function svn_get_repo_name {
-    if [ $(in_svn) ]; then
+    if $(in_svn); then
         svn info | sed -n 's/Repository\ Root:\ .*\///p' | read SVN_ROOT
     
         svn info | sed -n "s/URL:\ .*$SVN_ROOT\///p" | sed "s/\/.*$//"
@@ -21,13 +20,13 @@ function svn_get_repo_name {
 }
 
 function svn_get_rev_nr {
-    if [ $(in_svn) ]; then
+    if $(in_svn); then
         svn info 2> /dev/null | sed -n s/Revision:\ //p
     fi
 }
 
 function svn_dirty_choose {
-    if [ $(in_svn) ]; then
+    if $(in_svn); then
         s=$(svn status|grep -E '^\s*[ACDIM!?L]' 2>/dev/null)
         if [ $s ]; then 
             echo $1


### PR DESCRIPTION
Now in_svn returns an exit code, rather than a numeric value. This
is consistent with the way Unix commands operate, ans thus simplifies
its use in conditional statements. (No separate test is required).
