### PR TITLE
Make completion waiting dots themeable

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -62,8 +62,10 @@ zstyle ':completion:*:*:*:users' ignored-patterns \
 zstyle '*' single-ignored show
 
 if [ "x$COMPLETION_WAITING_DOTS" = "xtrue" ]; then
+  ZSH_THEME_COMPLETION_WAITING_DOTS="\e[31m......\e[0m"
+
   expand-or-complete-with-dots() {
-    echo -n "\e[31m......\e[0m"
+    echo -n "$ZSH_THEME_COMPLETION_WAITING_DOTS"
     zle expand-or-complete
     zle redisplay
   }


### PR DESCRIPTION
The completion waiting dots default to 6 red "." characters, this allows you to customise what's shown by overriding the ZSH_THEME_COMPLETION_WAITING_DOTS variable from a theme.
