### PR TITLE
`fc -l 1` instead of `history` in zsh_stats, fixes #2501

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -1,5 +1,5 @@
 function zsh_stats() {
-  history | awk '{CMD[$2]++;count++;}END { for (a in CMD)print CMD[a] " " CMD[a]/count*100 "% " a;}' | grep -v "./" | column -c3 -s " " -t | sort -nr | nl |  head -n20
+  fc -l 1 | awk '{CMD[$2]++;count++;}END { for (a in CMD)print CMD[a] " " CMD[a]/count*100 "% " a;}' | grep -v "./" | column -c3 -s " " -t | sort -nr | nl |  head -n20
 }
 
 function uninstall_oh_my_zsh() {


### PR DESCRIPTION
$HIST_STAMP breaks zsh_stats. see #2501
