### PR TITLE
tell users about the possibility to use a different `custom/` directory

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -58,7 +58,7 @@ h3. Customization
 If you want to override any of the default behavior, just add a new file (ending in @.zsh@) into the @custom/@ directory.
 If you have many functions which go well together you can put them as a *.plugin.zsh file in the @custom/plugins/@ directory and then enable this plugin.
 If you would like to override the functionality of a plugin distributed with oh-my-zsh, create a plugin of the same name in the @custom/plugins/@ directory and it will be loaded instead of the one in @plugins/@.
-
+You may specify a different location for your @custom/@ directory by setting @$ZSH_CUSTOM@ to your desired location in your @~/.zshrc@.
 
 h3. Uninstalling
 


### PR DESCRIPTION
Users should be informed about the possibility to use a different `custom/` directory via `$ZSH_CUSTOM`. I added a line in the `Readme`, that describes this option.
