### PR TITLE
rake plugin

### DIFF
--- a/plugins/rake/rake.plugin.zsh
+++ b/plugins/rake/rake.plugin.zsh
@@ -1,0 +1,6 @@
+alias rake="noglob rake" # allows square brackts for rake task invocation
+alias brake='noglob bundle exec rake' # execute the bundled rake gem
+alias srake='noglob sudo rake' # noglob must come before sudo
+alias sbrake='noglob sudo bundle exec rake' # altogether now ... 
+
+


### PR DESCRIPTION
Added a rake plugin which has some aliases which prepend the 'noglob' option when running rake commands. I have some (non-rails) rake tasks which accept arguments. The square brackets used in rake commands trigger the zsh file globbing and prevent me from running the task.
