### PR TITLE
theme agnoster: update characters to match latest powerline fonts

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -88,9 +88,9 @@ prompt_git() {
     zstyle ':vcs_info:*' stagedstr '✚'
     zstyle ':vcs_info:git:*' unstagedstr '●'
     zstyle ':vcs_info:*' formats ' %u%c'
-    zstyle ':vcs_info:*' actionformats '%u%c'
+    zstyle ':vcs_info:*' actionformats ' %u%c'
     vcs_info
-    echo -n "${ref/refs\/heads\// }${vcs_info_msg_0_}"
+    echo -n "${ref/refs\/heads\// }${vcs_info_msg_0_%% }"
   fi
 }
 


### PR DESCRIPTION
Clearing up some confusion in issue https://github.com/robbyrussell/oh-my-zsh/issues/1906. Powerline has changed the Unicode characters for font patching, see their change here: https://github.com/Lokaltog/powerline/commit/53fbfe15fead8cc7598bcb4ee9714a221ab7e446 which is described here: https://github.com/Lokaltog/powerline/issues/4. This pull request is to comply with those changes in agnoster.zsh-theme, which relies on a Powerline patched font. Users should patch their font with the latest version of Powerline or download the newest pre-patched fonts here https://github.com/Lokaltog/powerline-fonts.
![screen shot 2014-01-29 at 6 35 39 pm](https://f.cloud.github.com/assets/2744313/2036224/9376dd9a-8946-11e3-8412-936c23d45702.png)
