### PR TITLE
Autocomplete composer default methods if composer.json is not available

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -13,6 +13,8 @@ _composer_get_command_list () {
 _composer () {
   if [ -f composer.json ]; then
     compadd `_composer_get_command_list`
+  else
+    compadd create-project init search selfupdate show
   fi
 }
 


### PR DESCRIPTION
This plugin currently doesn't autocomplete composer commands if there is no composer.json in the current dir. However, the commands create-project, init, search, selfupdate and show are still useful without a composer.json!
