### PR TITLE
Vundle plugin with submodules

### DIFF
--- a/plugins/vundle/vundle.plugin.zsh
+++ b/plugins/vundle/vundle.plugin.zsh
@@ -4,7 +4,7 @@ function vundle-init () {
     mkdir -p ~/.vim/bundle/vundle/
   fi
 
-  if [ ! -d ~/.vim/bundle/vundle/.git/ ]
+  if [ ! -d ~/.vim/bundle/vundle/.git ] && [ ! -f ~/.vim/bundle/vundle/.git ]
   then
     git clone http://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
     echo "\n\tRead about vim configuration for vundle at https://github.com/gmarik/vundle\n"


### PR DESCRIPTION
When you have your vim config in a git repository, and have included vundle as a submodule, `~/.vim/bundle/vundle/.git` will be a file. Thus, I modified the check so it will also allow `~/.vim/bundle/vundle/.git` to be a file.
