### PR TITLE
More expressive symbols for git and mercurial.

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -90,7 +90,7 @@ prompt_git() {
     zstyle ':vcs_info:*' formats ' %u%c'
     zstyle ':vcs_info:*' actionformats '%u%c'
     vcs_info
-    echo -n "${ref/refs\/heads\// }${vcs_info_msg_0_}"
+    echo -n "${ref/refs\/heads\//± }${vcs_info_msg_0_}"
   fi
 }
 
@@ -110,7 +110,7 @@ prompt_hg() {
 				# if working copy is clean
 				prompt_segment green black
 			fi
-			echo -n $(hg prompt " {rev}@{branch}") $st
+			echo -n $(hg prompt "☿ {rev}@{branch}") $st
 		else
 			st=""
 			rev=$(hg id -n 2>/dev/null | sed 's/[^-0-9]//g')


### PR DESCRIPTION
Idea from http://stevelosh.com/blog/2010/02/my-extravagant-zsh-prompt/

> ☿ means “I’m in a Mercurial repository.”
> ± means “I’m in a git repository.”
