### PR TITLE
make git_prompt_info aware of detached HEAD

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -1,26 +1,39 @@
 # get the name of the branch we are on
 function git_prompt_info() {
-  ref=$(git symbolic-ref HEAD 2> /dev/null) || \
-  ref=$(git rev-parse --short HEAD 2> /dev/null) || return
+  ref=$(git symbolic-ref HEAD 2> /dev/null)
+
+  if [ -z $ref ]; then
+    # check if in detached HEAD mode
+    branch_name=$(git status -sb $(git_submodule_syntax) 2> /dev/null | head -n 1)
+    if [ "$branch_name" = "## HEAD (no branch)" ]; then
+      tag_name=$(git name-rev --name-only $(git --no-pager show --stat 2> /dev/null | head -n 1 | awk '{ print $2 }') 2> /dev/null)
+
+      # set ref to tag name if found, else set to short sha
+      if [ -n $tag_name ]; then
+      	ref=$tag_name
+      else
+		ref=$(git rev-parse --short HEAD 2> /dev/null)
+      fi
+    else
+      return
+    fi
+  fi
+
   echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
 }
 
 
 # Checks if working tree is dirty
 parse_git_dirty() {
-  local SUBMODULE_SYNTAX=''
   local GIT_STATUS=''
   local CLEAN_MESSAGE='nothing to commit (working directory clean)'
   if [[ "$(git config --get oh-my-zsh.hide-status)" != "1" ]]; then
-    if [[ $POST_1_7_2_GIT -gt 0 ]]; then
-          SUBMODULE_SYNTAX="--ignore-submodules=dirty"
-    fi
     if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" != "true" ]]; then
-        GIT_STATUS=$(git status -s ${SUBMODULE_SYNTAX} 2> /dev/null | tail -n1)
+        GIT_STATUS=$(git status -s ${git_submodule_syntax} 2> /dev/null | tail -n1)
     else
-        GIT_STATUS=$(git status -s ${SUBMODULE_SYNTAX} -uno 2> /dev/null | tail -n1)
+        GIT_STATUS=$(git status -s ${git_submodule_syntax} -uno 2> /dev/null | tail -n1)
     fi
-    if [[ -n $(git status -s ${SUBMODULE_SYNTAX} -uno  2> /dev/null) ]]; then
+    if [[ -n $(git status -s ${git_submodule_syntax} -uno  2> /dev/null) ]]; then
       echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
     else
       echo "$ZSH_THEME_GIT_PROMPT_CLEAN"
@@ -48,6 +61,14 @@ git_remote_status() {
             echo "$ZSH_THEME_GIT_PROMPT_DIVERGED_REMOTE"
         fi
     fi
+}
+
+git_submodule_syntax() {
+  if [[ $POST_1_7_2_GIT -gt 0 ]]; then
+    echo "--ignore-submodules=dirty"
+  else
+    echo ""
+  fi
 }
 
 # Checks if there are commits ahead from remote


### PR DESCRIPTION
This reopens an earlier pull requests (#1063), now rebased onto the master branch.

This patch updates the git_prompt_info function to first look at whether or not the repository is in a detached HEAD state and, if so, to attempt to determine if a tag is currently checked out.  This means that instead of getting something potentially less useful, like `HEAD~17` you can get something like `remotes/origin/v1.2.3`.

The rebaase was pretty clean, so I am confident this is working as well as before.  I would still really love to see this in upstream, so I can stop rebasing it every few months! :)  Thanks!
