### PR TITLE
New git-svn plugin with svnversion equivalent

### DIFF
--- a/plugins/git-svn/git-svn.plugin.zsh
+++ b/plugins/git-svn/git-svn.plugin.zsh
@@ -1,14 +1,23 @@
+# Git and svn mix
+alias git-svn-dcommit-push='git svn dcommit && git push github master:svntrunk'
+compdef git-svn-dcommit-push=git
+
+alias gsr='git svn rebase'
+alias gsd='git svn dcommit'
+
 #
 # git equivalent of svnversion
 #
 get_svnversion()
 {
-    alias git_svnversion="git svn find-rev `git describe --always` 2>/dev/null"
-    LANG=C SVN_VERSION=`/usr/bin/svnversion`
-    if [ "X$SVN_VERSION" == "Xexported" -o "X$SVN_VERSION" == "X" ]; then
-        git_svnversion
+    local git_version=`git describe --always 2>/dev/null`
+    local git_svnversion=`git svn find-rev $git_version 2>/dev/null`
+    local svn_version
+    LANG=C svn_version=`/usr/bin/svnversion`
+    if [ "X$svn_version" == "Xexported" -o "X$svn_version" == "X" ]; then
+        echo $git_svnversion
     else
-        echo $SVN_VERSION
+        echo $svn_version
     fi
 }
 alias svnversion=get_svnversion

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -39,12 +39,6 @@ compdef _git gm=git-merge
 alias grh='git reset HEAD'
 alias grhh='git reset HEAD --hard'
 
-# Git and svn mix
-alias git-svn-dcommit-push='git svn dcommit && git push github master:svntrunk'
-compdef git-svn-dcommit-push=git
-
-alias gsr='git svn rebase'
-alias gsd='git svn dcommit'
 #
 # Will return the current branch name
 # Usage example: git pull origin $(current_branch)


### PR DESCRIPTION
The main goal of the creation of this plugin is the addition of an equivalent of `svnversion` for git-svn (the `get_svnversion` function, which is inspired from http://goodliffe.blogspot.com/2009/08/code-how-to-spell-svnversion-in-git.html).
I think it is better to put this in a new _git-svn_ plugin instead of putting it in the existing _git_ plugin (as only people using git-svn may be interested).
Consequently I moved some aliases from the _git_ plugin to this new _git-svn_ plugin.
