### PR TITLE
rbenv plugin: don't clobber existing RBENV_ROOT & follow Homebrew's default behavior

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -10,12 +10,18 @@ FOUND_RBENV=0
 rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv")
 if _homebrew-installed && _rbenv-from-homebrew-installed ; then
     rbenvdirs=($(brew --prefix rbenv) "${rbenvdirs[@]}")
+    if [[ $RBENV_ROOT = '' ]]; then 
+      RBENV_ROOT="$HOME/.rbenv"
+    fi
 fi
 
 for rbenvdir in "${rbenvdirs[@]}" ; do
   if [ -d $rbenvdir/bin -a $FOUND_RBENV -eq 0 ] ; then
     FOUND_RBENV=1
-    export RBENV_ROOT=$rbenvdir
+    if [[ $RBENV_ROOT = '' ]]; then
+      RBENV_ROOT=$rbenvdir
+    fi
+    export RBENV_ROOT
     export PATH=${rbenvdir}/bin:$PATH
     eval "$(rbenv init --no-rehash - zsh)"
 


### PR DESCRIPTION
Currently the rbenv plugin clobbers any existing RBENV_ROOT env var and always sets $RBENV_ROOT to the directory containing rbenv's bin/ subdir. This isn't always what you want.

For example, when rbenv is installed via Homebrew on OS X, it leaves RBENV_ROOT set to `~/.rbenv` so that Rubies will be installed there, but the bin/ dir remains in `/usr/local/[blahblah]`. This works just fine, and in fact some programs (such as JetBrains' RubyMine) only support rbenv with Rubies installed in `~/.rbenv`, so it's important to leave it there when possible.

This PR leaves existing RBENV_ROOT values intact and causes Homebrew-installed rbenv's to default to the same setting that Homebrew would (`~/.rbenv`).
