### PR TITLE
virtualenv cleanup: replaces subshell with prompt expansion.

### DIFF
--- a/plugins/virtualenv/virtualenv.plugin.zsh
+++ b/plugins/virtualenv/virtualenv.plugin.zsh
@@ -1,9 +1,8 @@
 function virtualenv_prompt_info(){
-  local virtualenv_path="$VIRTUAL_ENV"
-  if [[ -n $virtualenv_path ]]; then
-    local virtualenv_name=`basename $virtualenv_path`
-    printf "%s[%s] " "%{${fg[yellow]}%}" $virtualenv_name
+  if [[ -n $VIRTUAL_ENV ]]; then
+    printf "%s[%s] " "%{${fg[yellow]}%}" ${${VIRTUAL_ENV}:t}
   fi
 }
 
+# disables prompt mangling in virtual_env/bin/activate
 export VIRTUAL_ENV_DISABLE_PROMPT=1


### PR DESCRIPTION
- :t parameter expansion returns the last portion of the path,
  equivalent to basename. I <3 zsh.
- adds comments for the VIRTUAL_ENV_DISABLE_PROMPT,
  used by virtual_env activate

See also:
  http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion
