### PR TITLE
Fix the command checks in the debian plugin

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -6,14 +6,14 @@
 
 # Use aptitude if installed, or apt-get if not.
 # You can just set apt_pref='apt-get' to override it.
-if [[ -e $( which aptitude 2>&1 ) ]]; then
+if whence aptitude > /dev/null; then
     apt_pref='aptitude'
 else
     apt_pref='apt-get'
 fi
 
 # Use sudo by default if it's installed
-if [[ -e $( which sudo 2>&1 ) ]]; then
+if whence sudo > /dev/null; then
     use_sudo=1
 fi
 


### PR DESCRIPTION
The previous implementation depended on the assumption that `which` would return a path when `sudo` and/or `aptitude` were installed; however, when a command is aliased, e.g., `alias sudo='nocorrect sudo'`, no path is returned. This caused a false negative on my box.

This may not be the best way to correct the issue. I am still new to zsh scripting and shell scripting in general.
