### PR TITLE
Fix for broken colors in "superjarin" theme

### DIFF
--- a/themes/superjarin.zsh-theme
+++ b/themes/superjarin.zsh-theme
@@ -11,13 +11,13 @@ fi
 # Append the current git branch, if in a git repository
 JARIN_CURRENT_LOCA_="%{$fg_bold[cyan]%}%~\$(git_prompt_info)%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[white]%} <%{$fg[magenta]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$fg[white]%}"
 
 # Do nothing if the branch is clean (no changes).
-ZSH_THEME_GIT_PROMPT_CLEAN="%{$reset_color%}>"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[white]%}>"
 
 # Add a yellow ✗ if the branch is dirty
-ZSH_THEME_GIT_PROMPT_DIRTY="%{$reset_color%}> %{$fg[yellow]%}✗"
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[white]%}> %{$fg[yellow]%}✗"
 
 # Put it all together!
 PROMPT="$JARIN_CURRENT_RUBY_ $JARIN_CURRENT_LOCA_ "


### PR DESCRIPTION
There's a coloration issue with the "superjarin" theme when inside of a git repo. Here are pictures of before and after this patch:

Before:
![Before](https://f.cloud.github.com/assets/2569502/614226/a2a56726-ce18-11e2-900a-6a7f102f3338.png)
After:
![After](https://f.cloud.github.com/assets/2569502/614227/a2dd9650-ce18-11e2-935d-7b8d1058afb6.png)
