### PR TITLE
Modified virtualenvwrapper plugin to prevent a possible circular execution loop

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -19,10 +19,10 @@ if [[ -f "$wrapsource" ]]; then
             # Activate the environment only if it is not already active
             if [[ "$VIRTUAL_ENV" != "$WORKON_HOME/$ENV_NAME" ]]; then
                 if [[ -e "$WORKON_HOME/$ENV_NAME/bin/activate" ]]; then
-                        if [[ -z ${CD_VIRTUAL_ENV} ]]; then
-                                export CD_VIRTUAL_ENV="$ENV_NAME"
-                                workon "$ENV_NAME" || unset CD_VIRTUAL_ENV
-                        fi
+                    if [[ -z ${CD_VIRTUAL_ENV} ]]; then
+                        export CD_VIRTUAL_ENV="$ENV_NAME"
+                        workon "$ENV_NAME" || unset CD_VIRTUAL_ENV
+                    fi
                 fi
             fi
         elif [ $CD_VIRTUAL_ENV ]; then


### PR DESCRIPTION
# Bug Fix

Modified _virtualenvwrapper plugin_ to prevent a possible circular execution loop that may happen when activating an environment.
### Motivation

In some environments, the `workon` command called inside `workon_cwd` function causes a circular loop calling the function again, until `zsh` complains either of `job table full` or `recursion limit exceeded`. Although the _virtualenv_ ends up activated, this consumes processing and leaves the user waiting (annoyed) for a while until the error occurs.
### Scenario and Solution

The `workon_cwd` function already makes some checks before activating a _virtualenv_, then - if it is successfully done - it sets the environment variable `CD_VIRTUAL_ENV`, which is used internally by the plugin. 

The solution found was to add another verification using the environment variable, in order to check if the _virtualenv_ is being set, and then, if not so, set the variable just before calling `workon`, making sure to unset it if something goes wrong.
