### PR TITLE
Fix .gitignore "custom" directory _again_

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 locals.zsh
 log/.zsh_history
 projects.zsh
--custom/*
--!custom/example
--!custom/example.zsh
+custom/*
+!custom/example
+!custom/example.zsh
 *.swp
 !custom/example.zshcache
 cache/


### PR DESCRIPTION
- Properly ignore the ./custom directory excluding the examples
- Lol, I'm not sure why this has been so tricky :tongue:
- See #2128, #2165

Try, try again! :smile: 
