### PR TITLE
Fixes git_compare_version() in lib/git.zsh and refactors the whole file

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -17,7 +17,7 @@
 #   check_git_show_status below)
 #   Dirty submodules are not tracked f your git version is post 1.7.2.
 #   To ignore untracked files making your branch dirty, set
-#   DISABLE_UNTRACKED_FILES_DIRTY to 'true
+#   DISABLE_UNTRACKED_FILES_DIRTY to 'true'
 #
 # git_prompt_short_sha and git_prompt_long_sha
 #   Delimited by

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -13,8 +13,8 @@
 #   The symbols used to show dirtyness (evaluated in parse_git_dirty) are
 #     ZSH_THEME_GIT_PROMPT_DIRTY
 #     ZSH_THEME_GIT_PROMPT_CLEAN
-#   Can be disabled if GIT_HIDE == 'true' or through your git config (see
-#   check_git_show_status below)
+#   Can be disabled if ZSH_THEME_GIT_PROMPT_HIDE == 'true'
+#   or through your git config (see check_git_show_status below)
 #   Dirty submodules are not tracked f your git version is post 1.7.2.
 #   To ignore untracked files making your branch dirty, set
 #   DISABLE_UNTRACKED_FILES_DIRTY to 'true'
@@ -54,7 +54,7 @@
 # get the name of the branch we are on
 function git_prompt_info() {
   local branch
-  [[ GIT_HIDE == 'true' ]] && return
+  [[ ZSH_THEME_GIT_PROMPT_HIDE == 'true' ]] && return
   branch=$(current_branch) || return 1
   printf '%s%s%s%s\n' \
     $ZSH_THEME_GIT_PROMPT_PREFIX \
@@ -75,7 +75,7 @@ git_current_branch() {
 
 # Checks if working tree is dirty
 parse_git_dirty() {
-  [[ GIT_HIDE == 'true' ]] && return
+  [[ ZSH_THEME_GIT_PROMPT_HIDE == 'true' ]] && return
   if git_is_clean; then
     echo $ZSH_THEME_GIT_PROMPT_CLEAN
   else
@@ -199,7 +199,7 @@ check_git_show_status() {
     # no need to set options if status is hidden anyway
     set_git_status_options
   else
-    GIT_HIDE='true'
+    ZSH_THEME_GIT_PROMPT_HIDE='true'
   fi
 }
 

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -52,7 +52,7 @@
 function git_prompt_info() {
   [[ GIT_HIDE == 'true' ]] && return
   ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
-  ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
+    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
   echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
 }
 
@@ -118,7 +118,6 @@ git_stash_status() {
   has_stashed_commits && echo $ZSH_THEME_GIT_PROMPT_STASHED
 }
 
-
 # Get the status of the working tree
 git_prompt_status() {
   local key
@@ -176,6 +175,7 @@ check_git_show_status() {
     GIT_HIDE='true'
   fi
 }
+
 #this is unlikely to change so make it all statically assigned
 check_git_show_status
 git_prompt_status_setup

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -56,7 +56,11 @@ function git_prompt_info() {
   [[ GIT_HIDE == 'true' ]] && return
   ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
-  echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
+  printf '%s%s%s%s\n' \
+    $ZSH_THEME_GIT_PROMPT_PREFIX \
+    ${ref#refs/heads/} \
+    $(parse_git_dirty) \
+    $ZSH_THEME_GIT_PROMPT_SUFFIX
 }
 
 
@@ -78,7 +82,10 @@ git_is_clean() {
 git_prompt_sha() {
   local sha
   sha=$(command git rev-parse $1 HEAD 2> /dev/null) && \
-    echo "$ZSH_THEME_GIT_PROMPT_SHA_BEFORE$sha$ZSH_THEME_GIT_PROMPT_SHA_AFTER"
+    printf '%s%s%s\n' \
+      $ZSH_THEME_GIT_PROMPT_SHA_BEFORE \
+      $sha \
+      $ZSH_THEME_GIT_PROMPT_SHA_AFTER
 }
 
 # The following are kept for backwards compatibility
@@ -144,7 +151,10 @@ setup_git_change_status() {
 git_prompt_status() {
   local git_index
   git_index=$(command git status --porcelain -b 2> /dev/null)
-  echo $(git_change_status $git_index)$(git_remote_status $git_index)$(git_stash_status)
+  printf '%s%s%s\n' \
+    $(git_change_status $git_index)\
+    $(git_remote_status $git_index)\
+    $(git_stash_status)
 }
 
 #compare the provided version of git to the version installed and on path

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -22,13 +22,13 @@ git_is_clean() {
 }
 
 # Formats prompt string for current git commit short SHA
-function git_prompt_short_sha() {
+git_prompt_short_sha() {
   SHA=$(command git rev-parse --short HEAD 2> /dev/null) && \
     echo "$ZSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$ZSH_THEME_GIT_PROMPT_SHA_AFTER"
 }
 
 # Formats prompt string for current git commit long SHA
-function git_prompt_long_sha() {
+git_prompt_long_sha() {
   SHA=$(command git rev-parse HEAD 2> /dev/null) && \
     echo "$ZSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$ZSH_THEME_GIT_PROMPT_SHA_AFTER"
 }
@@ -91,7 +91,7 @@ git_prompt_status() {
 #compare the provided version of git to the version installed and on path
 #prints 1 if installed version > input version
 #prints -1 otherwise
-function is_recent_git_version() {
+is_recent_git_version() {
   local not_recent_git
   local installed_git
   not_recent_git=(1 7 2);
@@ -106,7 +106,7 @@ function is_recent_git_version() {
   return 1
 }
 
-function set_git_status_options() {
+set_git_status_options() {
   GIT_STATUS_OPTIONS=''
   if is_recent_git_version; then
     GIT_STATUS_OPTIONS+='--ignore-submodules=dirty'
@@ -116,7 +116,7 @@ function set_git_status_options() {
   fi
 }
 
-function check_git_show_status() {
+check_git_show_status() {
   if [[ $(command git config --get oh-my-zsh.hide-status) != "1" ]]; then
     # no need to set options if status is hidden anyway
     set_git_status_options

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -1,10 +1,9 @@
 # get the name of the branch we are on
 function git_prompt_info() {
-  if [[ "$(git config --get oh-my-zsh.hide-status)" != "1" ]]; then
-    ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
-    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
-    echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
-  fi
+  [[ GIT_HIDE == 'true' ]] && return
+  ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
+  ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
+  echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
 }
 
 

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -1,3 +1,49 @@
+# Basic git handling - if you need more, check the plugin
+#
+# This file provides several methods to inform your prompt about your
+# git status. All symbols and delimiters used can be customized.
+#
+# The variables and methods at a glance:
+#
+# git_prompt_info
+#   Shows your branch and whether your working tree is dirty or not.
+#   The string is delimited by
+#     ZSH_THEME_GIT_PROMPT_PREFIX
+#     ZSH_THEME_GIT_PROMPT_SUFFIX
+#   The symbols used to show dirtyness (evaluated in parse_git_dirty) are
+#     ZSH_THEME_GIT_PROMPT_DIRTY
+#     ZSH_THEME_GIT_PROMPT_CLEAN
+#   Can be disabled if GIT_HIDE == 'true' or through your git config (see
+#   check_git_show_status below)
+#   Dirty submodules are not tracked by this function if your git version
+#   if post 1.7.2
+#
+# git_prompt_short_sha and git_prompt_long_sha
+#   Delimited by
+#     ZSH_THEME_GIT_PROMPT_SHA_BEFORE
+#     ZSH_THEME_GIT_PROMPT_SHA_AFTER
+#
+# git_remote_status
+#   Shows the difference between your local and its remote branch. Checks
+#   for ahead, behind or diverged status and is shown with the help of
+#     ZSH_THEME_GIT_PROMPT_AHEAD
+#     ZSH_THEME_GIT_PROMPT_BEHIND
+#     ZSH_THEME_GIT_PROMPT_DIVERGED
+#
+# git_stash_status
+#   Shows whether you have stashed commits or not
+#     ZSH_THEME_GIT_PROMPT_STASHED
+#
+# git_prompt_status
+#   More detailed information about the status of your working tree. Shows
+#   what exactly makes it dirty and as a superset includes the information
+#   of git_remote_status and git_stash_status
+#     ZSH_THEME_GIT_PROMPT_ADDED
+#     ZSH_THEME_GIT_PROMPT_DELETED
+#     ZSH_THEME_GIT_PROMPT_MODIFIED
+#     ZSH_THEME_GIT_PROMPT_UNMERGED
+#     ZSH_THEME_GIT_PROMPT_UNTRACKED
+
 # get the name of the branch we are on
 function git_prompt_info() {
   [[ GIT_HIDE == 'true' ]] && return
@@ -66,6 +112,11 @@ has_stashed_commits() {
   command git rev-parse --verify refs/stash &>/dev/null
 }
 
+git_stash_status() {
+  has_stashed_commits && echo $ZSH_THEME_GIT_PROMPT_STASHED
+}
+
+
 # Get the status of the working tree
 git_prompt_status() {
   local key
@@ -83,8 +134,7 @@ git_prompt_status() {
   done
 
   return_str+=$(git_remote_status $remote_line)
-  has_stashed_commits && return_str+=$ZSH_THEME_GIT_PROMPT_STASHED
-
+  return_str+=$(git_stash_status)
   echo $return_str
 }
 
@@ -127,4 +177,3 @@ check_git_show_status() {
 #this is unlikely to change so make it all statically assigned
 check_git_show_status
 git_prompt_status_setup
-

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -19,10 +19,13 @@
 #   To ignore untracked files making your branch dirty, set
 #   DISABLE_UNTRACKED_FILES_DIRTY to 'true'
 #
-# git_prompt_short_sha and git_prompt_long_sha
+# git_prompt_sha
 #   Delimited by
 #     ZSH_THEME_GIT_PROMPT_SHA_BEFORE
 #     ZSH_THEME_GIT_PROMPT_SHA_AFTER
+#   By default displays the long sha key, call git_prompt_sha --short
+#   to have it shortened. The former functions git_prompt_long_sha and
+#   git_prompt_short_sha are kept for backward compatibility.
 #
 # git_remote_status
 #   Shows the difference between your local and its remote branch. Checks
@@ -68,17 +71,15 @@ git_is_clean() {
   [[ $(command git status -s $GIT_STATUS_OPTIONS 2> /dev/null) == '' ]]
 }
 
-# Formats prompt string for current git commit short SHA
-git_prompt_short_sha() {
-  SHA=$(command git rev-parse --short HEAD 2> /dev/null) && \
+# Shows the long git sha, pass in --short to get it shortened
+git_prompt_sha() {
+  SHA=$(command git rev-parse $1 HEAD 2> /dev/null) && \
     echo "$ZSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$ZSH_THEME_GIT_PROMPT_SHA_AFTER"
 }
 
-# Formats prompt string for current git commit long SHA
-git_prompt_long_sha() {
-  SHA=$(command git rev-parse HEAD 2> /dev/null) && \
-    echo "$ZSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$ZSH_THEME_GIT_PROMPT_SHA_AFTER"
-}
+# The following are kept for backwards compatibility
+git_prompt_short_sha() { git_prompt_sha --short }
+git_prompt_long_sha() { git_prompt_sha }
 
 # get the difference between the local and remote branches
 git_remote_status() {

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -53,16 +53,25 @@
 
 # get the name of the branch we are on
 function git_prompt_info() {
+  local branch
   [[ GIT_HIDE == 'true' ]] && return
-  ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
-    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
+  branch=$(current_branch) || return 1
   printf '%s%s%s%s\n' \
     $ZSH_THEME_GIT_PROMPT_PREFIX \
-    ${ref#refs/heads/} \
+    $branch \
     $(parse_git_dirty) \
     $ZSH_THEME_GIT_PROMPT_SUFFIX
 }
 
+
+# Shows the current git branch.
+# Exits with 1 when git is not available
+git_current_branch() {
+  local ref
+  ref=$(command git symbolic-ref HEAD 2>/dev/null) || \
+    ref=$(command git rev-parse --short HEAD 2>/dev/null) || return 1
+  echo ${ref#refs/heads/}
+}
 
 # Checks if working tree is dirty
 parse_git_dirty() {

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -15,8 +15,9 @@
 #     ZSH_THEME_GIT_PROMPT_CLEAN
 #   Can be disabled if GIT_HIDE == 'true' or through your git config (see
 #   check_git_show_status below)
-#   Dirty submodules are not tracked by this function if your git version
-#   if post 1.7.2
+#   Dirty submodules are not tracked f your git version is post 1.7.2.
+#   To ignore untracked files making your branch dirty, set
+#   DISABLE_UNTRACKED_FILES_DIRTY to 'true
 #
 # git_prompt_short_sha and git_prompt_long_sha
 #   Delimited by

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -73,8 +73,9 @@ git_is_clean() {
 
 # Shows the long git sha, pass in --short to get it shortened
 git_prompt_sha() {
-  SHA=$(command git rev-parse $1 HEAD 2> /dev/null) && \
-    echo "$ZSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$ZSH_THEME_GIT_PROMPT_SHA_AFTER"
+  local sha
+  sha=$(command git rev-parse $1 HEAD 2> /dev/null) && \
+    echo "$ZSH_THEME_GIT_PROMPT_SHA_BEFORE$sha$ZSH_THEME_GIT_PROMPT_SHA_AFTER"
 }
 
 # The following are kept for backwards compatibility

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -117,7 +117,7 @@ git_prompt_status() {
 }
 
 #compare the provided version of git to the version installed and on path
-#prints 1 if input version <= installed version
+#prints 1 if installed version > input version
 #prints -1 otherwise
 function git_compare_version() {
   local INPUT_GIT_VERSION=$1;
@@ -127,12 +127,12 @@ function git_compare_version() {
   INSTALLED_GIT_VERSION=(${(s/./)INSTALLED_GIT_VERSION[3]});
 
   for i in {1..3}; do
-    if [[ $INSTALLED_GIT_VERSION[$i] -lt $INPUT_GIT_VERSION[$i] ]]; then
-      echo -1
+    if [[ $INSTALLED_GIT_VERSION[$i] -gt $INPUT_GIT_VERSION[$i] ]]; then
+      echo 1
       return 0
     fi
   done
-  echo 1
+  echo -1
 }
 
 #this is unlikely to change so make it all statically assigned


### PR DESCRIPTION
git_compare_version() is used to determine whether dirty submodules should be ignored or not, but git has to be more recent than version 1.7.2 to know about that option.

With the former comparison logic a check if git version 1.8.1 is more recent than 1.7.2 turned out negative, which is fixed through this pull request.

UPDATE: In addition to #2401 I refactored  the whole file.
- Cleans up it's functions
- Less duplication of code and logic
- Less querying of git and the general status,
- Adds functions that where buried inside of others before (git_stash_status, git_change_status) to gain better modularity.
- Adds a big documentation section where every function and customization variable is explained.
- Adds a function to hide/show the git prompt in specific large repositories - toggle_git_prompt_visibility

Might need some more testing if anything was broken, though I don't have any troubles locally.

Possibly breaking changes:
- Cuts the duplicated variables to show the git_remote_status.
