### PR TITLE
Undo commenting of the l alias for ls -la

### DIFF
--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -17,7 +17,7 @@ alias history='fc -l 1'
 
 # List direcory contents
 alias lsa='ls -lah'
-#alias l='ls -la'
+alias l='ls -la'
 alias ll='ls -l'
 alias la='ls -lA'
 alias sl=ls # often screw this up


### PR DESCRIPTION
In an accidentally included commit, the alias of `l` to `ls -la` was
commented out. This commit reverses that decision.
