### PR TITLE
Change bundler plugin's `bi` alias to a function

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -4,12 +4,30 @@ alias bp="bundle package"
 alias bo="bundle open"
 alias bu="bundle update"
 
-
 # The following is based on https://github.com/gma/bundler-exec
 
 bundled_commands=(annotate berks cap capify cucumber foodcritic foreman guard jekyll kitchen knife middleman nanoc rackup rainbows rake rspec ruby shotgun spec spin spork strainer tailor taps thin thor unicorn unicorn_rails puma)
 
 ## Functions
+
+bi() {
+  if _bundler-installed && _within-bundled-project; then
+    local bundler_version=`bundle version | cut -d' ' -f3`
+    if [[ $bundler_version > '1.4.0' || $bundler_version = '1.4.0' ]]; then
+      if [[ "$(uname)" == 'Darwin' ]]
+      then
+        local cores_num="$(sysctl hw.ncpu | awk '{print $2}')"
+      else
+        local cores_num="$(nproc)"
+      fi
+      bundle install --jobs=$cores_num $@
+    else
+      bundle install $@
+    fi
+  else
+    echo "Can't 'bundle install' outside a bundled project"
+  fi
+}
 
 _bundler-installed() {
   which bundle > /dev/null 2>&1
@@ -32,28 +50,14 @@ _run-with-bundler() {
   fi
 }
 
-if _bundler-installed; then
-	bundler_version=`bundle version | cut -d' ' -f3`
-	if [[ $bundler_version > '1.4.0' || $bundler_version = '1.4.0' ]]; then
-		if [[ "$(uname)" == 'Darwin' ]]
-		then
-			local cores_num="$(sysctl hw.ncpu | awk '{print $2}')"
-		else
-			local cores_num="$(nproc)"
-		fi
-		eval "alias bi='bundle install --jobs=$cores_num'"
-	else
-		alias bi='bundle install' 
-	fi
+## Main program
+for cmd in $bundled_commands; do
+  eval "function unbundled_$cmd () { $cmd \$@ }"
+  eval "function bundled_$cmd () { _run-with-bundler $cmd \$@}"
+  alias $cmd=bundled_$cmd
 
-	## Main program
-	for cmd in $bundled_commands; do
-		eval "function unbundled_$cmd () { $cmd \$@ }"
-		eval "function bundled_$cmd () { _run-with-bundler $cmd \$@}"
-		alias $cmd=bundled_$cmd
+  if which _$cmd > /dev/null 2>&1; then
+        compdef _$cmd bundled_$cmd=$cmd
+  fi
+done
 
-		if which _$cmd > /dev/null 2>&1; then
-			compdef _$cmd bundled_$cmd=$cmd
-		fi
-	done
-fi


### PR DESCRIPTION
Only check the bundler version when we call bi. This fixes two issues:
First, if there is no bundler available system-wide this will cause an
error each time zsh loads. Second, if new bundler is installed
system-wide but you change into an rbenv with an older version, the
alias will no longer work.

This fixes the bug / incompatibility introduced in https://github.com/robbyrussell/oh-my-zsh/pull/2107
