### PR TITLE
fix gpg-agent "running already" check

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -20,6 +20,8 @@ if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
     if [ -f "${GPG_ENV}" ]; then
         . ${GPG_ENV} > /dev/null
         export GPG_AGENT_INFO
+        export SSH_AUTH_SOCK
+        export SSH_AGENT_PID
     fi
 
     # check again if another agent is running using the newly sourced settings


### PR DESCRIPTION
The GPG_ENV file is sourced before doing the gpg-connect-agent check,
but this file (unlike the SSH_ENV file) doesn't export GPG_AGENT_INFO,
so the check always fails.  This results in new gpg-agents continuously
being spawned.

All this commit does is put in the single export to fix the problem.
