### PR TITLE
Virtualenvwrapper plugin used hardcoded paths, change this to look for executable in PATH

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -14,7 +14,7 @@ function title {
   fi
 }
 
-ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD
+ZSH_THEME_TERM_TAB_TITLE_IDLE="$HOST:%15<..<%~%<<" #15 char left truncated PWD
 ZSH_THEME_TERM_TITLE_IDLE="%n@%m: %~"
 
 #Appears when you have the prompt


### PR DESCRIPTION
Virtualenwrapper plugin now looks for virtualenvwrapper executable in PATH
using "command -v" instead of looking in hard-coded locations
