### PR TITLE
Maven plugin completion fix for other (than Java) JVM languages and/or missing test cases folder

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -163,7 +163,7 @@ function listMavenCompletions {
         cli:execute cli:execute-phase 
         archetype:generate generate-sources 
         cobertura:cobertura
-        -Dtest= `if [ -d ./src ] ; then find ./src/test/java -type f -name '*.java' | grep -v svn | sed 's?.*/\([^/]*\)\..*?-Dtest=\1?' ; fi`
+        -Dtest= `if [ -d ./src/test/java ] ; then find ./src/test/java -type f -name '*.java' | grep -v svn | sed 's?.*/\([^/]*\)\..*?-Dtest=\1?' ; fi`
     ); 
 }
 


### PR DESCRIPTION
Pressing TAB after mvn caused Unix find to fail in case of a Mirah or Scala project, because there were no src/test/java directory present.
