### PR TITLE
Steef theme - Don't list all files in a untracked directory

### DIFF
--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -81,7 +81,7 @@ add-zsh-hook chpwd steeef_chpwd
 function steeef_precmd {
     if [[ -n "$PR_GIT_UPDATE" ]] ; then
         # check for untracked files or updated submodules, since vcs_info doesn't
-        if [[ ! -z $(git ls-files --other --exclude-standard 2> /dev/null) ]]; then
+        if [[ ! -z $(git ls-files --other --exclude-standard --directory 2> /dev/null) ]]; then
             PR_GIT_UPDATE=1
             FMT_BRANCH="(%{$turquoise%}%b%u%c%{$hotpink%}●${PR_RST})"
         else


### PR DESCRIPTION
We only care if any untracked files exist.
Otherwise, untracked directories with many files causes the ohmyzsh prompt to hang while waiting for ls-files to complete.
