### PR TITLE
Added plugin for BEM

### DIFF
--- a/plugins/bem/bem.plugin.zsh
+++ b/plugins/bem/bem.plugin.zsh
@@ -1,0 +1,33 @@
+# Completion for bem command
+# Автодополнение для команды bem
+eval "$(bem completion 2> /dev/null)"
+
+# If we have bem in our project run them, otherwise run global bem
+# Если у нас есть установленный bem в папке с проектом, то запустим его
+# иначе - глобальный bem
+whichBem() {
+    bemPath="$1/node_modules/.bin/bem"
+    if [ -f ${bemPath} ]
+    then
+        echo ${bemPath}
+    else
+        if [ $1='/' ]
+        then
+            echo $(which bem)
+        else
+            parent=$(dirname $1)
+
+            echo $(whichBem $parent)
+        fi
+    fi
+}
+
+bem() {
+    bemCmd=$(whichBem $PWD)
+    if [ -f ${bemCmd} ]
+    then
+        bemCmd="${bemCmd} $@"
+        eval ${bemCmd}
+    fi
+}
+


### PR DESCRIPTION
BEM is a methodology for building big web applications [link](http://bem.github.com/bem-method/pages/beginning/beginning.en.html)
My plugin enables autocompletion for console bem tool and "local executable" detection.
For example if `$PWD/node_modules/.bin/bem` exists it will run them instead of running globally installed `bem` to support different `bem` tools versions. 
