### PR TITLE
prevent slowing of command prompt by hub aliased to git

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -134,7 +134,7 @@ function git_compare_version() {
 }
 
 #this is unlikely to change so make it all statically assigned
-POST_1_7_2_GIT=$(command git_compare_version "1.7.2")
+POST_1_7_2_GIT=$(git_compare_version "1.7.2")
 #clean up the namespace slightly by removing the checker function
 unset -f git_compare_version
 


### PR DESCRIPTION
i.e., it is recommended to alias `hub` to `git` but this slows the command
prompt. Using `command git` will ensure that the command in the user's
`PATH` will always be used.
