### PR TITLE
plugin for git-extras

### DIFF
--- a/plugins/git-extras/git-extras.plugin.zsh
+++ b/plugins/git-extras/git-extras.plugin.zsh
@@ -95,7 +95,7 @@ __git_author_names() {
 
 _git-changelog() {
     _arguments \
-        '(-l --list)'{-l, --list}'[list commits]' \
+        '(-l --list)'{-l,--list}'[list commits]' \
 }
 
 


### PR DESCRIPTION
This is a plugin for completion of the various commands added by git-extras (https://github.com/visionmedia/git-extras)

I'm quite new to zsh completion so the code is far from elegant.
Still, it should work as expected.
