### PR TITLE
Prevents oh-my-zsh loading the .zshenv twice

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -1,6 +1,6 @@
 # Check for updates on initial load...
 if [ "$DISABLE_AUTO_UPDATE" != "true" ]; then
-  /usr/bin/env ZSH=$ZSH DISABLE_UPDATE_PROMPT=$DISABLE_UPDATE_PROMPT zsh $ZSH/tools/check_for_upgrade.sh
+  /usr/bin/env ZSH=$ZSH DISABLE_UPDATE_PROMPT=$DISABLE_UPDATE_PROMPT zsh -f $ZSH/tools/check_for_upgrade.sh
 fi
 
 # Initializes Oh My Zsh


### PR DESCRIPTION
I was having the `.zshenv` file sourced twice, one before `.zshrc` and other after.

The problem is that when running the script to check for an upgrade, it's being called with the `zsh` command, which loads the environments.

In [http://zshwiki.org/home/config/files](zshwiki) says
- zshenv is the 1st file zsh reads; it's read for every shell, even if started with -f (setopt NO_RCS)
- .zshenv is the same, except that it's not read if zsh is started with -f

So I added the `-f` flag to prevent the `.zshenv` being sourced.
It worked for me. 

This should help speeding up new shell initializations and I haven't found any side effects.
