### PR TITLE
highlight the username when root

### DIFF
--- a/themes/ys.zsh-theme
+++ b/themes/ys.zsh-theme
@@ -32,3 +32,16 @@ PROMPT="
 ${git_info} \
 %{$fg[white]%}[%*]
 %{$terminfo[bold]$fg[red]%}$ %{$reset_color%}"
+
+if [[ "$(whoami)" == "root" ]]; then
+PROMPT="
+%{$terminfo[bold]$fg[blue]%}#%{$reset_color%} \
+%{$bg[yellow]%}%{$fg[cyan]%}%n%{$reset_color%} \
+%{$fg[white]%}at \
+%{$fg[green]%}$(box_name) \
+%{$fg[white]%}in \
+%{$terminfo[bold]$fg[yellow]%}${current_dir}%{$reset_color%}\
+${git_info} \
+%{$fg[white]%}[%*]
+%{$terminfo[bold]$fg[red]%}$ %{$reset_color%}"
+fi


### PR DESCRIPTION
Set the ys theme to highlight the username on the prompt when the user is root.

I made this as a proof of concept. I think it should be nice to have this on the other themes as well.

Also, this is probably not the best way to do that, but it works. I hope someone could enlighten me on how to do that properly.
