### PR TITLE
Added a check if homebrew is installed, fixed #1050

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -3,7 +3,7 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . /usr/share/autojump/autojump.zsh
   elif [ -f /etc/profile.d/autojump.zsh ]; then # manual installation
     . /etc/profile.d/autojump.zsh
-  elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump ]; then # mac os x with brew
+  elif [[ -n $commands[brew] ]] && [ $commands[brew] -a -f `brew --prefix`/etc/autojump ]; then # mac os x with brew
     . `brew --prefix`/etc/autojump
   fi
 fi


### PR DESCRIPTION
The autojump script assumes, that if the current system is no linux system, than it has to be a system using hombrew, so it does not even check, if "brew" is installed, this causing the error mentioned in #1050
