### PR TITLE
git: fix parse_git_dirty()

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -21,6 +21,8 @@ parse_git_dirty() {
     else
       echo "$ZSH_THEME_GIT_PROMPT_CLEAN"
     fi  
+  else
+    echo "$ZSH_THEME_GIT_PROMPT_CLEAN"
   fi  
 }
 


### PR DESCRIPTION
If oh-my-zsh.hide-status is configured, the 'clean' code won't be
generated, and some themes might end up distorted. Let's generate the
'clean' code even when we don't want the show the dirty status.

Signed-off-by: Felipe Contreras felipe.contreras@gmail.com
