### PR TITLE
add support for autojump installed via freebsd ports

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -3,6 +3,8 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . /usr/share/autojump/autojump.zsh
   elif [ -f /etc/profile.d/autojump.zsh ]; then # manual installation
     . /etc/profile.d/autojump.zsh
+  elif [ -f /usr/local/share/autojump/autojump.zsh ]; then # freebsd port
+    . /usr/local/share/autojump/autojump.zsh
   elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump ]; then # mac os x with brew
     . `brew --prefix`/etc/autojump
   fi


### PR DESCRIPTION
if installed via freebsd ports, the autojump.zsh file is placed at `/usr/local/share/autojump/autojump.zsh`, this patch tests for this file and includes if necessary.
