### PR TITLE
Backwards Compatible Jira URLs #1378

### DIFF
--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -1,20 +1,36 @@
 # To use: add a .jira-url file in the base of your project
+#         You can also set JIRA_URL in your .zshrc or put .jira-url in your home directory
+#         .jira-url in the current directory takes precedence
+#
+# If you use Rapid Board, set:
+#JIRA_RAPID_BOARD="yes"
+# in you .zshrc
+#
 # Setup: cd to/my/project
 #        echo "https://name.jira.com" >> .jira-url
 # Usage: jira           # opens a new issue
 #        jira ABC-123   # Opens an existing issue
 open_jira_issue () {
-  if [ ! -f .jira-url ]; then
-    echo "There is no .jira-url file in the current directory..."
-    return 0;
+  if [ -f .jira-url ]; then
+    jira_url=$(cat .jira-url)
+  elif [ -f ~/.jira-url ]; then
+    jira_url=$(cat ~/.jira-url)
+  elif [[ "x$JIRA_URL" != "x" ]]; then
+    jira_url=$JIRA_URL
   else
-    jira_url=$(cat .jira-url);
-    if [ -z "$1" ]; then
-      echo "Opening new issue";
-      `open $jira_url/secure/CreateIssue!default.jspa`;
+    echo "JIRA url is not specified anywhere."
+    return 0
+  fi
+
+  if [ -z "$1" ]; then
+    echo "Opening new issue"
+    `open $jira_url/secure/CreateIssue!default.jspa`
+  else
+    echo "Opening issue #$1"
+    if [[ "x$JIRA_RAPID_BOARD" = "yes" ]]; then
+      `open $jira_url/issues/$1`
     else
-      echo "Opening issue #$1";
-      `open $jira_url/browse/$1`;
+      `open $jira_url/browse/$1`
     fi
   fi
 }


### PR DESCRIPTION
Adds support for Rapid Board without breaking backwards compatibility (like #1378)
Allows JIRA url to be set in .zshrc, current directory, and/or home directory.
