### PR TITLE
ls -G alias fix for BSD systems

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -8,9 +8,7 @@ if [ "$DISABLE_LS_COLORS" != "true" ]
 then
 
   # Find the option for using colors in ls, depending on the version: Linux or BSD
-  if [[ $(uname -s) =~ ".*BSD$" ]]; then
-
-    print "BSD"
+  if [[ $(uname -s) =~ ".*win$" ]]; then
     # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors); 
     # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
     gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty' || colorls -G . &>/dev/null 2>&1 && alias ls='colorls -G'


### PR DESCRIPTION
BSD fix for unsupported ls -G alias and added fallback supprt for colorls as per Issue #836
