### PR TITLE
add git checkout dev alias for git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -25,6 +25,7 @@ compdef _git gca!=git-commit
 alias gco='git checkout'
 compdef _git gco=git-checkout
 alias gcm='git checkout master'
+alias gcd='git checkout dev'
 alias gr='git remote'
 compdef _git gr=git-remote
 alias grv='git remote -v'


### PR DESCRIPTION
dev branch is used very often, why not?
