### PR TITLE
Allow loading themes from $ZSH_CUSTOM/themes/

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -59,7 +59,11 @@ then
 else
   if [ ! "$ZSH_THEME" = ""  ]
   then
-    source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+    if [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
+      source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
+    else
+      source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+    fi
   fi
 fi
 


### PR DESCRIPTION
This allows the use of themes in the 'custom' directory location. It is convenient if the user wants to version the files in $ZSH_CUSTOM separately and also maintain separate themes.
