### PR TITLE
quote correctly(?) to avoid bogus output from subshells fixes #770

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -7,7 +7,7 @@ function title {
   if [[ "$TERM" == screen* ]]; then
     print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
   elif [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
-    print -Pn "\e]2;$2:q\a" #set window name
+    print -Pn $'\e]0;$2\a' #set window name
     print -Pn "\e]1;$1:q\a" #set icon (=tab) name (will override window name on broken terminal)
   fi
 }


### PR DESCRIPTION
TBH i don't understand exactly what's going on, but this was suggested by somebody who seems to know what he's talking about, and this seems to work fine for me.
see #770
