### PR TITLE
Added alias for git clean

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -62,6 +62,7 @@ alias gm='git merge'
 compdef _git gm=git-merge
 alias grh='git reset HEAD'
 alias grhh='git reset HEAD --hard'
+alias gclean='git reset --hard && git clean -dfx'
 alias gwc='git whatchanged -p --abbrev-commit --pretty=medium'
 alias gf='git ls-files | grep'
 alias gpoat='git push origin --all && git push origin --tags'


### PR DESCRIPTION
This alias uses `git reset --hard` to discard uncommited changes, followed by `git clean -dfx` to discard untracked files. The result is a pristine working directory. A better explanation can be found in the example [at the bottom of this page](http://www.atlassian.com/git/tutorial/undoing-changes#!clean).
