### PR TITLE
Refactor of init script

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -60,9 +60,8 @@ the "refcard":http://www.bash2zsh.com/zsh_refcard/refcard.pdf is pretty tasty fo
 
 h3. Customization
 
-If you want to override any of the default behavior, just add a new file (ending in @.zsh@) into the @custom/@ directory.
-If you have many functions which go well together you can put them as a *.plugin.zsh file in the @custom/plugins/@ directory and then enable this plugin.
-If you would like to override the functionality of a plugin distributed with oh-my-zsh, create a plugin of the same name in the @custom/plugins/@ directory and it will be loaded instead of the one in @plugins/@.
+Pretty much every single aspect of _Oh My Zsh_ is configurable to your needs - without the burden of maintaining your own fork!
+Be sure to check out our "Customization wiki":https://github.com/robbyrussell/oh-my-zsh/wiki/Customization for more info.
 
 h3. Updates
 

--- a/custom/customization.zsh
+++ b/custom/customization.zsh
@@ -1,0 +1,4 @@
+# This could be one of your customization files!
+#
+# Add aliases, functions or even patch oh-my-zsh's internals.
+

--- a/custom/example.zsh
+++ b/custom/example.zsh
@@ -1,5 +1,0 @@
-# Add yourself some shortcuts to projects you often work on
-# Example:
-#
-# brainstormr=/Users/robbyrussell/Projects/development/planetargon/brainstormr
-#

--- a/custom/example/example.plugin.zsh
+++ b/custom/example/example.plugin.zsh
@@ -1,2 +1,0 @@
-# Add your own custom plugins in the custom/plugins directory. Plugins placed
-# here will override ones with the same name in the main plugins directory.

--- a/custom/plugins/custom_plugin/custom_plugin.plugin.zsh
+++ b/custom/plugins/custom_plugin/custom_plugin.plugin.zsh
@@ -1,0 +1,4 @@
+# This is an example file to demonstrate the use of custom plugins.
+# It would be loaded if you add it to the plugins Array in your .zshrc file:
+#
+# plugins=(custom_plugin)

--- a/custom/themes/custom_theme.zsh-theme
+++ b/custom/themes/custom_theme.zsh-theme
@@ -1,0 +1,4 @@
+# This is an example file for a customized theme.
+#
+# Place your themes in this folder and enable theme
+# by setting ZSH_THEME in your .zshrc file.

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -32,15 +32,6 @@ else
     SCREEN_NO=""
 fi
 
