### PR TITLE
go: Add recursive gofmt alias

### DIFF
--- a/plugins/go/go.plugin.zsh
+++ b/plugins/go/go.plugin.zsh
@@ -149,3 +149,6 @@ __go_tool_complete() {
 }
 
 compdef __go_tool_complete go
+
+# aliases
+alias gfa='go fmt . ./...'


### PR DESCRIPTION
This shortcut make `go fmt` run on all files in the current directory and run recursively on folders. 
