### PR TITLE
fix pip plugin

### DIFF
--- a/plugins/pip/pip.plugin.zsh
+++ b/plugins/pip/pip.plugin.zsh
@@ -18,12 +18,12 @@ zsh-pip-clear-cache() {
 }
 
 zsh-pip-clean-packages() {
-    sed -nr '/<a href/ s/.*>([^<]+).*/\1/p'
+    sed -n '/<a href/ s/.*>\([^<]\{1,\}\).*/\1/p'
 }
 
 zsh-pip-cache-packages() {
-  if [[ ! -d ${PIP_CACHE_FILE:h} ]]; then
-      mkdir -p ${PIP_CACHE_FILE:h}
+  if [[ ! -d ${ZSH_PIP_CACHE_FILE:h} ]]; then
+      mkdir -p ${ZSH_PIP_CACHE_FILE:h}
   fi
 
   if [[ ! -f $ZSH_PIP_CACHE_FILE ]]; then


### PR DESCRIPTION
I had a couple problems with the pip plugin:
- It seemed to expect GNU sed and broke with BSD (read: OSX) sed. I've tested this version with both.
- It didn't create the parent directory of the cache file if it didn't exist apparently just due to a typo.
