### PR TITLE
Fix Empty LANG problem.

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -11,5 +11,3 @@ setopt long_list_jobs
 ## pager
 export PAGER="less"
 export LESS="-R"
-
-export LC_CTYPE=$LANG


### PR DESCRIPTION
In Mac OS X environment,
LANG is not set.

So, LC_CTYPE is overridden by empty.
