### PR TITLE
Fix gnzh theme to detect local rvm installations

### DIFF
--- a/themes/gnzh.zsh-theme
+++ b/themes/gnzh.zsh-theme
@@ -6,7 +6,7 @@ autoload -U colors zsh/terminfo # Used in the colour alias below
 colors
 setopt prompt_subst
 
-# make some aliases for the colours: (coud use normal escap.seq's too)
+# make some aliases for the colours: (could use normal escape sequences too)
 for color in RED GREEN YELLOW BLUE MAGENTA CYAN WHITE; do
   eval PR_$color='%{$fg[${(L)color}]%}'
 done
@@ -25,7 +25,7 @@ elif [[ $UID -eq 0 ]]; then # root
 fi
 
 # Check if we are on SSH or not
-if [[ -n "$SSH_CLIENT"  ||  -n "$SSH2_CLIENT" ]]; then 
+if [[ -n "$SSH_CLIENT"  ||  -n "$SSH2_CLIENT" ]]; then
   eval PR_HOST='${PR_YELLOW}%M${PR_NO_COLOR}' #SSH
 else
   eval PR_HOST='${PR_GREEN}%M${PR_NO_COLOR}' # no SSH
@@ -36,12 +36,12 @@ local return_code="%(?..%{$PR_RED%}%? ↵%{$PR_NO_COLOR%})"
 local user_host='${PR_USER}${PR_CYAN}@${PR_HOST}'
 local current_dir='%{$PR_BOLD$PR_BLUE%}%~%{$PR_NO_COLOR%}'
 local rvm_ruby=''
-if which rvm-prompt &> /dev/null; then
+if ${HOME}/.rvm/bin/rvm-prompt &> /dev/null; then # detect local user rvm installation
+  rvm_ruby='%{$PR_RED%}‹$(${HOME}/.rvm/bin/rvm-prompt i v g s)›%{$PR_NO_COLOR%}'
+elif which rvm-prompt &> /dev/null; then # detect sysem-wide rvm installation
   rvm_ruby='%{$PR_RED%}‹$(rvm-prompt i v g s)›%{$PR_NO_COLOR%}'
-else
-  if which rbenv &> /dev/null; then
-    rvm_ruby='%{$PR_RED%}‹$(rbenv version | sed -e "s/ (set.*$//")›%{$PR_NO_COLOR%}'
-  fi
+elif which rbenv &> /dev/null; then # detect Simple Ruby Version management
+  rvm_ruby='%{$PR_RED%}‹$(rbenv version | sed -e "s/ (set.*$//")›%{$PR_NO_COLOR%}'
 fi
 local git_branch='$(git_prompt_info)%{$PR_NO_COLOR%}'
 


### PR DESCRIPTION
gnzh rvm detection only detects system wide installations. I've fixed it so it now detects local installs too.

Since themes is loaded fairly early in `.zshrc`, rvm loading scripts and user path additions are usually aren't run until near the end. As a result, even though `rvm-prompt` works just fine in an interactive shell it's not detected when the theme is loaded.
