### PR TITLE
Update gitignore.plugin.zsh url

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,4 +1,4 @@
-function gi() { curl http://gitignore.io/api/$@ ;}
+function gi() { curl http://www.gitignore.io/api/$@ ;}
 
 _gitignireio_get_command_list() {
   curl -s http://gitignore.io/api/list | tr "," "\n"


### PR DESCRIPTION
Because gitignore.io moved to Heroku which does not allow naked domain, change URL from `http://gitignore.io/api` to `http://www.gitignore.io/api` 

http://www.gitignore.io/cli
