### PR TITLE
Improved the archlinux plugin

### DIFF
--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -8,7 +8,7 @@ if [[ -x `which yaourt` ]]; then
   }
   alias yaconf='yaourt -C'        # Fix all configuration files with vimdiff
   # Pacman - https://wiki.archlinux.org/index.php/Pacman_Tips
-  alias yaupg='yaourt -Syu'        # Synchronize with repositories before upgrading packages that are out of date on the local system.
+  alias yaupg='yaourt -Syua'        # Synchronize with repositories before upgrading packages (AUR packages too) that are out of date on the local system.
   alias yasu='yaourt --sucre'      # Same as yaupg, but without confirmation
   alias yain='yaourt -S'           # Install specific package(s) from the repositories
   alias yains='yaourt -U'          # Install specific package not from the repositories but from a file
@@ -18,6 +18,8 @@ if [[ -x `which yaourt` ]]; then
   alias yareps='yaourt -Ss'        # Search for package(s) in the repositories
   alias yaloc='yaourt -Qi'         # Display information about a given package in the local database
   alias yalocs='yaourt -Qs'        # Search for package(s) in the local database
+  alias yalst='yaourt -Qe'         # List installed packages, even those installed from AUR (they're tagged as "local")
+  alias yaorph='yaourt -Qtd'       # Remove orphans using yaourt
   # Additional yaourt alias examples
   if [[ -x `which abs` ]]; then
     alias yaupd='yaourt -Sy && sudo abs'   # Update and refresh the local package and ABS databases against repositories


### PR DESCRIPTION
I made some changes to the archlinux plugin :
- yaupg now also updates AUR packages, extremely useful for most archers
- Add yalst alias : it lists the installed packages, even from AUR, useful also when you want to do some spring cleanup
- Add yaorph alias : it removes orphans using yaourt, which is IMHO nicer than with pacman
