### PR TITLE
Update plugins/bundler/bundler.plugin.zsh

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -6,7 +6,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate cap capify cucumber foreman guard middleman nanoc rackup rainbows rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails puma zeus)
+bundled_commands=(annotate cap capify cucumber foreman guard middleman nanoc rackup rainbows rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails puma)
 
 ## Functions
 


### PR DESCRIPTION
The zeus command should not be executed via bundler, see: https://github.com/robbyrussell/oh-my-zsh/pull/1138

On most installations zeus is actually installed by running `gem install zeus` and this will cause problems as in most cases you dont want zeus in your gem file.
