### PR TITLE
'rails' command should not be run with bundle exec

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -6,7 +6,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate cap capify cucumber foreman guard middleman nanoc rackup rainbows rails rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails)
+bundled_commands=(annotate cap capify cucumber foreman guard middleman nanoc rackup rainbows rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails)
 
 ## Functions
 


### PR DESCRIPTION
Right now among bundled commands is 'rails' command. According this articles:
http://blog.wyeworks.com/2011/12/27/bundle-exec-rails-executes-bundler-setup-3-times
http://yehudakatz.com/2011/05/30/gem-versioning-and-bundler-doing-it-right/
rails should not be run with bundle exec
