### PR TITLE
git_prompt_status() slows down zsh with big git repositories

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -69,47 +69,49 @@ function git_prompt_long_sha() {
 
 # Get the status of the working tree
 git_prompt_status() {
-  INDEX=$(git status --porcelain -b 2> /dev/null)
   STATUS=""
-  if $(echo "$INDEX" | grep -E '^\?\? ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
-  elif $(echo "$INDEX" | grep '^M  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^ M ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  elif $(echo "$INDEX" | grep '^AM ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  elif $(echo "$INDEX" | grep '^ T ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^R  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_RENAMED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^ D ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
-  elif $(echo "$INDEX" | grep '^D  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
-  elif $(echo "$INDEX" | grep '^AD ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
-  fi
-  if $(git rev-parse --verify refs/stash >/dev/null 2>&1); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_STASHED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^UU ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_UNMERGED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^## .*ahead' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_AHEAD$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^## .*behind' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_BEHIND$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^## .*diverged' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DIVERGED$STATUS"
+  if [[ "$(git config --get oh-my-zsh.hide-status)" != "1" ]]; then
+   INDEX=$(git status --porcelain -b 2> /dev/null)
+   if $(echo "$INDEX" | grep -E '^\?\? ' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
+   fi
+   if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
+   elif $(echo "$INDEX" | grep '^M  ' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
+   fi
+   if $(echo "$INDEX" | grep '^ M ' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+   elif $(echo "$INDEX" | grep '^AM ' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+   elif $(echo "$INDEX" | grep '^ T ' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+   fi
+   if $(echo "$INDEX" | grep '^R  ' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_RENAMED$STATUS"
+   fi
+   if $(echo "$INDEX" | grep '^ D ' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
+   elif $(echo "$INDEX" | grep '^D  ' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
+   elif $(echo "$INDEX" | grep '^AD ' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
+   fi
+   if $(git rev-parse --verify refs/stash >/dev/null 2>&1); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_STASHED$STATUS"
+   fi
+   if $(echo "$INDEX" | grep '^UU ' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_UNMERGED$STATUS"
+   fi
+   if $(echo "$INDEX" | grep '^## .*ahead' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_AHEAD$STATUS"
+   fi
+   if $(echo "$INDEX" | grep '^## .*behind' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_BEHIND$STATUS"
+   fi
+   if $(echo "$INDEX" | grep '^## .*diverged' &> /dev/null); then
+     STATUS="$ZSH_THEME_GIT_PROMPT_DIVERGED$STATUS"
+   fi
   fi
   echo $STATUS
 }


### PR DESCRIPTION
When you use a theme which uses the git plugin (like fishy), the prompt generation is _very slow_ and sometimes it takes 2-3s to display the prompt. Even if you set the option "oh-my-zsh.hide-status" thought git config, it's slow. After some tests, I found that "git status" is the problem. It is actually used in git_prompt_status() to get the status of the current working tree and update the prompt.

I propose to don't update the prompt when the option "oh-my-zsh.hide-status"  is set, it would be very useful for important git repositories (like qtbase on gitorious)
