### PR TITLE
Update autojump pluging to check for manual local installation

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -3,6 +3,8 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . /usr/share/autojump/autojump.zsh
   elif [ -f /etc/profile.d/autojump.zsh ]; then # manual installation
     . /etc/profile.d/autojump.zsh
+  elif [ -f ~/.autojump/etc/profile.d/autojump.zsh ]; then # manual local installation
+    . ~/.autojump/etc/profile.d/autojump.zsh
   elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump ]; then # mac os x with brew
     . `brew --prefix`/etc/autojump
   fi


### PR DESCRIPTION
Recent versions of autojump have the option of installing locally into the user's home directory. I've updated the plugin to check for the local location and source it if necessary.
