### PR TITLE
Added nano plugin

### DIFF
--- a/plugins/nano/nano.plugin.zsh
+++ b/plugins/nano/nano.plugin.zsh
@@ -1,0 +1,14 @@
+
+# Nano
+# Sudo nano if files are not writeable for current user
+
+alias nano='nano'
+
+function nano () {
+  if [[ (-G $1) || (-O $1) ]]
+	then
+		nano $1
+	else
+		sudo nano $1
+	fi
+}


### PR DESCRIPTION
I would love to have this as a plugin in oh-my-zsh. When you need to quickly edit e.g. your hosts file or an apache config it is not unlikely you 'forget' to sudo these files when editing. This 'plugin' checks if the user is in the right group or has owner ship of the file, if not it will place sudo in front of the command. Well it is pretty self-explanatory. :)
