### PR TITLE
Use $ZSH_CUSTOM when looking for custom themes.

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -65,9 +65,9 @@ then
 else
   if [ ! "$ZSH_THEME" = ""  ]
   then
-    if [ -f "$ZSH/custom/$ZSH_THEME.zsh-theme" ]
+    if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]
     then
-      source "$ZSH/custom/$ZSH_THEME.zsh-theme"
+      source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
     else
       source "$ZSH/themes/$ZSH_THEME.zsh-theme"
     fi


### PR DESCRIPTION
the theme lookup was using `$ZSH/custom`, which didn't allow overriding with `$ZSH_CUSTOM`.
