### PR TITLE
Make git_remote_branch plugin git-flow friendly

### DIFF
--- a/plugins/git-remote-branch/git-remote-branch.plugin.zsh
+++ b/plugins/git-remote-branch/git-remote-branch.plugin.zsh
@@ -6,7 +6,8 @@ _git_remote_branch() {
       compadd create publish rename delete track
     elif (( CURRENT == 3 )); then
       # second arg: remote branch name
-      compadd `git branch -r | grep -v HEAD | sed "s/.*\///" | sed "s/ //g"`
+      remotes=`git remote | tr '\n' '|' | sed "s/\|$//g"`
+      compadd `git branch -r | grep -v HEAD | sed "s/$remotes\///" | sed "s/ //g"`
     elif (( CURRENT == 4 )); then
       # third arg: remote name
       compadd `git remote`


### PR DESCRIPTION
This is an update to the git_remote_branch plugin by @paulmars.

In its current form it will incorrectly complete git-flow style branches, like `feature/foobar`, giving just `foobar`.

The plugin is getting a list of all remote branch and stripping off everything before the last `/` to get branch names. This commit changes that to only remove `<remote_name>/` at the start of a branch name. So `origin/feature/foobar` gets stripped to `feature/foobar`.
