### PR TITLE
fix shell when bash is needed instead of sh

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -3,11 +3,11 @@ function zsh_stats() {
 }
 
 function uninstall_oh_my_zsh() {
-  /usr/bin/env ZSH=$ZSH bash $ZSH/tools/uninstall.sh
+  /usr/bin/env ZSH=$ZSH /bin/bash $ZSH/tools/uninstall.sh
 }
 
 function upgrade_oh_my_zsh() {
-  /usr/bin/env ZSH=$ZSH bash $ZSH/tools/upgrade.sh
+  /usr/bin/env ZSH=$ZSH /bin/bash $ZSH/tools/upgrade.sh
 }
 
 function take() {

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -9,7 +9,7 @@ function _update_zsh_update() {
 }
 
 function _upgrade_zsh() {
-  /usr/bin/env ZSH=$ZSH bash $ZSH/tools/upgrade.sh
+  /usr/bin/env ZSH=$ZSH /bin/bash $ZSH/tools/upgrade.sh
   # update the zsh file
   _update_zsh_update
 }


### PR DESCRIPTION
Hello Robby

under Debian sh is often aliased to dash, which doesn't support some bashisms (function keyword notably). So I replaced calls to sh with bash.
