### PR TITLE
Making auto-correction off by default

### DIFF
--- a/lib/correction.zsh
+++ b/lib/correction.zsh
@@ -1,14 +1,13 @@
-if [[ "$DISABLE_CORRECTION" == "true" ]]; then
-  return
-else
+alias man='nocorrect man'
+alias mv='nocorrect mv'
+alias mysql='nocorrect mysql'
+alias mkdir='nocorrect mkdir'
+alias gist='nocorrect gist'
+alias heroku='nocorrect heroku'
+alias ebuild='nocorrect ebuild'
+alias hpodder='nocorrect hpodder'
+alias sudo='nocorrect sudo'
+
+if [[ "$ENABLE_CORRECTION" == "true" ]]; then
   setopt correct_all
-  alias man='nocorrect man'
-  alias mv='nocorrect mv'
-  alias mysql='nocorrect mysql'
-  alias mkdir='nocorrect mkdir'
-  alias gist='nocorrect gist'
-  alias heroku='nocorrect heroku'
-  alias ebuild='nocorrect ebuild'
-  alias hpodder='nocorrect hpodder'
-  alias sudo='nocorrect sudo'
 fi


### PR DESCRIPTION
Adjustment to close #534
- Allows for the user to turn on auto-correction using the
  `$ENABLE_CORRECTION` variable
- Adds aliases regardless of variable assignment to aid users that use
  setopt to turn correction back on in their zshrc
