### PR TITLE
prompt git-rm as deleted

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -54,6 +54,8 @@ git_prompt_status() {
   fi
   if $(echo "$INDEX" | grep '^ D ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
+  elif $(echo "$INDEX" | grep '^D  ' &> /dev/null); then
+    STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
   elif $(echo "$INDEX" | grep '^AD ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
   fi


### PR DESCRIPTION
Hello,

updated "lib/git.zsh" to prompt deleted status when "git rm" was called.

Thanks,
- Tadaya
