### PR TITLE
Add new profiles plugin

### DIFF
--- a/plugins/profiles/profiles.plugin.zsh
+++ b/plugins/profiles/profiles.plugin.zsh
@@ -1,0 +1,12 @@
+# You will probably want to list this plugin as the first in your .zshrc.
+
+# This will look for a custom profile for the local machine and each domain or
+# subdomain it belongs to. (e.g. com, example.com and foo.example.com)
+parts=(${(s:.:)$(hostname)})
+for i in {${#parts}..1}; do
+  profile=${(j:.:)${parts[$i,${#parts}]}}
+  file=$ZSH_CUSTOM/profiles/$profile
+  if [ -f $file ]; then
+    source $file
+  fi
+done


### PR DESCRIPTION
Depending on the machine you're logged into, you may want to use
specific configuration. Add 'profiles' to your list of plugin will
try to find a profile for the local machine and each (sub)domain
it belongs to.
