### PR TITLE
screen: Bugfix extracted cmd, add customizable TITLE var

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -2,12 +2,23 @@
 #http://www.faqs.org/docs/Linux-mini/Xterm-Title.html#ss3.1
 #Fully support screen, iterm, and probably most modern xterm and rxvt
 #Limited support for Apple Terminal (Terminal can't set window or tab separately)
+
+ZSH_SCREEN_PLUGIN_ACTIVE=false
+for i in $plugins; do
+  if [[ "$i" == "screen" ]]; then
+    ZSH_SCREEN_PLUGIN_ACTIVE=true
+  fi
+done
+
 function title {
   if [[ "$DISABLE_AUTO_TITLE" == "true" ]] || [[ "$EMACS" == *term* ]]; then
     return
   fi
   if [[ "$TERM" == screen* ]]; then
-    print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
+    # do not set the screen hardstatus, if screen plugin is active
+    if [[ "$ZSH_SCREEN_PLUGIN_ACTIVE" != "true" ]]; then
+      print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
+    fi
   elif [[ "$TERM_PROGRAM" == "Apple_Terminal" ]]; then
     print -Pn "\e]1;$1:q\a" #set icon (=tab) name (will override window name on broken terminal)
   elif [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then

--- a/plugins/screen/screen.plugin.zsh
+++ b/plugins/screen/screen.plugin.zsh
@@ -39,16 +39,28 @@ if [[ "$TERM" == screen* ]]; then
   # called by zsh before executing a command
   function preexec()
   {
-    local -a cmd; cmd=(${(z)1}) # the command string
-    eval "tab_title=$TAB_TITLE_PREFIX:$TAB_TITLE_EXEC"
-    eval "tab_hardstatus=$TAB_HARDSTATUS_PREFIX:$TAB_HARDSTATUS_EXEC"
+    local -a cmd; cmd=(${(z)3}) # the command string
+    if [ "$TITLE" != "" ]
+    then
+      eval "tab_title=$TITLE:$TAB_TITLE_EXEC"
+      eval "tab_hardstatus=$TITLE:$TAB_HARDSTATUS_EXEC"
+    else
+      eval "tab_title=$TAB_TITLE_PREFIX:$TAB_TITLE_EXEC"
+      eval "tab_hardstatus=$TAB_HARDSTATUS_PREFIX:$TAB_HARDSTATUS_EXEC"
+    fi
     screen_set $tab_title $tab_hardstatus
   }
   # called by zsh before showing the prompt
   function precmd()
   {
-    eval "tab_title=$TAB_TITLE_PREFIX:$TAB_TITLE_PROMPT"
-    eval "tab_hardstatus=$TAB_HARDSTATUS_PREFIX:$TAB_HARDSTATUS_PROMPT"
+    if [ "$TITLE" != "" ]
+    then
+      eval "tab_title=$TITLE:$TAB_TITLE_PROMPT"
+      eval "tab_hardstatus=$TITLE:$TAB_HARDSTATUS_PROMPT"
+    else
+      eval "tab_title=$TAB_TITLE_PREFIX:$TAB_TITLE_PROMPT"
+      eval "tab_hardstatus=$TAB_HARDSTATUS_PREFIX:$TAB_HARDSTATUS_PROMPT"
+    fi
     screen_set $tab_title $tab_hardstatus
   }
 fi

--- a/plugins/screen/screen.plugin.zsh
+++ b/plugins/screen/screen.plugin.zsh
@@ -31,10 +31,10 @@ if [[ "$TERM" == screen* ]]; then
   function screen_set()
   {
     # set the tab window title (%t) for screen
-    print -nR $'\033k'$1$'\033'\\\
+    print -nR $'\033k'"$1"$'\033'\\\
 
     # set hardstatus of tab window (%h) for screen
-    print -nR $'\033]0;'$2$'\a'
+    print -nR $'\033_'"$2"$'\033'\\\
   }
   # called by zsh before executing a command
   function preexec()
@@ -42,8 +42,8 @@ if [[ "$TERM" == screen* ]]; then
     local -a cmd; cmd=(${(z)3}) # the command string
     if [ "$TITLE" != "" ]
     then
-      eval "tab_title=$TITLE:$TAB_TITLE_EXEC"
-      eval "tab_hardstatus=$TITLE:$TAB_HARDSTATUS_EXEC"
+      eval "tab_title=\"$TITLE\":$TAB_TITLE_EXEC"
+      eval "tab_hardstatus=\"$TITLE\":$TAB_HARDSTATUS_EXEC"
     else
       eval "tab_title=$TAB_TITLE_PREFIX:$TAB_TITLE_EXEC"
       eval "tab_hardstatus=$TAB_HARDSTATUS_PREFIX:$TAB_HARDSTATUS_EXEC"
@@ -55,8 +55,8 @@ if [[ "$TERM" == screen* ]]; then
   {
     if [ "$TITLE" != "" ]
     then
-      eval "tab_title=$TITLE:$TAB_TITLE_PROMPT"
-      eval "tab_hardstatus=$TITLE:$TAB_HARDSTATUS_PROMPT"
+      eval "tab_title=\"$TITLE\":$TAB_TITLE_PROMPT"
+      eval "tab_hardstatus=\"$TITLE\":$TAB_HARDSTATUS_PROMPT"
     else
       eval "tab_title=$TAB_TITLE_PREFIX:$TAB_TITLE_PROMPT"
       eval "tab_hardstatus=$TAB_HARDSTATUS_PREFIX:$TAB_HARDSTATUS_PROMPT"


### PR DESCRIPTION
Bugfix:
zsh doc:
"If the history mechanism is active, the string that the user typed is
passed as the first argument, otherwise it is an empty string."
The title of a screen window should not depend on the history. So this
patch uses the third passed argument ("the third argument contains the
full text that is being executed.").

TITLE variable:
This combines automatic title set with customizable titles. It's often
useful in a screen session to set a manual title. By using
TITLE=YOUR_TITLE, it will replace the generated prefix but still display
the executed command. "TITLE=" will cause the screen plugin to generate
the title prefix again.

Signed-off-by: Markus Pargmann mpargmann@allfex.org
