### PR TITLE
rbenv plugin now properly finds any rbenv in the PATH

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -1,43 +1,36 @@
-FOUND_RBENV=0
-for rbenvdir in "$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv" ; do
-  if [ -d $rbenvdir/bin -a $FOUND_RBENV -eq 0 ] ; then
-    FOUND_RBENV=1
-    export RBENV_ROOT=$rbenvdir
-    export PATH=${rbenvdir}/bin:$PATH
-    eval "$(rbenv init -)"
+if [[ $+commands[rbenv] -eq 1 ]] ; then
 
-    alias rubies="rbenv versions"
-    alias gemsets="rbenv gemset list"
+  eval "$(rbenv init -)"
 
-    function current_ruby() {
-      echo "$(rbenv version-name)"
-    }
+  alias rubies="rbenv versions"
+  alias gemsets="rbenv gemset list"
 
-    function current_gemset() {
-      echo "$(rbenv gemset active 2&>/dev/null | sed -e ":a" -e '$ s/\n/+/gp;N;b a' | head -n1)"
-    }
+  function current_ruby() {
+    echo "$(rbenv version-name)"
+  }
 
-    function gems {
-      local rbenv_path=$(rbenv prefix)
-      gem list $@ | sed \
-        -Ee "s/\([0-9\.]+( .+)?\)/$fg[blue]&$reset_color/g" \
-        -Ee "s|$(echo $rbenv_path)|$fg[magenta]\$rbenv_path$reset_color|g" \
-        -Ee "s/$current_ruby@global/$fg[yellow]&$reset_color/g" \
-        -Ee "s/$current_ruby$current_gemset$/$fg[green]&$reset_color/g"
-    }
+  function current_gemset() {
+    echo "$(rbenv gemset active 2&>/dev/null | sed -e ":a" -e '$ s/\n/+/gp;N;b a' | head -n1)"
+  }
 
-    function rbenv_prompt_info() {
-      if [[ -n $(current_gemset) ]] ; then
-        echo "$(current_ruby)@$(current_gemset)"
-      else
-        echo "$(current_ruby)"
-      fi
-    }
-  fi
-done
-unset rbenvdir
+  function gems {
+    local rbenv_path=$(rbenv prefix)
+    gem list $@ | sed \
+      -Ee "s/\([0-9\.]+( .+)?\)/$fg[blue]&$reset_color/g" \
+      -Ee "s|$(echo $rbenv_path)|$fg[magenta]\$rbenv_path$reset_color|g" \
+      -Ee "s/$current_ruby@global/$fg[yellow]&$reset_color/g" \
+      -Ee "s/$current_ruby$current_gemset$/$fg[green]&$reset_color/g"
+  }
 
-if [ $FOUND_RBENV -eq 0 ] ; then
+  function rbenv_prompt_info() {
+    if [[ -n $(current_gemset) ]] ; then
+      echo "$(current_ruby)@$(current_gemset)"
+    else
+      echo "$(current_ruby)"
+    fi
+  }
+
+else
   alias rubies='ruby -v'
   function gemsets() { echo 'not supported' }
   function rbenv_prompt_info() { echo "system: $(ruby -v | cut -f-2 -d ' ')" }


### PR DESCRIPTION
An alternative solution to #888.  Fixes #878.

Rather than do our own searching, this gives the user full control of the PATH variable and of the search order for rbenv.  It's also probably faster, since we let zsh do the searching for us.

(Originally proposed [here](https://github.com/robbyrussell/oh-my-zsh/pull/888#issuecomment-5766243).)
