### PR TITLE
Add km2c theme

### DIFF
--- a/themes/km2c.zsh-theme
+++ b/themes/km2c.zsh-theme
@@ -20,7 +20,7 @@ DIR_PROMPT_="%{$FG[002]%} %1~ % "
 GIT_PROMPT="%{$FG[117]%}\$(git_prompt_info)%{$reset_color%}\$(git_prompt_status)%{$reset_color%}%{$FG[117]%}%{$FG[208]%}» %{$reset_color%}"
 
 PROMPT="$SMILEY_$DIR_PROMPT_$GIT_PROMPT"
-RPROMPT="$RUBY_PROMPT_"
+RPROMPT="$RUBY_PROMPT"
 
 #Git prompt info
 ZSH_THEME_GIT_PROMPT_PREFIX="%B%F{208}| %{$reset_color%}%{$FG[117]%}git:(%{$FG[118]%}"


### PR DESCRIPTION
This theme is a frankenstein of other themes.  It uses the  Solarized dark theme and Bitstream Vera Sans Mono font.

![screen shot 2013-06-28 at 2 27 23 pm](https://f.cloud.github.com/assets/716440/723775/6ef04850-e020-11e2-9aa0-59db0fabba0d.png)
