### PR TITLE
zsh parameter added for `rbenv init`

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -4,7 +4,7 @@ for rbenvdir in "$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv" ; do
     FOUND_RBENV=1
     export RBENV_ROOT=$rbenvdir
     export PATH=${rbenvdir}/bin:$PATH
-    eval "$(rbenv init -)"
+    eval "$(rbenv init - zsh)"
 
     alias rubies="rbenv versions"
     alias gemsets="rbenv gemset list"


### PR DESCRIPTION
It seem it change only which completion file is loaded, but it removes the complete not found command error ;)
