### PR TITLE
Check bundler version to avoid error with unsupported command line arguments

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -4,13 +4,18 @@ alias bp="bundle package"
 alias bo="bundle open"
 alias bu="bundle update"
 
-if [[ "$(uname)" == 'Darwin' ]]
-then
-  local cores_num="$(sysctl hw.ncpu | awk '{print $2}')"
+bundler_version=`bundle version | cut -d' ' -f3`
+if [[ $bundler_version > '1.4.0' || $bundler_version = '1.4.0' ]]; then
+  if [[ "$(uname)" == 'Darwin' ]]
+  then
+    local cores_num="$(sysctl hw.ncpu | awk '{print $2}')"
+  else
+    local cores_num="$(nproc)"
+  fi
+  eval "alias bi='bundle install --jobs=$cores_num'"
 else
-  local cores_num="$(nproc)"
+  alias bi='bundle install' 
 fi
-eval "alias bi='bundle install --jobs=$cores_num'"
 
 # The following is based on https://github.com/gma/bundler-exec
 


### PR DESCRIPTION
This commit resolve problem described in #2080. It enable --jobs option if bundler version is great or equal than 1.4.0 only. This is required because 1.4.0 in pre-release state now.

P.S.
  I have tested it on Mac OS 10.8.5. Can anyone test it on *nix systems?
