### PR TITLE
blinks theme works with light and dark Solarized

### DIFF
--- a/themes/blinks.zsh-theme
+++ b/themes/blinks.zsh-theme
@@ -8,13 +8,23 @@ function _prompt_char() {
   fi
 }
 
+# This theme works with both the "dark" and "light" variants of the
+# Solarized color schema.  Set the SOLARIZED_THEME variable to one of
+# these two values to choose.  If you don't specify, we'll assume you're
+# using the "dark" variant.
+
+case ${SOLARIZED_THEME:-dark} in
+    light) bkg=white;;
+    *)     bkg=black;;
+esac
+
 ZSH_THEME_GIT_PROMPT_PREFIX=" [%{%B%F{blue}%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{%f%k%b%K{black}%B%F{green}%}]"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{%f%k%b%K{${bkg}}%B%F{green}%}]"
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{%F{red}%}*%{%f%k%b%}"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 
 PROMPT='%{%f%k%b%}
-%{%K{black}%B%F{green}%}%n%{%B%F{blue}%}@%{%B%F{cyan}%}%m%{%B%F{green}%} %{%b%F{yellow}%K{black}%}%~%{%B%F{green}%}$(git_prompt_info)%E%{%f%k%b%}
-%{%K{black}%}$(_prompt_char)%{%K{black}%} %#%{%f%k%b%} '
+%{%K{${bkg}}%B%F{green}%}%n%{%B%F{blue}%}@%{%B%F{cyan}%}%m%{%B%F{green}%} %{%b%F{yellow}%K{${bkg}}%}%~%{%B%F{green}%}$(git_prompt_info)%E%{%f%k%b%}
+%{%K{${bkg}}%}$(_prompt_char)%{%K{${bkg}}%} %#%{%f%k%b%} '
 
 RPROMPT='!%{%B%F{cyan}%}%!%{%f%k%b%}'


### PR DESCRIPTION
The blinks theme now looks good if you're using the light version of the
Solarized color scheme, too.  It still defaults to the dark version, so
it should work as before if you don't override things.  If you're using
the light version, just set SOLARIZED_THEME to "light" before sourcing
oh-my-zsh.
