### PR TITLE
Fix git status indicator not working correctly when using an older version of git Fix git status indicator not working when using an older version of git 

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -6,8 +6,6 @@ function git_prompt_info() {
 
 # Checks if working tree is dirty
 parse_git_dirty() {
-#do stuff here
-    ver=$(git --version | cut -d " " -f 3)
     if $(is_legacy_git); then
         echo $(parse_legacy_git_dirty)
     else
@@ -45,8 +43,6 @@ parse_recent_git_dirty() {
     echo "$ZSH_THEME_GIT_PROMPT_CLEAN"
   fi
 }
-
-
 
 # Checks if there are commits ahead from remote
 function git_prompt_ahead() {


### PR DESCRIPTION
commit dd14e075b7dd39906e2075ac6dd8f5bcc66b6129 made on December 21, 2011 by fl4t, described as "Ignore submodules dirty in prompt info" causes the git status indicator to never display the ZSH_THEME_GIT_PROMPT_DIRTY, when used with git<1.7.2.

This is due to the use of the --ignore-submodules option's usage in the lib/git.zsh file. This commit causes the shell to check the version number of git and, if the version is from before the --ignore-submodules option was added, it uses the --porcelain option to determine if anything has been changed.

(second commit is because I forgot to clean up a orphaned variable :P )
