### PR TITLE
Renaming config for parse_git_dirty() to avoid collision

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -13,7 +13,7 @@ parse_git_dirty() {
   local SUBMODULE_SYNTAX=''
   local GIT_STATUS=''
   local CLEAN_MESSAGE='nothing to commit (working directory clean)'
-  if [[ "$(command git config --get oh-my-zsh.hide-status)" != "1" ]]; then
+  if [[ "$(command git config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
     if [[ $POST_1_7_2_GIT -gt 0 ]]; then
           SUBMODULE_SYNTAX="--ignore-submodules=dirty"
     fi


### PR DESCRIPTION
Based on comments on https://github.com/robbyrussell/oh-my-zsh/pull/2270 a previous git config option was overriden.
The git config option for parse_git_dirty() will be renamed to be unique and clearer.
