### PR TITLE
Fix sprunge-plugin behaviour.

### DIFF
--- a/plugins/sprunge/sprunge.plugin.zsh
+++ b/plugins/sprunge/sprunge.plugin.zsh
@@ -57,8 +57,6 @@ sprunge() {
 	  fi
 	else
 	  echo Using input from a pipe or STDIN redirection... >&2
-	  while IFS= read -r line ; do
-		echo $line
-	  done | curl -F 'sprunge=<-' http://sprunge.us
+	  curl -F 'sprunge=<-' http://sprunge.us
 	fi
 }


### PR DESCRIPTION
The sprunge-plugin was removing whitespaces and tabs from files, so if you did something like:

cat foo.py | sprunge, all tabs in foo.py were lost.

The attached commit fixes this.
