### PR TITLE
fixed vagrant folder

### DIFF
--- a/plugins/vagrant/_vagrant
+++ b/plugins/vagrant/_vagrant
@@ -44,7 +44,7 @@ __task_list ()
 
 __box_list ()
 {
-    _wanted application expl 'command' compadd $(command ls -1 $HOME/.vagrant/boxes 2>/dev/null| sed -e 's/ /\\ /g')
+    _wanted application expl 'command' compadd $(command ls -1 $HOME/.vagrant.d/boxes 2>/dev/null| sed -e 's/ /\\ /g')
 }
 
 __vm_list ()


### PR DESCRIPTION
This fix enables autocompletion for installed vagrant base boxes.
