### PR TITLE
Update agnoster to use new powerline codepoints

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -26,7 +26,15 @@
 # A few utility functions to make it easy and re-usable to draw segmented prompts
 
 CURRENT_BG='NONE'
-SEGMENT_SEPARATOR=''
+
+if [ "x$USE_NEW_POWERLINE" = "xtrue" ]; then
+  SEGMENT_SEPARATOR=''
+  BRANCH_SYMBOL=''
+else
+  SEGMENT_SEPARATOR='⮀'
+  BRANCH_SYMBOL='⭠'
+fi
+
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,
@@ -90,43 +98,43 @@ prompt_git() {
     zstyle ':vcs_info:*' formats ' %u%c'
     zstyle ':vcs_info:*' actionformats '%u%c'
     vcs_info
-    echo -n "${ref/refs\/heads\// }${vcs_info_msg_0_}"
+    echo -n "${ref/refs\/heads\//$BRANCH_SYMBOL }${vcs_info_msg_0_}"
   fi
 }
 
 prompt_hg() {
-	local rev status
-	if $(hg id >/dev/null 2>&1); then
-		if $(hg prompt >/dev/null 2>&1); then
-			if [[ $(hg prompt "{status|unknown}") = "?" ]]; then
-				# if files are not added
-				prompt_segment red white
-				st='±'
-			elif [[ -n $(hg prompt "{status|modified}") ]]; then
-				# if any modification
-				prompt_segment yellow black
-				st='±'
-			else
-				# if working copy is clean
-				prompt_segment green black
-			fi
-			echo -n $(hg prompt "⭠ {rev}@{branch}") $st
-		else
-			st=""
-			rev=$(hg id -n 2>/dev/null | sed 's/[^-0-9]//g')
-			branch=$(hg id -b 2>/dev/null)
-			if `hg st | grep -Eq "^\?"`; then
-				prompt_segment red black
-				st='±'
-			elif `hg st | grep -Eq "^(M|A)"`; then
-				prompt_segment yellow black
-				st='±'
-			else
-				prompt_segment green black
-			fi
-			echo -n "⭠ $rev@$branch" $st
-		fi
-	fi
+  local rev status
+  if $(hg id >/dev/null 2>&1); then
+    if $(hg prompt >/dev/null 2>&1); then
+      if [[ $(hg prompt "{status|unknown}") = "?" ]]; then
+        # if files are not added
+        prompt_segment red white
+        st='±'
+      elif [[ -n $(hg prompt "{status|modified}") ]]; then
+        # if any modification
+        prompt_segment yellow black
+        st='±'
+      else
+        # if working copy is clean
+        prompt_segment green black
+      fi
+      echo -n $(hg prompt "$BRANCH_SYMBOL {rev}@{branch}") $st
+    else
+      st=""
+      rev=$(hg id -n 2>/dev/null | sed 's/[^-0-9]//g')
+      branch=$(hg id -b 2>/dev/null)
+      if `hg st | grep -Eq "^\?"`; then
+        prompt_segment red black
+        st='±'
+      elif `hg st | grep -Eq "^(M|A)"`; then
+        prompt_segment yellow black
+        st='±'
+      else
+        prompt_segment green black
+      fi
+      echo -n "$BRANCH_SYMBOL $rev@$branch" $st
+    fi
+  fi
 }
 
 # Dir: current working directory


### PR DESCRIPTION
This merges #1556 into the latest master and adds a configuration variable. By default, agnoster will use the old version of powerline. To use the new version, add `USE_NEW_POWERLINE="true"` to your `.zshrc`.

I also converted tabs to spaces in the `prompt_hg` function definition and updated it to use the configured `BRANCH_SYMBOL`.
