### PR TITLE
Fix 'docker build' arguments

### DIFF
--- a/plugins/docker/_docker
+++ b/plugins/docker/_docker
@@ -30,7 +30,7 @@ __attach() {
 __build() {
     _arguments \
         '-q=false[Suppress verbose build output]' \
-        '-t="[fuck to be applied to the resulting image in case of success]' \
+        '-t="[Repository name (and optionally a tag) to be applied to the resulting image in case of success]' \
         '*:files:_files'
 }
 


### PR DESCRIPTION
I think someone's tourette syndrome might have kicked in when previously entering the help text for this command. The supplied replacement is taken directly [from the docker documentation](http://docs.docker.io/en/latest/commandline/command/build/).
