### PR TITLE
Added support for grailsw command on Grails plugin

### DIFF
--- a/plugins/grails/grails.plugin.zsh
+++ b/plugins/grails/grails.plugin.zsh
@@ -52,3 +52,4 @@ _grails() {
 }
  
 compdef _grails grails
+compdef _grails grailsw


### PR DESCRIPTION
Grails wrapper creates a `grailsw` script in a Grails project. It has the same available command line arguments as the `grails` command.
