### PR TITLE
use pushdminus

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -2,6 +2,7 @@
 setopt auto_name_dirs
 setopt auto_pushd
 setopt pushd_ignore_dups
+setopt pushdminus
 
 alias ..='cd ..'
 alias cd..='cd ..'
@@ -11,14 +12,14 @@ alias cd.....='cd ../../../..'
 alias cd/='cd /'
 
 alias 1='cd -'
-alias 2='cd +2'
-alias 3='cd +3'
-alias 4='cd +4'
-alias 5='cd +5'
-alias 6='cd +6'
-alias 7='cd +7'
-alias 8='cd +8'
-alias 9='cd +9'
+alias 2='cd -2'
+alias 3='cd -3'
+alias 4='cd -4'
+alias 5='cd -5'
+alias 6='cd -6'
+alias 7='cd -7'
+alias 8='cd -8'
+alias 9='cd -9'
 
 cd () {
   if   [[ "x$*" == "x..." ]]; then


### PR DESCRIPTION
On my linux box `pushdminus` was set by default. This caused to work the stack the other way around.
To resolve this issue I've set `pushdminus` from oh-my-zsh. This way on all system it's the same.

It also would have been possible to `unsetopt pushdminus`. But because "go back one in the stack" is `cd -` and `-` is easier to type than a `+` (on a US keyboard) I've preferred this way.

(this is the proper pull request for #1581)