-# Apply theming defaults
-PS1="%n@%m:%~%# "
-
-# git theming default: Variables for theming the git info prompt
-ZSH_THEME_GIT_PROMPT_PREFIX="git:("         # Prefix at the very beginning of the prompt, before the branch name
-ZSH_THEME_GIT_PROMPT_SUFFIX=")"             # At the very end of the prompt
-ZSH_THEME_GIT_PROMPT_DIRTY="*"              # Text to display if the branch is dirty
-ZSH_THEME_GIT_PROMPT_CLEAN=""               # Text to display if the branch is clean
-
 # Setup the prompt with pretty colors
 setopt prompt_subst
 

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -64,12 +64,13 @@ load_customizations() { source_files $ZSH_CUSTOM/*.zsh }
 # Does nothing if ZSH_THEME is an empty string or unset
 _source_zsh_theme() {
   if [ "$ZSH_THEME" = "random" ]; then
+    local themes
+    local theme_name
     themes=($ZSH/themes/*zsh-theme)
-    N=${#themes[@]}
-    ((N=(RANDOM%N)+1))
-    RANDOM_THEME=${themes[$N]}
-    source "$RANDOM_THEME"
+    RANDOM_THEME=${themes[$RANDOM % ${#themes[@]}]}
     theme_name=$(basename $RANDOM_THEME .zsh-theme)
+
+    source "$RANDOM_THEME"
     echo "[oh-my-zsh] Random theme '$theme_name' loaded..."
   elif [ ! "$ZSH_THEME" = ""  ]; then
     # custom themes take precedence over built-in themes!

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -103,17 +103,19 @@ _default_theming() {
 }
 
 # Tries to source a theme given as ZSH_THEME.
-# If ZSH_THEME is not set, nothing is done at all. This is
-# to enable users do circumvent the theming of oh-my-zsh
-# on purpose.
-# If ZSH_THEME contains an invalid theme string, a fallback
-# is provided.
-# Takes an argument to provide a new value fo ZSH_THEME
-# before loading it.
-# Example to load a random theme::
+# If ZSH_THEME is not set, nothing  is done at all. This is to enable
+# users do circumvent the theming of oh-my-zsh on purpose.
+# If ZSH_THEME contains an invalid theme string, a fallback is provided.
+# Takes an argument to provide a new value fo ZSH_THEME before loading it.
+# Example to load a random theme:
 #   load_zsh_theme random
 # Example to load whatever ZSH_THEME currently is:
 #   load_zsh_theme
+#
+# A word of warning: The function doesn't clean up after itself - that means
+# that if you load a theme that define a precmd and or zsh hooks (examples
+# are pygmalion or pure) you will see remnants of their prompts if you load
+# another theme on the fly. Just open a new shell and you're good again.
 load_zsh_theme() {
   if [ ! "$1" = '' ]; then; ZSH_THEME="$1"; fi
   _source_zsh_theme || _default_theming

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -69,13 +69,14 @@ _source_zsh_theme() {
 
     source "$RANDOM_THEME"
     echo "[oh-my-zsh] Random theme '$theme_name' loaded..."
-  elif [ ! "$ZSH_THEME" = ""  ]; then
+  elif [ "$ZSH_THEME" != "" ]; then
+    echo ho
     local theme_path
     local zsh_path
 
     # custom themes take precedence over built-in themes!
+    theme_path="themes/$ZSH_THEME.zsh-theme"
     for zsh_path in $ZSH_CUSTOM $ZSH; do
-      theme_path="themes/$ZSH_THEME.zsh-theme"
       if [ -f "$zsh_path/$theme_path" ]; then
         source "$zsh_path/$theme_path"
         break

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -1,0 +1,1 @@
+oh-my-zsh.zsh

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -10,9 +10,10 @@ check_for_updates() {
   fi
 }
 
-# Resolves the names insode of the plugins array to their respective paths.
+# Resolves the names inside of the plugins array to their respective paths.
 # Custom plugins take precedence, if one is found, the default plugin won't
 # be added to ZSH_PLUGIN_PATHS.
+# This variable is used to initialize zsh completions and load the plugins.
 find_plugin_paths() {
   ZSH_PLUGIN_PATHS=()
   local plugin

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -31,16 +31,12 @@ find_plugin_paths() {
 }
 
 initialize_completions() {
-  # Figure out the SHORT hostname
-  if [ -n "$commands[scutil]" ]; then
-    # OS X
-    SHORT_HOST=$(scutil --get ComputerName)
-  else
-    SHORT_HOST=${HOST/.*/}
-  fi
+  # Figure out the SHORT hostname, scutil is for OS X users
+  local short_host
+  short_host=$($(scutil --get ComputerName 2>/dev/null) || echo ${HOST/.*/})
 
   # Save the location of the current completion dump file.
