### PR TITLE
Fix common-aliases on OSX/BSD

### DIFF
--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -38,7 +38,7 @@ alias -g NE="2> /dev/null"
 alias -g NUL="> /dev/null 2>&1"
 alias -g P="2>&1| pygmentize -l pytb"
 
-alias dud='du --max-depth=1 -h'
+alias dud='du -d 1 -h'
 alias duf='du -sh *'
 alias fd='find . -type d -name'
 alias ff='find . -type f -name'


### PR DESCRIPTION
Remove definition for `ls` (repeats things already done in lib/themes-and-appearance.zsh and that has builtin support for BSD/Darwin/etc.)

Clean up `dud` so it works on BSD/Darwin.

Fixes #2462 
