### PR TITLE
Fix gems helper command to work with GNU sed

### DIFF
--- a/plugins/rvm/rvm.plugin.zsh
+++ b/plugins/rvm/rvm.plugin.zsh
@@ -38,11 +38,11 @@ function gems {
 	local current_ruby=`rvm-prompt i v p`
 	local current_gemset=`rvm-prompt g`
 
-	gem list $@ | sed \
-		-Ee "s/\([0-9, \.]+( .+)?\)/$fg[blue]&$reset_color/g" \
-		-Ee "s|$(echo $rvm_path)|$fg[magenta]\$rvm_path$reset_color|g" \
-		-Ee "s/$current_ruby@global/$fg[yellow]&$reset_color/g" \
-		-Ee "s/$current_ruby$current_gemset$/$fg[green]&$reset_color/g"
+	gem list $@ | sed -E \
+		-e "s/\([0-9, \.]+( .+)?\)/$fg[blue]&$reset_color/g" \
+		-e "s|$(echo $rvm_path)|$fg[magenta]\$rvm_path$reset_color|g" \
+		-e "s/$current_ruby@global/$fg[yellow]&$reset_color/g" \
+		-e "s/$current_ruby$current_gemset$/$fg[green]&$reset_color/g"
 }
 
 function _rvm_completion {


### PR DESCRIPTION
Repeating the `-E` flag fails with GNU `sed` (brings up the usage/help description). This fixes the `gems` helper command with GNU `sed` (Linux) without breaking BSD `sed` (OS X) compatibility. Supersedes #411.
