### PR TITLE
New theme, modification of existing theme

### DIFF
--- a/themes/terminalparty-parens-fix.zsh-theme
+++ b/themes/terminalparty-parens-fix.zsh-theme
@@ -1,0 +1,9 @@
+PROMPT='%{$fg[green]%} %% '
+# RPS1='%{$fg[blue]%}%~%{$reset_color%} '
+RPS1='%{$fg[white]%}%2~$(git_prompt_info) %{$fg_bold[blue]%}%m%{$reset_color%}'
+
+ZSH_THEME_GIT_PROMPT_PREFIX=" %{$fg[yellow]%}("
+ZSH_THEME_GIT_PROMPT_SUFFIX=")%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_CLEAN=""
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[red]%} ⚡%{$fg[yellow]%}"
+


### PR DESCRIPTION
The existing 'terminalparty' theme has a white left parenthesis and a yellow right parenthesis for the git prompt. My commit adds a new theme 'terminalparty-parens-fix' to make both parentheses yellow.
