### PR TITLE
Tmux iTerm2 integration

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -38,7 +38,7 @@ if which tmux &> /dev/null
 	fi
 
 	# Set the correct local config file to use.
-	if [[ -f $HOME/.tmux.conf || -h $HOME/.tmux.conf ]]
+    if [[ "$ZSH_TMUX_ITERM2" == "false" ]] && (( [[ -f $HOME/.tmux.conf ]] || -h $HOME/.tmux.conf ]] ))
 	then
 		#use this when they have a ~/.tmux.conf
 		export _ZSH_TMUX_FIXED_CONFIG="$zsh_tmux_plugin_path/tmux.extra.conf"


### PR DESCRIPTION
This adds functionality to enable iTerm2 tmux integration as documented [here](https://code.google.com/p/iterm2/wiki/TmuxIntegration).

Essentially, if ZSH_TMUX_ITERM2 is set to true, the tmux plugin adds the option `-CC` to `tmux` whenever it is invoked. Enabling this also disables the loading of any "$HOME/.tmux.conf" configuration file, as they are not yet supported.

This works with ZSH_TMUX_AUTOSTART; however, I have noticed one bug, likely upstream with iTerm2, where a quick close and re-open of an iTerm2 tmux session, where the message "A tmux protocol error occurred. Reason: %begin with empty command queue" occurs, but I may be wrong.
