### PR TITLE
Adding /usr/bin/subl as one of Linux paths

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -12,8 +12,10 @@ _sublime_darwin_paths=(
 if [[ $('uname') == 'Linux' ]]; then
 	if [ -f '/usr/bin/sublime_text' ]; then
 		st_run() { nohup /usr/bin/sublime_text $@ > /dev/null & }
-	else
+	elif [ -f '/usr/bin/sublime-text' ]; then
 		st_run() { nohup /usr/bin/sublime-text $@ > /dev/null & }
+	else
+		st_run() { nohup /usr/bin/subl $@ > /dev/null & }
 	fi
 	alias st=st_run
 


### PR DESCRIPTION
In some Linux distributions Sublime Text 3 is installed to /usr/bin/subl.
