### PR TITLE
Fix some problems with git enabled prompts where they *always* claim to have untracked files

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -62,7 +62,7 @@ function git_prompt_long_sha() {
 git_prompt_status() {
   INDEX=$(git status --porcelain -b 2> /dev/null)
   STATUS=""
-  if $(echo "$INDEX" | grep '^?? ' &> /dev/null); then
+  if $(echo "$INDEX" | grep '^\?\? ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
   fi
   if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then


### PR DESCRIPTION
the problem was that 

grep '^?? ' 

matches any two characters at the beginning of a line. 
so the "## branchname" of a completely clean repository is also matched, which is incorrect.
