### PR TITLE
include default completion matcher if CASE_SENSITIVE

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -12,7 +12,7 @@ zmodload -i zsh/complist
 
 ## case-insensitive (all),partial-word and then substring completion
 if [ "x$CASE_SENSITIVE" = "xtrue" ]; then
-  zstyle ':completion:*' matcher-list 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
+  zstyle ':completion:*' matcher-list '' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
   unset CASE_SENSITIVE
 else
   zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'


### PR DESCRIPTION
Without this, completion behavior is odd. e.g., given the four files: `fooA.ext, fooA.ext2, fooB.ext, fooB.ext2`, typing `f<tab>` results in `f.ext<cursor>` making completion to either `fooA.ext` or `fooB.ext` difficult.

(This occurs often in python source trees with `prefix*.py{,c}` files)

This change makes the behavior identical to the case-insensitive completion with the exception, of course, of case sensitivity.
