### PR TITLE
Sublime plugin fix for Linux

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -1,9 +1,10 @@
 # Sublime Text 2 Aliases
-#unamestr = 'uname'
 
 if [[ $('uname') == 'Linux' ]]; then
-	alias st='/usr/bin/sublime_text&'
+	runst() { nohup /usr/bin/sublime-text-2 $@ > /dev/null & }
+	alias st=runst
 elif  [[ $('uname') == 'Darwin' ]]; then
-	alias st='open -a /Applications/Sublime Text 2.app'
+	alias st='open -a /Applications/Sublime\ Text\ 2.app'
 fi
 alias stt='st .'
+


### PR DESCRIPTION
- 'st' alias can take any arguments
- closing terminal session doesn't affect running Sublime Text instances
