### PR TITLE
Fixes #1485 Zeus should not be bundled

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -6,7 +6,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate cap capify cucumber foreman guard middleman nanoc rackup rainbows rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails puma zeus)
+bundled_commands=(annotate cap capify cucumber foreman guard middleman nanoc rackup rainbows rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails puma)
 
 ## Functions
 

--- a/plugins/zeus/zeus.plugin.zsh
+++ b/plugins/zeus/zeus.plugin.zsh
@@ -2,12 +2,6 @@
 # Zeus preloads your Rails environment and forks that process whenever
 # needed. This effectively speeds up Rails' boot process to under 1 sec.
 
-# Always use bundler.
-# Rails depends on bundler, so we can be pretty sure, that there are no
-# problems with this command. For all the other aliases I provided an
-# alternative, in case people have conflicts with other plugins (e.g. suse).
-alias zeus='bundle exec zeus'
-
 # Init
 alias zi='zeus init'
 alias zinit='zeus init'


### PR DESCRIPTION
**Note**: Freshly rebased branch.  See #1486

---

Fixes #1485 Zeus should not be bundled.

According to [`zeus` README](https://github.com/burke/zeus/blob/master/README.md), zeus should not be bundled.

> Q: "I should put it in my Gemfile, right?"
> 
> A: No. You can, but running bundle exec zeus instead of zeus adds precious seconds to commands that otherwise would be quite a bit faster. Zeus was built to be run from outside of bundler.
