### PR TITLE
fix for flazz theme

### DIFF
--- a/themes/flazz.zsh-theme
+++ b/themes/flazz.zsh-theme
@@ -7,7 +7,7 @@ local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 
 PROMPT='%m%{${fg_bold[magenta]}%} :: %{$reset_color%}%{${fg[green]}%}%3~ $(git_prompt_info)%{${fg_bold[$CARETCOLOR]}%}%#%{${reset_color}%} '
 
-RPS1='$(vi_mode_prompt_info) ${return_code}'
+RPS1='${vi_mode_prompt_info} ${return_code}'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}‹"
 ZSH_THEME_GIT_PROMPT_SUFFIX="› %{$reset_color%}"


### PR DESCRIPTION
wrong bracket type inside ' quotes was causing error message at prompt. "unknown command vi_mode_prompt_info". changed from $(variable) to ${variable}. (this is my first time using git hub)
