### PR TITLE
too many plugins = slow init warning

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -45,6 +45,7 @@ ZSH_THEME="robbyrussell"
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
+# Add wisely, as too many plugins slow down shell startup.
 plugins=(git)
 
 source $ZSH/oh-my-zsh.sh


### PR DESCRIPTION
This kind of warning would have helped me a lot. I made a mistake of blindly adding every plugin with a familiar name - got me into a state where my shell took a significant time to start and it wasn't obvious to me what was the cause - zsh, oh-my-zsh, some of the stuff I put in my rc file myself... It turned out that the plugins I had enabled introduced the most overhead.
