### PR TITLE
Fix sublime path on MacOS X

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -4,6 +4,6 @@
 if [[ $('uname') == 'Linux' ]]; then
 	alias st='/usr/bin/sublime_text&'
 elif  [[ $('uname') == 'Darwin' ]]; then
-	alias st='open -a /Applications/Sublime Text 2.app'
+	alias st='open -a "/Applications/Sublime Text 2.app"'
 fi
 alias stt='st .'


### PR DESCRIPTION
There was the issue
~➤ st .
The files /Users/apple/Text and /Users/apple/2.app do not exist
