### PR TITLE
remove the -v flag from a few mercurial aliases

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -1,14 +1,14 @@
 
 # Mercurial
-alias hgc='hg commit -v'
-alias hgb='hg branch -v'
+alias hgc='hg commit'
+alias hgb='hg branch'
 alias hgba='hg branches'
 alias hgco='hg checkout'
 alias hgd='hg diff'
 alias hged='hg diffmerge'
 # pull and update
-alias hgl='hg pull -u -v'
-alias hgp='hg push -v'
-alias hgs='hg status -v'
+alias hgl='hg pull -u'
+alias hgp='hg push'
+alias hgs='hg status'
 # this is the 'git commit --amend' equivalent
 alias hgca='hg qimport -r tip ; hg qrefresh -e ; hg qfinish tip'


### PR DESCRIPTION
The -v flag for these commands really isn't very useful.  It will
output some information about the hooks it is running, but that is
generally not useful and just noisy.  The desire to add -v to these
commands is exceptional and IMHO it's better to make the common
case of not seeing those messages the supported behavior.
