### PR TITLE
Support of parallel bundle install

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -1,9 +1,16 @@
 alias be="bundle exec"
-alias bi="bundle install"
 alias bl="bundle list"
 alias bp="bundle package"
 alias bo="bundle open"
 alias bu="bundle update"
+
+if [[ "$(uname)" == 'Darwin' ]]
+then
+  local cores_num="$(sysctl hw.ncpu | awk '{print $2}')"
+else
+  local cores_num="$(nproc)"
+fi
+eval "alias bi='bundle install --jobs=$cores_num'"
 
 # The following is based on https://github.com/gma/bundler-exec
 
@@ -42,3 +49,4 @@ for cmd in $bundled_commands; do
         compdef _$cmd bundled_$cmd=$cmd
   fi
 done
+


### PR DESCRIPTION
It allowes automaticly detect number of CPU cores and make bundle install --jobs=CORES_NUMBER through "bi" alias in bundler plugin

Requires bundler 1.4.0, which in pre now
