### PR TITLE
When using ssh-agent plugin, It output a warning message

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -57,7 +57,7 @@ if [[ ${_plugin__forwarding} == "yes" && -n "$SSH_AUTH_SOCK" ]]; then
 elif [ -f "${_plugin__ssh_env}" ]; then
   # Source SSH settings, if applicable
   . ${_plugin__ssh_env} > /dev/null
-  ps -x | grep ${SSH_AGENT_PID} | grep ssh-agent > /dev/null || {
+  ps x | grep ${SSH_AGENT_PID} | grep ssh-agent > /dev/null || {
     _plugin__start_agent;
   }
 else


### PR DESCRIPTION
It output an warning about `ps` command that It's using the plugin `ssh-agent`

```
warning: bad ps syntax, perhaps a bogus '-'?
See http://gitorious.org/procps/procps/blobs/master/Documentation/FAQ
```

Hope to fix, thanks.
