### PR TITLE
Sublime Text: Harmonize alias with the Sublime Text install instructions

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -21,7 +21,8 @@ elif  [[ $('uname') == 'Darwin' ]]; then
 
 	for _sublime_path in $_sublime_darwin_paths; do
 		if [[ -a $_sublime_path ]]; then
-			alias st="'$_sublime_path'"
+			alias subl="'$_sublime_path'"
+			alias st=subl
 			break
 		fi
 	done


### PR DESCRIPTION
The typical command is `subl`, not `st`. This leaves both for backward compatibility.

See http://www.sublimetext.com/docs/2/osx_command_line.html
