### PR TITLE
added autojump plugin support for mac os x, when port installed autojump

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -3,6 +3,8 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . /usr/share/autojump/autojump.zsh
   elif [ -f /etc/profile.d/autojump.zsh ]; then # manual installation
     . /etc/profile.d/autojump.zsh
+  elif [ -f /opt/local/etc/profile.d/autojump.zsh ]; then # mac os x with ports
+    . /opt/local/etc/profile.d/autojump.zsh
   elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump ]; then # mac os x with brew
     . `brew --prefix`/etc/autojump
   fi


### PR DESCRIPTION
It seems there is no easy way to ask macports where it installed the file autojump.zsh, so I'm using a manual file check (like the one used for the manual install, or the one given in https://github.com/zauberpony/oh-my-zsh/commit/de5643b56e8acf41b7b8eff97c209722bc8a315f for freebsd ports)

Thank you for oh-my-zsh, it's the best!
