### PR TITLE
Changing Debian plugin `aptitude` alias to `att`

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -21,7 +21,7 @@ fi
 # These are for more obscure uses of apt-get and aptitude that aren't covered
 # below.
 alias ag='apt-get'
-alias at='aptitude'
+alias att='aptitude'
 
 # Some self-explanatory aliases
 alias acs="apt-cache search"


### PR DESCRIPTION
Previously, its alias was `at` which conflicted with the old school
UNIX application execution scheduling.

I chose between the alias `att` and `api`. I chose the former because
_api_ could be associated with _Application Programming Interface_.

This commit fixes issue #1141.
