### PR TITLE
Addition of Battery Status to the pygmalion theme.

### DIFF
--- a/themes/milind.zsh-theme
+++ b/themes/milind.zsh-theme
@@ -1,4 +1,5 @@
-# Yay! High voltage and arrows!
+#Some cool additions to the awesome pygmalion theme
+#Milind Shakya
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$reset_color%}%{$fg[green]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "


### PR DESCRIPTION
Added a theme "pygmalion-battery.zsh-theme" that shows battery percentage, red if less than 15%, yellow if less than 60%, and green if less than 96%. 
