### PR TITLE
Sublime plugin fix for Ubuntu

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -2,8 +2,10 @@
 #unamestr = 'uname'
 
 if [[ $('uname') == 'Linux' ]]; then
-	alias st='/usr/bin/sublime_text&'
+        runst() { nohup /usr/bin/sublime-text $@ > /dev/null & }
+        alias st=runst
 elif  [[ $('uname') == 'Darwin' ]]; then
-	alias st='/Applications/Sublime\ Text\ 2.app/Contents/SharedSupport/bin/subl'
+        alias st='open -a /Applications/Sublime\ Text\ 2.app'
 fi
 alias stt='st .'
+


### PR DESCRIPTION
- 'st' alias can take any arguments
- closing terminal session doesn't affect running Sublime Text instances
