### PR TITLE
Displaying current tag in git prompt

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -2,6 +2,7 @@
 function git_prompt_info() {
   if [[ "$(git config --get oh-my-zsh.hide-status)" != "1" ]]; then
     ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
+    ref=$(command git describe --exact-match --tags $(git log -n1 --pretty='%h' 2> /dev/null) 2> /dev/null) || \
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
     echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
   fi


### PR DESCRIPTION
If your current branch is on a specific tag, it will be displayed as the git prompt, instead of the short sha.
