### PR TITLE
Allow the ability to search aliases

### DIFF
--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -24,3 +24,5 @@ alias sl=ls # often screw this up
 
 alias afind='ack-grep -il'
 
+# search aliases
+alias manalias='alias | grep -i'


### PR DESCRIPTION
One of the things I ended up doing after installing is trying to grep through the whole list of new aliases. Ended up trying this few times before realizing might be useful within zsh
