### PR TITLE
agnoster "classic"

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -95,7 +95,7 @@ prompt_dir() {
 prompt_status() {
   local symbols
   symbols=()
-  [[ $RETVAL -ne 0 ]] && symbols+="%{%F{red}%}$RETVAL"
+  [[ $RETVAL -ne 0 ]] && symbols+="%{%F{red}%}✘"
   [[ $UID -eq 0 ]] && symbols+="%{%F{yellow}%}⚡"
   [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{cyan}%}⚙"
 


### PR DESCRIPTION
As discussed (perhaps at too great length) in #1388, I strongly disagree with the change to include the numeric exit code in the agnoster theme. Each component of the prompt was explicitly weighed for relevance, aesthetics, and concision; an early version of the theme included a numeric status code, and at one point success was also indicated with a check mark. I rejected both of these ideas in the end, because the goal was to convey the right amount of information.

I completely understand if you'd rather let the community add to this theme — part of what makes OMZ great is, after all, community involvement — but I would be very grateful if we could change this back to the way it was.

Cheers!
