### PR TITLE
Updated virtualenvwrapper plugin to use which

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -1,5 +1,5 @@
 WRAPPER_FOUND=0
-for wrapsource in "/usr/bin/virtualenvwrapper.sh" "/usr/local/bin/virtualenvwrapper.sh" "/etc/bash_completion.d/virtualenvwrapper" ; do
+for wrapsource in `which virtualenvwrapper.sh 2>&1` "/etc/bash_completion.d/virtualenvwrapper" ; do
   if [[ -e $wrapsource ]] ; then
     WRAPPER_FOUND=1
     source $wrapsource


### PR DESCRIPTION
Previously the virtualenvwrapper plugin contained some hard-coded paths
to potential locations for virtualenvwrapper.sh.  This works most of the
time, however this falls apart if virtualenvwrapper.sh is not installed
in one of the listed locations (for example if it's installed using pip
--user).

To fix, I've replaced the hard-coded /usr/bin and /usr/local/bin paths
with `which virtualenvwrapper.sh`. This should find the shell script
anywhere if it's on the path which seems like better behaviour than
relying on it being in specific locations.
