### PR TITLE
Update _pass to follow symlinks for completion

### DIFF
--- a/plugins/pass/_pass
+++ b/plugins/pass/_pass
@@ -101,7 +101,7 @@ _pass_cmd_show () {
 _pass_complete_entries_helper () {
 	local IFS=$'\n'
 	local prefix="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
-	_values -C 'passwords' $(find "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print | sed -e "s#${prefix}.##" -e 's#\.gpg##' | sort)
+	_values -C 'passwords' $(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print | sed -e "s#${prefix}.##" -e 's#\.gpg##' | sort)
 }
 
 _pass_complete_entries_with_subdirs () {


### PR DESCRIPTION
If `PASSWORD_STORE_DIR:-$HOME/.password-store` is a symlink, Zsh throws:
`_values:compvalues:10: not enough arguments`.

Passing `-L` to find(1) fixes this.

Based on: http://comments.gmane.org/gmane.comp.encryption.pass/235
