### PR TITLE
fix root mode not working in bureau theme

### DIFF
--- a/themes/bureau.zsh-theme
+++ b/themes/bureau.zsh-theme
@@ -70,7 +70,7 @@ bureau_git_prompt () {
 
 _PATH="%{$fg_bold[white]%}%~%{$reset_color%}"
 
-if [[ "%#" == "#" ]]; then
+if [[ $EUID -eq 0 ]]; then
   _USERNAME="%{$fg_bold[red]%}%n"
   _LIBERTY="%{$fg[red]%}#"
 else


### PR DESCRIPTION
This fixes the method to check for root privileges of the bureau theme, which previously didn't work.
