### PR TITLE
Added clean/dirty characters for git repositories

### DIFF
--- a/themes/gnzh.zsh-theme
+++ b/themes/gnzh.zsh-theme
@@ -50,5 +50,10 @@ PROMPT="╭─${user_host} ${current_dir} ${rvm_ruby} ${git_branch}
 ╰─$PR_PROMPT "
 RPS1="${return_code}"
 
+# GIT section
+GIT_CLEAN_COLOR="%{$fg[green]%}"
+GIT_DIRTY_COLOR="%{$fg[red]%}"
+ZSH_THEME_GIT_PROMPT_CLEAN=" $GIT_CLEAN_COLOR✓"
+ZSH_THEME_GIT_PROMPT_DIRTY=" $GIT_DIRTY_COLOR✗"
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$PR_YELLOW%}‹"
 ZSH_THEME_GIT_PROMPT_SUFFIX="› %{$PR_NO_COLOR%}"


### PR DESCRIPTION
Hello,

I added a few lines to deal with git repositories in the gnzh theme :
- a green ✓ when it's clean
- a red ✗ when it's dirty
