### PR TITLE
Add command blacklist support to bundler plugin

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -13,6 +13,7 @@ fi
 eval "alias bi='bundle install --jobs=$cores_num'"
 
 # The following is based on https://github.com/gma/bundler-exec
+
 bundled_commands=(annotate berks cap capify cucumber foodcritic foreman guard jekyll kitchen knife middleman nanoc rackup rainbows rake rspec ruby shotgun spec spin spork strainer tailor taps thin thor unicorn unicorn_rails puma)
 
 # Remove $UNBUNDLED_COMMANDS from the bundled_commands list


### PR DESCRIPTION
The user can set a `$UNBUNDLED_COMMAND` option in their .zshrc:

``` bash
$UNBUNDLED_COMMAND=foreman
# or
$UNBUNDLED_COMMAND=(cucumber foreman rake)
```

The bundler plugin for oh-my-zsh won't force these commands to run with `bundle exec`.

It's much easier to exclude some commands like this than having to fork the whole project.
