### PR TITLE
Add completion for pip install -r - so that it autocompletes requirement...

### DIFF
--- a/plugins/pip/_pip
+++ b/plugins/pip/_pip
@@ -58,6 +58,7 @@ case "$words[1]" in
   	_arguments \
       '(-U --upgrade)'{-U,--upgrade}'[upgrade all packages to the newest available version]' \
       '(-f --find-links)'{-f,--find-links}'[URL for finding packages]' \
+      '(-r --requirement)'{-r,--requirement}'[Requirements file for packages to install]:File:_files' \
       '(--no-deps --no-dependencies)'{--no-deps,--no-dependencies}'[iIgnore package dependencies]' \
       '(--no-install)--no-install[only download packages]' \
       '(--no-download)--no-download[only install downloaded packages]' \


### PR DESCRIPTION
...s filenames

This is so that `pip install -r <TAB>` works to complete the filename of any requirement file (can be any text file), previously it would not do any completion and you had to type the whole filename.
