### PR TITLE
Added global aliases to process output of previous command.

### DIFF
--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -22,3 +22,9 @@ alias sl=ls # often screw this up
 
 alias afind='ack-grep -il'
 
+# Output aliases
+alias -g M='|more'
+alias -g L='|less'
+alias -g H='|head'
+alias -g T='|tail'
+alias -g N='2>/dev/null'


### PR DESCRIPTION
Added a aliases to process output prev command:

Examples:

```
cat some.txt T #=> cat some.txt | tail
exec_command N #=> exec_command 2>/dev/null
```
