### PR TITLE
Add support for chef environments in knife plugin

### DIFF
--- a/plugins/knife/_knife
+++ b/plugins/knife/_knife
@@ -26,7 +26,7 @@ _knife() {
   
   case $state in
   knifecmd)
-    compadd -Q "$@" bootstrap client configure cookbook "cookbook site" "data bag" exec index node recipe role search ssh status windows $cloudproviders
+    compadd -Q "$@" bootstrap client configure cookbook "cookbook site" "data bag" exec environment index node recipe role search ssh status windows $cloudproviders
   ;;
   knifesubcmd)
     case $words[2] in
@@ -42,6 +42,9 @@ _knife() {
     cookbook)
       compadd -Q "$@" test list create download delete "metadata from" show "bulk delete" metadata upload
     ;;
+  environment)
+      compadd -Q "$@" list create delete edit show "from file"
+      ;;
     node)
      compadd -Q "$@" "from file" create show edit delete list run_list "bulk delete"
     ;;
@@ -159,6 +162,10 @@ _chef_sitecookbooks_remote() {
 
 _chef_data_bags_remote() {
  (knife data bag list | grep \" | awk '{print $1}' | awk -F"," '{print $1}' | awk -F"\"" '{print $2}')
+}
+
+_chef_environments_remote() {
+  (knife environment list | awk '{print $1}')
 }
 
 # The chef_x_local functions use the knife config to find the paths of relevant objects x to be uploaded to the server


### PR DESCRIPTION
Chef 0.10 introduced support for environments, which the existing knife plugin does not include support for. Here's my update.
