### PR TITLE
lazyload virtualenvwrapper

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -1,4 +1,4 @@
-wrapsource=`which virtualenvwrapper.sh`
+wrapsource=`which virtualenvwrapper_lazy.sh`
 
 if [[ -f "$wrapsource" ]]; then
   source $wrapsource
@@ -36,5 +36,5 @@ if [[ -f "$wrapsource" ]]; then
     }
   fi
 else
-  print "zsh virtualenvwrapper plugin: Cannot find virtualenvwrapper.sh. Please install with \`pip install virtualenvwrapper\`."
+  print "zsh virtualenvwrapper plugin: Cannot find virtualenvwrapper_lazy.sh. Please install with \`pip install virtualenvwrapper\`."
 fi


### PR DESCRIPTION
Using lazy loading for virtualenvwrapper gives a mariginal speed
improvement and doesn't stop workon_cd from working. It has the
undesired effect of forcing you to call certain virtualenv commands
twice before they work (only once per shell instantiation).
