### PR TITLE
New clean theme - "Mefisto"

### DIFF
--- a/themes/mefisto.zsh-theme
+++ b/themes/mefisto.zsh-theme
@@ -1,12 +1,17 @@
 # diff color for root shell
 if [ $UID -eq 0 ]; then 
-        NCOLOR="red"; else NCOLOR="green"; fi
+        NCOLOR="red"
+        PCOLOR="red" 
+else 
+        NCOLOR="green" 
+        PCOLOR="green"
+fi
 
 # diff color for host if on SSH session
 if [[ -n "${SSH_CLIENT}"  ||  -n "${SSH2_CLIENT}" ]]; then 
         HCOLOR="yellow"; else HCOLOR="green"; fi
 
-PROMPT='%{$fg[cyan]%}[%{$reset_color%}%{$fg[$NCOLOR]%}%n%{$reset_color%}%{$fg[cyan]%}@%{$reset_color%}%{$fg[$HCOLOR]%}%m%{$reset_color%}%{$fg[cyan]%}]%{$reset_color%}%{$fg[cyan]%}[%{$reset_color%}%{$fg[blue]%}%B%c/%b%{$reset_color%}%{$fg[cyan]%}]%{$reset_color%}%{$fg[green]%}%#%{$reset_color%} '
+PROMPT='%{$fg[cyan]%}[%{$reset_color%}%{$fg[$NCOLOR]%}%n%{$reset_color%}%{$fg[cyan]%}@%{$reset_color%}%{$fg[$HCOLOR]%}%m%{$reset_color%}%{$fg[cyan]%}]%{$reset_color%}%{$fg[cyan]%}[%{$reset_color%}%{$fg[blue]%}%B%c/%b%{$reset_color%}%{$fg[cyan]%}]%{$reset_color%}%{$fg[$PCOLOR]%}%#%{$reset_color%} '
 
 RPROMPT='$(git_prompt_info)'
 


### PR DESCRIPTION
Hi
Just started using oh-my-zsh and couldn't find any theme that was clean and minimal (no rainbow colors, no 3 lines for prompt :D) and would
1) highlight root prompt
2) highlight host when on ssh
3) put any repository related info to right side prompt

So I ported my old prompt and here's what came out:

![screencap](http://farm8.staticflickr.com/7112/7118972869_7f4efd9878_c.jpg)
