### PR TITLE
sudo as an alias for sudo

### DIFF
--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -7,6 +7,7 @@ alias ...='cd ../..'
 alias -- -='cd -'
 
 # Super user
+alias sudo='sudo ' # http://www.shellperson.net/using-sudo-with-an-alias/
 alias _='sudo'
 alias please='sudo'
 


### PR DESCRIPTION
Say we have an alias ll='ls -l', for example. If we execute "sudo ll", we receive the following error:

```
sudo: ll: command not found
```

We most likely wanted the alias to be expanded before being passed to the sudo command, and that is exactly what this commit is about. The fix is simple, but having the alias sudo="sudo " is enough.

For more info:
http://www.shellperson.net/using-sudo-with-an-alias/
