### PR TITLE
Fix sourcing brew's autojump of version 21.0.3+

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -5,7 +5,7 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . /etc/profile.d/autojump.zsh
   elif [ -f /opt/local/etc/profile.d/autojump.zsh ]; then # mac os x with ports
     . /opt/local/etc/profile.d/autojump.zsh
-  elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump ]; then # mac os x with brew
-    . `brew --prefix`/etc/autojump
+  elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump.zsh ]; then # mac os x with brew
+    . `brew --prefix`/etc/autojump.zsh
   fi
 fi


### PR DESCRIPTION
Starting with autojump 21.0.3+ there is no file autojump in etc/
directory, so we source the autojump.zsh file directly. Version 20 has
it as well, so there should be no problems with earlier versions.

Comments on autojump's update in homebrew:
https://github.com/mxcl/homebrew/commit/5da9c4d5eb38e6abb516ba648898fb374ec360cd#Library/Formula/autojump.rb
