### PR TITLE
Write the update file even if `CLOBBER` is unset.

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -5,7 +5,7 @@ function _current_epoch() {
 }
 
 function _update_zsh_update() {
-  echo "LAST_EPOCH=$(_current_epoch)" > ~/.zsh-update
+  echo "LAST_EPOCH=$(_current_epoch)" >! ~/.zsh-update
 }
 
 function _upgrade_zsh() {


### PR DESCRIPTION
My zsh-update was always erroring out with the following:

```
_update_zsh_update:1: file exists: /Path/To/Home/.zsh-update
```

This fixes that by force-opening `.zsh-update` with `>!` instead of `>`.
