### PR TITLE
tmux source command is not source but source-file

### DIFF
--- a/plugins/tmux/tmux.extra.conf
+++ b/plugins/tmux/tmux.extra.conf
@@ -1,2 +1,2 @@
 set -g default-terminal $ZSH_TMUX_TERM
-source $HOME/.tmux.conf
+source-file $HOME/.tmux.conf


### PR DESCRIPTION
My tmux was displaying errors when I was using tmux plugin from oh-my-zsh and not reading my .tmux.conf at all.
