### PR TITLE
Fix gallois theme

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -138,7 +138,7 @@ compdef _git glp=git-log
 #
 # This function return a warning if the current branch is a wip
 function work_in_progress() {
-  if $(git log -n 1 | grep -q -c wip); then
+  if $(git log -n 1 2>/dev/null | grep -q -c wip); then
     echo "WIP!!"
   fi
 }


### PR DESCRIPTION
I noticed that the function `work_in_progress`, which is used in the "gallois"-theme, would print `fatal: bad default revision 'HEAD'` in a new folder after `git init`.

This is the fix.
