### PR TITLE
Added -r option to PAGER

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -9,5 +9,5 @@ bindkey "^[m" copy-prev-shell-word
 setopt long_list_jobs
 
 ## pager
-export PAGER=less
+export PAGER='less -r'
 export LC_CTYPE=$LANG


### PR DESCRIPTION
Hi, 
I added the -r option so that less can display control character properly. This is especially needed for things like IPython, which uses $PAGER to figure what pager program to use.

Keep up with the great work on oh-my-zsh!

Cheers!

Giovanni
