### PR TITLE
Fix function/alias naming clash between bower and bundle plugin

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -3,6 +3,7 @@ alias bl="bundle list"
 alias bp="bundle package"
 alias bo="bundle open"
 alias bu="bundle update"
+alias bi="bundle_install"
 
 # The following is based on https://github.com/gma/bundler-exec
 
@@ -15,7 +16,7 @@ done
 
 ## Functions
 
-bi() {
+bundle_install() {
   if _bundler-installed && _within-bundled-project; then
     local bundler_version=`bundle version | cut -d' ' -f3`
     if [[ $bundler_version > '1.4.0' || $bundler_version = '1.4.0' ]]; then


### PR DESCRIPTION
Since the `bower` plugin specifies a `bi` alias and `bundle` plugin specifies
a `bi` function, there is a name clash when using both plugins, which results
in the message "Can't 'bundle install' outside a bundled project" when trying
to execute `bower`.

This addresses #2486
