### PR TITLE
Fix for "?" and "!" in svn status output

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -29,7 +29,7 @@ function svn_get_rev_nr {
 function svn_dirty_choose {
     if [ $(in_svn) ]; then
         svn status 2> /dev/null | grep -Eq '^\s*[ACDIM!?L]'
-	if [ $pipestatus[-1] -ne 0 ]; then
+        if [ $pipestatus[-1] -ne 0 ]; then
             echo $1
         else 
             echo $2


### PR DESCRIPTION
Fix a bug in the "svn" module that leaks this error to stderr when an SVN working copy contains unknown files (status ?).:

```
svn_dirty_choose:3: condition expected: ?
```
