### PR TITLE
replace hostname -s with hostname in ys theme for compatibility

### DIFF
--- a/themes/ys.zsh-theme
+++ b/themes/ys.zsh-theme
@@ -8,7 +8,7 @@
 
 # Machine name.
 function box_name {
-    [ -f ~/.box-name ] && cat ~/.box-name || hostname -s
+    [ -f ~/.box-name ] && cat ~/.box-name || hostname
 }
 
 # Directory info.


### PR DESCRIPTION
hostname -s is not available on every implementation of hostname, e.g. Cygwin uses hostname from coreutils which doesn't work.
