### PR TITLE
Fix a bug in the upgrade tool

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,5 +1,4 @@
 current_path=`pwd`
-current_path=${current_path/ /\\ }
 printf '\033[0;34m%s\033[0m\n' "Upgrading Oh My Zsh"
 cd "$ZSH"
 


### PR DESCRIPTION
This line doesn't meet the POSIX standard, and may cause compatibility problems.

As far as I can tell, there is no good reason for the second line of the "tools/upgrade.sh" to be there. If escaping white space where necessary, that method would be insufficient. Worse, since the only later use of the variable has it in double quotes having backslash escapes for spaces actually breaks it.
