### PR TITLE
gradle plugin: corrected a logical error in _gradle_does_task_list_need_...

### DIFF
--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -60,8 +60,8 @@ function in_gradle() {
 ############################################################################
 _gradle_does_task_list_need_generating () {
   [ ! -f .gradletasknamecache ] && return 0;
-  [ .gradletasknamecache -nt build.gradle ] && return 0;
-  return 1;
+  [ .gradletasknamecache -nt build.gradle ] && return 1;
+  return 0;
 }
 
 


### PR DESCRIPTION
Due to this error the task name cache from the gradle plugin was never used.
