### PR TITLE
virtualenvwrapper plugin invalid

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -1,4 +1,4 @@
-virtualenvwrapper='virtualenvwrapper_lazy.sh'
+virtualenvwrapper=`virtualenvwrapper_lazy.sh`
 if (( $+commands[$virtualenvwrapper] )); then
   source ${${virtualenvwrapper}:c}
 


### PR DESCRIPTION
- in e73dd2cdf895879a3584eca3a475f33f72f48da8 replace the backtick quotes
