### PR TITLE
Added Grails wrapper `grailsw` support in Grails plugin

### DIFF
--- a/plugins/grails/grails.plugin.zsh
+++ b/plugins/grails/grails.plugin.zsh
@@ -52,3 +52,4 @@ _grails() {
 }
  
 compdef _grails grails
+compdef _grails grailsw


### PR DESCRIPTION
Added support for Grails wrapper command `grailsw` using same allowed arguments as basic `grails` command.
