### PR TITLE
Fix Symfony2 command completion 'permission denied'

### DIFF
--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -1,7 +1,7 @@
 # Symfony2 basic command completion
 
 _symfony2_get_command_list () {
-	app/console --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
+	php app/console --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
 }
 
 _symfony2 () {


### PR DESCRIPTION
app/console by default (if you create a new Symfony project via composer create-project or by downloading it from symfony.com) is not executable. Therefore I get the following error:

sf2 _symfony2_get_command_list:1: permission denied: app/console 
_symfony2_get_command_list:1: permission denied: app/console
_symfony2_get_command_list:1: permission denied: app/console

To make command completion work without changing app/console you just have to let php run it.
