### PR TITLE
Added a completion plugin for the new aws-cli tool

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -1,0 +1,17 @@
+export AWS_HOME=~/.aws
+
+function agp {
+  echo $AWS_DEFAULT_PROFILE
+  
+}
+function asp {
+  export AWS_DEFAULT_PROFILE=$1
+    export RPROMPT="<aws:$AWS_DEFAULT_PROFILE>"
+    
+}
+function aws_profiles {
+  reply=($(grep profile $AWS_HOME/config|sed -e 's/.*profile \([a-zA-Z0-9_-]*\).*/\1/'))
+}
+
+compctl -K aws_profiles asp
+source `which aws_zsh_completer.sh`


### PR DESCRIPTION
Besides providing shell completion for the aws command, it also supports quickly switching between AWS profiles defined in ~/.aws/config using the 'asp' alias.

Mostly based on code written by @elias5000
