### PR TITLE
Add theme support to the mercurial plugin similar to the git one

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -12,3 +12,25 @@ alias hgp='hg push'
 alias hgs='hg status'
 # this is the 'git commit --amend' equivalent
 alias hgca='hg qimport -r tip ; hg qrefresh -e ; hg qfinish tip'
+
+# Theme vars and functions
+ZSH_THEME_HG_PROMPT_PREFIX="hg:("          # Prefix at the very beginning of the prompt, before the branch name
+ZSH_THEME_HG_PROMPT_SUFFIX=")"             # At the very end of the prompt
+ZSH_THEME_HG_PROMPT_DIRTY="*"              # Text to display if the branch is dirty
+ZSH_THEME_HG_PROMPT_CLEAN=""               # Text to display if the branch is clean
+
+# get the name of the branch we are on
+function hg_prompt_info() {
+  ref=$(hg branch 2> /dev/null) || return
+  echo "$ZSH_THEME_HG_PROMPT_PREFIX${ref}$(parse_hg_dirty)$ZSH_THEME_HG_PROMPT_SUFFIX"
+}
+
+# Checks if working tree is dirty
+parse_hg_dirty() {
+  if [[ -n $(hg status 2> /dev/null) ]]; then
+    echo "$ZSH_THEME_HG_PROMPT_DIRTY"
+  else
+    echo "$ZSH_THEME_HG_PROMPT_CLEAN"
+  fi
+}
+


### PR DESCRIPTION
Added ZSH_THEME_HG_PROMPT_PREFIX/SUFFIX/DIRTY/CLEAN vars and functions to go along with. An example theme using them can be seen here: https://github.com/cadetZemm/zemm-blinks.zsh-theme
