### PR TITLE
extend mercurial plugin

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -17,8 +17,40 @@ alias hgs='hg status'
 # this is the 'git commit --amend' equivalent
 alias hgca='hg qimport -r tip ; hg qrefresh -e ; hg qfinish tip'
 
-function hg_current_branch() {
-  if [ -d .hg ]; then
-    echo hg:$(hg branch)
+function in_hg() {
+  if [[ -d .hg ]] || $(hg summary > /dev/null 2>&1); then
+    echo 1
   fi
+}
+
+function hg_get_branch_name() {
+  if [ $(in_hg) ]; then
+    echo $(hg branch)
+  fi
+}
+
+function hg_prompt_info {
+  if [ $(in_hg) ]; then
+    _DISPLAY=$(hg_get_branch_name)
+    echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_HG_PROMPT_PREFIX\
+$ZSH_THEME_REPO_NAME_COLOR$_DISPLAY$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_HG_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR$(hg_dirty)$ZSH_PROMPT_BASE_COLOR"
+    unset _DISPLAY
+  fi
+}
+
+function hg_dirty_choose {
+  if [ $(in_hg) ]; then
+    hg status 2> /dev/null | grep -Eq '^\s*[ACDIM!?L]'
+    if [ $pipestatus[-1] -eq 0 ]; then
+      # Grep exits with 0 when "One or more lines were selected", return "dirty".
+      echo $1
+    else
+      # Otherwise, no lines were found, or an error occurred. Return clean.
+      echo $2
+    fi
+  fi
+}
+
+function hg_dirty {
+  hg_dirty_choose $ZSH_THEME_HG_PROMPT_DIRTY $ZSH_THEME_HG_PROMPT_CLEAN
 }


### PR DESCRIPTION
I want to display branch names and staging status of mercurial repositories in my promt. 
Thus, the mercurial plugin was extended to define some functions (similar to the svn plugin).

Implement: in_hg(), hg_get_branch_name(), hg_prompt_info(), and hg_dirty()
