### PR TITLE
Add support for Homebrew installed Python for plugins/virtualenvwrapper

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -1,5 +1,5 @@
 WRAPPER_FOUND=0
-for wrapsource in "/usr/bin/virtualenvwrapper.sh" "/usr/local/bin/virtualenvwrapper.sh" "/etc/bash_completion.d/virtualenvwrapper" ; do
+for wrapsource in "/usr/bin/virtualenvwrapper.sh" "/usr/local/bin/virtualenvwrapper.sh" "/etc/bash_completion.d/virtualenvwrapper" "/usr/local/share/python/virtualenvwrapper.sh"; do
   if [[ -e $wrapsource ]] ; then
     WRAPPER_FOUND=1
     source $wrapsource


### PR DESCRIPTION
Homebrew installs the virtualenvwrapper.sh shell script in /usr/local/share/python.  This patch adds that path to the candidate list of paths for finding the script.
