### PR TITLE
Added ability to override default `bundle exec` commands in custom configuration file

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -6,7 +6,13 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate cap capify cucumber ey foreman guard heroku middleman nanoc rackup rainbows rails rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails)
+if [ -f $ZSH_CUSTOM/bundle-commands.zsh ]; then
+  source $ZSH_CUSTOM/bundle-exec.zsh
+fi
+
+if [[ -z "${bundled_commands}" ]]; then
+  bundled_commands=(annotate cap capify cucumber ey foreman guard heroku middleman nanoc rackup rainbows rails rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails)
+fi
 
 ## Functions
 


### PR DESCRIPTION
I'm not sure if this is the best way to go about this, so feel free to improve. But being able to easily configure this would be helpful. In the mean time, I'm just overriding the default plugin.
