### PR TITLE
Add maildir segment to agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -118,6 +118,22 @@ prompt_hg() {
 	fi
 }
 
+prompt_maildir() {
+  # Avoid zsh complaining for ** not matching anything.
+  unsetopt nomatch 2>/dev/null
+  # Only enable this segment if the $MAILDIR variable is set.
+  if [[ -n "$MAILDIR" ]] then
+    # $MAILDIR should be set to something like "~/Maildir/INBOX/new" for a single maildir, or
+    # "~/Maildir/**/INBOX/new" in case of multiple maildirs in the same folder (if using offlineimap
+    # or similar).
+    eval ls "$MAILDIR/*" >/dev/null 2>&1
+    # ls succeeds if there is at least one file matching the pattern.
+    if [[ $? -eq 0 ]] then
+      prompt_segment black red "M"
+    fi
+  fi
+}
+
 # Dir: current working directory
 prompt_dir() {
   prompt_segment blue black '%~'
@@ -145,6 +161,7 @@ build_prompt() {
   prompt_dir
   prompt_git
   prompt_hg
+  prompt_maildir
   prompt_end
 }
 


### PR DESCRIPTION
This adds an extra segment to the agnoster theme, showing whether the local Malibox contains any unread email; useful for mutt/offlineimap users, it works as long as the $MAILDIR env variable is set, and pointing to the Maildir folder (which contains the actual individual mailboxes).
![Screen Shot 2013-04-15 at 15 10 03](https://f.cloud.github.com/assets/387628/380998/a0ca7564-a5d6-11e2-8bc4-1bac09d726e1.png)
