### PR TITLE
Fix $ZSH_CUSTOM variable

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -65,12 +65,11 @@ then
 else
   if [ ! "$ZSH_THEME" = ""  ]
   then
-    if [ -f "$ZSH/custom/$ZSH_THEME.zsh-theme" ]
+    if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]
     then
-      source "$ZSH/custom/$ZSH_THEME.zsh-theme"
+      source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
     else
       source "$ZSH/themes/$ZSH_THEME.zsh-theme"
     fi
   fi
 fi
-


### PR DESCRIPTION
When you set `$ZSH_CUSTOM` to anything else than `$ZSH/custom` two odd things happen:
- If there are no `*.zsh` files in your new `$ZSH_CUSTOM` path, zsh prints a "no matches found" error.
- Themes in `$ZSH_CUSTOM` can not be loaded.

This pull request fixes both of those issues :)
