### PR TITLE
Update fishy theme to collapse working directory in PROMPT

### DIFF
--- a/themes/fishy.zsh-theme
+++ b/themes/fishy.zsh-theme
@@ -1,7 +1,11 @@
 # ZSH Theme emulating the Fish shell's default prompt.
 
+_fishy_collapsed_wd() {
+  echo $(pwd | perl -pe "s|^$HOME|~|g; s|/([^/])[^/]*(?=/)|/\$1|g")
+}
+
 local user_color='green'; [ $UID -eq 0 ] && user_color='red'
-PROMPT='%n@%m %{$fg[$user_color]%}%~%{$reset_color%}%(!.#.>) '
+PROMPT='%n@%m %{$fg[$user_color]%}$(_fishy_collapsed_wd)%{$reset_color%}%(!.#.>) '
 PROMPT2='%{$fg[red]%}\ %{$reset_color%}'
 
 local return_status="%{$fg_bold[red]%}%(?..%?)%{$reset_color%}"


### PR DESCRIPTION
For non-trailing path components, we show only the first character. So, as in Fish proper, a pathologically lengthy path like ~/some/really/really/really/long/path/name is collapsed to ~/s/r/r/r/l/p/name.
