### PR TITLE
pipe git version check error to /dev/null (for when git doesn't exist)

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -112,7 +112,7 @@ function git_compare_version() {
   local INPUT_GIT_VERSION=$1;
   local INSTALLED_GIT_VERSION
   INPUT_GIT_VERSION=(${(s/./)INPUT_GIT_VERSION});
-  INSTALLED_GIT_VERSION=($(git --version));
+  INSTALLED_GIT_VERSION=($(git --version 2>/dev/null));
   INSTALLED_GIT_VERSION=(${(s/./)INSTALLED_GIT_VERSION[3]});
 
   for i in {1..3}; do


### PR DESCRIPTION
If you share your home directory among multiple machines, not all of which have git installed, oh-my-zsh throws up error messages on starting the shell. This silences the one that occurs when git doesn't exist.
