### PR TITLE
theme agnoster: remove trailing space

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -88,9 +88,9 @@ prompt_git() {
     zstyle ':vcs_info:*' stagedstr '✚'
     zstyle ':vcs_info:git:*' unstagedstr '●'
     zstyle ':vcs_info:*' formats ' %u%c'
-    zstyle ':vcs_info:*' actionformats '%u%c'
+    zstyle ':vcs_info:*' actionformats ' %u%c'
     vcs_info
-    echo -n "${ref/refs\/heads\//⭠ }${vcs_info_msg_0_}"
+    echo -n "${ref/refs\/heads\//⭠ }${vcs_info_msg_0_%% }"
   fi
 }
 


### PR DESCRIPTION
If there is no change in repository currently a space is shown after the branch/tag name .
I added a right-trim to the vcs_info which removes  the space if nether the dot nor the plus is shown.
