### PR TITLE
Fixes tmuxinator plugin `find` on OSX

### DIFF
--- a/plugins/tmuxinator/_tmuxinator
+++ b/plugins/tmuxinator/_tmuxinator
@@ -25,7 +25,7 @@ case $state in
   args)
     case $line[1] in
       start|open|copy|delete)
-        _configs=(`find ~/.tmuxinator/ -name \*.yml | cut -d/ -f5 | sed s:.yml::g`)
+        _configs=(`find ~/.tmuxinator -name \*.yml | cut -d/ -f5 | sed s:.yml::g`)
         _values 'configs' $_configs
         ret=0
         ;;


### PR DESCRIPTION
On OSX `find ~/.tmuxinator/` returns an extra slash after `.tmuxinator//`, so the `cut -d/ -f5` returns empty lines instead of project names. 

``` bash
$ find ~/.tmuxinator/ -name \*.yml
=> /Users/pablo/.tmuxinator//project1.yml
=> /Users/pablo/.tmuxinator//project2.yml
=> /Users/pablo/.tmuxinator//project3.yml

$ find ~/.tmuxinator/ -name \*.yml | cut -d/ -f5
=>
=>
=>

$ find ~/.tmuxinator -name \*.yml | cut -d/ -f5
=> project1.yml
=> project2.yml
=> project3.yml
```

This PR replaces `find ~/.tmuxinator/` with ``find ~/.tmuxinator`  which works fine on OSX and others UNIX based.
