### PR TITLE
sonicradish - 256 color oh-my-zsh theme [dark/solarized]

### DIFF
--- a/themes/sonicradish.zsh-theme
+++ b/themes/sonicradish.zsh-theme
@@ -35,5 +35,3 @@ ZSH_THEME_GIT_PROMPT_DELETED="%{$FG[103]%}✖%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_RENAMED="%{$FG[103]%}➜%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_UNMERGED="%{$FG[103]%}═%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$FG[103]%}✭%{$reset_color%}"
-
-export LSCOLORS=dxfxcxdxbxexexabagacad


### PR DESCRIPTION
sonicradish theme - requires 256 color enabled terminal

Forked from oh-my-zsh muse theme and inspired by mustang vim theme 

Dark Background and Solarized Dark look great [ tested on OS X ]

This theme displays different prompt for root and non-root users [see screenshot]

Screenshot: https://img.skitch.com/20120221-eb1cxey5aun84tb1ak7fm376k.png

muse: https://github.com/robbyrussell/oh-my-zsh/blob/master/themes/muse.zsh-theme
mustang: http://hcalves.deviantart.com/art/Mustang-Vim-Colorscheme-98974484http://hcalves.deviantart.com/art/Mustang-Vim-Colorscheme-98974484
