### PR TITLE
global ssh_known_hosts file

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -32,9 +32,11 @@ zstyle ':completion:*:cd:*' tag-order local-directories directory-stack path-dir
 cdpath=(.)
 
 # use /etc/hosts and known_hosts for hostname completion
+[ -r /etc/ssh/ssh_known_hosts ] && _global_ssh_hosts=(${${${${(f)"$(</etc/ssh/ssh_known_hosts)"}:#[\|]*}%%\ *}%%,*}) || _ssh_hosts=()
 [ -r ~/.ssh/known_hosts ] && _ssh_hosts=(${${${${(f)"$(<$HOME/.ssh/known_hosts)"}:#[\|]*}%%\ *}%%,*}) || _ssh_hosts=()
 [ -r /etc/hosts ] && : ${(A)_etc_hosts:=${(s: :)${(ps:\t:)${${(f)~~"$(</etc/hosts)"}%%\#*}##[:blank:]#[^[:blank:]]#}}} || _etc_hosts=()
 hosts=(
+  "$_global_ssh_hosts[@]"
   "$_ssh_hosts[@]"
   "$_etc_hosts[@]"
   `hostname`


### PR DESCRIPTION
In my organization we use Puppet to assemble public keys of all systems into /etc/ssh/ssh_known_hosts instead of building a local user .ssh/known_hosts over time.  I modified the completion code to add these hosts to $hosts for completion of ssh commands.
