### PR TITLE
Agnotsa final arrow colour is no longer slightly lighter

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -47,7 +47,7 @@ prompt_segment() {
 # End the prompt, closing any open segments
 prompt_end() {
   if [[ -n $CURRENT_BG ]]; then
-    echo -n " %{%k%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR"
+    echo -n " %{%K%F{$CURRENT_BG}%}$SEGMENT_SEPARATOR"
   else
     echo -n "%{%k%}"
   fi


### PR DESCRIPTION
Just done a clean install of Solarized theme, Powerline fonts (Meslo) and OMZ using Terminal.app

Using "agnosta" theme the final > arrow (segment separator) would always show as slightly than the background colour. 

This change fixes that issue and matches more closely the behaviour of prompt_segment
