### PR TITLE
Fixed comments in zshrc.zsh-template about disabling auto updates.

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -14,7 +14,7 @@ ZSH_THEME="robbyrussell"
 # Set to this to use case-sensitive completion
 # CASE_SENSITIVE="true"
 
-# Comment this out to disable bi-weekly auto-update checks
+# Uncomment this to disable bi-weekly auto-update checks
 # DISABLE_AUTO_UPDATE="true"
 
 # Uncomment to change how often before auto-updates occur? (in days)


### PR DESCRIPTION
Previously they did not make sense nor were they accurate.

The comment in the template indicated that you should comment out an already commented out line to disable bi-weekly updates.
