### PR TITLE
change nyancat telnet server

### DIFF
--- a/plugins/nyan/nyan.plugin.zsh
+++ b/plugins/nyan/nyan.plugin.zsh
@@ -1,5 +1,5 @@
 if [[ -x `which nc` ]]; then
-  alias nyan='nc -v nyan.howes.net.nz 23' # nyan cat
+  alias nyan='nc -v nyancat.dakko.us 23' # nyan cat
 fi
 
 


### PR DESCRIPTION
miku.acm.uiuc.edu was decommissioned a while ago; this is a sanctioned mirror; it's also coincidentally the same length
