### PR TITLE
Update sublime.plugin.zsh

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -1,14 +1,12 @@
-# Sublime Text 2 Aliases
+# Sublime Text Aliases
 
 local _sublime_darwin_paths > /dev/null 2>&1
 _sublime_darwin_paths=(
     "/usr/local/bin/subl"
-    "$HOME/Applications/Sublime Text 3.app/Contents/SharedSupport/bin/subl"
-    "$HOME/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
     "$HOME/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
-    "/Applications/Sublime Text 3.app/Contents/SharedSupport/bin/subl"
-    "/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
+    "$HOME/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
     "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
+    "/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
 )
 
 if [[ $('uname') == 'Linux' ]]; then


### PR DESCRIPTION
There's no Sublime Text 1, and Sublime Text 3's appname is `Sublime Text.app`.

I ran into this issue a while ago. I could not set the subl cli to the newest Sublime Text because this alias was preventing it. I think the most recent version of Sublime Text should be picked up by the subl alias.
