### PR TITLE
Change sublime text path select priority on mac.

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -2,10 +2,11 @@
 
 local _sublime_darwin_paths > /dev/null 2>&1
 _sublime_darwin_paths=(
-	"$HOME/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
+	"/usr/local/bin/subl"
 	"$HOME/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
-	"/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
+	"$HOME/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
 	"/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
+	"/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
 )
 
 if [[ $('uname') == 'Linux' ]]; then


### PR DESCRIPTION
User created symbolic link for sublime binary is now top priority, since this allows users to actually specify which version of sublime they want to use. Sublime text 2 binary has higher priority over sublime text (3) binary, since sublime text 2 is considered more stable.
