### PR TITLE
Fix bira theme to show current rvm environment

### DIFF
--- a/themes/bira.zsh-theme
+++ b/themes/bira.zsh-theme
@@ -4,7 +4,7 @@ local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 local user_host='%{$terminfo[bold]$fg[green]%}%n@%m%{$reset_color%}'
 local current_dir='%{$terminfo[bold]$fg[blue]%} %~%{$reset_color%}'
 local rvm_ruby=''
-if which rvm-prompt &> /dev/null; then
+if [[ -s ~/.rvm/scripts/rvm ]] ; then 
   rvm_ruby='%{$fg[red]%}‹$(rvm-prompt i v g)›%{$reset_color%}'
 else
   if which rbenv &> /dev/null; then


### PR DESCRIPTION
I liked bira theme the most, but it's integration with RVM didn't work OOTB on my Linux Mint 14 - current rvm wasn't shown in prompt. Simple fix was to copy from one of the themes which has this integration working and paste into bira.
