### PR TITLE
Fix a bug.

### DIFF
--- a/lib/correction.zsh
+++ b/lib/correction.zsh
@@ -1,6 +1,6 @@
 alias man='nocorrect man'
 alias mv='nocorrect mv'
-alias mysql='nocorrect mysql'
+# alias mysql='nocorrect mysql'
 alias mkdir='nocorrect mkdir'
 alias gist='nocorrect gist'
 alias heroku='nocorrect heroku'


### PR DESCRIPTION
In macOS, I install mysql using brew, and type mysql it will redirect to /var/empty. 
See following issues:
http://stackoverflow.com/questions/10442449/cant-use-which-mysql-in-zsh-but-in-bash-work
http://stackoverflow.com/questions/7956345/osx-mysql-command-goes-in-var-empty
