### PR TITLE
gitfast: Use upstream git completion but oh-my-zsh prompt

### DIFF
--- a/plugins/gitfast/gitfast.plugin.zsh
+++ b/plugins/gitfast/gitfast.plugin.zsh
@@ -1,7 +1,10 @@
 dir=$(dirname $0)
 source $dir/../git/git.plugin.zsh
-source $dir/git-prompt.sh
 
-function git_prompt_info() {
-  __git_ps1 "${ZSH_THEME_GIT_PROMPT_PREFIX//\%/%%}%s${ZSH_THEME_GIT_PROMPT_SUFFIX//\%/%%}"
-}
+if [ -z "$GITFAST_USE_OHMYZSH_PROMPT" ]; then
+    source $dir/git-prompt.sh
+
+    function git_prompt_info() {
+      __git_ps1 "${ZSH_THEME_GIT_PROMPT_PREFIX//\%/%%}%s${ZSH_THEME_GIT_PROMPT_SUFFIX//\%/%%}"
+    }
+fi


### PR DESCRIPTION
The gitfast plugin lets you use the faster upstream zsh completion macros.  Currently, it also forces you into using the upstream prompt expressions.  I want to be able to choose which of the two upstream bits to use — I want upstream completion but oh-my-zsh prompts, for instance.
