### PR TITLE
Fix autojump plugin error on Linux with manual installation of autojump

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -3,6 +3,8 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . /usr/share/autojump/autojump.zsh
   elif [ -f /etc/profile.d/autojump.zsh ]; then # manual installation
     . /etc/profile.d/autojump.zsh
+  elif [ -f $HOME/.autojump/etc/profile.d/autojump.zsh ]; then # manual user-local installation
+    . $HOME/.autojump/etc/profile.d/autojump.zsh
   elif [ -f /opt/local/etc/profile.d/autojump.zsh ]; then # mac os x with ports
     . /opt/local/etc/profile.d/autojump.zsh
   elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump ]; then # mac os x with brew


### PR DESCRIPTION
If you manually install autojump as advised by the autojump README by running
the install.sh script, it will install by default to $HOME/.autojump.

Add an extra case in the zsh autojump plugin to find the new file and stop a
syntax error in the else clause every time a new zsh starts (running brew when
brew does not exist).
