### PR TITLE
take in chris sexton's changes to the pow plugin

### DIFF
--- a/plugins/pow/pow.plugin.zsh
+++ b/plugins/pow/pow.plugin.zsh
@@ -34,6 +34,7 @@ rack_root_detect(){
   [[ ${basedir} == "/" ]] && return 1
   echo `basename $basedir | sed -E "s/.(com|net|org)//"`
 }
+
 kapow(){
   local vhost=$1
   [ ! -n "$vhost" ] && vhost=$(rack_root_detect)
@@ -43,11 +44,23 @@ kapow(){
     return 1
   fi
 
-  # [ ! -d "~/.pow/${vhost}/tmp" ] &&  mkdir -p "~/.pow/$vhost/tmp"
+  [ ! -d ~/.pow/${vhost}/tmp ] && mkdir -p ~/.pow/$vhost/tmp
   touch ~/.pow/$vhost/tmp/restart.txt;
   [ $? -eq 0 ] &&  echo "pow: restarting $vhost.dev"
 }
 compctl -W ~/.pow -/ kapow
+
+powit(){
+	local basedir=$(pwd)
+  local vhost=$1
+  [ ! -n "$vhost" ] && vhost=$(rack_root_detect)
+  if [ ! -h ~/.pow/$vhost ]
+	then
+		echo "pow: Symlinking your app with pow. ${vhost}"
+	  [ ! -d ~/.pow/${vhost} ] && ln -s $basedir ~/.pow/$vhost
+    return 1
+  fi
+}
 
 # View the standard out (puts) from any pow app
 alias kaput="tail -f ~/Library/Logs/Pow/apps/*"


### PR DESCRIPTION
Adds a kapow command that will restart an app
  $ kapow myapp
Supports command completion.

If you are not already using completion you might need to enable it with

   autoload -U compinit compinit

Changes:

Defaults to the current application, and will walk up the tree to find 
a config.ru file and restart the corresponding app

Will Detect if a app does not exist in pow and print a (slightly) helpful 
error message

https://gist.github.com/1019777/70dbb46db9bd5b346faf543a9dd4edac4782adda
