### PR TITLE
Add a command to show unresolve files in merge

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -15,6 +15,8 @@ alias hgp='hg push'
 alias hgs='hg status'
 # this is the 'git commit --amend' equivalent
 alias hgca='hg qimport -r tip ; hg qrefresh -e ; hg qfinish tip'
+# list unresolved files (since hg does not list unmerged files in the status command)
+alias hgun='hg resolve --list'
 
 function in_hg() {
   if [[ -d .hg ]] || $(hg summary > /dev/null 2>&1); then


### PR DESCRIPTION
Since `hg status` does not show unresolved files, I added `hgun` as an alias for `hg resolve --list` to list all files needing resolution.
