### PR TITLE
plugin last-working-dir: create cache-directory if it doesn't exist

### DIFF
--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -4,6 +4,7 @@
 
 # Flag indicating if we've previously jumped to last directory.
 typeset -g ZSH_LAST_WORKING_DIRECTORY
+mkdir -p "$ZSH/cache"
 local cache_file="$ZSH/cache/last-working-dir"
 
 # Updates the last directory once directory is changed.


### PR DESCRIPTION
fixed a small bug coming up while first using the last-working-dir-plugin. 
