### PR TITLE
Mercurial repository info in agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -87,12 +87,11 @@ prompt_hg() {
 	local rev status
 	if $(hg id >/dev/null 2>&1); then
 		if $(hg prompt >/dev/null 2>&1); then
-			st=$(hg prompt {status})
-			if [[ $st = "?" ]]; then
+			if [[ $(hg prompt "{status|unknown}") = "?" ]]; then
 				# if files are not added
 				prompt_segment red white
 				st='±'
-			elif [[ -n $st ]]; then
+			elif [[ -n $(hg prompt "{status|modified}") ]]; then
 				# if any modification
 				prompt_segment yellow black
 				st='±'


### PR DESCRIPTION
I modded agnoster theme to add the same functionality it has for git. It displays the status of the mercurial repository, if any in cwd.
![Capture d e cran 2013-01-20 a 13 17 11](https://f.cloud.github.com/assets/353843/81147/6cf91e16-62fb-11e2-948d-d1f6909a1528.png)
