### PR TITLE
Modify tmuxinator has a bug when no project

### DIFF
--- a/plugins/tmuxinator/_tmuxinator
+++ b/plugins/tmuxinator/_tmuxinator
@@ -25,8 +25,9 @@ case $state in
   args)
     case $line[1] in
       start|open|copy|delete)
-        _configs=(`tmuxinator list | sed -n 's/^[ \t]\+//p'`)
-        _values 'configs' $_configs
+        _configs=$(tmuxinator list | sed -n 's/^[ \t]\+//p')
+
+        test "x$_configs" != "x" && compadd $_configs
         ret=0
         ;;
     esac


### PR DESCRIPTION
When no project if TAB for  tmuxinator start|open|copy|delete that dispaly :
_values:compvalues:10: not enough arguments
