### PR TITLE
Fixed 'ls' issue on NetBSD

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -7,13 +7,12 @@ export LSCOLORS="Gxfxcxdxbxegedabagacad"
 if [ "$DISABLE_LS_COLORS" != "true" ]
 then
   # Find the option for using colors in ls, depending on the version: Linux or BSD
-  if [[ "$(uname -s)" == "NetBSD" ]]
-  then
-      # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors); 
-      # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
-      gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty'
+  if [[ "$(uname -s)" == "NetBSD" ]]; then
+    # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors); 
+    # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
+    gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty'
   else
-      ls --color -d . &>/dev/null 2>&1 && alias ls='ls --color=tty' || alias ls='ls -G'
+    ls --color -d . &>/dev/null 2>&1 && alias ls='ls --color=tty' || alias ls='ls -G'
   fi
 fi
 


### PR DESCRIPTION
NetBSD's `ls` doesn't support `--color` or `-G`, but it ends up aliased to `ls -G` anyway, causing an error when used. This patch fixes the issue and also aliases `ls` to `gls` (GNU ls - supports colors), if available. 
