### PR TITLE
Fixed the rfind command in the  ruby plugin

### DIFF
--- a/plugins/ruby/ruby.plugin.zsh
+++ b/plugins/ruby/ruby.plugin.zsh
@@ -3,4 +3,4 @@
 alias sgem='sudo gem'
 
 # Find ruby file
-alias rfind='find . -name *.rb | xargs grep -n'
+alias rfind='find . -name "*.rb" | xargs grep -n'


### PR DESCRIPTION
I tried to use rfind plugin in the ruby plugin. I experienced some problem with that command. I looked into it and found that adding "" to 
  alias rfind='find . -name *.rb | xargs grep -n' 
solved the problem.

The string now look like this:
  alias rfind='find . -name "*.rb" | xargs grep -n' 
