### PR TITLE
Only `setopt correct`, not "correct_all".

### DIFF
--- a/lib/correction.zsh
+++ b/lib/correction.zsh
@@ -1,10 +1,2 @@
-setopt correct_all
-
-alias man='nocorrect man'
-alias mv='nocorrect mv'
-alias mysql='nocorrect mysql'
-alias mkdir='nocorrect mkdir'
-alias gist='nocorrect gist'
-alias heroku='nocorrect heroku'
-alias ebuild='nocorrect ebuild'
-alias hpodder='nocorrect hpodder'
+# correct commands, but not any arguments (correct_all would do that)
+setopt correct


### PR DESCRIPTION
Using the correct_all option is too distracting, and needs a lot of
`nocorrect` aliases to work around this.

Using only "correct" to correct the command itself is more friendly.
