### PR TITLE
pow plugin - commands to restart pow and list urls

### DIFF
--- a/plugins/pow/pow.plugin.zsh
+++ b/plugins/pow/pow.plugin.zsh
@@ -72,5 +72,14 @@ powed(){
   find ~/.pow/ -type l -lname "*$basedir*" -exec basename {}'.dev' \;
 }
 
+# Restart pow process
+# taken from http://www.matthewratzloff.com/blog/2011/12/23/restarting-pow-when-dns-stops-responding
+repow(){
+  lsof | grep 20560 | awk '{print $2}' | xargs kill -9
+  launchctl unload ~/Library/LaunchAgents/cx.pow.powd.plist
+  launchctl load ~/Library/LaunchAgents/cx.pow.powd.plist
+  echo "restarted pow"
+}
+
 # View the standard out (puts) from any pow app
 alias kaput="tail -f ~/Library/Logs/Pow/apps/*"


### PR DESCRIPTION
I refactored the rake_root_detect function a bit so we have a function to find just the root rack directory without the sed to cut out the tld.

Added repow to restart the pow process
