### PR TITLE
Fixed base64 decode parameter for newer versions of base64 binary

### DIFF
--- a/plugins/encode64/encode64.plugin.zsh
+++ b/plugins/encode64/encode64.plugin.zsh
@@ -1,4 +1,4 @@
 encode64(){ echo -n $1 | base64 }
-decode64(){ echo -n $1 | base64 -D }
+decode64(){ echo -n $1 | base64 --decode }
 alias e64=encode64
 alias d64=decode64


### PR DESCRIPTION
In OS X, the shipping binary for "base64" uses -D has the decode parameter. This is not supported in newer versions of base64 so people that have installed Homebrew's "coreutils" brew, or even on non-OS X operating systems will get:

```
% decode64 d2VsY29tZQ==
base64: invalid option -- 'D'
Try 'base64 --help' for more information.
```

This commit will modify the decode parameter to use "--decode" which works across all versions of base64.
