### PR TITLE
Plugin for git_remote_branch autocomplete.

### DIFF
--- a/plugins/git-remote-branch/git-remote-branch.plugin.zsh
+++ b/plugins/git-remote-branch/git-remote-branch.plugin.zsh
@@ -1,0 +1,18 @@
+_git_remote_branch() {
+  ref=$(git symbolic-ref HEAD 2> /dev/null)
+  if [[ -n $ref ]]; then
+    if (( CURRENT == 2 )); then
+      # first arg: operation
+      compadd create publish rename delete track
+    elif (( CURRENT == 3 )); then
+      # second arg: remote branch name
+      compadd `git branch -r | grep -v HEAD | sed "s/.*\///" | sed "s/ //g"`
+    elif (( CURRENT == 4 )); then
+      # third arg: remote name
+      compadd `git remote`
+    fi
+  else;
+    _files
+  fi
+}
+compdef _git_remote_branch grb


### PR DESCRIPTION
git_remote_branch is a wrapper for git. This plugin lets zsh autocomplete for that wrapper.
