### PR TITLE
Fixes Af-Magic theme PROMPT being overwritten by RPROMPT (a.k.a. Af-Magic theme looks broken)

### DIFF
--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -27,7 +27,7 @@ eval my_gray='$FG[237]'
 eval my_orange='$FG[214]'
 
 # right prompt
-PROMPT='$(virtualenv_prompt_info)$my_gray%n@%m%{$reset_color%}%'
+RPROMPT='$(virtualenv_prompt_info)$my_gray%n@%m%{$reset_color%}%'
 
 # git settings
 ZSH_THEME_GIT_PROMPT_PREFIX="$FG[075](branch:"


### PR DESCRIPTION
For Af-Magic theme, `PROMPT` was overwritten with `RPROMPT`'s content by mistake in commit b38db4a. This pull request aims to fix it.
