### PR TITLE
RVM plugin: use latest rubies

### DIFF
--- a/plugins/rvm/rvm.plugin.zsh
+++ b/plugins/rvm/rvm.plugin.zsh
@@ -1,8 +1,8 @@
 alias rubies='rvm list rubies'
 alias gemsets='rvm gemset list'
 
-local ruby18='ruby-1.8.7-p334'
-local ruby19='ruby-1.9.2-p180'
+local ruby18='ruby-1.8.7-p358'
+local ruby19='ruby-1.9.3-p125'
 
 function rb18 {
 	if [ -z "$1" ]; then


### PR DESCRIPTION
These variables are hard-coded into the RVM plugin. They are updated to refer to the latest ruby patches available.
