### PR TITLE
Remove brackets from URLs when parsing user SSH known hosts

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -33,7 +33,7 @@ cdpath=(.)
 
 # use /etc/hosts and known_hosts for hostname completion
 [ -r /etc/ssh/ssh_known_hosts ] && _global_ssh_hosts=(${${${${(f)"$(</etc/ssh/ssh_known_hosts)"}:#[\|]*}%%\ *}%%,*}) || _global_ssh_hosts=()
-[ -r ~/.ssh/known_hosts ] && _ssh_hosts=(${(S)${(S)${${${${(f)"$(<$HOME/.ssh/known_hosts)"}:#[\|]*}%%\ *}%%,*}#[\[]}#[\]]}) || _ssh_hosts=()
+[ -r ~/.ssh/known_hosts ] && _ssh_hosts=(${${(S)${(S)${${${${(f)"$(<$HOME/.ssh/known_hosts)"}:#[\|]*}%%\ *}%%,*}#[\[]}#[\]]}%%:*}) || _ssh_hosts=()
 [ -r ~/.ssh/config ] && _ssh_config=($(cat ~/.ssh/config | sed -ne 's/Host[=\t ]//p')) || _ssh_config=()
 [ -r /etc/hosts ] && : ${(A)_etc_hosts:=${(s: :)${(ps:\t:)${${(f)~~"$(</etc/hosts)"}%%\#*}##[:blank:]#[^[:blank:]]#}}} || _etc_hosts=()
 hosts=(


### PR DESCRIPTION
With _OpenSSH_6.2p2, OSSLShim 0.9.8r 8 Dec 2011_ the hostnames from `$HOME/.ssh/known_hosts` are surrounded by brackets when the URL includes a custom port — _ie_ not port 22, _eg_ `[100.200.30.40]:1234`.

Those brackets need to be removed for `ssh` completion. This is done by adding two more parameter substitutions — maybe there is a more elegant way, feel free to improve.

This change should not break anything: the substitutions are performed last so they should not have any undesirable side-effect, and brackets are forbidden in FQDNs anyway.

Maybe this is also necessary for `/etc/ssh/known_hosts` but I am not able to reproduce that configuration right now.
