### PR TITLE
Allow you to customize the path to knife config files

### DIFF
--- a/plugins/knife/_knife
+++ b/plugins/knife/_knife
@@ -1,5 +1,10 @@
 #compdef knife
 
+# You can override the path to knife.rb and your cookbooks by setting
+# KNIFE_CONF_PATH=/path/to/my/.chef/knife.rb
+# KNIFE_COOKBOOK_PATH=/path/to/my/chef/cookbooks
+# Read around where these are used for more detail.
+
 # These flags should be available everywhere according to man knife
 knife_general_flags=( --help --server-url --key --config --editor --format --log_level --logfile --no-editor --user --print-after --version --yes )
 


### PR DESCRIPTION
The path to knife.rb is currently harcoded to $HOME/.chef/knife.rb.  Mine lives elsewhere.
Set KNIFE_CONF_PATH in your .zshrc to override $HOME/.chef/knife.rb.  Not setting that variable leaves it as it behaved before.
The plugin attempts to get the path to the cookbooks from the knife.rb conf file.  However, the knife.rb conf allows ruby in the cookbook_path definition (in my case cookbook_path is "#{current_dir}/../cookbooks"). Since zsh is not using ruby to parse the conf file, it fails to expand variables like #{current_dir}.  Rather than try and use ruby to interpret knife.rb (which is scary), I added an override for the cookbook directory.  Set KNIFE_COOKBOOK_PATH in your .zshrc to skip examining knife.rb for the cookbook_path.
