### PR TITLE
sublime pluginn : Added alias for Sublime Text 2 on Linux

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -1,8 +1,9 @@
 # Sublime Text 2 Aliases
 #unamestr = 'uname'
-if [[ uname == 'Linux' ]]; then
-	alias st='open -a /usr/bin/sublime_text'
-elif  [[ uname == 'Darwin' ]]; then
-	alias st='open -a "/Applications/Sublime Text 2.app'
+
+if [[ $('uname') == 'Linux' ]]; then
+	alias st='/usr/bin/sublime_text&'
+elif  [[ $('uname') == 'Darwin' ]]; then
+	alias st='open -a /Applications/Sublime Text 2.app'
 fi
 alias stt='st .'


### PR DESCRIPTION
Detects the platform using "uname", and sets the alias accordingly.
If you are using Linux, this assumes that you have created a
symbolic link to /usr/bin/sublime_text.

Varun Vijayaraghavan
varun.kvv@gmail.com
