### PR TITLE
Add alias for "composer dump-autoload"

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -24,6 +24,7 @@ alias csu='composer self-update'
 alias cu='composer update'
 alias ci='composer install'
 alias ccp='composer create-project'
+alias cdu='composer dump-autoload'
 
 # install composer in the current directory
 alias cget='curl -s https://getcomposer.org/installer | php'


### PR DESCRIPTION
An often used command on Composer-based frameworks as they use Composer's autoload for their own files and classes.
