### PR TITLE
Prevent errors in prompts if no battery info available.

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -79,4 +79,14 @@ elif [[ $(uname) == "Linux"  ]] ; then
       echo "∞"
     fi
   }
+else
+	# Empty functions so we don't cause errors in prompts
+	function battery_pct_remaining() {
+	}
+
+	function battery_time_remaining() {
+	}
+
+	function battery_pct_prompt() {
+	}
 fi


### PR DESCRIPTION
Define empty battery info functions instead of none at all if we can't figure out the platform. This means one .zshrc can be used on multiple machines even if not all of them have batteries.
