### PR TITLE
Fix install.sh compatibility with /bin/sh

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -36,4 +36,4 @@ echo "\033[0;32m"'                        /____/                       '"\033[0m
 
 echo "\n\n \033[0;32m....is now installed.\033[0m"
 /usr/bin/env zsh
-source ~/.zshrc
+. ~/.zshrc


### PR DESCRIPTION
Hi,
If not having /bin/sh as a symlink to BASH or any other shell that supports command "source" then the last line of install.sh fails to execute.
Not that it fails installtion, just throws annoying error on "source: not found"
I replaced "source" with "." which is supported in all shells afaik.
Cheers
