### PR TITLE
Add autoenv plugin, which adopts using Kenneth Reitz's autoenv.

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -29,6 +29,9 @@ cd () {
     cd ../../../..
   elif [[ "x$*" == "x......" ]]; then
     cd ../../../../..
+  elif [ -d ~/.autoenv ]; then
+    source ~/.autoenv/activate.sh
+    autoenv_cd "$@"
   else
     builtin cd "$@"
   fi

--- a/plugins/autoenv/autoenv.plugin.zsh
+++ b/plugins/autoenv/autoenv.plugin.zsh
@@ -1,0 +1,18 @@
+# The use_env call below is a reusable command to activate/create a new Python
+# virtualenv, requiring only a single declarative line of code in your .env files.
+# It only performs an action if the requested virtualenv is not the current one.
+use_env() {
+    typeset venv
+    venv="$1"
+    if [[ "${VIRTUAL_ENV:t}" != "$venv" ]]; then
+        if workon | grep -q "$venv"; then
+            workon "$venv"
+        else
+            echo -n "Create virtualenv $venv now? (Yn) "
+            read answer
+            if [[ "$answer" == "Y" ]]; then
+                mkvirtualenv "$venv"
+            fi
+        fi
+    fi
+}


### PR DESCRIPTION
Hi, 

I've added a plugin for using [autoenv](https://github.com/kennethreitz/autoenv). When cd'ed into a directory, autoenv checks whether there is an .env file in this directory; if there is one it executes the contents of this .env file.

This commit changes the overridden cd () in lib/directories.zsh. The plugin assumes autoenv is installed under ~/.autoenv a.k.a autoenv is git checked-out to .autoenv. I'm open to any suggestions about that.

The use_env function in the plugin is used to auto-activate virtualenv and needs virtualenvwrapper. The code is taken from https://github.com/kennethreitz/autoenv/wiki/Cookbook

For the autoenv users, I think this plugin would help much. I'd be pleased if you merge the code into master branch. I'd also appreciate any comments on how to improve the code.

Peace!

-Serdar
