### PR TITLE
Add sudo plugin which bind \e\e to add sudo in front of the command

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -1,0 +1,7 @@
+sudo-command-line() {
+    [[ -z "$BUFFER" ]] && zle up-history
+    [[ "$BUFFER" != "sudo *" ]] && BUFFER="sudo $BUFFER"
+    zle end-of-line
+}
+zle -N sudo-command-line
+bindkey '\e\e' sudo-command-line


### PR DESCRIPTION
type:
$ pacman -Syu
then, press <esc><esc>, and the command will be:
$ sudo pacman -Syu
or, add sudo to the previous command if nothing is type yet.
