### PR TITLE
Optionally disable git_prompt_info with git config option for very large repos

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -1,8 +1,10 @@
 # get the name of the branch we are on
 function git_prompt_info() {
-  ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
-  ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
-  echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+  if [[ "$(git config --get oh-my-zsh.hide-status)" != "1" ]]; then
+    ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
+    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
+    echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+  fi
 }
 
 


### PR DESCRIPTION
This adds a check to git_prompt_info for the git config option `oh-my-zsh.hide-status` before doing anything.

Having repo status in the prompt for very large repos becomes unmanageable and `git status` takes too long to return if it is executed before every PROMPT is shown.

This allows git_prompt_info to be enabled by default but disabled on a repo by repo basis if the flag is set to `1`.

This is nothing more than an updated version of https://github.com/robbyrussell/oh-my-zsh/pull/1772 to bring it up to date with the current layout of lib/git.zsh
