### PR TITLE
Auto title now disabled in emacs term mode

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -3,7 +3,9 @@
 #Fully support screen, iterm, and probably most modern xterm and rxvt
 #Limited support for Apple Terminal (Terminal can't set window or tab separately)
 function title {
-  [ "$DISABLE_AUTO_TITLE" != "true" ] || return
+  if [[ "$DISABLE_AUTO_TITLE" == "true" ]] || [[ "$EMACS" == *term* ]]; then
+    return
+  fi
   if [[ "$TERM" == screen* ]]; then
     print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
   elif [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then


### PR DESCRIPTION
Emacs term mode has issues with the method of terminal titling used. It will print out the fully expanded command and/or the title line before and/or after commands are executed. This will happen regardless of whether or not a theme is in use, however themes may cause additional output.
ex:
chaosdata@box:~% ls
2;ls --color=tty;ls<output>

Emacs term mode adds, among other things, an environmental variable "EMACS" set to a version string (ex "23.3.1 (term:0.96)" ). I changed the logic in title to determine whether or not the terminal emulator is Emacs, and then not set a title if the former is true.
