### PR TITLE
Replace reset-prompt with push-line and accept-line

### DIFF
--- a/plugins/per-directory-history/per-directory-history.plugin.zsh
+++ b/plugins/per-directory-history/per-directory-history.plugin.zsh
@@ -65,12 +65,13 @@
 function per-directory-history-toggle-history() {
   if [[ $_per_directory_history_is_global == true ]]; then
     _per-directory-history-set-directory-history
-    echo "using local history\n"
+    print "\nusing local history\n"
   else
     _per-directory-history-set-global-history
-    echo "using global history\n"
+    print "\nusing global history\n"
   fi
-  zle reset-prompt
+  zle .push-line
+  zle .accept-line
 }
 
 autoload per-directory-history-toggle-history


### PR DESCRIPTION
The in memory history is not updated until an accept line command, so you
have to push enter before it is correct, this commit replaces the reset-prompt
with an accept-line.  It also adds a push-line, to preserve the current editing
buffer
