### PR TITLE
Changes to the way oh-my-zsh sources custom scripts

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -21,13 +21,24 @@ fi
 for config_file ($ZSH/lib/*.zsh); do
   filename=$(basename "$config_file")
   if [ -f $ZSH_CUSTOM/$filename ]; then
-    #echo "source $ZSH_CUSTOM/$filename"
+    # echo "source $ZSH_CUSTOM/$filename"
     source $ZSH_CUSTOM/$filename
   elif [ -f $config_file ]; then
-    #echo "source $config_file"
+    # echo "source $config_file"
     source $config_file
   fi
 done
+unset config_file
+
+# Now source all remaining .zsh scripts in ZSH_CUSTOM
+for config_file ($ZSH_CUSTOM/*.zsh); do
+  filename=$(basename "$config_file")
+  if [ ! -f $ZSH/lib/$filename ]; then
+    # echo "source $config_file"
+    source $config_file
+  fi
+done
+unset config_file
 
 is_plugin() {
   local base_dir=$1
@@ -49,7 +60,6 @@ done
 autoload -U compinit
 compinit -i
 
-
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do
   if [ -f $ZSH_CUSTOM/$plugin/$plugin.plugin.zsh ]; then
@@ -58,9 +68,6 @@ for plugin ($plugins); do
     source $ZSH/plugins/$plugin/$plugin.plugin.zsh
   fi
 done
-
-# Unser variables
-unset config_file
 unset plugin
 
 # Load the theme


### PR DESCRIPTION
This is my suggested change to the behaviour of oh-my-zsh main script. It will now first look what scripts have been specified in $ZSH/custom. If they happen to have the same name as scripts in $ZSH/lib, then they are sourced instead (i.e. custom files now override oh-my-zsh settings). I decided to do this so that I can have direct control over what oh-my-zsh does to my shell without modifying your default script files. If this is not a functionality you are looking for, feel free to ignore the pull request.

Secondly, custom plugins now go directly into $ZSH/custom/<myplugin> directory instead of $ZSH/custom/plugins/<myplugin>. The script has no functionality to source anything in any other $ZSH/custom subfolders, so why have the plugins subfolder anyway?
