### PR TITLE
Full width separator for af-magic theme

### DIFF
--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -14,8 +14,8 @@ if [ $UID -eq 0 ]; then NCOLOR="red"; else NCOLOR="green"; fi
 local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 
 # primary prompt
-PROMPT_SEP=`printf '-%.0s' {1..$COLUMNS}`
-PROMPT='$FG[237]$PROMPT_SEP%{$reset_color%}
+ln_sep() { printf '-%.0s' {1..$COLUMNS}; }
+PROMPT='$FG[237]$(ln_sep)%{$reset_color%}
 $FG[032]%~\
 $(git_prompt_info) \
 $FG[105]%(!.#.»)%{$reset_color%} '


### PR DESCRIPTION
I really the command separator, it makes it easier to navigate in scrollback. This changes the width of the separator from hard-coded, to the width of the terminal, provided by COLUMNS environment variable.
