### PR TITLE
make command-not found compatible with other systems

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -2,4 +2,6 @@
 # as seen in http://www.porcheron.info/command-not-found-for-zsh/
 # this is installed in Ubuntu
 
-source /etc/zsh_command_not_found
+if [ -f /etc/zsh_command_not_found ]; then
+	source /etc/zsh_command_not_found
+fi


### PR DESCRIPTION
I use the same config file on my mac and linux machines, so I suppose it's better to do it like this.
