### PR TITLE
Add branch status support to git_prompt_status

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -38,7 +38,7 @@ function git_prompt_long_sha() {
 
 # Get the status of the working tree
 git_prompt_status() {
-  INDEX=$(git status --porcelain 2> /dev/null)
+  INDEX=$(git status --porcelain -b 2> /dev/null)
   STATUS=""
   if $(echo "$INDEX" | grep '^?? ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
@@ -65,6 +65,15 @@ git_prompt_status() {
   fi
   if $(echo "$INDEX" | grep '^UU ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_UNMERGED$STATUS"
+  fi
+  if $(echo "$INDEX" | grep '^## .*ahead' &> /dev/null); then
+    STATUS="$ZSH_THEME_GIT_PROMPT_AHEAD$STATUS"
+  fi
+  if $(echo "$INDEX" | grep '^## .*behind' &> /dev/null); then
+    STATUS="$ZSH_THEME_GIT_PROMPT_BEHIND$STATUS"
+  fi
+  if $(echo "$INDEX" | grep '^## .*diverged' &> /dev/null); then
+    STATUS="$ZSH_THEME_GIT_PROMPT_DIVERGED$STATUS"
   fi
   echo $STATUS
 }


### PR DESCRIPTION
This patch makes git_prompt_status support three new status variables:
- ZSH_THEME_GIT_PROMPT_AHEAD
- ZSH_THEME_GIT_PROMPT_BEHIND
- ZSH_THEME_GIT_PROMPT_DIVERGED

With these extra variables it's easy to see (1) if you have commits in
your local branch that weren't pushed to the remote (AHEAD), (2) if
there are commits in the remote that you haven't merged/rebased yet
(BEHIND) or (3) if you have local unpushed commits AND the remote has
some commits you haven't merged yet (DIVERGED).

Refer to the first line displayed on `git status -b --porcelain`.

An example setup in a .zsh-theme file would be:

ZSH_THEME_GIT_PROMPT_AHEAD="↑"
ZSH_THEME_GIT_PROMPT_BEHIND="↓"
ZSH_THEME_GIT_PROMPT_DIVERGED="↕"
