### PR TITLE
Insert ZSH_THEME_GIT_PROMPT_CLEAN into gitfast's prompt.

### DIFF
--- a/plugins/gitfast/gitfast.plugin.zsh
+++ b/plugins/gitfast/gitfast.plugin.zsh
@@ -3,5 +3,5 @@ source $dir/../git/git.plugin.zsh
 source $dir/git-prompt.sh
 
 function git_prompt_info() {
-  __git_ps1 "${ZSH_THEME_GIT_PROMPT_PREFIX//\%/%%}%s${ZSH_THEME_GIT_PROMPT_SUFFIX//\%/%%}"
+  __git_ps1 "${ZSH_THEME_GIT_PROMPT_PREFIX//\%/%%}%s${ZSH_THEME_GIT_PROMPT_CLEAN//\%/%%}${ZSH_THEME_GIT_PROMPT_SUFFIX//\%/%%}"
 }


### PR DESCRIPTION
Otherwise we're missing a closing paren in the prompt, at least on
robbyrussel theme.
