### PR TITLE
This fixes checking for git untracked items

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -62,7 +62,7 @@ function git_prompt_long_sha() {
 git_prompt_status() {
   INDEX=$(git status --porcelain -b 2> /dev/null)
   STATUS=""
-  if $(echo "$INDEX" | grep '^\?\? ' &> /dev/null); then
+  if $(echo "$INDEX" | grep -E '^\?\? ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
   fi
   if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then


### PR DESCRIPTION
The grep expression was incorrect for normal grep. Adding the `-E` option
fixed the escaping of the question marks.
