### PR TITLE
new faster SVN plugin

### DIFF
--- a/plugins/svn-fast-info/svn-fast-info.plugin.zsh
+++ b/plugins/svn-fast-info/svn-fast-info.plugin.zsh
@@ -6,8 +6,10 @@
 # Use `svn_prompt_info` method to enquire the svn data.
 # It's faster because his efficient use of svn (single svn call) which saves a lot on a huge codebase
 # It displays the current status of the local files (added, deleted, modified, replaced, or else...)
+#
+# Use as a drop-in replacement of the svn plugin not as complementary plugin
 
-function svn_fast_info() {
+function svn_prompt_info() {
   local info
   info=$(svn info 2>&1) || return 1; # capture stdout and stderr
   local repo_need_upgrade=$(svn_repo_need_upgrade $info)


### PR DESCRIPTION
Faster alternative to the current SVN plugin implementation.

It sould work with svn 1.6, 1.7, 1.8.
Use `svn_prompt_info` method to enquire the svn data.
It's faster because his efficient use of svn (single svn call) done in the `parse_svn` function
Also changed prompt suffix _after_ the svn dirty marker
Reports the svn upgrade error

**\* IMPORTANT **\* DO NO USE with the simple svn plugin, this plugin acts as a replacement of it.
