### PR TITLE
"Which" command fails on systems with aliases.

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -4,16 +4,26 @@
 #
 # Debian-related zsh aliases and functions for zsh
 
+# Function to check if a command exists
+exists() {
+    if command -v $1 >/dev/null 2>&1 
+    then
+        return 0
+    else
+        return 1
+    fi
+}
+
 # Use aptitude if installed, or apt-get if not.
 # You can just set apt_pref='apt-get' to override it.
-if [[ -e $( which aptitude 2>&1 ) ]]; then
+if exists aptitude; then
     apt_pref='aptitude'
 else
     apt_pref='apt-get'
 fi
 
 # Use sudo by default if it's installed
-if [[ -e $( which sudo 2>&1 ) ]]; then
+if exists sudo; then
     use_sudo=1
 fi
 


### PR DESCRIPTION
This plugin was not finding my sudo command correctly because it's aliased. Using the "command" command reports its existence correctly. Also, it has better performance since another process is not started.

Thanks! 
