### PR TITLE
Updating was breaking

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,6 +1,6 @@
 current_path=`pwd`
 printf '\033[0;34m%s\033[0m\n' "Upgrading Oh My Zsh"
-cd $ZSH
+cd "$ZSH"
 
 if git pull origin master
 then


### PR DESCRIPTION
When I tried to update ZSH I was getting an error that the path didn't exist, this was because there's a space in my user directory, the fix was to add double-quotes around `$ZSH` in line 3 of tools/upgrade.sh
