### PR TITLE
Fixing install.sh to make it sh friendly.

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -6,7 +6,7 @@ fi
 
 echo "\033[0;34mCloning Oh My Zsh...\033[0m"
 which git > /dev/null
-if [[ $? -eq 0 ]]; then
+if [ $? -eq 0 ]; then
   /usr/bin/env git clone https://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh
 else
   echo "git not installed"


### PR DESCRIPTION
This should work, some people complained about how it couldn't find [[ which is a bash built in, so this is for devices that don't use bash (or some subset) as sh.
