### PR TITLE
Change duplicated alias name

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -78,7 +78,7 @@ compdef _git gm=git-mergetool
 alias gg='git gui citool'
 alias gga='git gui citool --amend'
 alias gk='gitk --all --branches'
-alias gss='git stash show --text'
+alias gsts='git stash show --text'
 
 # Will cd into the top of the current repository
 # or submodule.


### PR DESCRIPTION
Git plugin has two aliases named `gss`. One is for `git stash -s` and another is for `git stash show --text`. Later one overrides first one.
I just renamed stash alias to `gsts`, which is, I believe, not bad.
