### PR TITLE
Move example aliases to 'custom' section of the .zshrc template

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -7,10 +7,6 @@ export ZSH=$HOME/.oh-my-zsh
 # time that oh-my-zsh is loaded.
 ZSH_THEME="robbyrussell"
 
-# Example aliases
-# alias zshconfig="mate ~/.zshrc"
-# alias ohmyzsh="mate ~/.oh-my-zsh"
-
 # Uncomment the following line to use case-sensitive completion.
 # CASE_SENSITIVE="true"
 
@@ -72,3 +68,12 @@ export PATH=$HOME/bin:/usr/local/bin:$PATH
 
 # ssh
 # export SSH_KEY_PATH="~/.ssh/dsa_id"
+
+# Set personal aliases, overriding those provided by oh-my-zsh libs,
+# plugins, and themes. Aliases can be placed here, though oh-my-zsh
+# users are encouraged to define aliases within the ZSH_CUSTOM folder.
+# For a full list of active aliases, run `alias`.
+#
+# Example aliases
+# alias zshconfig="mate ~/.zshrc"
+# alias ohmyzsh="mate ~/.oh-my-zsh"


### PR DESCRIPTION
By convention, user-specific aliases are kept in each user's `.zshrc` file. The .zshrc template provided by oh-my-zsh has an area for example aliases, though these were being loaded _before_ other aliases in libs, plugins, and themes. As a result, personal aliases could be overwritten as other items are loaded by oh-my-zsh.

To make personal customization easier, the sample aliases section of the .zshrc template has been moved to the area dedicated for personal customization. This section of the configuration is processed after all other items are loaded, preventing personal aliases and exports from being inadvertently clobbered by oh-my-zsh.
