### PR TITLE
Add afl=apt-file list and arei=sudo apt-get reinstall to debian.plugin.zsh

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -31,6 +31,7 @@ alias as="aptitude -F \"* %p -> %d \n(%v/%V)\" \
 
 # apt-file
 alias afs='apt-file search --regexp'
+alias afl='apt-file list'
 
 
 # These are apt-get only
@@ -49,6 +50,7 @@ if [[ $use_sudo -eq 1 ]]; then
     alias afu='sudo apt-file update'
     alias ag='sudo $apt_pref upgrade'
     alias ai='sudo $apt_pref install'
+    alias arei='sudo $apt_pref reinstall'
     # Install all packages given on the command line while using only the first word of each line:
     # acs ... | ail
     alias ail="sed -e 's/  */ /g' -e 's/ *//' | cut -s -d ' ' -f 1 | "' xargs sudo $apt_pref install'


### PR DESCRIPTION
Summary is self-explanatory.

I use these two abbreviations, and would like to share them with the community.
