### PR TITLE
Use `vcs_info` in gentoo theme for other VCSes

### DIFF
--- a/themes/gentoo.zsh-theme
+++ b/themes/gentoo.zsh-theme
@@ -2,7 +2,28 @@ function prompt_char {
 	if [ $UID -eq 0 ]; then echo "#"; else echo $; fi
 }
 
-PROMPT='%(!.%{$fg_bold[red]%}.%{$fg_bold[green]%}%n@)%m %{$fg_bold[blue]%}%(!.%1~.%~) $(git_prompt_info)%_$(prompt_char)%{$reset_color%} '
+get_git_dirty() {
+  git diff --quiet || echo '*'
+}
 
-ZSH_THEME_GIT_PROMPT_PREFIX="("
-ZSH_THEME_GIT_PROMPT_SUFFIX=") "
+autoload -Uz vcs_info
+autoload -U colors && colors
+zstyle ':vcs_info:*' check-for-changes true
+zstyle ':vcs_info:*' unstagedstr '%F{red}*'   # display this when there are unstaged changes
+zstyle ':vcs_info:*' stagedstr '%F{yellow}+'  # display this when there are staged changes
+zstyle ':vcs_info:*' actionformats \
+    '%F{5}%F{5}[%F{2}%b%F{3}|%F{1}%a%c%u%F{5}]%f '
+zstyle ':vcs_info:*' formats       \
+    '%F{5}%F{5}[%F{2}%b%c%u%F{5}]%f '
+zstyle ':vcs_info:(sv[nk]|bzr):*' branchformat '%b%F{1}:%F{3}%r'
+zstyle ':vcs_info:*' enable git cvs svn
+
+theme_precmd () {
+    vcs_info
+}
+
+setopt prompt_subst
+PROMPT='%(!.%{$fg_bold[red]%}.%{$fg_bold[green]%}%n@)%m %{$fg_bold[blue]%}%(!.%1~.%~) ${vcs_info_msg_0_}%_$(prompt_char)%{$reset_color%} '
+
+autoload -U add-zsh-hook
+add-zsh-hook precmd theme_precmd


### PR DESCRIPTION
I love gentoo theme of oh-my-zsh, however it is somewhat too simple.

Now it can show svn/cvs info with `vcs_info`, instead of git only.

Most code of this commit is from `apple` theme, thanks to the two contributors!
