### PR TITLE
Add autocompletion plugin for meteor command

### DIFF
--- a/plugins/meteor/_meteor
+++ b/plugins/meteor/_meteor
@@ -4,6 +4,13 @@
 # Meteor Autocomplete plugin for Oh-My-Zsh, based on homebrew completion
 # Original author: Dimitri JORGE (https://github.com/jorge-d)
 
+_meteor_all_packages() {
+  packages=(`meteor list | cut -d" " -f1`)
+}
+_meteor_installed_packages() {
+  installed_packages=(`meteor list --using`)
+}
+
 local -a _1st_arguments
 _1st_arguments=(
   'run:[Default] Run this project in local development mode'
@@ -21,6 +28,9 @@ _1st_arguments=(
   'test-packages:Test one or more packages'
 )
 
+local expl
+local -a packages installed_packages
+
 if (( CURRENT == 2 )); then
   _describe -t commands "meteor subcommand" _1st_arguments
   return
@@ -28,5 +38,11 @@ fi
 
 case "$words[2]" in
     help)
-      _describe -t commands "brew subcommand" _1st_arguments
+      _describe -t commands "meteor subcommand" _1st_arguments ;;
+    remove)
+      _meteor_installed_packages
+      _wanted installed_packages expl 'installed packages' compadd -a installed_packages ;;
+    add)
+      _meteor_all_packages
+      _wanted packages expl 'all packages' compadd -a packages ;;
 esac


### PR DESCRIPTION
Hi,

I just wrote a simple autocompletion plugin for [Meteor](http://meteor.com).
Here is how it looks like:
![screen shot 2013-09-01 at 6 35 04 pm](https://f.cloud.github.com/assets/1178099/1064317/8546432a-1324-11e3-8396-be34ec8588c8.png)
![screen shot 2013-09-01 at 7 24 57 pm](https://f.cloud.github.com/assets/1178099/1064395/83d4cdd4-132b-11e3-863d-a835fcd2e0d8.png)
![screen shot 2013-09-01 at 7 25 09 pm](https://f.cloud.github.com/assets/1178099/1064397/88b7bdc0-132b-11e3-93dd-b7f0046cd6d3.png)

It's my first plugin so I would be glad to hear if I did something wrong :)

Thank you !
