### PR TITLE
Add postgres plugin to oh-my-zsh

### DIFF
--- a/plugins/postgres-homebrew/postgres-homebrew.plugin.zsh
+++ b/plugins/postgres-homebrew/postgres-homebrew.plugin.zsh
@@ -1,0 +1,6 @@
+# commands to control local postgres installation
+# paths are for osx installation via macports
+
+alias startpost='pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log start'
+alias stoppost='pg_ctl -D /usr/local/var/postgres stop -s -m fast'
+alias restartpost='stoppost && sleep 1 && startpost'


### PR DESCRIPTION
Adding aliases to stop, start and restart postgres via a homebrew installed version of postgres on OSX.
