### PR TITLE
Cancel upgrade if the current user doesn't have write permissions for the oh-my-zsh directory.

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -22,6 +22,10 @@ fi
 
 [ -f ~/.profile ] && source ~/.profile
 
+# Cancel upgrade if the current user doesn't have write permissions for the
+# oh-my-zsh directory.
+[[ -w "$ZSH" ]] || return 0
+
 if [ -f ~/.zsh-update ]
 then
   . ~/.zsh-update


### PR DESCRIPTION
This should fix the problem introduced [here](https://github.com/robbyrussell/oh-my-zsh/pull/2358).
