### PR TITLE
Don't clobber standard Esc+. behavior

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -3,7 +3,6 @@
 bindkey -e
 bindkey '\ew' kill-region
 bindkey -s '\el' "ls\n"
-bindkey -s '\e.' "..\n"
 bindkey '^r' history-incremental-search-backward
 bindkey "^[[5~" up-line-or-history
 bindkey "^[[6~" down-line-or-history


### PR DESCRIPTION
Esc+. works as "last arg" on both bash and zsh. Seems like a shame to introduce a new standard.
