### PR TITLE
Fix bundler plugin for root level folders

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -20,7 +20,7 @@ _bundler-installed() {
 
 _within-bundled-project() {
   local check_dir=$PWD
-  while [ "$(dirname $check_dir)" != "/" ]; do
+  while [ $check_dir != "/" ]; do
     [ -f "$check_dir/Gemfile" ] && return
     check_dir="$(dirname $check_dir)"
   done


### PR DESCRIPTION
This fix allows `_within-bundled-project()` to properly pickup a `Gemfile` within a root level folder (ie. `/my_project`)
