### PR TITLE
Add www in front of gitignore.io domain

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,7 +1,7 @@
-function gi() { curl http://gitignore.io/api/$@ ;}
+function gi() { curl http://www.gitignore.io/api/$@ ;}
 
 _gitignireio_get_command_list() {
-  curl -s http://gitignore.io/api/list | tr "," "\n"
+  curl -s http://www.gitignore.io/api/list | tr "," "\n"
 }
 
 _gitignireio () {


### PR DESCRIPTION
As per `http://www.gitignore.io/cli`'s news (in yellow at the top) there's now need to add `www` before the actual gitignore url.
