### PR TITLE
Add pip3 completion support to pip plugin

### DIFF
--- a/plugins/pip/_pip
+++ b/plugins/pip/_pip
@@ -1,4 +1,4 @@
-#compdef pip pip3 pip-3.2 pip-3.3 pip-3.4
+#compdef pip pip2 pip-2.7 pip3 pip-3.2 pip-3.3 pip-3.4
 #autoload
 
 # pip zsh completion, based on homebrew completion


### PR DESCRIPTION
This just uses the same completion for pip3 that is used for pip2, which is slightly incomplete but better than nothing.
