### PR TITLE
Fixes for vi-mode terminal overwriting bugs

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -1,8 +1,26 @@
-function zle-line-init zle-keymap-select {
+# Ensures that $terminfo values are valid and updates editor information when
+# the keymap changes.
+function zle-keymap-select zle-line-init zle-line-finish {
+  # The terminal must be in application mode when ZLE is active for $terminfo
+  # values to be valid.
+  if (( $+terminfo[smkx] && $+terminfo[rmkx] )); then
+    case "$0" in
+      (zle-line-init)
+        # Enable terminal application mode.
+        echoti smkx
+      ;;
+      (zle-line-finish)
+        # Disable terminal application mode.
+        echoti rmkx
+      ;;
+    esac
+  fi
   zle reset-prompt
+  zle -R
 }
 
 zle -N zle-line-init
+zle -N zle-line-finish
 zle -N zle-keymap-select
 
 #changing mode clobbers the keybinds, so store the keybinds before and execute 


### PR DESCRIPTION
fixes #387 and https://github.com/robbyrussell/oh-my-zsh/pull/1321#issuecomment-9959540
and other problems of prompt overwriting when people did not realize that it
was vi mode causing the problem.  Hat tip to sorin ionescu, as I took this code
from [prezto](https://github.com/sorin-ionescu/prezto)
