### PR TITLE
Removed calls to compinit in the extract and the bundler plugins.

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -1,5 +1,3 @@
-fpath=($ZSH/plugins/bundler $fpath)
-
 alias be="bundle exec"
 alias bi="bundle install"
 alias bl="bundle list"

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -78,6 +78,3 @@ function extract() {
 
 alias x=extract
 
-# add extract completion function to path
-fpath=($ZSH/plugins/extract $fpath)
-


### PR DESCRIPTION
compinit should only be called once, after all modules, libs, etc are imported.

This change yields a much improved startup time, going from a life-sapping 3 seconds average before, to a much snappier 0.2 seconds average.
