### PR TITLE
Removed annoying newline at the start of each prompt.

### DIFF
--- a/themes/juanghurtado.zsh-theme
+++ b/themes/juanghurtado.zsh-theme
@@ -40,7 +40,6 @@ ZSH_THEME_GIT_PROMPT_SHA_BEFORE=" %{$WHITE%}[%{$YELLOW%}"
 ZSH_THEME_GIT_PROMPT_SHA_AFTER="%{$WHITE%}]"
 
 # Prompt format
-PROMPT='
-%{$GREEN_BOLD%}%n@%m%{$WHITE%}:%{$YELLOW%}%~%u$(parse_git_dirty)$(git_prompt_ahead)%{$RESET_COLOR%}
+PROMPT='%{$GREEN_BOLD%}%n@%m%{$WHITE%}:%{$YELLOW%}%~%u$(parse_git_dirty)$(git_prompt_ahead)%{$RESET_COLOR%}
 %{$BLUE%}>%{$RESET_COLOR%} '
 RPROMPT='%{$GREEN_BOLD%}$(current_branch)$(git_prompt_short_sha)$(git_prompt_status)%{$RESET_COLOR%}'


### PR DESCRIPTION
Perhaps it was deliberate, but I found the newline particularly annoying, especially after `clear`ing my screen, as it leaves a blank line at the top of the screen. If a blank line is really desired, it should probably go at the end.
