### PR TITLE
Disable ssh-agent support in gpg-agent-plugin if another ssh-agent is already available.

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -1,19 +1,18 @@
 local GPG_ENV=$HOME/.gnupg/gpg-agent.env
 
 function start_agent_nossh {
-    eval $(/usr/bin/env gpg-agent --daemon --write-env-file ${GPG_ENV}) > /dev/null
+    eval $(/usr/bin/env gpg-agent --quiet --daemon --write-env-file ${GPG_ENV} 2> /dev/null)
+    chmod 600 ${GPG_ENV}
     export GPG_AGENT_INFO
 }
 
 function start_agent_withssh {
-    eval $(/usr/bin/env gpg-agent --daemon --enable-ssh-support --write-env-file ${GPG_ENV}) > /dev/null
+    eval $(/usr/bin/env gpg-agent --quiet --daemon --enable-ssh-support --write-env-file ${GPG_ENV} 2> /dev/null)
+    chmod 600 ${GPG_ENV}
     export GPG_AGENT_INFO
     export SSH_AUTH_SOCK
     export SSH_AGENT_PID
 }
-
-# make sure all created files are u=rw only
-umask 177
 
 # source settings of old agent, if applicable
 if [ -f "${GPG_ENV}" ]; then


### PR DESCRIPTION
The gpg-agent-plugin overwrites an already running ssh-agent. This patch fixes that by disabling ssh-agent-support if another ssh-agent ist configured and running.
