### PR TITLE
sublime text not found in Ubuntu 

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -2,7 +2,11 @@
 #unamestr = 'uname'
 
 if [[ $('uname') == 'Linux' ]]; then
-	alias st='/usr/bin/sublime_text&'
+	if [ -f '/usr/bin/sublime_text' ]; then
+		alias st='/usr/bin/sublime_text&'
+	else
+		alias st='/usr/bin/sublime-text&'
+	fi
 elif  [[ $('uname') == 'Darwin' ]]; then
 	alias st='/Applications/Sublime\ Text\ 2.app/Contents/SharedSupport/bin/subl'
 fi


### PR DESCRIPTION
Considering the situation when installing sublime text via apt-get (WebUpd8 Sublime Text 2 PPA)
