### PR TITLE
Prevents echo of _sublime_darwin_paths contents on zsh startup

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -1,6 +1,6 @@
 # Sublime Text 2 Aliases
 
-local _sublime_darwin_paths
+local _sublime_darwin_paths > /dev/null 2>&1
 _sublime_darwin_paths=(
 	"$HOME/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
 	"$HOME/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"


### PR DESCRIPTION
Just a tiny little fix.
