### PR TITLE
Add Feature: Local Customizations Folder (to simplify maintenance)

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -69,6 +69,8 @@ for config_file ($ZSH_LOCAL/*.zsh) source $config_file
 if [ "$ZSH_THEME" = "random" ]
 then
   themes=($ZSH/themes/*zsh-theme)
+  themes+=($ZSH_CUSTOM/*zsh-theme)
+  themes+=($ZSH_LOCAL/*zsh-theme)
   N=${#themes[@]}
   ((N=(RANDOM%N)+1))
   RANDOM_THEME=${themes[$N]}


### PR DESCRIPTION
**Problem**

Zsh configuration is very personal. The way "oh-my-zsh" deals with customizations has created an explosion of pull requests some of which are probably too narrow to be in the main repo. This is a maintenance burden. Imo, only generic functionality should be added to this repo - not personal adjustments and tweaks.

**One solution**

Allow users to make tweaks outside of the repo.  This will deincentivize fork/pulls for personal changes.

In this pull I added the concept of 'local customizations'. Instead of adding tweaks to `~/.oh-my-zsh` you can instead add them to `~/.zsh`. You can then separately track this folder in a personal repo. I added mine to my dotfiles repo, for example.

This is backward compatible with the `/custom` folder, but imo we should phase that idea out. Also, adjustments in the `~/.zsh` folder have precedence over those in `/custom`.
