### PR TITLE
Autojump plugin: check user local installation first.

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -1,5 +1,7 @@
 if [ $commands[autojump] ]; then # check if autojump is installed
-  if [ -f /usr/share/autojump/autojump.zsh ]; then # debian and ubuntu package
+  if [ -f $HOME/.autojump/etc/profile.d/autojump.zsh ]; then # manual user-local installation
+    . $HOME/.autojump/etc/profile.d/autojump.zsh
+  elif [ -f /usr/share/autojump/autojump.zsh ]; then # debian and ubuntu package
     . /usr/share/autojump/autojump.zsh
   elif [ -f /etc/profile.d/autojump.zsh ]; then # manual installation
     . /etc/profile.d/autojump.zsh
@@ -7,8 +9,6 @@ if [ $commands[autojump] ]; then # check if autojump is installed
     . /etc/profile.d/autojump.sh
   elif [ -f /usr/local/share/autojump/autojump.zsh ]; then # freebsd installation
     . /usr/local/share/autojump/autojump.zsh
-  elif [ -f $HOME/.autojump/etc/profile.d/autojump.zsh ]; then # manual user-local installation
-    . $HOME/.autojump/etc/profile.d/autojump.zsh
   elif [ -f /opt/local/etc/profile.d/autojump.zsh ]; then # mac os x with ports
     . /opt/local/etc/profile.d/autojump.zsh
   elif [ $commands[brew] -a -f `brew --prefix`/etc/autojump.zsh ]; then # mac os x with brew


### PR DESCRIPTION
Users may install their own version of autojump to override the system
installed version.
