### PR TITLE
Added spin to bundled_commands (Bundler plugin)

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -6,7 +6,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate cap capify cucumber ey foreman guard middleman nanoc rackup rainbows rails rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails)
+bundled_commands=(annotate cap capify cucumber ey foreman guard middleman nanoc rackup rainbows rails rake rspec ruby shotgun spec spin spork thin thor unicorn unicorn_rails)
 
 ## Functions
 


### PR DESCRIPTION
There is a Spin project (https://github.com/jstorimer/spin) which add the `spin` executable command (https://github.com/jstorimer/spin/blob/master/bin/spin). It should be listed in `bundled_commands` as well.
