### PR TITLE
Set the '-R' option for less not in $PAGER, but as $LESS

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -9,5 +9,7 @@ bindkey "^[m" copy-prev-shell-word
 setopt long_list_jobs
 
 ## pager
-export PAGER="less -R"
+export PAGER="less"
+export LESS="-R"
+
 export LC_CTYPE=$LANG


### PR DESCRIPTION
Through pull request #984, the `-R` option for `less` has been added to `$PAGER`. However, there are tools out there that can't handle it if `$PAGER` contains a command line option and expect it to point directly to an executable instead. While one could of course argue that that's the fault of those programs, `less` fortunately offers a convenient way to store default options (see its man page):

> Options are also taken from the environment variable "LESS".

This of course also sets the option when `less` is called directly and not through `$PAGER`, what I think is a sensible thing as well. Note additionally that it's consistent with the way `$GREP_OPTIONS` options are set.
