### PR TITLE
Avoid evaluating special chars in $LINE on title command (fixes #2234)

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -28,7 +28,7 @@ function omz_termsupport_preexec {
   setopt extended_glob
   local CMD=${1[(wr)^(*=*|sudo|ssh|rake|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
   local LINE="${2:gs/%/%%}"
-  title "$CMD" '%100>...>$LINE%<<'
+  title '$CMD' '%100>...>$LINE%<<'
 }
 
 autoload -U add-zsh-hook


### PR DESCRIPTION
If we use [strong quoting](http://wiki.bash-hackers.org/syntax/quoting#strong_quoting) we don't need to escape every single special character.
