### PR TITLE
Use git internal's @{upstream} reference to notice unmerged commits to a remote

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -19,11 +19,10 @@ parse_git_dirty() {
 }
 
 
-# Checks if there are commits ahead from remote
+# Checks if there are commits ahead the upstream (the tracked remote branch)
 function git_prompt_ahead() {
-  if $(echo "$(git log origin/$(current_branch)..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
-    echo "$ZSH_THEME_GIT_PROMPT_AHEAD"
-  fi
+  local cherries=$(git cherry @{upstream}) 2> /dev/null
+  [ $cherries ] && echo "$ZSH_THEME_GIT_PROMPT_AHEAD"
 }
 
 # Formats prompt string for current git commit short SHA


### PR DESCRIPTION
We could try to guess the tracked remote branch by hardcoding the remote to `origin` and using the current branch name as the remote branch. This can work most of the time, but it is not robust. What if you set your master branch to push to another remote? This happens when I play with two or more forks on Github, I set the `origin` to the original repo I cloned from first and then fork thereafter.

I think using git internal reference to @{upstream} should be bullet proof for any kind of possible configuration you may have. And it is quite clean. Unknown but clean.

What do you think?
