### PR TITLE
Use precmd hook instead of chpwd for updating OS X proxy icon

### DIFF
--- a/plugins/terminalapp/terminalapp.plugin.zsh
+++ b/plugins/terminalapp/terminalapp.plugin.zsh
@@ -32,7 +32,7 @@ if [[ "$TERM_PROGRAM" == "Apple_Terminal" ]] && [[ -z "$INSIDE_EMACS" ]]; then
     # Register the function so it is called whenever the working
     # directory changes.
     autoload add-zsh-hook
-    add-zsh-hook chpwd update_terminal_cwd
+    add-zsh-hook precmd update_terminal_cwd
 
     # Tell the terminal about the initial directory.
     update_terminal_cwd


### PR DESCRIPTION
I'm not an oh-my-zsh user, but I have for years used the exact same trick to update the proxy icon in the OS X Terminal title bar when using zsh.  I first came across it in this MacOSXHints post:

http://hints.macworld.com/article.php?story=20110722211753852

Recently I realised that a problem I was observing with the (Python) virtualenvwrapper tool could be traced back to this function.  The problem is documented in this issue I filed (while mistakenly believing the problem to lie with virtualenvwrapper):

https://bitbucket.org/dhellmann/virtualenvwrapper/issue/216/lsvirtualenv-and-workon-output-broken-in

The solution I'm proposing here is to use the precmd hook instead of chpwd. This resolves the actual issue, which is that a bunch of text (wrapped in control characters) was spewed to STDOUT upon returning from a subshell in which the working directory was changed.  (In theory, other 3rd party applications might also be affected.)

It does, of course, mean that the function to update the proxy icon will be executed a great deal more frequently, though that shouldn't be an issue on a modern system.
