### PR TITLE
New plugin: `perhost`.

### DIFF
--- a/plugins/perhost/README.rst
+++ b/plugins/perhost/README.rst
@@ -1,0 +1,9 @@
+Per host configuration
+======================
+
+The plugin ``perhost`` allows you to execute a ZSH script named after the
+current hostname. The files live in the directory ``~/.zsh/perhost``.
+
+To create a file with the correct name, type the following::
+
+    vim ~/.zsh/perhost/`hostname`.zsh

--- a/plugins/perhost/perhost.plugin.zsh
+++ b/plugins/perhost/perhost.plugin.zsh
@@ -1,0 +1,4 @@
+local hostconfig=~/.zsh/perhost/$(hostname).zsh
+if [ -f ${hostconfig} ]; then
+    source ${hostconfig}
+fi


### PR DESCRIPTION
This plugin allows you to load settings based on the current hostname. The
per-host config files are stored in `~/.zsh/perhost`. I was not sure whether
to look in `~/.zsh` or rather in `~/.oh-my-zsh/etc/perhost`.

Both seemed fine to me, although I slightly prefer the second. Any thoughts?
