### PR TITLE
Plugin Update - Updated url to www.gitignore.io because of move to heroku

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,7 +1,7 @@
-function gi() { curl http://gitignore.io/api/$@ ;}
+function gi() { curl http://www.gitignore.io/api/$@ ;}
 
 _gitignireio_get_command_list() {
-  curl -s http://gitignore.io/api/list | tr "," "\n"
+  curl -s http://www.gitignore.io/api/list | tr "," "\n"
 }
 
 _gitignireio () {


### PR DESCRIPTION
The url for the api has changed due to a move to heroku. The old url without www. prefix will no longer work as heroku does not allow naked domains.
