### PR TITLE
Bugfix/gitversionfix

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -8,7 +8,7 @@ function git_prompt_info() {
 # Checks if working tree is dirty
 parse_git_dirty() {
   local SUBMODULE_SYNTAX=''
-  if [[ POST_1_7_2_GIT -gt 0 ]]; then
+  if [[ $POST_1_7_2_GIT -gt 0 ]]; then
         SUBMODULE_SYNTAX="--ignore-submodules=dirty"
   fi
   if [[ -n $(git status -s ${SUBMODULE_SYNTAX}  2> /dev/null) ]]; then


### PR DESCRIPTION
Fixes the following issues
Issue #69
Issue #896

Similar to to:
Pull Request #872

Repost of Pull Request #898

git_parse_dirty is broken for versions of git less than 1.7.2
(i.e. for anyone running centos)

I've modified parse_git_dirty() in lib/git.zsh to only use the "--ignore-submodules=dirty" syntax if the installed version of git is at least 1.7.2.

I added a function git_compare_version to the same file. It prints 1 if the installed git version is >= to the input version.

I've made the function evaluate only once at zsh startup as suggested by scialex
