### PR TITLE
Fix ls alias on OpenBSD

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -7,8 +7,8 @@ export LSCOLORS="Gxfxcxdxbxegedabagacad"
 if [ "$DISABLE_LS_COLORS" != "true" ]
 then
   # Find the option for using colors in ls, depending on the version: Linux or BSD
-  if [[ "$(uname -s)" == "NetBSD" ]]; then
-    # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors); 
+  if [[ "$(uname -s)" =~ "BSD$" ]]; then
+    # On NetBSD or OpenBSD, test if "gls" (GNU ls) is installed (this one supports colors); 
     # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
     gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty'
   else


### PR DESCRIPTION
Theme and appearance checks whether the OS is NetBSD before setting an alias for ls. The same thing applies to OpenBSD, so I made the check for the platform more general and it now works on OpenBSD (and anything else that ends with 'BSD') too.
