### PR TITLE
Fix Sublime Text 2 path on MacOS

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -4,6 +4,6 @@
 if [[ $('uname') == 'Linux' ]]; then
 	alias st='/usr/bin/sublime_text&'
 elif  [[ $('uname') == 'Darwin' ]]; then
-	alias st='open -a /Applications/Sublime Text 2.app'
+	alias st='open -a /Applications/Sublime\ Text\ 2.app'
 fi
 alias stt='st .'


### PR DESCRIPTION
The path was not escaped which prevented sublime text from opening. This fixes it.
