### PR TITLE
Removing 'ey' from bundled_commands

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -6,7 +6,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate cap capify cucumber ey foreman guard middleman nanoc rackup rainbows rails rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails)
+bundled_commands=(annotate cap capify cucumber foreman guard middleman nanoc rackup rainbows rails rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails)
 
 ## Functions
 


### PR DESCRIPTION
The engineyard gem should usually be installed as a system gem, not bundled with an app. There's usually no problem doing this, but there are some edge-cases where bundling the gem can cause problems.

Additionally, our documentation doesn't mention bundling the gem and we've just been dealing with a customer who had problems using the gem due to the oh-my-zsh bundler plugin trying to run ey via bundle exec.
