### PR TITLE
WORK plugin added

### DIFF
--- a/plugins/work/work.plugin.zsh
+++ b/plugins/work/work.plugin.zsh
@@ -1,0 +1,27 @@
+typeset -A _WORKPLUGIN_DIRS_FULLPATH
+
+for dir in $WORKPLUGIN_DIRS; do
+    _WORKPLUGIN_DIRS_FULLPATH[$dir]="$HOME/$dir"
+done
+
+work() {
+    local dir
+    for dir in $_WORKPLUGIN_DIRS_FULLPATH; do
+        if [[ -d "$dir/$1" ]]; then
+            builtin cd "$dir/$1"
+            break
+        fi
+    done
+    if [[ $(type -w "WORKPLUGIN_CALLBACK") == "WORKPLUGIN_CALLBACK: function" ]]; then
+        WORKPLUGIN_CALLBACK "$1"
+    fi
+}
+
+_work_comp() {
+    local dir
+    for dir in $_WORKPLUGIN_DIRS_FULLPATH; do
+        compadd $(ls $dir)
+    done
+}
+
+compdef _work_comp work


### PR DESCRIPTION
- before definition of zsh plugins set `WORKPLUGIN_DIRS` variable with
  list of your "work" directories relative to your $HOME, such as `WORKPLUGIN_DIRS=('work' 'src')`
- now you can use `work` command in your zshell, which will change CWD to
  first occurrence of `WORKPLUGIN_DIRS` sub folders
- directories competition is supported
- also, you can define `WORKPLUGIN_CALLBACK` function, which will be
  called after directory change. In my case, I use it to call
  `virtualenvwrapper`'s `workon` function:

``` sh
WORKPLUGIN_CALLBACK() {
    deactivate 2> /dev/null
    workon "$1" 2> /dev/null
}
```
