### PR TITLE
fixed typo in agnoster theme that was causing zsh to complain

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -106,7 +106,7 @@ prompt_status() {
 build_prompt() {
   RETVAL=$?
   prompt_status
-  prompt_contextx
+  prompt_context
   prompt_dir
   prompt_git
   prompt_end


### PR DESCRIPTION
This fixes a typo in the agnoster theme that was causing zsh to complain:
"build_prompt:3: command not found: prompt_contextx" at each prompt.
