### PR TITLE
Add candy-wrapper theme

### DIFF
--- a/themes/candy-wrapper.zsh-theme
+++ b/themes/candy-wrapper.zsh-theme
@@ -1,0 +1,7 @@
+PROMPT=$'(%{$fg[red]%}%n@%m%{$reset_color%}) %F{81}%~%{$reset_color%} $(rvm_prompt_info) $(git_prompt_info)\
+%F{81}↪ %{$reset_color%}'
+
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[green]%}["
+ZSH_THEME_GIT_PROMPT_SUFFIX="]%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg[red]%}*%{$fg[green]%}"
+ZSH_THEME_GIT_PROMPT_CLEAN=""


### PR DESCRIPTION
This is custom theme based on the candy theme.  This does away with the 
timestamp in the prompt and uses stronger colors that work better against a
dark background.
