### PR TITLE
Call current_branch() only once by using the cached value.

### DIFF
--- a/themes/eastwood.zsh-theme
+++ b/themes/eastwood.zsh-theme
@@ -16,7 +16,7 @@ ZSH_THEME_GIT_PROMPT_CLEAN=""
 git_custom_status() {
   local cb=$(current_branch)
   if [ -n "$cb" ]; then
-    echo "$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_PREFIX$(current_branch)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+    echo "$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_PREFIX$cb$ZSH_THEME_GIT_PROMPT_SUFFIX"
   fi
 }
 

--- a/themes/gallois.zsh-theme
+++ b/themes/gallois.zsh-theme
@@ -7,7 +7,7 @@ ZSH_THEME_GIT_PROMPT_CLEAN=""
 git_custom_status() {
   local cb=$(current_branch)
   if [ -n "$cb" ]; then
-    echo "$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_PREFIX$(current_branch)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+    echo "$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_PREFIX$cb$ZSH_THEME_GIT_PROMPT_SUFFIX"
   fi
 }
 


### PR DESCRIPTION
A small optimization which calls current_branch() only once in the Eastwood and Gallois themes.
