### PR TITLE
Some fixes for the agnoster theme / Fixed autocompletion for autojump with homebrew

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -1,4 +1,4 @@
-if [ $commands[autojump] ]; then # check if autojump is
+if [ $commands[autojump] ]; then # check if autojump is installed
   if [ -f /usr/share/autojump/autojump.zsh ]; then # debian and ubuntu package
     . /usr/share/autojump/autojump.zsh
   elif [ -f /etc/profile.d/autojump.zsh ]; then # manual installation


### PR DESCRIPTION
# agnoster theme
- Correction of function name 'prompt_context'. I guess the name 'prompt_contextx' was a typo or something.
- Fixed an issue with the displaying of branch information within git repos.
# autojump plugin
- Fixed shell completion for homebrew installations
