### PR TITLE
Cache for fasd --init

### DIFF
--- a/plugins/fasd/fasd.plugin.zsh
+++ b/plugins/fasd/fasd.plugin.zsh
@@ -1,5 +1,10 @@
 if [ $commands[fasd] ]; then # check if fasd is installed
-  eval "$(fasd --init auto)"
+  fasd_cache="$HOME/.fasd-init-cache"
+  if [ "$(command -v fasd)" -nt "$fasd_cache" -o ! -s "$fasd_cache" ]; then
+    fasd --init auto >| "$fasd_cache"
+  fi
+  source "$fasd_cache"
+  unset fasd_cache
   alias v='f -e vim'
   alias o='a -e open'
 fi


### PR DESCRIPTION
Using cache technique for faster fasd --init as shown at:
 https://github.com/clvv/fasdi#install
