### PR TITLE
provide the unbundled commands

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -33,6 +33,7 @@ _run-with-bundler() {
 
 ## Main program
 for cmd in $bundled_commands; do
+  eval "function unbundled_$cmd () { $cmd \$@ }"
   eval "function bundled_$cmd () { _run-with-bundler $cmd \$@}"
   alias $cmd=bundled_$cmd
 


### PR DESCRIPTION
Hi all,

I am using the zsh bundler plugin.

When I am using the Bundler gem to build a gem and running `rake -T`, I see the following:

`rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)`

This is because I have a `Gemfile` file but have not define rake dependency, but it's no necessary.

So I think it would be nice to provide the unbundled commands like `unbundled_rake`.
