### PR TITLE
Git info: show tag instead of commit id if available.

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -1,6 +1,7 @@
 # get the name of the branch we are on
 function git_prompt_info() {
   ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
+  ref=$(command git describe --tags --exact-match HEAD 2> /dev/null) || \
   ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
   echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
 }


### PR DESCRIPTION
Updated the implementation of git_prompt_info so that tag name
is shown when a tag points to the commit where HEAD points to
in detached mode.
