### PR TITLE
Revert "Fix to restore bindings after switching to vi-mode" 

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -5,12 +5,7 @@ function zle-line-init zle-keymap-select {
 zle -N zle-line-init
 zle -N zle-keymap-select
 
-#changing mode clobbers the keybinds, so store the keybinds before and execute 
-#them after
-binds=`bindkey -L`
 bindkey -v
-for bind in ${(@f)binds}; do eval $bind; done
-unset binds
 
 # if mode indicator wasn't setup by theme, define default
 if [[ "$MODE_INDICATOR" == "" ]]; then


### PR DESCRIPTION
This reverts commit b609aa0e6c981f2039d777687cb01a84587f6edc -- this commit
was a bad idea, because it makes vi-mode very difficult to use. The default
`bindkey` keybindings are NOT MEANT to coexist with `bindkey -v` Vi mode;
that's why `bindkey -v` clears them in the first place! Restoring all of the
default keybindings after enabling Vi mode, the way the reverted commit did,
causes many collisions between those default keybindings that begin with ESC
and the command-mode-initiating ESC of Vi mode. See Issue #1438 of
robbyrussell/oh-my-zsh. If people have custom keybindings, they should create
them in their ~/.zshrc AFTER enabling the vi-mode plugin and sourcing
oh-my-zsh.sh.
