### PR TITLE
Ruby patchlevels in the RVM plugin are out-of-date

### DIFF
--- a/plugins/rvm/rvm.plugin.zsh
+++ b/plugins/rvm/rvm.plugin.zsh
@@ -1,8 +1,8 @@
 alias rubies='rvm list rubies'
 alias gemsets='rvm gemset list'
 
-local ruby18='ruby-1.8.7-p334'
-local ruby19='ruby-1.9.2-p180'
+local ruby18='ruby-1.8.7-p352'
+local ruby19='ruby-1.9.3-p194'
 
 function rb18 {
 	if [ -z "$1" ]; then


### PR DESCRIPTION
Ruby [recommends](http://www.ruby-lang.org/en/downloads/) using the latest stable version 1.9.3-p194. Also, the command `rvm install 1.8.7` will install the latest 1.8.7-p352 patchlevel.