-  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${short_host}-${ZSH_VERSION}"
 
   # plugins need to be added to the functions path before compinit
   fpath=($ZSH_PLUGIN_PATHS $fpath)

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -69,9 +69,12 @@ _source_zsh_theme() {
     source "$RANDOM_THEME"
     echo "[oh-my-zsh] Random theme '$theme_name' loaded..."
   elif [ ! "$ZSH_THEME" = ""  ]; then
+    local theme_path
+    local zsh_path
+
     # custom themes take precedence over built-in themes!
     for zsh_path in $ZSH_CUSTOM $ZSH; do
-      local theme_path="themes/$ZSH_THEME.zsh-theme"
+      theme_path="themes/$ZSH_THEME.zsh-theme"
       if [ -f "$zsh_path/$theme_path" ]; then
         source "$zsh_path/$theme_path"
         break

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -76,7 +76,8 @@ _source_zsh_theme() {
     ((N=(RANDOM%N)+1))
     RANDOM_THEME=${themes[$N]}
     source "$RANDOM_THEME"
-    echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+    theme_name=$(basename $RANDOM_THEME .zsh-theme)
+    echo "[oh-my-zsh] Random theme '$theme_name' loaded..."
   elif; then
     if [ ! "$ZSH_THEME" = ""  ]; then
       if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -10,9 +10,9 @@ check_for_updates() {
   fi
 }
 
-# Resolves plugin names to their respective paths.
-# If a custom plugin is defined, the default plugin
-# won't be added to the plugin_paths.
+# Resolves the names insode of the plugins array to their respective paths.
+# Custom plugins take precedence, if one is found, the default plugin won't
+# be added to ZSH_PLUGIN_PATHS.
 find_plugin_paths() {
   ZSH_PLUGIN_PATHS=()
   local plugin

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -67,22 +67,56 @@ for config_file ($ZSH_CUSTOM/*.zsh(N)); do
 done
 unset config_file
 
-# Load the theme
-if [ "$ZSH_THEME" = "random" ]; then
-  themes=($ZSH/themes/*zsh-theme)
-  N=${#themes[@]}
-  ((N=(RANDOM%N)+1))
-  RANDOM_THEME=${themes[$N]}
-  source "$RANDOM_THEME"
-  echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
-else
-  if [ ! "$ZSH_THEME" = ""  ]; then
-    if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then
-      source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
-    elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
-      source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
-    else
-      source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+# Sources ZSH_THEME
+# Does nothing if ZSH_THEME is an empty string or unset
+_source_zsh_theme() {
+  if [ "$ZSH_THEME" = "random" ]; then
+    themes=($ZSH/themes/*zsh-theme)
+    N=${#themes[@]}
+    ((N=(RANDOM%N)+1))
+    RANDOM_THEME=${themes[$N]}
+    source "$RANDOM_THEME"
+    echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+  elif; then
+    if [ ! "$ZSH_THEME" = ""  ]; then
+      if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then
+        source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
+      elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
+        source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
+      else
+        source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+      fi
     fi
   fi
-fi
+}
+
+_default_theming() {
+  echo "Falling back to default theming"
+  # default prompt
+  PS1="%n@%m:%~%# "
+
+  # default variables for theming the git info prompt
+  ZSH_THEME_GIT_PROMPT_PREFIX="git:("         # Prefix at the very beginning of the prompt, before the branch name
+  ZSH_THEME_GIT_PROMPT_SUFFIX=")"             # At the very end of the prompt
+  ZSH_THEME_GIT_PROMPT_DIRTY="*"              # Text to display if the branch is dirty
+  ZSH_THEME_GIT_PROMPT_CLEAN=""               # Text to display if the branch is clean
+}
+
+# Tries to source a theme given as ZSH_THEME.
+# If ZSH_THEME is not set, nothing is done at all. This is
+# to enable users do circumvent the theming of oh-my-zsh
+# on purpose.
+# If ZSH_THEME contains an invalid theme string, a fallback
+# is provided.
+# Takes an argument to provide a new value fo ZSH_THEME
+# before loading it.
+# Example to load a random theme::
+#   load_zsh_theme random
+# Example to load whatever ZSH_THEME currently is:
+#   load_zsh_theme
+load_zsh_theme() {
+  if [ ! "$1" = '' ]; then; ZSH_THEME="$1"; fi
+  _source_zsh_theme || _default_theming
+}
+
+load_zsh_theme

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -15,6 +15,10 @@ check_for_updates() {
 # won't be added to the plugin_paths.
 find_plugin_paths() {
   ZSH_PLUGIN_PATHS=()
+  local plugin
+  local plugin_path
+  local zsh_path
+
   for plugin ($plugins); do
     plugin_path="plugins/$plugin/$plugin.plugin.zsh"
     for zsh_path in $ZSH_CUSTOM $ZSH; do
@@ -46,6 +50,7 @@ initialize_completions() {
 }
 
 source_files() {
+  local file
   for file in $@; do
     source $file
   done
@@ -69,7 +74,7 @@ _source_zsh_theme() {
   elif [ ! "$ZSH_THEME" = ""  ]; then
     # custom themes take precedence over built-in themes!
     for zsh_path in $ZSH_CUSTOM $ZSH; do
-      theme_path="themes/$ZSH_THEME.zsh-theme"
+      local theme_path="themes/$ZSH_THEME.zsh-theme"
       if [ -f "$zsh_path/$theme_path" ]; then
         source "$zsh_path/$theme_path"
         break

--- a/oh-my-zsh.zsh
+++ b/oh-my-zsh.zsh
@@ -22,7 +22,7 @@ find_plugin_paths() {
   local zsh_path
 
   for plugin in $plugins; do
-    plugin_path="plugins/$plugin/$plugin.plugin.zsh"
+    plugin_path=plugins/$plugin/$plugin.plugin.zsh
     for zsh_path in $ZSH_CUSTOM $ZSH; do
       plugin_file=$zsh_path/$plugin_path
       if [[ -f $plugin_file ]]; then
@@ -41,7 +41,7 @@ initialize_completions() {
   short_host=$($(scutil --get ComputerName 2>/dev/null) || echo ${HOST/.*/})
 
   # Save the location of the current completion dump file.
-  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-$short_host-$ZSH_VERSION"
+  ZSH_COMPDUMP=${ZDOTDIR:-${HOME}}/.zcompdump-$short_host-$ZSH_VERSION
 
   # plugins need to be added to the functions path before compinit
   for plugin in $ZSH_PLUGIN_PATHS; { fpath=($(dirname $plugin) $fpath) }

--- a/oh-my-zsh.zsh
+++ b/oh-my-zsh.zsh
@@ -43,8 +43,8 @@ initialize_completions() {
   # Save the location of the current completion dump file.
   ZSH_COMPDUMP=${ZDOTDIR:-${HOME}}/.zcompdump-$short_host-$ZSH_VERSION
 
-  # plugins need to be added to the functions path before compinit
-  for plugin in $ZSH_PLUGIN_PATHS; { fpath=($(dirname $plugin) $fpath) }
+  # the plugin directories need to be added to the functions path before compinit
+  for plugin in $ZSH_PLUGIN_PATHS; { fpath=(${plugin:h} $fpath) }
 
   autoload -U compinit
   compinit -i -d $ZSH_COMPDUMP

--- a/oh-my-zsh.zsh
+++ b/oh-my-zsh.zsh
@@ -42,7 +42,7 @@ initialize_completions() {
   local plugin
 
   # Figure out the SHORT hostname, scutil is for OS X users
-  short_host=$($(scutil --get ComputerName 2>/dev/null) || echo ${HOST/.*/})
+  short_host=$(scutil --get ComputerName 2>/dev/null) || short_host=${HOST/.*/}
 
   # Save the location of the current completion dump file.
   ZSH_COMPDUMP=${ZDOTDIR:-${HOME}}/.zcompdump-$short_host-$ZSH_VERSION

--- a/oh-my-zsh.zsh
+++ b/oh-my-zsh.zsh
@@ -17,14 +17,16 @@ check_for_updates() {
 find_plugin_paths() {
   ZSH_PLUGIN_PATHS=()
   local plugin
+  local plugin_file
   local plugin_path
   local zsh_path
 
   for plugin in $plugins; do
     plugin_path="plugins/$plugin/$plugin.plugin.zsh"
     for zsh_path in $ZSH_CUSTOM $ZSH; do
-      if [[ -f $zsh_path/$plugin_path ]]; then
-        ZSH_PLUGIN_PATHS+=$zsh_path/$plugin_path
+      plugin_file=$zsh_path/$plugin_path
+      if [[ -f $plugin_file ]]; then
+        ZSH_PLUGIN_PATHS+=$plugin_file
         break
       fi
     done
@@ -68,14 +70,16 @@ _source_zsh_theme() {
     source "$RANDOM_THEME"
     echo "[oh-my-zsh] Random theme '$theme_name' loaded..."
   elif [[ $ZSH_THEME != '' ]]; then
+    local theme_file
     local theme_path
     local zsh_path
 
     # custom themes take precedence over built-in themes!
     theme_path="themes/$ZSH_THEME.zsh-theme"
     for zsh_path in $ZSH_CUSTOM $ZSH; do
-      if [[ -f $zsh_path/$theme_path ]]; then
-        source $zsh_path/$theme_path
+      theme_file=$zsh_path/$theme_path
+      if [[ -f $theme_file ]]; then
+        source $theme_file
         break
       fi
     done

--- a/oh-my-zsh.zsh
+++ b/oh-my-zsh.zsh
@@ -4,7 +4,7 @@
 # its awesomeness at a single glance.
 
 check_for_updates() {
-  if [ "$DISABLE_AUTO_UPDATE" != "true" ]; then
+  if [[ $DISABLE_AUTO_UPDATE != "true" ]]; then
     /usr/bin/env ZSH=$ZSH DISABLE_UPDATE_PROMPT=$DISABLE_UPDATE_PROMPT \
       zsh -f $ZSH/tools/check_for_upgrade.sh
   fi
@@ -20,11 +20,11 @@ find_plugin_paths() {
   local plugin_path
   local zsh_path
 
-  for plugin ($plugins); do
+  for plugin in $plugins; do
     plugin_path="plugins/$plugin/$plugin.plugin.zsh"
     for zsh_path in $ZSH_CUSTOM $ZSH; do
-      if [ -f "$zsh_path/$plugin_path" ]; then
-        ZSH_PLUGIN_PATHS+="$zsh_path/$plugin_path"
+      if [[ -f $zsh_path/$plugin_path ]]; then
+        ZSH_PLUGIN_PATHS+=$zsh_path/$plugin_path
         break
       fi
     done
@@ -37,20 +37,18 @@ initialize_completions() {
   short_host=$($(scutil --get ComputerName 2>/dev/null) || echo ${HOST/.*/})
 
   # Save the location of the current completion dump file.
-  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${short_host}-${ZSH_VERSION}"
+  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-$short_host-$ZSH_VERSION"
 
   # plugins need to be added to the functions path before compinit
   fpath=($ZSH_PLUGIN_PATHS $fpath)
 
   autoload -U compinit
-  compinit -i -d "${ZSH_COMPDUMP}"
+  compinit -i -d $ZSH_COMPDUMP
 }
 
 source_files() {
   local file
-  for file in $@; do
-    source $file
-  done
+  for file in $@; { source $file }
 }
 
 load_lib_files() { source_files $ZSH/lib/*.zsh }
@@ -60,7 +58,7 @@ load_customizations() { source_files $ZSH_CUSTOM/*.zsh }
 # Sources ZSH_THEME
 # Does nothing if ZSH_THEME is an empty string or unset
 _source_zsh_theme() {
-  if [ "$ZSH_THEME" = "random" ]; then
+  if [[ $ZSH_THEME = "random" ]]; then
     local themes
     local theme_name
     themes=($ZSH/themes/*zsh-theme)
@@ -69,16 +67,15 @@ _source_zsh_theme() {
 
     source "$RANDOM_THEME"
     echo "[oh-my-zsh] Random theme '$theme_name' loaded..."
-  elif [ "$ZSH_THEME" != "" ]; then
-    echo ho
+  elif [[ $ZSH_THEME != '' ]]; then
     local theme_path
     local zsh_path
 
     # custom themes take precedence over built-in themes!
     theme_path="themes/$ZSH_THEME.zsh-theme"
     for zsh_path in $ZSH_CUSTOM $ZSH; do
-      if [ -f "$zsh_path/$theme_path" ]; then
-        source "$zsh_path/$theme_path"
+      if [[ -f $zsh_path/$theme_path ]]; then
+        source $zsh_path/$theme_path
         break
       fi
     done
@@ -112,10 +109,11 @@ _default_theming() {
 # are pygmalion or pure) you will see remnants of their prompts if you load
 # another theme on the fly. Just open a new shell and you're good again.
 load_zsh_theme() {
-  if [ ! "$1" = '' ]; then; ZSH_THEME="$1"; fi
+  [[ $1 != '' ]] && ZSH_THEME=$1
   _source_zsh_theme || _default_theming
 }
 
+# This is where the magic happens
 check_for_updates
 find_plugin_paths
 initialize_completions

--- a/oh-my-zsh.zsh
+++ b/oh-my-zsh.zsh
@@ -34,15 +34,17 @@ find_plugin_paths() {
 }
 
 initialize_completions() {
-  # Figure out the SHORT hostname, scutil is for OS X users
   local short_host
+  local plugin
+
+  # Figure out the SHORT hostname, scutil is for OS X users
   short_host=$($(scutil --get ComputerName 2>/dev/null) || echo ${HOST/.*/})
 
   # Save the location of the current completion dump file.
   ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-$short_host-$ZSH_VERSION"
 
   # plugins need to be added to the functions path before compinit
-  fpath=($ZSH_PLUGIN_PATHS $fpath)
+  for plugin in $ZSH_PLUGIN_PATHS; { fpath=($(dirname $plugin) $fpath) }
 
   autoload -U compinit
   compinit -i -d $ZSH_COMPDUMP

--- a/oh-my-zsh.zsh
+++ b/oh-my-zsh.zsh
@@ -3,6 +3,10 @@
 # Skip to the bottom of the file to see how oh-my-zsh loads
 # its awesomeness at a single glance.
 
+# For backward compatibility we need to set ZSH_CUSTOM, otherwise
+# we break the script.
+ZSH_CUSTOM=${ZSH_CUSTOM:=$ZSH/custom}
+
 check_for_updates() {
   if [[ $DISABLE_AUTO_UPDATE != "true" ]]; then
     /usr/bin/env ZSH=$ZSH DISABLE_UPDATE_PROMPT=$DISABLE_UPDATE_PROMPT \
@@ -57,6 +61,7 @@ source_files() {
 
 load_lib_files() { source_files $ZSH/lib/*.zsh }
 load_plugins() { source_files $ZSH_PLUGIN_PATHS }
+
 load_customizations() { source_files $ZSH_CUSTOM/*.zsh }
 
 # Sources ZSH_THEME

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -5,6 +5,7 @@ ZSH=$HOME/.oh-my-zsh
 # Look in ~/.oh-my-zsh/themes/
 # Optionally, if you set this to "random", it'll load a random theme each
 # time that oh-my-zsh is loaded.
+# If you want to bypass oh-my-zsh's theme handling, comment this line.
 ZSH_THEME="robbyrussell"
 
 # Example aliases

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -48,7 +48,7 @@ ZSH_THEME="robbyrussell"
 # Example format: plugins=(rails git textmate ruby lighthouse)
 plugins=(git)
 
-source $ZSH/oh-my-zsh.sh
+source $ZSH/oh-my-zsh.zsh
 
 # User configuration
 


### PR DESCRIPTION
A completely refactored oh-my-zsh script. This works on top of the commits I mentioned in #2295 and also the commit of #2113. (read first)

It's basically a big clean up, that shouldn't really break anything - it works almost completely the same, just tidier.
- Wraps each step up in an own function, which makes the code more self documenting.
- Refactored out all duplication
  - Checking twice for plugins erased. The plugin names are expanded to their full plugin path now just once, whether it resides in the custom or the default directory. They are stuffed in a variable which is reused (check comment starting on line 8).
  - Using variables instead of writing the paths out 4 times on 4 lines.
  - Sourcing of files wrapped in a function.
- Deletes the addition of $ZSH/functions and $ZSH/completions to fpath - those two directories do no exist (any more?)
- Fix of #2342 is applied.

Breaking changes:
- Plugins are only changed against the *.plugin.zsh naming convention, the variant with underscore is not checked. If that breaks plugins shipped with oh-my-zsh, I will change their names.
- Custom themes have to be in a themes folder and not at the top level of the custom dir - as it would be documented in the wiki text I wrote.
- I don't think both deprecated options are widely used anyway, but I could be wrong.

Proposal:
- Adding a changelog file, that is displayed in upgrade.sh. It might not have to all complete at all times, but in case any relevant changes are merged in, this could be a good place to inform people about was might affect them after upgrading.

Probably controversial:
- The file is mildly converted to zsh syntax. I think it's safe to assume that people will use zsh when they source this file :). Can be reverted back in a single step, however, I placed a symbolic link to avoid breaking backward compatibility. People sourcing oh-my-zsh.sh in their .zshrc will be redirected to the new oh-my-zsh.zsh file.

A question left:
- Could someone check the message of commit 7e79ed795f9d392de460efc87d1a787e2400eee7? It's regarding adding the plugin paths to fpath. The refactor does now exactly as the former script, but I am actually not sure that it's needed. Can someone explain this?

If people want to dig in further how oh-my-zsh works, this will be the file they first look at - it's easier to get an overview this way IMO.

Curious to hear your opinions.

Update: Also revampled lib/git.zsh - see #2386.
