### PR TITLE
Add support for mosh (remote-shell) tab completion.

### DIFF
--- a/plugins/mosh/mosh.plugin.zsh
+++ b/plugins/mosh/mosh.plugin.zsh
@@ -1,0 +1,2 @@
+# Allow SSH tab completion for mosh hostnames
+compdef mosh=ssh


### PR DESCRIPTION
A super-simple plugin to allow for mosh to support tab-completion. 
