### PR TITLE
make pygmalion theme use two lines when needed

### DIFF
--- a/themes/pygmalion.zsh-theme
+++ b/themes/pygmalion.zsh-theme
@@ -18,7 +18,7 @@ prompt_setup_pygmalion(){
 prompt_pygmalion_precmd(){
   local gitinfo=$(git_prompt_info)
   local gitinfo_nocolor=$(echo "$gitinfo" | perl -pe "s/%\{[^}]+\}//g")
-  local exp_nocolor=$(print -P "$base_prompt_nocolor$gitinfo_nocolor$post_prompt_nocolor")
+  local exp_nocolor="$(print -P \"$base_prompt_nocolor$gitinfo_nocolor$post_prompt_nocolor\")"
   local prompt_length=${#exp_nocolor}
 
   local nl=""


### PR DESCRIPTION
if the length of the prompt (excluding color escapes) exceeds 40 characters, emit the arrow prompt on its own line

This helps a lot on smaller terminals

Illustration: 

![illustraion](http://i.imgur.com/QHQWi.png)

The top prompt is the default look, the second one has a path that exceeds 40 characters and thus is shown on two lines.

Is it ok to update an existing theme like this or do you prefer if I create a pilif theme that has this extension?
