### PR TITLE
Battery plugin: Fixed Kernel type detection 

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -8,7 +8,7 @@
 # Modified to add support for Apple Mac   #
 ###########################################
 
-if [[ $(uname) -eq "Darwin" ]] ; then
+if [[ $(uname) == "Darwin" ]] ; then
 
   function battery_pct_remaining() {
     if [[ $(ioreg -rc AppleSmartBattery | grep -c '^.*"ExternalConnected"\ =\ No') -eq 1 ]] ; then
@@ -46,7 +46,7 @@ if [[ $(uname) -eq "Darwin" ]] ; then
     fi
   }
 
-elif [[ $(uname) -eq "Linux"  ]] ; then
+elif [[ $(uname) == "Linux"  ]] ; then
 
   if [[ $(acpi 2&>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
     function battery_pct_remaining() { echo "$(acpi | cut -f2 -d ',' | tr -cd '[:digit:]')" }


### PR DESCRIPTION
Hi,

Sorry, that last commit used the wrong operators to check for kernel version, it would automatically assume to be a mac for some reason. I have corrected this now and checked on my debian laptop that is can now detect the difference.

Regards,
Sean
