### PR TITLE
Fixes "ComputerName: not set" issue #2155

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -38,13 +38,7 @@ for plugin ($plugins); do
   fi
 done
 
-# Figure out the SHORT hostname
-if [ -n "$commands[scutil]" ]; then
-  # OS X
-  SHORT_HOST=$(scutil --get ComputerName)
-else
-  SHORT_HOST=${HOST/.*/}
-fi
+SHORT_HOST=$(hostname -s)
 
 # Save the location of the current completion dump file.
 ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"


### PR DESCRIPTION
As already mentioned in #2155 `ComputerName` has to be set before, otherwise you get `ComputerName: not set` on startup. I think `hostname -s` is more common/global way to get short host name.

Tested on OS X 10.8.5 and Ubuntu 12.10
