### PR TITLE
Add support of multiple screen variants in screen plugin

### DIFF
--- a/plugins/screen/screen.plugin.zsh
+++ b/plugins/screen/screen.plugin.zsh
@@ -1,6 +1,6 @@
 # if using GNU screen, let the zsh tell screen what the title and hardstatus
 # of the tab window should be.
-if [[ $TERM == "screen" ]]; then
+if [[ "$TERM" == screen* ]]; then
   if [[ $_GET_PATH == '' ]]; then
     _GET_PATH='echo $PWD | sed "s/^\/Users\//~/;s/^\/home\//~/;s/^~$USER/~/"'
   fi


### PR DESCRIPTION
If background-color-erase enabled for screen then $TERM will be set to "screen-bce", and this case is not supported by screen plugin.
