### PR TITLE
Add Thor to bundled commands

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -10,7 +10,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate cap capify cucumber foreman guard heroku nanoc rackup rainbows rake rspec ruby shotgun spec spork thin unicorn unicorn_rails)
+bundled_commands=(annotate cap capify cucumber foreman guard heroku nanoc rackup rainbows rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails)
 
 ## Functions
 


### PR DESCRIPTION
Thor should be a bundled command when using Bundler plugin because it rely on ruby version running
