### PR TITLE
Respect DISABLE_UNTRACKED_FILES_DIRTY variable in parse_git_dirty()

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -20,7 +20,7 @@ parse_git_dirty() {
     else
         GIT_STATUS=$(git status -s ${SUBMODULE_SYNTAX} -uno 2> /dev/null | tail -n1)
     fi
-    if [[ -n $(git status -s ${SUBMODULE_SYNTAX} -uno  2> /dev/null) ]]; then
+    if [[ -n $GIT_STATUS ]]; then
       echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
     else
       echo "$ZSH_THEME_GIT_PROMPT_CLEAN"


### PR DESCRIPTION
New files would never be seen as dirty. I guess this was added but forgot to be used.
