### PR TITLE
Being more careful with .zshrc during install/uninstall.

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -13,9 +13,8 @@ hash git >/dev/null && /usr/bin/env git clone https://github.com/robbyrussell/oh
 echo "\033[0;34mLooking for an existing zsh config...\033[0m"
 if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]
 then
-  echo "\033[0;33mFound ~/.zshrc.\033[0m \033[0;32]Backing up to ~/.zshrc.pre-oh-my-zsh\033[0m";
-  cp ~/.zshrc ~/.zshrc.pre-oh-my-zsh;
-  rm ~/.zshrc;
+  echo "\033[0;33mFound ~/.zshrc\033[0m \033[0;32] -- Renaming to ~/.zshrc.pre-oh-my-zsh\033[0m";
+  mv ~/.zshrc ~/.zshrc.pre-oh-my-zsh;
 fi
 
 echo "\033[0;34mUsing the Oh My Zsh template file and adding it to ~/.zshrc\033[0m"

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -4,12 +4,20 @@ then
   rm -rf ~/.oh-my-zsh
 fi
 
-echo "Looking for an existing zsh config..."
+echo "Looking for original zsh config..."
 if [ -f ~/.zshrc.pre-oh-my-zsh ] || [ -h ~/.zshrc.pre-oh-my-zsh ]
 then
-  echo "Found ~/.zshrc. Backing up to ~/.zshrc.pre-oh-my-zsh";
-  rm ~/.zshrc;
-  cp ~/.zshrc.pre-oh-my-zsh ~/.zshrc;
+  echo "Found ~/.zshrc.pre-oh-my-zsh -- Restoring to ~/.zshrc";
+
+  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]
+  then
+    ZSHRC_SAVE=".zshrc.omz-uninstalled-`date +%Y%m%d%H%M%S`";
+    echo "Found ~/.zshrc -- Renaming to ~/${ZSHRC_SAVE}";
+    mv ~/.zshrc ~/${ZSHRC_SAVE};
+  fi
+
+  mv ~/.zshrc.pre-oh-my-zsh ~/.zshrc;
+
   source ~/.zshrc;
 else
   echo "Switching back to bash"


### PR DESCRIPTION
install.sh:
  In the case where copy fails, remove will probably succeed.
For example, if the file system were full.  So we're trying
to be more careful with .zshrc here.

uninstall.sh:
  The messages are not accurate to what the script is doing
with .zshrc -- It says, "Backing up to .zshrc.pre-oh-my-zsh"
but the next line removes it.  So we should rename .zshrc
instead of removing it before we restore the original.
