### PR TITLE
jump plugin: fix autocompletion with single mark

### DIFF
--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -38,7 +38,13 @@ marks() {
 }
 
 _completemarks() {
-	reply=($(ls $MARKPATH/**/*(-) | grep : | sed -E 's/(.*)\/([_\da-zA-Z\-]*):$/\2/g'))
+	if [[ $(ls "${MARKPATH}" | wc -l) -gt 1 ]]; then
+		reply=($(ls $MARKPATH/**/*(-) | grep : | sed -E 's/(.*)\/([_\da-zA-Z\-]*):$/\2/g'))
+	else
+		if readlink -e "${MARKPATH}"/* &>/dev/null; then
+			reply=($(ls "${MARKPATH}"))
+		fi
+	fi
 }
 compctl -K _completemarks jump
 compctl -K _completemarks unmark


### PR DESCRIPTION
Autocompletion fails if there's only one mark, since the ls command
will not display the parent directory with the trailing colon.
Handling the single mark case separately and validating the symlink
explicitly, resolves the issue.
