### PR TITLE
Added brute force package completion to pip plugin

### DIFF
--- a/plugins/pip/_pip
+++ b/plugins/pip/_pip
@@ -6,6 +6,7 @@
 _pip_all() {
   # we cache the list of packages (originally from the macports plugin)
   if (( ! $+piplist )); then
+    echo -n " (caching package index...)"
 	piplist=($(pip search * | cut -d ' ' -f 1 | tr '[A-Z]' '[a-z]'))
   fi
 }


### PR DESCRIPTION
Hi,

I added a brute force package completion to the pip plugin, which I reported missing in issue #726.

https://github.com/robbyrussell/oh-my-zsh/issues/726

There is no caching in the pip install sub command, compared to the brew version, so the completion is a bit sluggish but better than nothing.

I also made it a bit more similar to the brew plugin.

Best Regards,
Max
