### PR TITLE
Correctly detect JIRA Rapid Board

### DIFF
--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -3,7 +3,7 @@
 #         .jira-url in the current directory takes precedence
 #
 # If you use Rapid Board, set:
-#JIRA_RAPID_BOARD="yes"
+#JIRA_RAPID_BOARD="true"
 # in you .zshrc
 #
 # Setup: cd to/my/project
@@ -34,7 +34,7 @@ open_jira_issue () {
     `open $jira_url/secure/CreateIssue!default.jspa`
   else
     echo "Opening issue #$1"
-    if [[ "x$JIRA_RAPID_BOARD" = "yes" ]]; then
+    if [[ "x$JIRA_RAPID_BOARD" = "xtrue" ]]; then
       $open_cmd  "$jira_url/issues/$1"
     else
       $open_cmd  "$jira_url/browse/$1"


### PR DESCRIPTION
- Add "x" in front of the value we check against...
- Use true instead of yes (more consistent with the rest of ohmyzsh)

The fact that no one seems to have raised this as an issue leads me to believe it's not used that much...
