### PR TITLE
Fix slow shell prompt when aliasing hub as git

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -1,6 +1,6 @@
 # get the name of the branch we are on
 function git_prompt_info() {
-  if [[ "$(git config --get oh-my-zsh.hide-status)" != "1" ]]; then
+  if [[ "$(command git config --get oh-my-zsh.hide-status)" != "1" ]]; then
     ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
     echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"


### PR DESCRIPTION
The `git` should be `command git` to avoid aliases.
