### PR TITLE
bundler plugin - don't "bundle exec rails" 

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -10,7 +10,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(cap capify cucumber foreman guard heroku nanoc rackup rails rainbows rake rspec ruby shotgun spec spork thin unicorn unicorn_rails)
+bundled_commands=(cap capify cucumber foreman guard heroku nanoc rackup rainbows rake rspec ruby shotgun spec spork thin unicorn unicorn_rails)
 
 ## Functions
 


### PR DESCRIPTION
As per http://blog.wyeworks.com/2011/12/27/bundle-exec-rails-executes-bundler-setup-3-times
