### PR TITLE
parse_git_dirty bug fix

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -128,6 +128,9 @@ function git_compare_version() {
     if [[ $INSTALLED_GIT_VERSION[$i] -lt $INPUT_GIT_VERSION[$i] ]]; then
       echo -1
       return 0
+    else
+      echo 1
+      return 0
     fi
   done
   echo 1


### PR DESCRIPTION
the parse_git_dirty is always use -uno, that made the $DISABLE_UNTRACKED_FILES_DIRTY not working

please see code
