### PR TITLE
Remove foreman from the bundler plugin

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -7,7 +7,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate cap capify cucumber foreman guard jekyll middleman nanoc rackup rainbows rake rspec ruby shotgun spec spin spork thin thor unicorn unicorn_rails puma)
+bundled_commands=(annotate cap capify cucumber guard jekyll middleman nanoc rackup rainbows rake rspec ruby shotgun spec spin spork thin thor unicorn unicorn_rails puma)
 
 ## Functions
 


### PR DESCRIPTION
"foreman is not part of the bundle"

Fixes rbenv/bundler conflict with foreman by removing the latter from bundler.plugin.zsh
