### PR TITLE
Add alias to rails plugin

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -51,6 +51,7 @@ alias rds='rake db:seed'
 alias rdd='rake db:drop'
 alias rdtc='rake db:test:clone'
 alias rdtp='rake db:test:prepare'
+alias rdmtc='rake db:migrate db:test:clone'
 
 alias rlc='rake log:clear'
 alias rn='rake notes'


### PR DESCRIPTION
Add rdbm alias.
Since this rails plugin consolidated functionality of rails3 plugin, it makes sense to add command from it. This way it will be backward compatible.
