### PR TITLE
psgrep plugin

### DIFF
--- a/plugins/psgrep/psgrep.plugin.zsh
+++ b/plugins/psgrep/psgrep.plugin.zsh
@@ -1,0 +1,7 @@
+# Grep out of ps.  Cut to 80 chars
+function psgrep 
+{ 
+   /bin/ps alxw |head -1
+   /bin/ps alxw |grep $1 |grep -v "grep $1" |cut -c 1-$COLUMNS
+}
+


### PR DESCRIPTION
This is an alias/command that I've carried around in various shells

psgrep <string>

displays all processes matching the string (trimmed to you window width, and excludes the grep itself)
