### PR TITLE
Fix for github plugin's empty_gh function

### DIFF
--- a/plugins/github/github.plugin.zsh
+++ b/plugins/github/github.plugin.zsh
@@ -40,7 +40,7 @@ fi
 #
 # Use this when creating a new repo from scratch.
 empty_gh() { # [NAME_OF_REPO]
-    repo = $1
+    repo="$1"
     ghuser=$(  git config github.user )
 
     mkdir "$repo"


### PR DESCRIPTION
This fixes the "empty_gh:1: command not found: repo" error.
