### PR TITLE
use feature names instead of failing branch names in "git flow feature"

### DIFF
--- a/plugins/git-flow/git-flow.plugin.zsh
+++ b/plugins/git-flow/git-flow.plugin.zsh
@@ -237,13 +237,13 @@ __git-flow-feature ()
 
 				(diff)
 					_arguments \
-						':branch:__git_branch_names'\
+						':branch:__git_flow_feature_list'\
 				;;
 
 				(rebase)
 					_arguments \
 						-i'[Do an interactive rebase]' \
-						':branch:__git_branch_names'
+						':branch:__git_flow_feature_list'
 				;;
 
 				(checkout)
@@ -254,7 +254,7 @@ __git-flow-feature ()
 				(pull)
 					_arguments \
 						':remote:__git_remotes'\
-						':branch:__git_branch_names'
+						':branch:__git_flow_feature_list'
 				;;
 
 				*)


### PR DESCRIPTION
The auto-completion for some sub-commands of "git flow feature" uses branch names instead of feature names, which results in a "branch not found" error. This fixes it on my machine
