### PR TITLE
#955 Fixing "command not found `git_compare_version` error"

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -69,10 +69,6 @@ git_prompt_status() {
   echo $STATUS
 }
 
-#this is unlikely to change so make it all statically assigned
-POST_1_7_2_GIT=$(git_compare_version "1.7.2")
-#clean up the namespace slightly by removing the checker function
-unset -f git_compare_version()
 
 #compare the provided version of git to the version installed and on path
 #prints 1 if input version <= installed version
@@ -93,4 +89,7 @@ function git_compare_version() {
   echo 1
 }
 
-
+#this is unlikely to change so make it all statically assigned
+POST_1_7_2_GIT=$(git_compare_version "1.7.2")
+#clean up the namespace slightly by removing the checker function
+unset -f git_compare_version


### PR DESCRIPTION
- moved function block before using it
- removed parenthesis on `unset` builtin call
