### PR TITLE
blue-time theme

### DIFF
--- a/themes/blue-time.zsh-theme
+++ b/themes/blue-time.zsh-theme
@@ -1,0 +1,34 @@
+# af-magic.zsh-theme
+#
+# Author: Jairo Sanchez
+# Based on Andy Fleming's af-magic-zsh-theme found at https://github.com/andyfleming/oh-my-zsh
+#
+# Created on:		Nov 08, 2013
+# Last modified on:	Nov 08, 2013
+
+
+
+if [ $UID -eq 0 ]; then NCOLOR="red"; else NCOLOR="green"; fi
+local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
+
+# primary prompt
+#PROMPT='$FG[237]------------------------------------------------------------%{$reset_color%}
+PROMPT='$FG[032]%~\
+$(git_prompt_info) \
+$FG[105]%(!.#.»)%{$reset_color%} '
+PROMPT2='%{$fg[red]%}\ %{$reset_color%}'
+RPS1='${return_code}'
+
+
+# color vars
+eval my_gray='$FG[237]'
+eval my_orange='$FG[214]'
+
+# right prompt
+RPROMPT='$my_gray%m:%*%{$reset_color%}%'
+
+# git settings
+ZSH_THEME_GIT_PROMPT_PREFIX="$FG[075](branch:"
+ZSH_THEME_GIT_PROMPT_CLEAN=""
+ZSH_THEME_GIT_PROMPT_DIRTY="$my_orange*%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="$FG[075])%{$reset_color%}"


### PR DESCRIPTION
Added new theme based on Andy Fleming's [af-magic-zsh theme](https://github.com/andyfleming/oh-my-zsh)
Blue left-prompt:

```
/current/working/dir (git-info) >>
```

Gray right-prompt with 

```
hostname:time
```
