### PR TITLE
`setopt append_history` is not necessary.

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -3,7 +3,6 @@ HISTFILE=$HOME/.zsh_history
 HISTSIZE=10000
 SAVEHIST=10000
 
-setopt append_history
 setopt extended_history
 setopt hist_expire_dups_first
 setopt hist_ignore_dups # ignore duplication command history list


### PR DESCRIPTION
Especially given the inc_append_history option, it is not necessary to
set the (default) append_history option.
