### PR TITLE
Unset `config_file` variable in oh-my-zsh.sh

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -56,6 +56,7 @@ done
 for config_file ($ZSH_CUSTOM/*.zsh(N)); do
   source $config_file
 done
+unset config_file
 
 # Load the theme
 if [ "$ZSH_THEME" = "random" ]


### PR DESCRIPTION
`config_file` variable will mess up with `cd` auto-complete command.

eg. I have a local dir named `Code`, and when I type `cd co<Tab>`,
config_file will show up, and doesn't make any sense...
