### PR TITLE
Make the 'd' alias only show the directories that can be cd'd to using the number aliases.

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -36,7 +36,7 @@ cd () {
 
 alias md='mkdir -p'
 alias rd=rmdir
-alias d='dirs -v'
+alias d='dirs -v | head -10'
 
 # mkdir & cd to it
 function mcd() { 


### PR DESCRIPTION
It is annoying how if you have had a shell open for a while the 'd' alias will show far more directories then you can jump to using the 1,2,3,4,... aliases. This patch limits the number of directories shown by 'd' to the 10 you can jump to.
