### PR TITLE
Allow muting certain upgrade messages using the $OMZ_UPGRADE_TEXT variable

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,16 +1,22 @@
-printf '\033[0;34m%s\033[0m\n' "Upgrading Oh My Zsh"
+if [[ $OMZ_UPGRADE_TEXT != "error" ]] && [[ $OMZ_UPGRADE_TEXT != "none" ]]; then
+  printf '\033[0;34m%s\033[0m\n' "Upgrading Oh My Zsh"
+fi
 cd "$ZSH"
 if git pull --rebase origin master
 then
-  printf '\033[0;32m%s\033[0m\n' '         __                                     __   '
-  printf '\033[0;32m%s\033[0m\n' '  ____  / /_     ____ ___  __  __   ____  _____/ /_  '
-  printf '\033[0;32m%s\033[0m\n' ' / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \ '
-  printf '\033[0;32m%s\033[0m\n' '/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / / '
-  printf '\033[0;32m%s\033[0m\n' '\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/  '
-  printf '\033[0;32m%s\033[0m\n' '                        /____/                       '
-  printf '\033[0;34m%s\033[0m\n' 'Hooray! Oh My Zsh has been updated and/or is at the current version.'
-  printf '\033[0;34m%s\033[1m%s\033[0m\n' 'To keep up on the latest, be sure to follow Oh My Zsh on twitter: ' 'http://twitter.com/ohmyzsh'
-else
+  if [[ $OMZ_UPGRADE_TEXT != "noasciiart" ]] && [[ $OMZ_UPGRADE_TEXT != "error" ]] && [[ $OMZ_UPGRADE_TEXT != "none" ]]; then
+    printf '\033[0;32m%s\033[0m\n' '         __                                     __   '
+    printf '\033[0;32m%s\033[0m\n' '  ____  / /_     ____ ___  __  __   ____  _____/ /_  '
+    printf '\033[0;32m%s\033[0m\n' ' / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \ '
+    printf '\033[0;32m%s\033[0m\n' '/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / / '
+    printf '\033[0;32m%s\033[0m\n' '\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/  '
+    printf '\033[0;32m%s\033[0m\n' '                        /____/                       '
+  fi
+  if [[ $OMZ_UPGRADE_TEXT != "error" ]] && [[ $OMZ_UPGRADE_TEXT != "none" ]]; then
+    printf '\033[0;34m%s\033[0m\n' 'Hooray! Oh My Zsh has been updated and/or is at the current version.'
+    printf '\033[0;34m%s\033[1m%s\033[0m\n' 'To keep up on the latest, be sure to follow Oh My Zsh on twitter: ' 'http://twitter.com/ohmyzsh'
+  fi
+elif [[ $OMZ_UPGRADE_TEXT != "none" ]]; then
   printf '\033[0;31m%s\033[0m\n' 'There was an error updating. Try again later?'
 fi
 


### PR DESCRIPTION
The upgrade script now determines how verbose it should be based on `$OMZ_UPGRADE_TEXT`. You can think of that variable as sort of a log level for the upgrade script. These are the possible values:
- default: print everything (same as before)
- `noasciiart`: print everything except the huge ASCII art saying “oh my zsh”
- `error`: only print the error message if the update fails
- `none`: print nothing
