### PR TITLE
Fix ssh-agent plugin on OS X.

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -57,7 +57,13 @@ if [[ ${_plugin__forwarding} == "yes" && -n "$SSH_AUTH_SOCK" ]]; then
 elif [ -f "${_plugin__ssh_env}" ]; then
   # Source SSH settings, if applicable
   . ${_plugin__ssh_env} > /dev/null
-  ps x | grep ${SSH_AGENT_PID} | grep ssh-agent > /dev/null || {
+  PLATFORM=`uname`
+  if [[ ${PLATFORM} == "Darwin" ]]; then
+    PS_FLAGS="-ef"
+  else
+    PS_FLAGS="x"
+  fi
+  ps ${PS_FLAGS} | grep ${SSH_AGENT_PID} | grep ssh-agent > /dev/null || {
     _plugin__start_agent;
   }
 else


### PR DESCRIPTION
In b2376c3, the `ps` command was changed away from `ps -ef` to
`ps x` (well, `ps -x`, but it was supposed to be `ps x`) because
OpenBSD doesn't support `-ef`. Sadly, OS X doesn't support `ps x`.
This fix adds a switch to use the old flags on OS X, and the newer,
more concise flags on other platforms.
