### PR TITLE
Added missing status case where a tracked file has both staged and unstaged changes.

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -67,10 +67,10 @@ git_prompt_status() {
   fi
   if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
-  elif $(echo "$INDEX" | grep '^M  ' &> /dev/null); then
+  elif $(echo "$INDEX" | grep '^M[M ] ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
   fi
-  if $(echo "$INDEX" | grep '^ M ' &> /dev/null); then
+  if $(echo "$INDEX" | grep '^[M ]M ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
   elif $(echo "$INDEX" | grep '^AM ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"


### PR DESCRIPTION
Two of the git prompt status flags, `ZSH_THEME_GIT_PROMPT_ADDED` and `ZSH_THEME_GIT_PROMPT_MODIFIED`, don't get added to the status prompt in the case where a tracked file has both staged and unstaged changes. When the theme doesn't use the dirty/clean flags, it can appear as if the repo is pristine.
