### PR TITLE
Don’t report that Oh My Zsh has been updated when it hasn’t.

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,12 +1,19 @@
 current_path=`pwd`
 printf '\033[0;34m%s\033[0m\n' "Upgrading Oh My Zsh"
-( cd $ZSH && git pull origin master )
-printf '\033[0;32m%s\033[0m\n' '         __                                     __   '
-printf '\033[0;32m%s\033[0m\n' '  ____  / /_     ____ ___  __  __   ____  _____/ /_  '
-printf '\033[0;32m%s\033[0m\n' ' / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \ '
-printf '\033[0;32m%s\033[0m\n' '/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / / '
-printf '\033[0;32m%s\033[0m\n' '\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/  '
-printf '\033[0;32m%s\033[0m\n' '                        /____/                       '
-printf '\033[0;34m%s\033[0m\n' 'Hooray! Oh My Zsh has been updated and/or is at the current version.'
-printf '\033[0;34m%s\033[1m%s\033[0m\n' 'To keep up on the latest, be sure to follow Oh My Zsh on twitter: ' 'http://twitter.com/ohmyzsh'
+cd $ZSH
+
+if git pull origin master
+then
+  printf '\033[0;32m%s\033[0m\n' '         __                                     __   '
+  printf '\033[0;32m%s\033[0m\n' '  ____  / /_     ____ ___  __  __   ____  _____/ /_  '
+  printf '\033[0;32m%s\033[0m\n' ' / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \ '
+  printf '\033[0;32m%s\033[0m\n' '/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / / '
+  printf '\033[0;32m%s\033[0m\n' '\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/  '
+  printf '\033[0;32m%s\033[0m\n' '                        /____/                       '
+  printf '\033[0;34m%s\033[0m\n' 'Hooray! Oh My Zsh has been updated and/or is at the current version.'
+  printf '\033[0;34m%s\033[1m%s\033[0m\n' 'To keep up on the latest, be sure to follow Oh My Zsh on twitter: ' 'http://twitter.com/ohmyzsh'
+else
+  printf '\033[0;31m%s\033[0m\n' 'There was an error updating. Try again later?'
+fi
+
 cd "$current_path"


### PR DESCRIPTION
Hardly a crisis, but this morning when I accepted the suggestion to update without being connected to the Internet, Oh My Zsh failed to fetch the update but reported that it had updated successfully. (The place where I’m staying has a terrible wireless router, so I use a terminal command to cycle the wireless card until it can find the router, but I couldn’t run the command until I passed the update prompt.)

![Reporting an update that didn’t happen](http://chromatin.ca/images/false_update.png)

I edited the update script, attempting to follow conventions, though the tone of output messages is more difficult to emulate than code formatting, heh.

![Reporting a failed update](http://chromatin.ca/images/truthful_nonupdate.png)

Thanks for this project!
