### PR TITLE
Adding logic for ~/Applications folder installs of Sublime Text 2

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -1,9 +1,16 @@
 # Sublime Text 2 Aliases
 #unamestr = 'uname'
 
+local _sublime_darwin_subl=/Applications/Sublime\ Text\ 2.app/Contents/SharedSupport/bin/subl
+
 if [[ $('uname') == 'Linux' ]]; then
 	alias st='/usr/bin/sublime_text&'
 elif  [[ $('uname') == 'Darwin' ]]; then
-	alias st='/Applications/Sublime\ Text\ 2.app/Contents/SharedSupport/bin/subl'
+	# Check if Sublime is installed in user's home application directory
+	if [[ -a $HOME/${_sublime_darwin_subl} ]]; then
+		alias st='$HOME/${_sublime_darwin_subl}'
+	else
+		alias st='${_sublime_darwin_subl}'
+	fi
 fi
 alias stt='st .'


### PR DESCRIPTION
A nice feature for Mac users who use their Home Application folder 
