### PR TITLE
fix for failing substition & eliminated unnecessary cd

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,8 +1,5 @@
-current_path=`pwd`
-current_path=${current_path/ /\\ }
 printf '\033[0;34m%s\033[0m\n' "Upgrading Oh My Zsh"
 cd "$ZSH"
-
 if git pull origin master
 then
   printf '\033[0;32m%s\033[0m\n' '         __                                     __   '
@@ -17,4 +14,3 @@ else
   printf '\033[0;31m%s\033[0m\n' 'There was an error updating. Try again later?'
 fi
 
-cd "$current_path"


### PR DESCRIPTION
Fixes https://github.com/robbyrussell/oh-my-zsh/issues/1705#issuecomment-16887176
and https://github.com/robbyrussell/oh-my-zsh/issues/1744 (kind of)

Changing the working directory in a sub-subshell
does not change the working directory of the executing
shell.

The substitution was broken for me on _all_ my machines,
so I started looking into the business.
