### PR TITLE
last-working-dir: Use >! to overwrite $cache_file

### DIFF
--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -9,7 +9,7 @@ local cache_file="$ZSH/cache/last-working-dir"
 
 # Updates the last directory once directory is changed.
 function chpwd() {
-        # Use >! in case noclobber is set to avoid "file exists" error
+  # Use >! in case noclobber is set to avoid "file exists" error
 	echo "$PWD" >! "$cache_file"
 }
 


### PR DESCRIPTION
Use ">!" to overwrite $cache_file in case noclobber is set. 
When noclobber is set, zsh will not allow the use of ">" to overwrite
the contents of a file. Instead, it displays a "file exists" error.
By using ">!" instead, we tell zsh to overwrite the file without
complaining.
