### PR TITLE
Update themes/agnoster.zsh-theme::removed the extra ending 'x' from line 109

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -106,7 +106,7 @@ prompt_status() {
 build_prompt() {
   RETVAL=$?
   prompt_status
-  prompt_contextx
+  prompt_context
   prompt_dir
   prompt_git
   prompt_end


### PR DESCRIPTION
removed the extra ending 'x' from line 109 to fix "build_prompt:3: command not found: prompt_contextx" error found on my Mac OSX lion.
