### PR TITLE
Fix to restore bindings after switching to vi-mode

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -5,7 +5,12 @@ function zle-line-init zle-keymap-select {
 zle -N zle-line-init
 zle -N zle-keymap-select
 
+#changing mode clobbers the keybinds, so store the keybinds before and execute 
+#them after
+binds=`bindkey -L`
 bindkey -v
+for bind in ${(@f)binds}; do eval $bind; done
+unset binds
 
 # if mode indicator wasn't setup by theme, define default
 if [[ "$MODE_INDICATOR" == "" ]]; then


### PR DESCRIPTION
the vi-mode plugin destroys any bindings made before it is sourced due to the
'bindkey -v' call to switch to using vi-mode.  This patch saves the bindings
before invoking 'bindkey -v' then rebinds them afterwards, this fixes a number
of outstanding issues due to people using vi-mode and having things in oh-my-zsh
break due to the bindings being destroyed

This fixes #1307 #817 #562 #800 and numerous other issues where the bindings are removed due to using the vi-mode.  Using vi-mode as it is also removes a lot of the functionality provided by oh-my-zsh, because all the custom bindings are gone.
