### PR TITLE
Fix the svn plugin only outputting the 1st path segment

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -16,7 +16,7 @@ function svn_get_repo_name {
     if [ $(in_svn) ]; then
         svn info | sed -n 's/Repository\ Root:\ .*\///p' | read SVN_ROOT
     
-        svn info | sed -n "s/URL:\ .*$SVN_ROOT\///p" | sed "s/\/.*$//"
+        svn info | sed -n "s/URL:\ .*$SVN_ROOT\///p"
     fi
 }
 


### PR DESCRIPTION
Currently, the svn plugin only shows the first path segment after the URL, which breaks when using a standard trunk/branches/tags(/releases) Subversion layout.
