### PR TITLE
Add rake-fast plugin for fast rake autocompletion

### DIFF
--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -15,11 +15,6 @@
 # which is inspired by this Ruby on Rails trick from 2006:
 # http://weblog.rubyonrails.org/2006/3/9/fast-rake-task-completion-for-zsh/
 
-# Author: Kevin Bongart
-# contact@kevinbongart.net
-# http://kevinbongart.net
-# https://github.com/KevinBongart
-
 _rake_refresh () {
   if [ -f .rake_tasks ]; then
     rm .rake_tasks


### PR DESCRIPTION
# rake-fast

Fast rake autocompletion plugin for [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)

**[See a 10-second video example](https://v.usetapes.com/71A26Nskcs)**
## What?

This script caches the output for later usage and significantly speeds it up.

It generates a file .rake_tasks in parallel to the Rakefile. It also checks the file modification dates to see if it needs to regenerate the cache file.

This is based on [this pull request by Ullrich Schäfer](https://github.com/robb/.dotfiles/pull/10/), which is inspired by [this Ruby on Rails trick from 2006](http://weblog.rubyonrails.org/2006/3/9/fast-rake-task-completion-for-zsh/).

Think about that. 2006.

You can force .rake_tasks to refresh with:

``` bash
$ rake_refresh
```

You'll also want to add `.rake_tasks` to your [global .gitignore](https://help.github.com/articles/ignoring-files#global-gitignore)
