### PR TITLE
Debian plugin now pipes which stderr to stdout

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -6,14 +6,14 @@
 
 # Use aptitude if installed, or apt-get if not.
 # You can just set apt_pref='apt-get' to override it.
-if [[ -e $( which aptitude ) ]]; then
+if [[ -e $( which aptitude 2>&1 ) ]]; then
     apt_pref='aptitude'
 else
     apt_pref='apt-get'
 fi
 
 # Use sudo by default if it's installed
-if [[ -e $( which sudo ) ]]; then
+if [[ -e $( which sudo 2>&1 ) ]]; then
     use_sudo=1
 fi
 


### PR DESCRIPTION
The debian plugin calls which to determine whether aptitude & sudo are
installed.  However, if these are not installed then the error output
from which will be output.  Since this isn't really an error condition,
this commit updates the which calls to pipe stderr to stdout, thus
hiding the error messages.
