### PR TITLE
Fixed Mac OS X Terminal.app related issue with extra newlines echoed

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -6,6 +6,8 @@ function title {
   [ "$DISABLE_AUTO_TITLE" != "true" ] || return
   if [[ "$TERM" == screen* ]]; then
     print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
+  elif [[ "$TERM_PROGRAM" == "Apple_Terminal" ]]; then
+    print -Pn "\e]1;$1:q\a" #set icon (=tab) name (will override window name on broken terminal)
   elif [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
     print -Pn "\e]2;$2:q\a" #set window name
     print -Pn "\e]1;$1:q\a" #set icon (=tab) name (will override window name on broken terminal)


### PR DESCRIPTION
See: http://stackoverflow.com/questions/9029921/zsh-outputting-extra-newlines-when-echoing-a-multiline-variable/9030611#9030611 for an example of the issue in action.

I found that the real root of the problem was an issue with with Terminal.app handling the tab/window titles getting updated.
