### PR TITLE
fix title setting bug in xterm and urxvt 

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -27,7 +27,7 @@ function omz_termsupport_preexec {
   emulate -L zsh
   setopt extended_glob
   local CMD=${1[(wr)^(*=*|sudo|ssh|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
-  title "$CMD" "%100>...>$2%<<"
+  title "$CMD" "%100>...>${2:gs/%/%%}%<<"
 }
 
 autoload -U add-zsh-hook


### PR DESCRIPTION
Before this patch, commands containing %-signs set the title wrong
(urxvt and xterm) [1] and produce strange output in urxvt [2].
### test for bug 1:

```
> sleep 10 && echo %
```

sets title to "sleep 10 && echo %<<"

```
> sleep 10 && echo %f
```

doesn't change the title at all
### test for bug 2 (only urxvt):

```
> echo %f
39m%f
```
