### PR TITLE
Added 'jekyll' to list of bundled commands

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -6,7 +6,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate cap capify cucumber foreman guard middleman nanoc rackup rainbows rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails puma)
+bundled_commands=(annotate cap capify cucumber foreman guard jekyll middleman nanoc rackup rainbows rake rspec ruby shotgun spec spork thin thor unicorn unicorn_rails puma)
 
 ## Functions
 


### PR DESCRIPTION
What do you think about having [Jekyll](http://jekyllrb.com/) be handled by this wonderful plugin as well?
