### PR TITLE
Added fetch -p alias on git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -38,6 +38,8 @@ alias gm='git merge'
 compdef _git gm=git-merge
 alias grh='git reset HEAD'
 alias grhh='git reset HEAD --hard'
+alias gfp='git fetch -p'
+
 
 # Git and svn mix
 alias git-svn-dcommit-push='git svn dcommit && git push github master:svntrunk'


### PR DESCRIPTION
added gsp alias for git fetch -p command. Still wondering there isn't any git init alias. Thanks! 
