### PR TITLE
Bwana plugin for reading man pages in the browser

### DIFF
--- a/plugins/bwana/bwana.plugin.zsh
+++ b/plugins/bwana/bwana.plugin.zsh
@@ -1,0 +1,13 @@
+#
+# Requires http://www.bruji.com/bwana/
+#
+if [[ -e /Applications/Bwana.app ]] ||
+    ( system_profiler -detailLevel mini SPApplicationsDataType | grep -q Bwana )
+then
+  function man() {
+    open "man:$1"
+  }
+else
+  echo "Bwana lets you read man files in Safari through a man: URI scheme" 
+  echo "To use it within Zsh, install it from http://www.bruji.com/bwana/"
+fi


### PR DESCRIPTION
I added console integration for reading man pages in the browser using a "man:" url scheme. This way `man whatever` will open in the browser.

See http://www.bruji.com/bwana/
