### PR TITLE
osx-plugin: Do not clear new tab when calling it with an argument.

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -6,7 +6,7 @@
 # ------------------------------------------------------------------------------
 
 function tab() {
-  local command="cd \\\"$PWD\\\""
+  local command="cd \\\"$PWD\\\"; clear; "
   (( $# > 0 )) && command="${command}; $*"
 
   the_app=$(
@@ -34,7 +34,7 @@ EOF
           launch session "Default Session"
           set current_session to current session
           tell current_session
-            write text "${command}; clear;"
+            write text "${command}"
           end tell
         end tell
       end tell


### PR DESCRIPTION
Hi,

thanks for sharing oh-my-zsh. Just a small improvement for the osx-plugin.
Do not clear the result of a command when using tab $x with iterm.

Thank you and best regards,
Christoph
