### PR TITLE
Allow themes in ZSH_CUSTOM folder

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -65,9 +65,9 @@ then
 else
   if [ ! "$ZSH_THEME" = ""  ]
   then
-    if [ -f "$ZSH/custom/$ZSH_THEME.zsh-theme" ]
+    if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]
     then
-      source "$ZSH/custom/$ZSH_THEME.zsh-theme"
+      source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
     else
       source "$ZSH/themes/$ZSH_THEME.zsh-theme"
     fi


### PR DESCRIPTION
https://github.com/robbyrussell/oh-my-zsh/pull/525 added the possibility to use a folder outside of the oh-my-zsh repo to allow including oh-my-zsh as a submodule while keeping custom modifications. This path, if set, is currently not used for theme path resolution. This patch changes theme lookup from $ZSH/custom to $ZSH_CUSTOM, to allow for custom themes with oh-my-zsh as submodule.
