### PR TITLE
update the default config of auto correction

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -26,8 +26,8 @@ ZSH_THEME="robbyrussell"
 # Uncomment following line if you want to disable autosetting terminal title.
 # DISABLE_AUTO_TITLE="true"
 
-# Uncomment following line if you want to disable command autocorrection
-# DISABLE_CORRECTION="true"
+# Uncomment following line if you want to enable command autocorrection
+# ENABLE_CORRECTION="true"
 
 # Uncomment following line if you want red dots to be displayed while waiting for completion
 # COMPLETION_WAITING_DOTS="true"


### PR DESCRIPTION
The auto-correction is set off by default now.   according to https://github.com/robbyrussell/oh-my-zsh/pull/2316

But the default config file is old.
