### PR TITLE
.DS_Store & .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ custom/*
 !custom/example.zsh
 cache
 *.swp
+.DS_Store


### PR DESCRIPTION
It really bugged to never have a clean git repo just because of a `.DS_Store` sitting in the `themes` directory. `.DS_Store` files are generated by Mac OS X and are virtually impossible to remove. As it hurts nobody I'd suggest to add `.DS_Store` to the `.gitignore` so that the repo keeps clean (better for updates, too).
