### PR TITLE
Re-enable autocompletion for usernames.

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -45,7 +45,6 @@ hosts=(
   localhost
 )
 zstyle ':completion:*:hosts' hosts $hosts
-zstyle ':completion:*' users off
 
 # Use caching so that commands like apt and dpkg complete are useable
 zstyle ':completion::complete:*' use-cache 1


### PR DESCRIPTION
Has been accidentally disabled in commit c4434d2.
See issues [1857](https://github.com/robbyrussell/oh-my-zsh/issues/1857) and [2013](https://github.com/robbyrussell/oh-my-zsh/issues/2013).
