### PR TITLE
rbenv plugin now uses 'brew --prefix rbenv' command to find rbenv folder

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -1,14 +1,14 @@
-function is_homebrew_installed() {
+_homebrew-installed() {
   type brew &> /dev/null
 }
 
-function is_rbenv_installed() {
+_rbenv-from-homebrew-installed() {
   brew --prefix rbenv &> /dev/null
 }
 
 FOUND_RBENV=0
 rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv")
-if is_homebrew_installed && is_rbenv_installed ; then
+if _homebrew-installed && _rbenv-from-homebrew-installed ; then
     rbenvdirs=($(brew --prefix rbenv) "${rbenvdirs[@]}")
 fi
 


### PR DESCRIPTION
Updated rbenv plugin to work correctly with homebrew
