### PR TITLE
Add ZSH_THEME_GIT_PROMPT_UNTRACKED

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -4,12 +4,19 @@ function git_prompt_info() {
   echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
 }
 
-# Checks if working tree is dirty
-parse_git_dirty() {
-  if [[ -n $(git status -s --ignore-submodules=dirty 2> /dev/null) ]]; then
-    echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
-  else
-    echo "$ZSH_THEME_GIT_PROMPT_CLEAN"
+parse_git_dirty () {
+  gitstat=$(git status 2>/dev/null | grep '\(# Untracked\|# Changes\|# Changed but not updated:\)')
+
+  if [[ $(echo ${gitstat} | grep -c "^\(# Untracked files:\|# Changed but not updated:\|# Changes not staged for commit:\)$") > 0 ]]; then
+	echo -n "$ZSH_THEME_GIT_PROMPT_UNTRACKED"
+  fi 
+
+  if [[ $(echo ${gitstat} | grep -c "^# Changes to be committed:$") > 0 ]]; then
+	echo -n "$ZSH_THEME_GIT_PROMPT_DIRTY"
+  fi
+
+  if [[ $(echo ${gitstat} | grep -v '^$' | wc -l | tr -d ' ') == 0 ]]; then
+	echo -n "$ZSH_THEME_GIT_PROMPT_CLEAN"
   fi
 }
 
@@ -18,6 +25,15 @@ function git_prompt_ahead() {
   if $(echo "$(git log origin/$(current_branch)..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
     echo "$ZSH_THEME_GIT_PROMPT_AHEAD"
   fi
+}
+
+#
+# Will return the current branch name
+# Usage example: git pull origin $(current_branch)
+#
+function current_branch() {
+  ref=$(git symbolic-ref HEAD 2> /dev/null) || return
+  echo ${ref#refs/heads/}
 }
 
 # Formats prompt string for current git commit short SHA


### PR DESCRIPTION
Add the ability for zsh themes to differentiate between untracked files and a simply dirty repository.

Coppied from (Steve Losh's)[https://github.com/sjl/oh-my-zsh/] fork.
He didn't seem to be making a pull request, so here's one.
