### PR TITLE
Fix starting multiple gpg-agents once more

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -19,6 +19,9 @@ if ! gpg-connect-agent --quiet /bye > /dev/null 2> /dev/null; then
     # source settings of old agent, if applicable
     if [ -f "${GPG_ENV}" ]; then
         . ${GPG_ENV} > /dev/null
+        export GPG_AGENT_INFO
+        export SSH_AUTH_SOCK
+        export SSH_AGENT_PID
     fi
 
     # check again if another agent is running using the newly sourced settings


### PR DESCRIPTION
Even though commit 711e96b1a277b1d5b9771c2eec19fa34f796839b fixed
checking for gpg-agents already running, there was one pre-existing
problem due to which my gpg-agents were still spawning multiple times.
The only thing missing was exporting the variables sourced from the
environment file.

Even though double checking for the agent, before and after (possible)
sourcing, seems redundant to me, I'm keeping it in and only fixing
that one thing.
