### PR TITLE
Update themes/minimal.zsh-theme

### DIFF
--- a/themes/minimal.zsh-theme
+++ b/themes/minimal.zsh-theme
@@ -1,15 +1,18 @@
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$reset_color%}%{$fg[white]%}["
-ZSH_THEME_GIT_PROMPT_SUFFIX="]%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[red]%}●%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_CLEAN=""
+ZSH_THEME_GIT_PROMPT_SUFFIX=""
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[red]%}●%{$reset_color%}]%{$reset_color%} "
+ZSH_THEME_GIT_PROMPT_CLEAN="]%{$reset_color%} "
+ZSH_THEME_SVN_PROMPT_PREFIX=$ZSH_THEME_GIT_PROMPT_PREFIX
+ZSH_THEME_SVN_PROMPT_SUFFIX=$ZSH_THEME_GIT_PROMPT_SUFFIX
+ZSH_THEME_SVN_PROMPT_DIRTY=$ZSH_THEME_GIT_PROMPT_DIRTY
+ZSH_THEME_SVN_PROMPT_CLEAN=$ZSH_THEME_GIT_PROMPT_CLEAN
 
-#Customized git status, oh-my-zsh currently does not allow render dirty status before branch
-git_custom_status() {
-  local cb=$(current_branch)
-  if [ -n "$cb" ]; then
-    echo "- $ZSH_THEME_GIT_PROMPT_PREFIX$(current_branch)$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
-  fi
+vcs_status() {
+    if [[ ( $(whence in_svn) != "" ) && ( $(in_svn) == 1 ) ]]; then
+        svn_prompt_info
+    else
+        git_prompt_info
+    fi
 }
 
-
-PROMPT='%2~ $(git_custom_status) »%b '
+PROMPT='%2~ $(vcs_status)»%b '


### PR DESCRIPTION
Cleans up minimal theme by not using a custom prompt function
Removed case of 2 spaces showing if not in a version controlled folder
Adds support for svn_prompt_info
