### PR TITLE
Faster status checks for huge git repos

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -13,7 +13,7 @@ parse_git_dirty() {
     if [[ $POST_1_7_2_GIT -gt 0 ]]; then
           SUBMODULE_SYNTAX="--ignore-submodules=dirty"
     fi
-    if [[ -n $(git diff ${SUBMODULE_SYNTAX} HEAD 2> /dev/null) ]]; then
+    if [[ -n $(git status -s ${SUBMODULE_SYNTAX} -uno  2> /dev/null) ]]; then
       echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
     else
       echo "$ZSH_THEME_GIT_PROMPT_CLEAN"


### PR DESCRIPTION
The current status check for git repos can take several seconds when dealing with huge repos (WebKit in my case). It means a ~10 seconds delay for each command ran on the CLI.
Thanks to some twitter ranting, @paulirish and https://gist.github.com/3898739, I replaced `git status` with `git diff`.
AFAICT, `diff` based dirty/clean reports are identical to those of `status`, while being an order of magnitude faster (around 0.5 sec for the WebKit repo on my machine).
