### PR TITLE
Load symlink custom files

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -51,7 +51,7 @@ for plugin ($plugins); do
 done
 
 # Load all of your custom configurations from custom/
-for config_file ($ZSH_CUSTOM/*.zsh(.N)) source $config_file
+for config_file ($ZSH_CUSTOM/*.zsh(N)) source $config_file
 
 # Load the theme
 if [ "$ZSH_THEME" = "random" ]


### PR DESCRIPTION
`(.)` search only real files.
    The deletion of it enables searching symlink *.zsh files
