### PR TITLE
Create the zcompdump based on version and host

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -38,10 +38,20 @@ for plugin ($plugins); do
   fi
 done
 
+# Figure out the SHORT hostname
+if [ -n "$commands[scutil]" ]; then
+  # OS X
+  SHORT_HOST=$(scutil --get ComputerName)
+else
+  SHORT_HOST=${HOST/.*/}
+fi
+
+# Save the location of the current completion dump file.
+ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+
 # Load and run compinit
 autoload -U compinit
-compinit -i
-
+compinit -i -d "${ZSH_COMPDUMP}"
 
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do


### PR DESCRIPTION
This will prevent lots of subtle problems that happen when people upgrade ZSH
or use NFS mounted home directories.

The ZSH_COMPDUMP variable can also be used to implement `zcompile` and other
fun features in the future.
