### PR TITLE
Typo in cd-wrapper

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -26,9 +26,9 @@ cd () {
   elif [[ "x$*" == "x...." ]]; then
     cd ../../..
   elif [[ "x$*" == "x....." ]]; then
-    cd ../../..
-  elif [[ "x$*" == "x......" ]]; then
     cd ../../../..
+  elif [[ "x$*" == "x......" ]]; then
+    cd ../../../../..
   else
     builtin cd "$@"
   fi


### PR DESCRIPTION
The commands `cd .....` (5 dots -> 4 up)  and `cd ......` (6 dots -> 5 up) go up one parent directory less than expected.
