### PR TITLE
Added git_prompt_behind() function

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -26,6 +26,14 @@ function git_prompt_ahead() {
   fi
 }
 
+# Checks if there are commits behind from remote
+function git_prompt_behind() {
+  local cb=$(current_branch)
+  if $(echo "$(git log $cb..origin/$cb 2> /dev/null)" | grep '^commit' &> /dev/null); then
+    echo "$ZSH_THEME_GIT_PROMPT_BEHIND"
+  fi
+}
+
 # Formats prompt string for current git commit short SHA
 function git_prompt_short_sha() {
   SHA=$(git rev-parse --short HEAD 2> /dev/null) && echo "$ZSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$ZSH_THEME_GIT_PROMPT_SHA_AFTER"


### PR DESCRIPTION
Added `git_prompt_behind()` function for checks if there are commits behind from remote and set `ZSH_THEME_GIT_PROMPT_BEHIND` variable, so themes can do something like that:

``` shell
## Git prompt behind
ZSH_THEME_GIT_PROMPT_BEHIND="↓"

## Git prompt ahead
ZSH_THEME_GIT_PROMPT_AHEAD="↑"
```

and use the function for `PROMPT` composition:

``` shell
## Wrap multiple prompt infos
function git_prompt_info_plus() {
    echo "$(git_prompt_ahead)$(git_prompt_behind)$(git_prompt_status)"
}
```

I hope it can be useful to someone.
