### PR TITLE
Updated svn.plugin.zsh to behave more like lib/git.zsh

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -1,7 +1,14 @@
 function svn_prompt_info {
     if [ $(in_svn) ]; then
+        if [ "x$SVN_SHOW_BRANCH" = "xtrue" ]; then
+            unset SVN_SHOW_BRANCH
+            _DISPLAY=$(svn_get_branch_name)
+        else
+            _DISPLAY=$(svn_get_repo_name)
+        fi
         echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_PREFIX\
-$ZSH_THEME_REPO_NAME_COLOR$(svn_get_repo_name)$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR$(svn_dirty)$ZSH_PROMPT_BASE_COLOR"
+$ZSH_THEME_REPO_NAME_COLOR$_DISPLAY$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR$(svn_dirty)$ZSH_PROMPT_BASE_COLOR"
+        unset _DISPLAY
     fi
 }
 
@@ -18,6 +25,16 @@ function svn_get_repo_name {
     
         svn info | sed -n "s/URL:\ .*$SVN_ROOT\///p"
     fi
+}
+
+function svn_get_branch_name {
+    _DISPLAY=$(svn info 2> /dev/null | awk -F/ '/^URL:/ { for (i=0; i<=NF; i++) { if ($i == "branches" || $i == "tags" ) { print $(i+1); break }; if ($i == "trunk") { print $i; break } } }')
+    if [ "x$_DISPLAY" = "x" ]; then
+        svn_get_repo_name
+    else
+        echo $_DISPLAY
+    fi
+    unset _DISPLAY
 }
 
 function svn_get_rev_nr {


### PR DESCRIPTION
Behave more like lib/git.zsh.
Set `SVN_SHOW_BRANCH="true"` to display branch/tag or trunk instead of just repo name.
Falls back to repo name if branch information is not available.

Idea and awk call from [revans/bash-it](https://github.com/revans/bash-it/)
