### PR TITLE
updated url to point to http://www.gitignore.io based on the notificatio...

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,7 +1,7 @@
 function gi() { curl http://www.gitignore.io/api/$@ ;}
 
 _gitignireio_get_command_list() {
-  curl -s http://gitignore.io/api/list | tr "," "\n"
+  curl -s http://www.gitignore.io/api/list | tr "," "\n"
 }
 
 _gitignireio () {


### PR DESCRIPTION
On January 6th, 2014 gitignore.io moved to Heroku which doesn't allow naked domains. If your gi command is not functioning, update your script to point to www.gitignore.io instead of gitignore.io
