### PR TITLE
`command_not_found` plugin will cause a warning when activate in non-ubuntu system

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -2,4 +2,6 @@
 # as seen in http://www.porcheron.info/command-not-found-for-zsh/
 # this is installed in Ubuntu
 
-source /etc/zsh_command_not_found
+if [[ -f "/etc/zsh_command_not_found" ]]; then
+    source /etc/zsh_command_not_found
+fi


### PR DESCRIPTION
Check if file exists before source can fix this warning.
