### PR TITLE
Added the spectrum_bls function, which prints all 256 colors set as the background.

### DIFF
--- a/lib/spectrum.zsh
+++ b/lib/spectrum.zsh
@@ -26,3 +26,10 @@ function spectrum_ls() {
   done
 }
 
+# Show all 256 colors where the background is set to specific color
+function spectrum_bls() {
+  for code in {000..255}; do
+    ((cc = code + 1))
+    print -P -- "$BG[$code]$code: Test %{$reset_color%}"
+  done
+}


### PR DESCRIPTION
We can easily see which color we want to set when changing the PS1 shell variable,
since the colors are more distinctive.

This can be used by executing the following command in command-line:
# spectrum_bls
