### PR TITLE
Option to remove bundled commands in Bundler Plugin

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -34,11 +34,13 @@ _run-with-bundler() {
 
 ## Main program
 for cmd in $bundled_commands; do
-  eval "function unbundled_$cmd () { $cmd \$@ }"
-  eval "function bundled_$cmd () { _run-with-bundler $cmd \$@}"
-  alias $cmd=bundled_$cmd
+  if [[ ${REMOVE_BUNDLED_COMMANDS[(r)$cmd]} != $cmd ]]; then
+    eval "function unbundled_$cmd () { $cmd \$@ }"
+    eval "function bundled_$cmd () { _run-with-bundler $cmd \$@}"
+    alias $cmd=bundled_$cmd
 
-  if which _$cmd > /dev/null 2>&1; then
-        compdef _$cmd bundled_$cmd=$cmd
+    if which _$cmd > /dev/null 2>&1; then
+          compdef _$cmd bundled_$cmd=$cmd
+    fi
   fi
 done


### PR DESCRIPTION
Added REMOVE_BUNDLED_COMMANDS to remove the commands from being bundled when executed.
It has to be an array.
