### PR TITLE
source ~/.profile for upgrading (to source the proxy configuration)

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -20,6 +20,8 @@ if [[ -z "$epoch_target" ]]; then
   epoch_target=13
 fi
 
+[ ~/.profile ] && source ~/.profile
+
 if [ -f ~/.zsh-update ]
 then
   . ~/.zsh-update


### PR DESCRIPTION
This ensure a configuration file is read when the upgrade process is launched. This read the proxy configuration set up in the ~/.profile file.
