### PR TITLE
Checks untracked files instead of directories

### DIFF
--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -81,7 +81,7 @@ add-zsh-hook chpwd steeef_chpwd
 function steeef_precmd {
     if [[ -n "$PR_GIT_UPDATE" ]] ; then
         # check for untracked files or updated submodules, since vcs_info doesn't
-        if git ls-files --other --exclude-standard --directory 2> /dev/null | grep -q "."; then
+        if git ls-files --other --exclude-standard 2> /dev/null | grep -q "."; then
             PR_GIT_UPDATE=1
             FMT_BRANCH="(%{$turquoise%}%b%u%c%{$hotpink%}●${PR_RST})"
         else


### PR DESCRIPTION
When the user creates an empty directory under the repository, the untracked flag will be set on (indicated by a 'hotpink' dot), but if the user want to clear the untracked flag using git diff or git status, he may find nothing changed. Removing `--directory` flag can avoid this problem. @steeef what do you think?
