### PR TITLE
[agnoster-theme] modifying theme for dirty/staged files

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -71,7 +71,6 @@ prompt_context() {
 prompt_git() {
   local ref dirty
   if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
-    ZSH_THEME_GIT_PROMPT_DIRTY='±'
     dirty=$(parse_git_dirty)
     ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git show-ref --head -s --abbrev |head -n1 2> /dev/null)"
     if [[ -n $dirty ]]; then
@@ -79,7 +78,19 @@ prompt_git() {
     else
       prompt_segment green black
     fi
-    echo -n "${ref/refs\/heads\//⭠ }$dirty"
+
+    setopt promptsubst
+    autoload -Uz vcs_info
+
+    zstyle ':vcs_info:*' enable git
+    zstyle ':vcs_info:*' get-revision true
+    zstyle ':vcs_info:*' check-for-changes true
+    zstyle ':vcs_info:*' stagedstr '✚'
+    zstyle ':vcs_info:git:*' unstagedstr '●'
+    zstyle ':vcs_info:*' formats ' %u%c'
+    zstyle ':vcs_info:*' actionformats '%u%c'
+    vcs_info
+    echo -n "${ref/refs\/heads\//⭠ }${vcs_info_msg_0_}"
   fi
 }
 


### PR DESCRIPTION
Changes to show dot for dirty files and plus for staged files in git repos

e.g.:
![Screenshot_1_30_13_8_49_PM](https://f.cloud.github.com/assets/1200246/113266/7ea7f9d4-6b48-11e2-89ea-914c7db48ca8.png)
