### PR TITLE
Adding torrent tools plugin.

### DIFF
--- a/plugins/torrent/torrent.plugin.zsh
+++ b/plugins/torrent/torrent.plugin.zsh
@@ -1,0 +1,17 @@
+#
+# Algorithm borrowed from http://wiki.rtorrent.org/MagnetUri and adapted to work with zsh.
+#
+
+function magnet_to_torrent() {
+	[[ "$1" =~ xt=urn:btih:([^\&/]+) ]] || return 1
+
+	hashh=${match[1]}
+
+	if [[ "$1" =~ dn=([^\&/]+) ]];then
+	  filename=${match[1]}
+	else
+	  filename=$hashh
+	fi
+
+	echo "d10:magnet-uri${#1}:${1}e" > "$filename.torrent"
+}


### PR DESCRIPTION
Only one tool exists right now, that is to convert a magnetlink into a
torrent file.
