### PR TITLE
Show the rake task name in the screen window

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -26,7 +26,7 @@ function omz_termsupport_precmd {
 function omz_termsupport_preexec {
   emulate -L zsh
   setopt extended_glob
-  local CMD=${1[(wr)^(*=*|sudo|ssh|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
+  local CMD=${1[(wr)^(*=*|sudo|ssh|rake|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
   title "$CMD" "%100>...>$2%<<"
 }
 


### PR DESCRIPTION
This show the rake task running not "rake" in a window where you are
running a rake task.
