### PR TITLE
change cache_path to use XDG_CACHE_HOME or ~/.cache

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -43,8 +43,9 @@ hosts=(
 zstyle ':completion:*:hosts' hosts $hosts
 
 # Use caching so that commands like apt and dpkg complete are useable
+[[ -n "$XDG_CACHE_HOME" ]] && cache_dir=$XDG_CACHE_HOME || cache_dir="$HOME/.cache"
 zstyle ':completion::complete:*' use-cache 1
-zstyle ':completion::complete:*' cache-path ~/.oh-my-zsh/cache/
+zstyle ':completion::complete:*' cache-path $cache_dir/oh-my-zsh/
 
 # Don't complete uninteresting users
 zstyle ':completion:*:*:*:users' ignored-patterns \


### PR DESCRIPTION
When putting oh-my-zsh in an other directory than `.oh-my-zsh`, the `.oh-my-zsh` directory still must exist for the `~/.oh-my-zsh/cache/` directory. To solve this it would probably be better to use `XDG_CACHE_HOME/.oh-my-zsh` or `~/.cache/.oh-my-zsh` (though I don't know how this works for Mac OS).
