### PR TITLE
check_for_upgrade.sh: source ~/.profile only if it exists

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -20,7 +20,7 @@ if [[ -z "$epoch_target" ]]; then
   epoch_target=13
 fi
 
-[ ~/.profile ] && source ~/.profile
+[ -f ~/.profile ] && source ~/.profile
 
 if [ -f ~/.zsh-update ]
 then


### PR DESCRIPTION
When entering a new session, check_for_upgrade.sh is sourced and throws an error if `~/.profile` doesn't exist.

This fixes the problem.
