### PR TITLE
Added flag.io plugin

### DIFF
--- a/plugins/flagio/flagio.plugin.zsh
+++ b/plugins/flagio/flagio.plugin.zsh
@@ -1,15 +1,17 @@
 # Upload files to flag.io
 upload() {
+  local file
+
   if [ $# -lt 1 ]; then
     printf 'usage: upload <file> [<file> ...]\n'
     return 1
   fi
 
-  for path in $@; do
-    if [ -f "$path" ]; then
-      curl -sT "$path" flag.io | egrep -v '^#'
+  for file in $@; do
+    if [ -f "$file" ]; then
+      curl -sT "$file" flag.io | egrep -v '^#'
     else
-      printf 'File not found: %s\n' "$path"
+      printf 'File not found: %s\n' "$file"
     fi
   done
 }


### PR DESCRIPTION
Hey,

here is a little plugin to upload files to flag.io. 

`usage: upload <file> [<file> ...]`

I am not sure about curl. Is it installed on OS X by default?
