### PR TITLE
Escape $ZSH path in upgrade_oh_my_zsh

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,6 +1,6 @@
 current_path=`pwd`
 printf '\033[0;34m%s\033[0m\n' "Upgrading Oh My Zsh"
-cd $ZSH
+cd "$ZSH"
 
 if git pull origin master
 then


### PR DESCRIPTION
The upgrade function was broken on my box due to an unquoted use of $ZSH. My home directory path contains a space, but, by using 'cd $ZSH', the whitespace was not escaped.
