### PR TITLE
Better custom theme loading

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -73,6 +73,9 @@ else
     if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]
     then
       source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
+    elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]
+    then
+      source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
     else
       source "$ZSH/themes/$ZSH_THEME.zsh-theme"
     fi


### PR DESCRIPTION
For better organization of custom themes, one can organize them in **custom/themes**, instead of dumping them all in the **custom** directory. However, `oh-my-zsh.sh` does not currently check that path for themes, despite it being a logical place for themes, as it mimics default oh-my-zsh directory structure.

In my small tweak, `oh-my-zsh.sh` now also checks for **$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme** when attempting to load a theme.

For example:

```
$ ls .oh-my-zsh/custom
foo bar blah customtheme.zsh-theme anothertheme.zsh-theme
```

Becomes

```
$ ls .oh-my-zsh/custom
foo bar blah
$ ls .oh-my-zsh/custom/themes
customtheme.zsh-theme anothertheme.zsh-theme
```
