### PR TITLE
Fixed a UTF-8 problem in the theme "fishy"

### DIFF
--- a/themes/fishy.zsh-theme
+++ b/themes/fishy.zsh-theme
@@ -1,8 +1,13 @@
 # ZSH Theme emulating the Fish shell's default prompt.
 
 _fishy_collapsed_wd() {
-  echo $(pwd | perl -pe "s|^$HOME|~|g; s|/([^/])[^/]*(?=/)|/\$1|g")
-}
+  echo $(pwd | perl -pe "
+   BEGIN {
+      binmode STDIN,  ':encoding(UTF-8)';
+      binmode STDOUT, ':encoding(UTF-8)';
+   }; s|^$HOME|~|g; s|/([^/])[^/]*(?=/)|/\$1|g
+")
+} 
 
 local user_color='green'; [ $UID -eq 0 ] && user_color='red'
 PROMPT='%n@%m %{$fg[$user_color]%}$(_fishy_collapsed_wd)%{$reset_color%}%(!.#.>) '


### PR DESCRIPTION
To imitate the default behaviour of `fish(1)` `fishy.zsh-theme` includes a function to collapse the current working directory shown in the prompt from `/path/to/something` to `/p/t/something`. It calls `perl -pe` to do so. Unfortunately, as it is now the Perl one-liner breaks when the fed multibyte UTF-8 characters. This commit fixes that by forcing Perl to use UTF-8 I/O.

Before:

```
dbohdan@bayes /m/D/D/�/�/testls
```

After:

```
dbohdan@bayes /m/D/D/М/Р/test> ls
```

(Those are Cyrillic "М" and "P".)
