### PR TITLE
Prevent starting multiple gpg-agents

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -21,7 +21,7 @@ if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
         . ${GPG_ENV} > /dev/null
     fi
 
-    # check again if another agent is running using the newly sources settings
+    # check again if another agent is running using the newly sourced settings
     if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
         # check for existing ssh-agent
         if ssh-add -l > /dev/null 2> /dev/null; then


### PR DESCRIPTION
Don't just overwrite the environment. First check for a running agent (an
x-session might have one running). If no agent is found, source the
environment and check again using those settings. If again no agent is
found, start a new instance.

This closes #1561
