### PR TITLE
Steef theme - Improved git untracked file detection

### DIFF
--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -81,7 +81,7 @@ add-zsh-hook chpwd steeef_chpwd
 function steeef_precmd {
     if [[ -n "$PR_GIT_UPDATE" ]] ; then
         # check for untracked files or updated submodules, since vcs_info doesn't
-        if git ls-files --other --exclude-standard 2> /dev/null | grep -q "."; then
+        if git ls-files --other --exclude-standard --directory 2> /dev/null | grep -q "."; then
             PR_GIT_UPDATE=1
             FMT_BRANCH="(%{$turquoise%}%b%u%c%{$hotpink%}●${PR_RST})"
         else


### PR DESCRIPTION
Use `--directory` flag with the `git ls-files` command to prevent needlessly recursing into untracked directories.

Use grep to detect files in the ls-files output so zsh doesn't store the (potentially large) output from `ls-files`. 
