### PR TITLE
Updates to style and svn plugin (correct branch display)

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -1,22 +1,21 @@
 function svn_prompt_info {
     if [ $(in_svn) ]; then
         echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_PREFIX\
-$ZSH_THEME_REPO_NAME_COLOR$(svn_get_repo_name)$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR$(svn_dirty)$ZSH_PROMPT_BASE_COLOR"
+$ZSH_THEME_REPO_NAME_COLOR$(svn_get_branch_name):$(svn_get_rev_nr)$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR$(svn_dirty)$ZSH_PROMPT_BASE_COLOR"
     fi
 }
 
-
 function in_svn() {
-    if [[ -d .svn ]]; then
+    info=$(svn info 2> /dev/null) || return
+    if [ $info ]; then
         echo 1
     fi
 }
 
-function svn_get_repo_name {
+function svn_get_branch_name {
     if [ $(in_svn) ]; then
-        svn info | sed -n 's/Repository\ Root:\ .*\///p' | read SVN_ROOT
-    
-        svn info | sed -n "s/URL:\ .*$SVN_ROOT\///p"
+      svn info | grep '^URL:' | egrep -o '(tags|branches)/[^/]+|trunk' | egrep -o '[^/]+$' | read SVN_URL
+      echo $SVN_URL
     fi
 }
 


### PR DESCRIPTION
Subversion 1.7 centralises metadata into a single location - a single
.svn directory in the project's root, rather than one for every
directory in the working copy. This change utilises 'svn info' to work
out whether or not the pwd is under subversion, so oh-my-zsh's svn
plugin will work regardless of the svn version.
