### PR TITLE
Makes history-substring-search use term specific up and down buttons.

### DIFF
--- a/plugins/history-substring-search/history-substring-search.zsh
+++ b/plugins/history-substring-search/history-substring-search.zsh
@@ -164,8 +164,12 @@ zle -N history-substring-search-up
 zle -N history-substring-search-down
 
 zmodload zsh/terminfo
-bindkey "$terminfo[kcuu1]" history-substring-search-up
-bindkey "$terminfo[kcud1]" history-substring-search-down
+if [[ -n "$terminfo[kcuu1]" ]]; then
+  bindkey "$terminfo[kcuu1]" history-substring-search-up
+fi
+if [[ -n "$terminfo[kcud1]" ]]; then
+  bindkey "$terminfo[kcud1]" history-substring-search-down
+fi
 
 #-----------------------------------------------------------------------------
 # implementation details


### PR DESCRIPTION
Fixes #2089 and problems with some linux distributions and/or terminals.
