### PR TITLE
added new alias 'acsh' for 'apt-cache show'

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -25,6 +25,7 @@ alias at='aptitude'
 
 # Some self-explanatory aliases
 alias acs="apt-cache search"
+alias acsh="apt-cache show"
 alias aps='aptitude search'
 alias as="aptitude -F \"* %p -> %d \n(%v/%V)\" \
 		--no-gui --disable-columns search"	# search package


### PR DESCRIPTION
Hello!

This simply adds another alias in the debian plugin
