### PR TITLE
modified git_prompt_status

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -66,7 +66,9 @@ git_prompt_status() {
   if echo "$INDEX" | grep '^UU ' &> /dev/null; then
     STATUS="$ZSH_THEME_GIT_PROMPT_UNMERGED$STATUS"
   fi
-  echo $STATUS
+  if [ "$STATUS" != "" ];then
+	  echo $STATUS
+  fi
 }
 
 #compare the provided version of git to the version installed and on path


### PR DESCRIPTION
modified test expression because $(echo | grep foo) returns 'true' in
some zsh ( for example 4.2.6 )
