### PR TITLE
Explicitly tell rbenv to use zsh

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -4,7 +4,7 @@ for rbenvdir in "$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv" ; do
     FOUND_RBENV=1
     export RBENV_ROOT=$rbenvdir
     export PATH=${rbenvdir}/bin:$PATH
-    eval "$(rbenv init -)"
+    eval "$(rbenv init - zsh)"
 
     alias rubies="rbenv versions"
     alias gemsets="rbenv gemset list"


### PR DESCRIPTION
According to @graywh's comment on:
https://github.com/sstephenson/rbenv/issues/185
