### PR TITLE
URL Tools Plugin

### DIFF
--- a/plugins/urltools/urltools.plugin.zsh
+++ b/plugins/urltools/urltools.plugin.zsh
@@ -1,0 +1,9 @@
+# URL Tools
+# Adds handy command line aliases useful for dealing with URLs
+#
+# Taken from:
+# http://ruslanspivak.com/2010/06/02/urlencode-and-urldecode-from-a-command-line/
+
+alias urlencode='python -c "import sys, urllib as ul; print ul.quote_plus(sys.argv[1])"'
+
+alias urldecode='python -c "import sys, urllib as ul; print ul.unquote_plus(sys.argv[1])"'


### PR DESCRIPTION
Adds some command line tools that are handy for dealing with complex URLs. Especially useful for wrapping up complicated URLs before you pass them in to curl.
- Added urlencode: alias to encode URLs from the command line using Python
- Added urldecode: alias to decode URLs from the command line using Python
