### PR TITLE
Fix agnoster prompt to use newer powerline values

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -26,7 +26,7 @@
 # A few utility functions to make it easy and re-usable to draw segmented prompts
 
 CURRENT_BG='NONE'
-SEGMENT_SEPARATOR='\u2b80'
+SEGMENT_SEPARATOR='\ue0b0'
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,
@@ -90,7 +90,7 @@ prompt_git() {
     zstyle ':vcs_info:*' formats ' %u%c'
     zstyle ':vcs_info:*' actionformats '%u%c'
     vcs_info
-    echo -n "${ref/refs\/heads\//\u2b60 }${vcs_info_msg_0_}"
+    echo -n "${ref/refs\/heads\//\ue0a0 }${vcs_info_msg_0_}"
   fi
 }
 
@@ -110,7 +110,7 @@ prompt_hg() {
 				# if working copy is clean
 				prompt_segment green black
 			fi
-			echo -n $(hg prompt "\u2b60 {rev}@{branch}") $st
+			echo -n $(hg prompt "\ue0a0 {rev}@{branch}") $st
 		else
 			st=""
 			rev=$(hg id -n 2>/dev/null | sed 's/[^-0-9]//g')
@@ -124,7 +124,7 @@ prompt_hg() {
 			else
 				prompt_segment green black
 			fi
-			echo -n "\u2b60 $rev@$branch" $st
+			echo -n "\ue0a0 $rev@$branch" $st
 		fi
 	fi
 }


### PR DESCRIPTION
Change #2065 converted inline characters to hex values, but used the unicode values prior 97849bd, breaking the prompt for anyone that has updated since then.
