### PR TITLE
Modify readme to clarify the manual way

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -26,17 +26,20 @@ h3. The manual way
 
   @git clone git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh@
 
-2. Create a new zsh config by copying the zsh template we've provided.
+2. *OPTIONAL* Backup your existing ~/.zshrc file
+
+  @cp ~/.zshrc ~/.zshrc.orig@
+
+3. Create a new zsh config by copying the zsh template we've provided.
 
   @cp ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc@
 
-  *NOTE*: If you already have a ~/.zshrc file, you should back it up. @cp ~/.zshrc ~/.zshrc.orig@ in case you want to go back to your original settings.
 
-3. Set zsh as your default shell:
+4. Set zsh as your default shell:
 
   @chsh -s /bin/zsh@
 
-4. Start / restart zsh (open a new terminal is easy enough...)
+5. Start / restart zsh (open a new terminal is easy enough...)
 
 h3. Problems?
 


### PR DESCRIPTION
When I was reading the online README I missed this syntax `cp ~/.oh-my-zsh/templates/zshrc.zsh-template ~/.zshrc` due to it being preceded by the NOTE. I've rearranged the instructions for clarity.

Thanks for all that you do!
