### PR TITLE
Fix hg_dirty_choose function and add mercurial support for DISABLE_UNTRA...

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -39,7 +39,11 @@ $ZSH_THEME_REPO_NAME_COLOR$_DISPLAY$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_HG_PROMPT_SU
 
 function hg_dirty_choose {
   if [ $(in_hg) ]; then
-    hg status 2> /dev/null | grep -Eq '^\s*[ACDIM!?L]'
+    if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" == "true" ]]; then
+      hg status -q 2> /dev/null | grep -Eq '^\s*[ACDIMR!L].*$'
+    else
+      hg status 2> /dev/null | grep -Eq '^\s*[ACDIMR!?L].*$'
+    fi
     if [ $pipestatus[-1] -eq 0 ]; then
       # Grep exits with 0 when "One or more lines were selected", return "dirty".
       echo $1


### PR DESCRIPTION
...CKED_FILES_DIRTY

The grep in hg_dirty_choose never had results as it didn't match the whole line meaning repos were always clean.
