### PR TITLE
Updates and refactors spectrum.zsh

### DIFF
--- a/lib/spectrum.zsh
+++ b/lib/spectrum.zsh
@@ -19,17 +19,19 @@ for color in {000..255}; do
     BG[$color]="%{[48;5;${color}m%}"
 done
 
+
+ZSH_SPECTRUM_TEXT=${ZSH_SPECTRUM_TEXT:-Arma virumque cano Troiae qui primus ab oris}
+
 # Show all 256 colors with color number
 function spectrum_ls() {
   for code in {000..255}; do
-    print -P -- "$code: %F{$code}Test%f"
+    print -P -- "$code: %F{$code}$ZSH_SPECTRUM_TEXT%f"
   done
 }
 
 # Show all 256 colors where the background is set to specific color
 function spectrum_bls() {
   for code in {000..255}; do
-    ((cc = code + 1))
-    print -P -- "$BG[$code]$code: Test %{$reset_color%}"
+    print -P -- "$BG[$code]$code: $ZSH_SPECTRUM_TEXT %{$reset_color%}"
   done
 }


### PR DESCRIPTION
Minor stuff.

Deletes a line that looks like remnants of an older try to implement the method (l. 32) and provides more text instead of the plain 'Test'. I think the colors are easier to distinct visually if you see a longer string.

If people are funny they can provide a custom string in ZSH_SPECTRUM_TEXT and have that displayed in spectrum functions.

Closes #2577 
