### PR TITLE
Fix backwards svn "dirty" state detection

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -1,3 +1,4 @@
+
 function svn_prompt_info {
     if [ $(in_svn) ]; then
         echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_SVN_PROMPT_PREFIX\
@@ -29,9 +30,11 @@ function svn_get_rev_nr {
 function svn_dirty_choose {
     if [ $(in_svn) ]; then
         svn status 2> /dev/null | grep -Eq '^\s*[ACDIM!?L]'
-        if [ $pipestatus[-1] -ne 0 ]; then
+        if [ $pipestatus[-1] -eq 0 ]; then
+            # Grep exits with 0 when "One or more lines were selected", return "dirty".
             echo $1
         else
+            # Otherwise, no lines were found, or an error occurred. Return clean.
             echo $2
         fi
     fi


### PR DESCRIPTION
The condition was backwards, so the "dirty" marker only showed for clean working copies.
