### PR TITLE
rvm plugin: update to ruby version helpers and rvm-update

### DIFF
--- a/plugins/rvm/rvm.plugin.zsh
+++ b/plugins/rvm/rvm.plugin.zsh
@@ -3,9 +3,9 @@ fpath=($rvm_path/scripts/zsh/Completion $fpath)
 alias rubies='rvm list rubies'
 alias gemsets='rvm gemset list'
 
-local ruby18='ruby-1.8.7-p371'
-local ruby19='ruby-1.9.3-p392'
-local ruby20='ruby-2.0.0-p0'
+local ruby18='ruby-1.8.7'
+local ruby19='ruby-1.9.3'
+local ruby20='ruby-2.0.0'
 
 function rb18 {
 	if [ -z "$1" ]; then
@@ -42,7 +42,6 @@ compdef _rb20 rb20
 
 function rvm-update {
 	rvm get head
-	rvm reload # TODO: Reload rvm completion?
 }
 
 # TODO: Make this usable w/o rvm.


### PR DESCRIPTION
- the current patch levels hard-coded here are pretty dated. I updated the
  ruby version helpers to use loose ruby version matchers so they don't
  continually need to be updated with every new patch level release.
- `rvm get head` actually performs an `rvm reload` in the post install.
  there's no need to do again here in rvm-update so I've removed that.
