### PR TITLE
Plugin to make life of sysadmins easier who deal with large number of servers

### DIFF
--- a/plugins/ssh/ssh.plugin.zsh
+++ b/plugins/ssh/ssh.plugin.zsh
@@ -44,8 +44,9 @@ function ssh() {
 
 	if [ -z "$host" ]; then
 		$actual_ssh $*
-	fi	
-
+		return
+	fi
+	
 	shift
 
 	$actual_ssh $(echo $ssh_hosts[$param]) $* # $() to circumvent ssh from b0rking if options are present in map


### PR DESCRIPTION
SSH hostnames can be long and it's boring to type the user@hostname every time.
Out of frustration, I developed this plugin.

It uses an associative array to map nicknames into actual user@hostname or extra options/whatever.

The plugin file has documentation.
