### PR TITLE
Fix ssh-agent plugin for OpenBSD, making it more portable

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -48,7 +48,7 @@ if [[ ${_plugin__forwarding} == "yes" && -n "$SSH_AUTH_SOCK" ]]; then
 elif [ -f "${_plugin__ssh_env}" ]; then
   # Source SSH settings, if applicable
   . ${_plugin__ssh_env} > /dev/null
-  ps -ef | grep ${SSH_AGENT_PID} | grep ssh-agent$ > /dev/null || {
+  ps -x | grep ${SSH_AGENT_PID} | grep ssh-agent > /dev/null || {
     _plugin__start_agent;
   }
 else


### PR DESCRIPTION
OpenBSD doesn't have -ef flags for ps. Both linux and OpenBSD have -x flags which works just as greate here
