### PR TITLE
Add last command's 'exit status' display to mortalscumbag theme

### DIFF
--- a/themes/mortalscumbag.zsh-theme
+++ b/themes/mortalscumbag.zsh-theme
@@ -47,7 +47,7 @@ function ssh_connection() {
 }
 
 local ret_status="%(?:%{$fg_bold[green]%}:%{$fg_bold[red]%})%?%{$reset_color%}"
-PROMPT=$'\n$(ssh_connection)%{$fg_bold[cyan]%}%n@%m%{$reset_color%}$(my_git_prompt) : %~\n[${ret_status}] %# '
+PROMPT=$'\n$(ssh_connection)%{$fg_bold[green]%}%n@%m%{$reset_color%}$(my_git_prompt) : %~\n[${ret_status}] %# '
 
 ZSH_THEME_PROMPT_RETURNCODE_PREFIX="%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_PREFIX=" $fg[white]‹ %{$fg_bold[yellow]%}"


### PR DESCRIPTION
I really like the mortalscumbag theme, because of the minimalist design, so I thought that adding this small feature will add more functionality to it, without ruining the intended design.

Sorry about the previous bloated pull request. Apparently, I don't know much about how pull requests actually work and added by mistake some former commits that were already pushed upstream.
