### PR TITLE
Add jump plugin, which allows you to easily jump around the file system

### DIFF
--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -13,14 +13,13 @@ jump() {
 }
 
 mark() {
-	DIR="$(pwd)"
 	if (( $# == 0 )); then
-		MARK=$(basename $DIR)
+		MARK=$(basename "$(pwd)")
 	else
-		MARK=$1
+		MARK="$1"
 	fi
-	if read -q \?"Mark ${DIR} as ${MARK}? (y/n) "; then
-		mkdir -p "$MARKPATH"; ln -s "${DIR}" "$MARKPATH/$MARK"
+	if read -q \?"Mark $(pwd) as ${MARK}? (y/n) "; then
+		mkdir -p "$MARKPATH"; ln -s "$(pwd)" "$MARKPATH/$MARK"
 	fi
 }
 


### PR DESCRIPTION
Easily jump around the file system by manually adding marks. 
marks are stored as symbolic links in the directory $MARKPATH (default $HOME/.marks)

This functionality complements autojump, which keeps a database of the most-common used directories.

Usage: 

jump FOO: jump to a mark named FOO
mark FOO: create a mark named FOO
unmark FOO: delete a mark
marks: lists all marks
