### PR TITLE
Bower plugin

### DIFF
--- a/plugins/bower/bower.plugin.zsh
+++ b/plugins/bower/bower.plugin.zsh
@@ -1,0 +1,38 @@
+alias bi="bower install"
+alias bl="bower list"
+alias bs="bower search"
+
+bower_package_list=''
+
+_bower ()
+{
+	local curcontext="$curcontext" state line
+	typeset -A opt_args
+
+	_arguments -C \
+		':command:->command' \
+		'*::options:->options'
+
+	case $state in
+		(command)
+
+			local -a subcommands
+			subcommands=(${=$(bower help | grep help | sed -e 's/,//g')})
+			_describe -t commands 'bower' subcommands
+		;;
+
+		(options)
+			case $line[1] in
+
+				(install)
+				    if [ -z "$bower_package_list" ];then
+                    bower_package_list=$(bower search | awk 'NR > 2' | cut -d '-' -f 2 | cut -d ' ' -f 2 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g")
+                fi
+				    compadd "$@" $(echo $bower_package_list)
+                ;;
+			esac
+		;;
+	esac
+}
+
+compdef _bower bower


### PR DESCRIPTION
Hi!

I've noticed, that a few folks are using this plugin, so I thought it would be nice to make it available from the original repo.

Here is the description:

Bower is a package manager for the web.
This plugin provides some aliases and completitions for this great tool.
### Aliases

`bi`: installs a package (`bower install`)
`bl`: lists installed packages (`bower list`)
`bs`: searches for packages (`bower search`)
### Completition

It completes the basic commands for bower. It uses the `bower help` command to achieve this, not a burned-in list of commands.
It also provides completition for bower install, uses the output of bower search. It takes a few seconds for the first time (in the session), but then the output of `bower search` is cached, so things then speed up a lot.
### Example

```
# to install jquery for example
bi jq<TAB>
```
