### PR TITLE
Fixes _rails_command in new rails plugin

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -1,10 +1,10 @@
 function _rails_command () {
-  if [ -e "script/server" ]; then
-    ruby script/$@
+  if [ -e "bin/rails" ]; then
+    bin/rails $@
   elif [ -e "script/rails" ]; then
     ruby script/rails $@
-  elif [ -e "bin/rails" ]; then
-    bin/rails $@
+  elif [ -e "script/server" ]; then
+    ruby script/$@
   else
     rails $@
   fi


### PR DESCRIPTION
Changes precedence of the conditional clause, more recent versions come
first now. Fixes problems when users update their app and still have
the old rails files inside of their file tree.
Closes #2405 - check the discussion there for further info.
