### PR TITLE
Fix typo in agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -106,7 +106,7 @@ prompt_status() {
 build_prompt() {
   RETVAL=$?
   prompt_status
-  prompt_contextx
+  prompt_context
   prompt_dir
   prompt_git
   prompt_end


### PR DESCRIPTION
It recently broke my fancy shell. `s/prompt_contextx/prompt_context`
