### PR TITLE
Exit early from git plugin if not in git repo.

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -73,12 +73,14 @@ alias gsd='git svn dcommit'
 # Usage example: git pull origin $(current_branch)
 #
 function current_branch() {
+  if [ ! -d .git ]; then return; fi
   ref=$(git symbolic-ref HEAD 2> /dev/null) || \
   ref=$(git rev-parse --short HEAD 2> /dev/null) || return
   echo ${ref#refs/heads/}
 }
 
 function current_repository() {
+  if [ ! -d .git ]; then return; fi
   ref=$(git symbolic-ref HEAD 2> /dev/null) || \
   ref=$(git rev-parse --short HEAD 2> /dev/null) || return
   echo $(git remote -v | cut -d':' -f 2)


### PR DESCRIPTION
Added check for .git directory in current, before wasting time querying git. This saves seconds on my pc.
