### PR TITLE
BUGFIX: load custom themes from user defined custom path

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -65,9 +65,9 @@ then
 else
   if [ ! "$ZSH_THEME" = ""  ]
   then
-    if [ -f "$ZSH/custom/$ZSH_THEME.zsh-theme" ]
+    if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]
     then
-      source "$ZSH/custom/$ZSH_THEME.zsh-theme"
+      source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
     else
       source "$ZSH/themes/$ZSH_THEME.zsh-theme"
     fi


### PR DESCRIPTION
User kibs added the functionality to manually set the location of the custom directory via `$ZSH_CUSTOM` in this commit: https://github.com/robbyrussell/oh-my-zsh/commit/3780247f633d99b6870e39ea77c540ebb5125095 .

It seems though, that he forgot to change the path for custom themes. Currently, themes that aren't found in the default `$ZSH/themes` directory are loaded from `$ZSH/custom`. They should be loaded from  `$ZSH_CUSTOM` instead, to allow users to place their own themes outside the oh-my-zsh directory, too. This way, they can track their themes via Git (or whatever they use) which is currently not possible.
