### PR TITLE
Allow custom/*.zsh configs to override lib/*.zsh files of the same name.

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -9,9 +9,16 @@ fi
 # add a function path
 fpath=($ZSH/functions $ZSH/completions $fpath)
 
-# Load all of the config files in ~/oh-my-zsh that end in .zsh
-# TIP: Add files you don't want in git to .gitignore
-for config_file ($ZSH/lib/*.zsh) source $config_file
+# Load all library config files in the lib/ folder. If a config file with the
+# same name exists under custom/ load that instead. This allows you to override
+# default behaviors
+for library ($ZSH/lib/*.zsh); do
+  if [ -f $ZSH/custom/$library:t ]; then
+    source $ZSH/custom/$library:t
+  elif [ -f $library ]; then
+    source $library
+  fi
+done
 
 # Set ZSH_CUSTOM to the path where your custom config files
 # and plugins exists, or else we will use the default custom/
@@ -49,9 +56,6 @@ for plugin ($plugins); do
     source $ZSH/plugins/$plugin/$plugin.plugin.zsh
   fi
 done
-
-# Load all of your custom configurations from custom/
-for config_file ($ZSH_CUSTOM/*.zsh(N)) source $config_file
 
 # Load the theme
 if [ "$ZSH_THEME" = "random" ]


### PR DESCRIPTION
This lets you replace default oh-my-zsh behavior with settings more to your
liking. You can still add on to default oh-my-zsh settings by adding them to
`~/.zshrc` or directly to the `lib/*.zsh` files.

The README was a bit confusing regarding this. The first line in the
customization section says: "If you want to override any of the default
behavior, just add a new file (ending in .zsh) into the custom/ directory."

When I tried this I found that the `custom/*.zsh` files would get sourced in
addition to the defaults under `lib/` but not instead of. For example, I wanted
to remove all the aliases setup in `lib/directories.zsh` so I created
`custom/directories.zsh` containing only:

```
# Changing/making/removing directory
setopt auto_name_dirs
setopt auto_pushd
setopt pushd_ignore_dups
```

It turns out this file is sourced but `lib/directires.zsh` is also sourced so the
aliases within are still created.

This change will source the `custom/*.zsh` files in place of their brethren in `lib/*.zsh`
