### PR TITLE
Automatically jump to last working directory for new shells

### DIFF
--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -1,0 +1,23 @@
+#!/usr/bin/env zsh
+# Keeps track of the last used working directory and automatically jumps
+# into it for new shells.
+
+# Flag indicating if we've previously jumped to last directory.
+typeset -g ZSH_LAST_WORKING_DIRECTORY
+
+# Updates the last directory once directory is changed.
+function cd() {
+	builtin cd "$@" && echo "$PWD" > "$ZSH/cache/last-working-dir"
+}
+alias chdir=cd
+
+# Changes directory to the last working directory.
+function lwd() {
+	[[ ! -r ~/.zsh_lwd ]] || builtin cd `cat "$ZSH/cache/last-working-dir"`
+}
+
+# Automatically jump to last working directory unless this isn't the first time
+# this plugin has been loaded.
+if [[ "$ZSH_LAST_WORKING_DIRECTORY" == "" ]]; then
+	lwd 2>/dev/null && ZSH_LAST_WORKING_DIRECTORY=1 || true
+fi


### PR DESCRIPTION
Overrides the cd command to keep track of directory changes. Once zsh is
loaded, the last directory will be restored. Mimics how tabs works in
many terminals.
