### PR TITLE
Git Plugin: add 'grhh' alias for 'git reset HEAD --hard'

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -36,8 +36,8 @@ alias ga='git add'
 compdef _git ga=git-add
 alias gm='git merge'
 compdef _git gm=git-merge
+alias grh='git reset HEAD'
 alias grhh='git reset HEAD --hard'
-compdef _git grhh=git-reset-head-hard
 
 # Git and svn mix
 alias git-svn-dcommit-push='git svn dcommit && git push github master:svntrunk'


### PR DESCRIPTION
I use 'git reset HEAD --hard' all the time and figured this alias would be a helpful addition to the git plugin.
