### PR TITLE
gentoo linux support

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -3,6 +3,8 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . /usr/share/autojump/autojump.zsh
   elif [ -f /etc/profile.d/autojump.zsh ]; then # manual installation
     . /etc/profile.d/autojump.zsh
+  elif [ -f /etc/profile.d/autojump.sh ]; then # gentoo installation
+    . /etc/profile.d/autojump.sh
   elif [ -f $HOME/.autojump/etc/profile.d/autojump.zsh ]; then # manual user-local installation
     . $HOME/.autojump/etc/profile.d/autojump.zsh
   elif [ -f /opt/local/etc/profile.d/autojump.zsh ]; then # mac os x with ports


### PR DESCRIPTION
Patched for myself when had found that gentoo configuration file for autojump is not descriped (defaulting to Mac OS x not installed)
