### PR TITLE
Add configuration placeholders to installer template

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -44,4 +44,21 @@ plugins=(git)
 
 source $ZSH/oh-my-zsh.sh
 
-# Customize to your needs...
+# User configuration
+
+export PATH=$HOME/bin:/usr/local/bin:$PATH
+# export MANPATH="/usr/local/man:$MANPATH"
+
+# # Preferred editor for local and remote sessions
+# if [[ -n $SSH_CONNECTION ]]; then
+#   export EDITOR='vim'
+# else
+#   export EDITOR='mvim'
+# fi
+
+# Compilation flags
+# export ARCHFLAGS="-arch x86_64"
+
+# ssh
+# export SSH_KEY_PATH="~/.ssh/dsa_id"
+

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -21,7 +21,9 @@ echo "\033[0;34mUsing the Oh My Zsh template file and adding it to ~/.zshrc\033[
 cp ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc
 
 echo "\033[0;34mCopying your current PATH and adding it to the end of ~/.zshrc for you.\033[0m"
-echo "export PATH=\$PATH:$PATH" >> ~/.zshrc
+sed -i -e "/export PATH=/ c\\
+export PATH=\"$PATH\"
+" ~/.zshrc
 
 echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
 chsh -s `which zsh`
@@ -34,5 +36,6 @@ echo "\033[0;32m"'\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/  '"\033[0m
 echo "\033[0;32m"'                        /____/                       '"\033[0m"
 
 echo "\n\n \033[0;32m....is now installed.\033[0m"
+echo "\n\n \033[0;32mPlease look over the ~/.zshrc file to select plugins, themes, and options.\033[0m"
 /usr/bin/env zsh
 source ~/.zshrc


### PR DESCRIPTION
The installer script should say where to go and what to do with the installed configuration.

I added some commented lines in the zshrc template to show what kind of customization belongs in there. (PATH, EDITOR, etc.)
