### PR TITLE
Update plugins/sublime/sublime.plugin.zsh

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -2,7 +2,8 @@
 #unamestr = 'uname'
 
 if [[ $('uname') == 'Linux' ]]; then
-	alias st='/usr/bin/sublime_text&'
+	st_run() { nohup /usr/bin/sublime_text $@ > /dev/null & }
+  	alias st=st_run
 elif  [[ $('uname') == 'Darwin' ]]; then
 	alias st='/Applications/Sublime\ Text\ 2.app/Contents/SharedSupport/bin/subl'
 fi


### PR DESCRIPTION
previous sublime_text& doesn't work with command line arguments on linux.
