### PR TITLE
Add a configuration option to disable autocorrect

### DIFF
--- a/lib/correction.zsh
+++ b/lib/correction.zsh
@@ -1,10 +1,14 @@
-setopt correct_all
+if [[ "$DISABLE_CORRECTION" == "true" ]]; then
+  return
+else
+  setopt correct_all
 
-alias man='nocorrect man'
-alias mv='nocorrect mv'
-alias mysql='nocorrect mysql'
-alias mkdir='nocorrect mkdir'
-alias gist='nocorrect gist'
-alias heroku='nocorrect heroku'
-alias ebuild='nocorrect ebuild'
-alias hpodder='nocorrect hpodder'
+  alias man='nocorrect man'
+  alias mv='nocorrect mv'
+  alias mysql='nocorrect mysql'
+  alias mkdir='nocorrect mkdir'
+  alias gist='nocorrect gist'
+  alias heroku='nocorrect heroku'
+  alias ebuild='nocorrect ebuild'
+  alias hpodder='nocorrect hpodder'
+fi

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -23,6 +23,9 @@ ZSH_THEME="robbyrussell"
 # Uncomment following line if you want to disable autosetting terminal title.
 # DISABLE_AUTO_TITLE="true"
 
+# Uncomment following line if you want to disable command autocorrection
+# DISABLE_CORRECTION="true"
+
 # Uncomment following line if you want red dots to be displayed while waiting for completion
 # COMPLETION_WAITING_DOTS="true"
 


### PR DESCRIPTION
Although an 'unsetopt correct_all' as the end of .zshrc achieves the same thing, it's a little obtuse. This change provides a configuration option for autocorrect in the same vein as the existing options in the zshrc template.
