### PR TITLE
Bundler plugin: Unknown switches '--jobs=4'

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -1,4 +1,5 @@
 alias be="bundle exec"
+alias bi="bundle install"
 alias bl="bundle list"
 alias bp="bundle package"
 alias bo="bundle open"
@@ -10,7 +11,7 @@ then
 else
   local cores_num="$(nproc)"
 fi
-eval "alias bi='bundle install --jobs=$cores_num'"
+export BUNDLE_JOBS=$cores_num
 
 # The following is based on https://github.com/gma/bundler-exec
 


### PR DESCRIPTION
If "bundler" plugin enabled and run `bi` shortcut, Bundler throws exception:

```
~/projects/rails_project$ bi                                                                                                            
Unknown switches '--jobs=4'
```

My environment:

```
Ruby 2.1.0dev (2013-10-11) [x86_64-darwin11.4.2]
Bundler version 1.3.5
```

The parallel gem installations ('--jobs=N') is feature in Bundler 1.4.0.pre.1,
so I think plugin should detect version for this option,
or there is no need in this feature.

What you think?
