### PR TITLE
fix(tools/check_for_upgrade): Don't source profile

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -20,8 +20,6 @@ if [[ -z "$epoch_target" ]]; then
   epoch_target=13
 fi
 
-[ -f ~/.profile ] && source ~/.profile
-
 if [ -f ~/.zsh-update ]
 then
   . ~/.zsh-update


### PR DESCRIPTION
Reverts #2296, but mostly #1883. 

There is no need to source ~/.profile when this script is read. oh-my-zsh writes no configuration data in ~/.profile.

If the user wishes to use data within ~/.profile, then they should source it in another place.

Fixes #2315
Fixes #1509 
Fixes #1898 
