### PR TITLE
Fix git status indicator not working correctly when using an older version of git

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -6,7 +6,7 @@ function git_prompt_info() {
 
 # Checks if working tree is dirty
 parse_git_dirty() {
-    if $(is_legacy_git); then
+    if [ "true" = "$IS_LEGACY_GIT" ]; then
         echo $(parse_legacy_git_dirty)
     else
         echo $(parse_recent_git_dirty)
@@ -15,20 +15,26 @@ parse_git_dirty() {
 
 # echos the string 'true' if this git is old enough not to have --ignore-submodules
 # echos false otherwise 
-is_legacy_git() {
+get_is_legacy_git() {
     checkit() {
         if [ $1 -gt 1 ]; then
-            echo false
+            echo "false"
         elif [ $1 -eq 1 -a $2 -gt 7 ]; then
-            echo false
+            echo "false"
         elif [ $1 -eq 1 -a $2 -eq 7 -a $3 -ge 2 ]; then
-            echo false
+            echo "false"
         else
-            echo true 
+            echo "true" 
         fi
     }
     echo $(checkit $(git --version | cut -d " " -f 3 | tr '.' ' '))
 }
+
+#this is unlikely to change so make it all statically assigned
+IS_LEGACY_GIT=$(get_is_legacy_git)
+
+#clean up the namespace slightly by removing the checker function
+unset -f get_is_legacy_git
 
 # Checks if working tree is dirty when --ignore-submodules is not present
 parse_legacy_git_dirty() {


### PR DESCRIPTION
commit dd14e07 made on December 21, 2011 by fl4t, described as "Ignore submodules dirty in prompt info" causes the git status indicator to never display the ZSH_THEME_GIT_PROMPT_DIRTY, when used with git<1.7.2.

This is due to the use of the --ignore-submodules option's usage in the lib/git.zsh file. This commit causes the shell to check the version number of git and, if the version is from before the --ignore-submodules option was added, it uses the --porcelain option to determine if anything has been changed.
