### PR TITLE
Fix sudo check in case it is aliased

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -13,7 +13,7 @@ else
 fi
 
 # Use sudo by default if it's installed
-if [[ -e $( which sudo 2>&1 ) ]]; then
+if [[ -e $( command which sudo 2>&1 ) ]]; then
     use_sudo=1
 fi
 


### PR DESCRIPTION
"if [[ -e $( which sudo 2>&1 ) ]]" check fails if sudo is aliased to something else such as "nocorrect sudo". Using "command" eliminates this.
