### PR TITLE
Colemak plugin

### DIFF
--- a/plugins/colemak/colemak-less
+++ b/plugins/colemak/colemak-less
@@ -1,0 +1,6 @@
+n    forw-line
+e    back-line
+k    repeat-search
+\ek  repeat-search-all
+K    reverse-search
+\eK  reverse-search-all

--- a/plugins/colemak/colemak.plugin.zsh
+++ b/plugins/colemak/colemak.plugin.zsh
@@ -1,0 +1,22 @@
+# ctrl-j newline
+bindkey '^n' accept-line
+bindkey -a '^n' accept-line
+
+# another rotation to match qwerty
+bindkey -a 'n' down-line-or-history
+bindkey -a 'e' up-line-or-history
+bindkey -a 'i' vi-forward-char
+
+# make qwerty
+bindkey -a 'k' vi-repeat-search
+bindkey -a 'K' vi-rev-repeat-search
+bindkey -a 'u' vi-insert
+bindkey -a 'U' vi-insert-bol
+bindkey -a 'l' vi-undo-change
+bindkey -a 'N' vi-join
+
+# spare
+bindkey -a 'j' vi-forward-word-end
+bindkey -a 'J' vi-forward-blank-word-end
+
+lesskey $ZSH_CUSTOM/plugins/colemak/colemak-less


### PR DESCRIPTION
a plugin for useing the colemak[1] keyboard layout and vi-mode in zsh, rotates
  some keys around in vi command mode so that the physical hjkl keys are still
  used for movement, all the rotated keys are either in colemak's location or
  qwerty's location, so it is easy to pick up

  [1] www.colemak.com
