### PR TITLE
Improve the `ls --color` detection on OS X

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -7,8 +7,8 @@ export LSCOLORS="Gxfxcxdxbxegedabagacad"
 if [ "$DISABLE_LS_COLORS" != "true" ]
 then
   # Find the option for using colors in ls, depending on the version: Linux or BSD
-  if [[ "$(uname -s)" == "NetBSD" ]]; then
-    # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors); 
+  if [[ "$(uname -s)" =~ "(NetBSD|Darwin)" ]]; then
+    # On NetBSD and OS X, test if "gls" (GNU ls) is installed (this one supports colors); 
     # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
     gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty'
   else


### PR DESCRIPTION
GNU command line tools installed by `homebrew` (probably the most popular package manager on OS X) are prefixed by `g`, thus we should detect `gls` instead of `ls` for `--color` switch.
