### PR TITLE
Getting the hostname, correctly everywhere.

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -39,7 +39,7 @@ hosts=(
   "$_global_ssh_hosts[@]"
   "$_ssh_hosts[@]"
   "$_etc_hosts[@]"
-  `hostname`
+  "$HOST"
   localhost
 )
 zstyle ':completion:*:hosts' hosts $hosts


### PR DESCRIPTION
There appears to be a inconsistent behavior on many distros and OS's on how to get the current node name.

I was thinking on using `uname -n` but, unfortunately, it is very inconsistent across platforms. But luckily ZSH exports a variable **$HOST** containing the name of the current host and we also save a subshell call in order to get the string.

This could also fix robbyrussell/oh-my-zsh#653 and It seems the implementation was introduced with robbyrussell/oh-my-zsh#127 

Also I noticed that many themes use `hostname` or `hostname -s`, should those also be changed?
