### PR TITLE
Fix RVM Ruby prompt on superjarin theme

### DIFF
--- a/themes/superjarin.zsh-theme
+++ b/themes/superjarin.zsh-theme
@@ -1,5 +1,5 @@
 # Grab the current version of ruby in use (via RVM): [ruby-1.8.7]
-if which rvm-prompt &> /dev/null; then
+if [ -e ~/.rvm/bin/rvm-prompt ]; then
   JARIN_CURRENT_RUBY_="%{$fg[white]%}[%{$fg[red]%}\$(~/.rvm/bin/rvm-prompt i v)%{$fg[white]%}]%{$reset_color%}"
 else
   if which rbenv &> /dev/null; then


### PR DESCRIPTION
It seems like the test to see if RVM is installed was not working.

This fix may also apply to the other themes that show the RVM Ruby version in the prompt, but I didn't want to mess around with the other themes because I haven't tested them.
