### PR TITLE
Added my own theme

### DIFF
--- a/themes/koraktor.zsh-theme
+++ b/themes/koraktor.zsh-theme
@@ -1,0 +1,28 @@
++vi-git-submodule-unstaged () {
+  if ( cd $hook_com[base]; `git submodule status | grep -cqv "^ "` ) ; then
+    hook_com[unstaged]=${hook_com[unstaged]:-"%{$FG[202]%}"}
+    hook_com[unstaged]+='ɱ'
+  fi
+}
+
++vi-git-clean () {
+  if [[ -z ${hook_com[staged]} ]] && [[ -z ${hook_com[unstaged]} ]] ; then
+    hook_com[staged]="%{$FG[034]%}✓"
+  fi
+  hook_com[staged]=" ${hook_com[staged]}"
+}
+
+autoload -Uz vcs_info
+zstyle ':vcs_info:*' check-for-changes true
+zstyle ':vcs_info:*' unstagedstr "%{$FG[202]%}✻"
+zstyle ':vcs_info:*' stagedstr "%{$FG[118]%}✚"
+zstyle ':vcs_info:*' actionformats "%{$FG[064]%}±%{$FG[235]%}[%{$FG[088]%}%b%{$FG[235]%}|%{$FG[033]%}%a%c%u%{$FG[235]%}] "
+zstyle ':vcs_info:*' formats "%{$FG[064]%}±%{$FG[235]%}[%{$FG[088]%}%b%c%u%{$FG[235]%}] "
+zstyle ':vcs_info:*' enable git
+zstyle ':vcs_info:git*+set-message:*' hooks git-submodule-unstaged git-clean
+
+precmd () {
+  vcs_info
+}
+
+PROMPT='%{$FG[088]%}◷%{$FG[006]%}%T %{$FG[024]%}%3~ $vcs_info_msg_0_%{$reset_color%}'


### PR DESCRIPTION
Just finished my first theme for zsh, maybe some others find it as useful as I do:

[![screenshot](https://lh4.googleusercontent.com/-QVfWH_gGYNw/TuEWUlC0YMI/AAAAAAAABKU/Vu8pl7hT7ek/s682/oh-my-zsh-theme-koraktor.png)](https://lh4.googleusercontent.com/-QVfWH_gGYNw/TuEWUlC0YMI/AAAAAAAABKU/Vu8pl7hT7ek/s682/oh-my-zsh-theme-koraktor.png)

It consists of a clock symbol and the current time (24h), the current path (limited to three sub-paths) and some Git information. Besides the usual staged (a yellow-greenish plus) and unstaged (an orange asterisk) markers it adds two addional symbols. A green checkmark for a clean workdir (untracked files are igored) and an orange `m` for unstaged submodule commits. The screenshot should give a good impression on how it looks like in action.

PS: Sorry, no support for other VCSs.
