### PR TITLE
Added git and zsh detection before installing.

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,3 +1,15 @@
+if ! git --version >/dev/null 2>&1
+then
+  echo "\033[0;33mCan't find git.\033[0m You need to install \033[1;31mgit\033[0m if you want to install oh-my-zsh"
+  exit
+fi
+
+if ! zsh --version >/dev/null 2>&1
+then
+  echo "\033[0;33mCan't find zsh.\033[0m You need to install \033[1;31mzsh\033[0m if you want to install oh-my-zsh"
+  exit
+fi
+
 if [ -d ~/.oh-my-zsh ]
 then
   echo "\033[0;33mYou already have Oh My Zsh installed.\033[0m You'll need to remove ~/.oh-my-zsh if you want to install"


### PR DESCRIPTION
Hi!

I added git and zsh detection before installing oh-my-zsh.

This detection might sound redundant, but is actually useful because it happened to me too many times, to install oh-my-zsh on a clean vps, before installing git and zsh. In this particular case, the script always outputs "oh-my-zsh installed." which is not correct.

Cheers!
