### PR TITLE
Vagrant plugin: Rendering the 'vagrant box (remove|repackage)' completion code independant of Vagrant implementation details.

### DIFF
--- a/plugins/vagrant/_vagrant
+++ b/plugins/vagrant/_vagrant
@@ -43,7 +43,7 @@ __task_list ()
 
 __box_list ()
 {
-    _wanted application expl 'command' compadd $(command ls -1 $HOME/.vagrant/boxes 2>/dev/null| sed -e 's/ /\\ /g')
+    _wanted application expl 'command' compadd $(command vagrant box list | sed -e 's/ /\\ /g')
 }
 
 __vagrant-box ()


### PR DESCRIPTION
I was wondering why Vagrant's box-command related command-line completion wasn't working for me; somewhere along the line, Vagrant changed its .d directory from .vagrant to .vagrant.d. I've changed the code to query Vagrant via its publicized command-line interface, thus freeing us from relying on implementation/version-specific details.
