### PR TITLE
Use terminfo key codes instead of hardcoded ones for key bindings

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -20,31 +20,24 @@ bindkey -e                                          # Use emacs key bindings
 bindkey '\ew' kill-region                           # [Esc-w] - Kill from the cursor to the mark
 bindkey -s '\el' 'ls\n'                             # [Esc-l] - run command: ls
 bindkey '^r' history-incremental-search-backward    # [Ctrl-r] - Search backward incrementally for a specified string. The string may begin with ^ to anchor the search to the beginning of the line.
-bindkey '^[[5~' up-line-or-history                  # [PageUp] - Up a line of history
-bindkey '^[[6~' down-line-or-history                # [PageDown] - Down a line of history
+bindkey "${terminfo[kpp]}" up-line-or-history       # [PageUp] - Up a line of history
+bindkey "${terminfo[knp]}" down-line-or-history     # [PageDown] - Down a line of history
 
-bindkey '^[[A' up-line-or-search                    # start typing + [Up-Arrow] - fuzzy find history forward
-bindkey '^[[B' down-line-or-search                  # start typing + [Down-Arrow] - fuzzy find history backward
+bindkey "${terminfo[kcuu1]}" up-line-or-search      # start typing + [Up-Arrow] - fuzzy find history forward
+bindkey "${terminfo[kcud1]}" down-line-or-search    # start typing + [Down-Arrow] - fuzzy find history backward
 
-bindkey '^[[H' beginning-of-line                    # [Home] - Go to beginning of line
-bindkey '^[[1~' beginning-of-line                   # [Home] - Go to beginning of line
-bindkey '^[OH' beginning-of-line                    # [Home] - Go to beginning of line
-bindkey '^[[F'  end-of-line                         # [End] - Go to end of line
-bindkey '^[[4~' end-of-line                         # [End] - Go to end of line
-bindkey '^[OF' end-of-line                          # [End] - Go to end of line
+bindkey "${terminfo[khome]}" beginning-of-line      # [Home] - Go to beginning of line
+bindkey "${terminfo[kend]}"  end-of-line            # [End] - Go to end of line
 
 bindkey ' ' magic-space                             # [Space] - do history expansion
 
 bindkey '^[[1;5C' forward-word                      # [Ctrl-RightArrow] - move forward one word
 bindkey '^[[1;5D' backward-word                     # [Ctrl-LeftArrow] - move backward one word
 
-bindkey '^[[Z' reverse-menu-complete                # [TODO] - Perform menu completion, like menu-complete, except that if a menu completion is already in progress, move to the previous completion rather than the next.
+bindkey "${terminfo[kcbt]}" reverse-menu-complete   # [Shift-Tab] - move through the completion menu backwards
 
-# Make the delete key (or Fn + Delete on the Mac) work instead of outputting a ~
-bindkey '^?' backward-delete-char                   # [Delete] - delete backward
-bindkey '^[[3~' delete-char                         # [fn-Delete] - delete forward
-bindkey '^[3;5~' delete-char                        # [TODO] - delete forward
-bindkey '\e[3~' delete-char                         # [TODO] - delete forward
+bindkey '^?' backward-delete-char                   # [Backspace] - delete backward
+bindkey "${terminfo[kdch1]}" delete-char            # [Delete] - delete forward
 
 # consider emacs keybindings:
 


### PR DESCRIPTION
Hardcoded key escape sequences (such as `[[A` for arrow-up) serve their purpose in most cases, but not in any terminal configuration. It's a better practice to query the right codes dynamically from `$terminfo` instead.

I expect this to become a real-world problem as soon as recent Debian and Ubuntu versions become used more widely: Those ship with a `/etc/zsh/zshrc` which enables "application mode", in which oh-my-zsh's key bindings partially don't work. I've written down more about that problem [on my blog](http://www.f30.me/2012/10/oh-my-zsh-key-bindings-on-ubuntu-12-10/).

My commits migrate the key bindings to terminfo wherever possible. Please note that in order to use `$terminfo`, my code hast to activate the "application mode" as well and might therefore break custom hardcoded key bindings. I based my work on the documentation efforts by @kylewest from pull request #889.
