### PR TITLE
README should have link to wiki for plugins

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -43,7 +43,7 @@ You _might_ need to modify your PATH in ~/.zshrc if you're not able to find some
 
 h2. Usage
 
-* enable the plugins you want in your @~/.zshrc@ (take a look at @plugins/@ to see what's possible)
+* enable the plugins you want in your @~/.zshrc@ (take a look at the @plugins/@ directory and the "wiki":https://github.com/robbyrussell/oh-my-zsh/wiki/Plugins to see what's possible)
 ** example: @plugins=(git osx ruby)@
 * Theme support: Change the @ZSH_THEME@ environment variable in @~/.zshrc@.
 ** Take a look at the "current themes":https://wiki.github.com/robbyrussell/oh-my-zsh/themes that come bundled with _Oh My Zsh_.


### PR DESCRIPTION
The wiki is more readable than going to the plugins directory in Finder or terminal etc. and navigating around. I've added a link from the README.textile file.
