### PR TITLE
Fixed node-docs

### DIFF
--- a/plugins/node/node.plugin.zsh
+++ b/plugins/node/node.plugin.zsh
@@ -1,5 +1,5 @@
 # Open the node api for your current version to the optional section.
 # TODO: Make the section part easier to use.
 function node-docs {
-	open "http://nodejs.org/docs/$(node --version)/api/all.html#$1"
+	open "http://nodejs.org/docs/$(node --version)/api/all.html#all_$1"
 }


### PR DESCRIPTION
The `#anchor` tags on [nodejs.org](http://nodejs.org/docs/v0.8.2/api/all.html) changed. This fixes the `node-docs` command.
