### PR TITLE
Fix mismatched quote in yum plugin

### DIFF
--- a/plugins/yum/yum.plugin.zsh
+++ b/plugins/yum/yum.plugin.zsh
@@ -5,7 +5,7 @@ alias yp="yum info"                         # show package info
 alias yl="yum list"                         # list packages
 alias ygl="yum grouplist"                   # list package groups
 alias yli="yum list installed"              # print all installed packages
-alias ymc="yum makecache                    # rebuilds the yum package list
+alias ymc="yum makecache"                   # rebuilds the yum package list
 
 alias yu="sudo yum update"                  # upgrate packages
 alias yi="sudo yum install"                 # install package


### PR DESCRIPTION
Eliminates a warning when the yum plugin is used.
