### PR TITLE
Change hardcoded ~/.oh-my-zsh to $ZSH.

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -46,7 +46,7 @@ zstyle ':completion:*:hosts' hosts $hosts
 
 # Use caching so that commands like apt and dpkg complete are useable
 zstyle ':completion::complete:*' use-cache 1
-zstyle ':completion::complete:*' cache-path ~/.oh-my-zsh/cache/
+zstyle ':completion::complete:*' cache-path $ZSH/cache/
 
 # Don't complete uninteresting users
 zstyle ':completion:*:*:*:users' ignored-patterns \

--- a/plugins/dirpersist/dirpersist.plugin.zsh
+++ b/plugins/dirpersist/dirpersist.plugin.zsh
@@ -12,7 +12,7 @@ dirpersistinstall () {
     if grep 'dirpersiststore' ~/.zlogout > /dev/null; then
     else
         if read -q \?"Would you like to set up your .zlogout file for use with dirspersist? (y/n) "; then
-            echo "# Store dirs stack\n# See ~/.oh-my-zsh/plugins/dirspersist.plugin.zsh\ndirpersiststore" >> ~/.zlogout
+            echo "# Store dirs stack\n# See $ZSH/plugins/dirspersist.plugin.zsh\ndirpersiststore" >> ~/.zlogout
         else
             echo "If you don't want this message to appear, remove dirspersist from \$plugins"
         fi


### PR DESCRIPTION
The completion setup ignored $ZSH and always created ~/.oh-my-zsh/cache, which kind of defeats the purpose of having ohmyzsh tucked away somewhere else.

The dirpersist plugin had also ~/.oh-my-zsh hardcoded, but only in a comment optionally written to ~/.zlogout.
