### PR TITLE
Fix template .zshrc by exporting ZSH

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -1,5 +1,5 @@
 # Path to your oh-my-zsh configuration.
-ZSH=$HOME/.oh-my-zsh
+export ZSH=$HOME/.oh-my-zsh
 
 # Set name of the theme to load.
 # Look in ~/.oh-my-zsh/themes/


### PR DESCRIPTION
When setting up manually, template .zshrc worked for me but the source of oh-my-zsh.sh at the end would fail until ZSH was exported.

ERRORS I WAS GETTING
sh: can't open input file: /tools/check_for_upgrade.sh
./oh-my-zsh.sh: line 14: syntax error near unexpected token `('
./oh-my-zsh.sh: line 14:`for config_file ($ZSH/lib/*.zsh) source $config_file'
