### PR TITLE
theme-chooser should warn in env variable $ZSH is not set

### DIFF
--- a/tools/theme_chooser.sh
+++ b/tools/theme_chooser.sh
@@ -9,6 +9,12 @@
 
 THEMES_DIR="$ZSH/themes"
 FAVLIST="${HOME}/.zsh_favlist"
+
+if [ -z "$ZSH" ]; then
+    echo "You probably need to set the environment value $ZSH, e.g. 'export ZSH; $0'"
+    exit
+fi
+
 source $ZSH/oh-my-zsh.sh
 
 function noyes() {


### PR DESCRIPTION
The theme-chooser tool is a bit tricky to use otherwise. If the env. var $ZSH isn't set, then theme-chooser is unable to source various files and fails to run. This patch warns and then exits is $ZSH is not set. 
