### PR TITLE
Add "agnoster" theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -1,6 +1,6 @@
 # vim:ft=zsh ts=2 sw=2 sts=2
 #
-# agnoster's Theme
+# agnoster's Theme - https://gist.github.com/3712874
 # A Powerline-inspired theme for ZSH
 #
 # # README


### PR DESCRIPTION
I know in general you don't want more themes, but you mentioned you might make an exception for this one (https://twitter.com/ohmyzsh/status/250400677522702336), so I thought I'd offer a pull request so you can decide.

I think this theme actually has a few novel things going for it. The one thing that I'd consider to be a real downside is that for the theme to work properly, a user must be using a Powerline-patched font. While these are readily available, and documented in the theme, the odds of a user simply changing their ZSH_THEME to "agnoster" and then being frustrated when it doesn't render properly could be considered too high.

Anyway, otherwise I think it's a quite delightful theme ;-). I'd prefer for there to be a cleaner way to browse and discover themes, and see their prerequisites clearly advertised.

It might be best to simply point people at the gist (https://gist.github.com/3712874), where the prereq is a bit clearer. Obviously it means more work to install, but since the user would need to install a font anyway, I don't think that's too great a burden. Probably better for you, at any rate, to have fewer people coming and complaining when the prompt doesn't render correctly! I know what a pain that can be.

But if you decide you just got to have it, you're very welcome to merge, as you see fit.

Cheers, and thanks for OMZ!
