### PR TITLE
make git_prompt_info aware of detached HEAD and tags

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -3,7 +3,7 @@ function git_prompt_info() {
   ref=$(git symbolic-ref HEAD 2> /dev/null)
   if [ -z $ref ]; then
     # check if in detached HEAD mode
-    branch_name=$(git status -sb $(git_submodule_syntax) 2> /dev/null)
+    branch_name=$(git status -sb $(git_submodule_syntax) 2> /dev/null | head -n 1)
     if [ "$branch_name" = "## HEAD (no branch)" ]; then
       # set tag name if found
       tag_name=$(git name-rev --name-only $(git --no-pager show --stat 2> /dev/null | head -n 1 | awk '{ print $2 }') 2> /dev/null)


### PR DESCRIPTION
This patch updates the git_prompt_info function to first look at whether or not the repository is in a detached HEAD state and, if so, to attempt to determine if a tag is currently checked out.

I think this is a useful addition, since currently when a repository is in this state, git_prompt_info returns a blank string, which can lead users to falsely believe they are not in a git repository at all.

Please tell me if I have broken any style or scripting guidelines and I will make corrections.  Thanks for all your hard work.
