### PR TITLE
pathmunge

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -33,4 +33,38 @@ plugins=(git)
 
 source $ZSH/oh-my-zsh.sh
 
+# Provide pathmunge for /etc/profile.d scripts                                       
+pathmunge()                                                                          
+{                                                                                    
+if ! echo $PATH | /bin/grep -qE "(^|:)$1($|:)" ; then                            
+  if [ "$2" = "after" ] ; then                                                 
+    PATH=$PATH:$1                                                            
+  else                                                                         
+    PATH=$1:$PATH                                                            
+  fi                                                                                                                                                                                                                                 
+fi                                                                               
+}
+
+_src_etc_profile_d()
+{
+    #  Make the *.sh things happier, and have possible ~/.zshenv options like
+    # NOMATCH ignored.
+    emulate -L ksh
+
+
+    # from bashrc, with zsh fixes
+    if [[ ! -o login ]]; then # We're not a login shell
+        for i in /etc/profile.d/*.sh; do
+            if [ -r "$i" ]; then
+                . $i
+            fi
+        done
+        unset i
+    fi
+}
+_src_etc_profile_d
+
+unset -f pathmunge _src_etc_profile_d
+
 # Customize to your needs...
+


### PR DESCRIPTION
pathmunge was missing on fedora, so I added it hopefully to the right place. Without it stuff in /etc/profile.d is ignored.
