### PR TITLE
Use $cmd_open  instead of plain open while opening a new issue in jira.

### DIFF
--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -31,7 +31,7 @@ open_jira_issue () {
 
   if [ -z "$1" ]; then
     echo "Opening new issue"
-    `open $jira_url/secure/CreateIssue!default.jspa`
+    $open_cmd "$jira_url/secure/CreateIssue!default.jspa"
   else
     echo "Opening issue #$1"
     if [[ "x$JIRA_RAPID_BOARD" = "xtrue" ]]; then


### PR DESCRIPTION
Here is a bugfix for jira plugin.

I'm using Ubuntu. When I tried opening a new issue by giving "jira" command, I get the following error:

`% jira 
Opening new issue
Couldn't get a file descriptor referring to the console
`

So, when I change the plain "open" command with previously assigned open_cmd variable, this will fix the issue for both linux and Mac's I think.
