### PR TITLE
Added m and rails to list of bundled commands.

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -6,7 +6,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate cap capify cucumber foreman guard middleman nanoc rackup rainbows rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails puma)
+bundled_commands=(annotate cap capify cucumber foreman guard m middleman nanoc rackup rails rainbows rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails puma)
 
 ## Functions
 


### PR DESCRIPTION
Added `m` (which is a nice test runner, see [here](https://github.com/qrush/m)) and `rails` to the list of bundled commands.
