### PR TITLE
new SEGMENT_SEPARATOR which works with most standard fonts

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -26,7 +26,7 @@
 # A few utility functions to make it easy and re-usable to draw segmented prompts
 
 CURRENT_BG='NONE'
-SEGMENT_SEPARATOR=''
+SEGMENT_SEPARATOR='⮀'
 
 # Begin a segment
 # Takes two arguments, background and foreground. Both can be omitted,


### PR DESCRIPTION
the previuous separator was not working for me (and some friends of mine) even with the powerline patched fonts. I copied the arrow from https://gist.github.com/agnoster/3712874 and pasted it into my configuration. Now it works with nearly every font.
