### PR TITLE
Add output message to commands modified to run automatically through bundler

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -29,6 +29,7 @@ _within-bundled-project() {
 
 _run-with-bundler() {
   if _bundler-installed && _within-bundled-project; then
+    echo "Running command with 'bundle exec'"
     bundle exec $@
   else
     $@


### PR DESCRIPTION
If a command is automatically routed through bundle exec it can be confusing to know what it is actually running, so I built a small echo when this happens.
