### PR TITLE
Adding a fix for the DISABLE_UNTRACKED_FILES_DIRTY option.

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -15,12 +15,12 @@ parse_git_dirty() {
     if [[ $POST_1_7_2_GIT -gt 0 ]]; then
           SUBMODULE_SYNTAX="--ignore-submodules=dirty"
     fi
-    if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" != "true" ]]; then
-        GIT_STATUS=$(git status -s ${SUBMODULE_SYNTAX} 2> /dev/null | tail -n1)
-    else
+    if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" == "true" ]]; then
         GIT_STATUS=$(git status -s ${SUBMODULE_SYNTAX} -uno 2> /dev/null | tail -n1)
+    else
+        GIT_STATUS=$(git status -s ${SUBMODULE_SYNTAX} 2> /dev/null | tail -n1)
     fi
-    if [[ -n $(git status -s ${SUBMODULE_SYNTAX} -uno  2> /dev/null) ]]; then
+    if [[ -n $GIT_STATUS ]]; then
       echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
     else
       echo "$ZSH_THEME_GIT_PROMPT_CLEAN"


### PR DESCRIPTION
A change made by Jeremy Attali (e41714d7) adds a feature that gives the user an option to disable the reporting a repo with untracked files as dirty. Unfortunately, it doesn't work in the latest revision due to the fact that the line following the added code simply ignores the new code added by Jeremy and instead performs a status on the repo with options to automatically ignore untracked files (see the line below):

```
if [[ -n $(git status -s ${SUBMODULE_SYNTAX} -uno  2> /dev/null) ]]; then
```

This change, just updates the line above to use the `GIT_STATUS` variable that Jeremy's code sets to decide whether or not to show the repo as dirty (see below):

```
if [[ -n $GIT_STATUS ]]; then
```

Finally, since the Jeremy's change creates a new optional setting `DISABLE_UNTRACKED_FILES_DIRTY` I updated his code to check if this is set, since it is not the default, rather than checking that is is set to false. This just seems a bit cleaner and easier to read.
