### PR TITLE
Add option to prevent checking git repository status when accessing repo over a slow connection.

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -1,8 +1,10 @@
 # get the name of the branch we are on
 function git_prompt_info() {
-  ref=$(git symbolic-ref HEAD 2> /dev/null) || \
-  ref=$(git rev-parse --short HEAD 2> /dev/null) || return
-  echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+  if [[ "$(git config --get oh-my-zsh.show-branch-on-only)" == "$(hostname)" || -z "$(git config --get oh-my-zsh.show-branch-on-only)" ]]; then
+    ref=$(git symbolic-ref HEAD 2> /dev/null) || \
+    ref=$(git rev-parse --short HEAD 2> /dev/null) || return
+    echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+  fi
 }
 
 


### PR DESCRIPTION
Currently when one has an network share mounted, navigating into directories containing git repositories can be extremely slow.

This modification allows one to specify in one's repository configuration a single hostname in the `oh-my-zsh.show-branch-on-only` configuration key that ZSH will check prior to checking a repository's status.  Should this configuration setting be specified, and the hostname in its value not match one's hostname, repository status will not be checked.
