### PR TITLE
Fix WIP false positive

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -142,13 +142,13 @@ compdef _git glp=git-log
 #
 # This function return a warning if the current branch is a wip
 function work_in_progress() {
-  if $(git log -n 1 2>/dev/null | grep -q -c "--wip--"); then
+  if $(git log -n 1 2>/dev/null | grep -q -c "\-\-wip\-\-"); then
     echo "WIP!!"
   fi
 }
 # these alias commit and uncomit wip branches
 alias gwip='git add -A; git ls-files --deleted -z | xargs -0 git rm; git commit -m "--wip--"'
-alias gunwip='git log -n 1 | grep -q -c "--wip--" && git reset HEAD~1'
+alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
 
 # these alias ignore changes to file
 alias gignore='git update-index --assume-unchanged'


### PR DESCRIPTION
If the commit message has any words starting with "wip" there is a false positive WIP!! notification which startled me.
