### PR TITLE
Adding the psgrep plugin

### DIFF
--- a/plugins/psgrep/psgrep.plugin.zsh
+++ b/plugins/psgrep/psgrep.plugin.zsh
@@ -1,0 +1,7 @@
+# Grep out of ps.  Cut to 80 chars
+function psgrep 
+{ 
+   /bin/ps alxw |head -1
+   /bin/ps alxw |grep $1 |grep -v "grep $1" |cut -c 1-$COLUMNS
+}
+


### PR DESCRIPTION
Trying this again.  

I've been carrying psgrep around in tcsh/csh/bash/zsh.  I use it almost daily.

psgrep <string>

ouptuts a process list that matches string.  it's smart enough to not match itself.  Cuts off at terminal window width.

Hope you find it useful.
