### PR TITLE
Use $ZSH_CUSTOM rather than $ZSH/custom for themes

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -69,7 +69,7 @@ else
     then
       source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
     else
-      source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
+      source "$ZSH/themes/$ZSH_THEME.zsh-theme"
     fi
   fi
 fi


### PR DESCRIPTION
If users have altered $ZSH_CUSTOM, theme loading still only searches $ZSH/custom (~/.oh-my-zsh/custom). This commit allows themes to live wherever $ZSH_CUSTOM points.
