### PR TITLE
Add shebang in tool script headers for portability

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 ZSH=`/usr/bin/env|grep 'ZSH='|cut -d '=' -f 2`
 if [ -d "$ZSH" ]
 then

--- a/tools/require_tool.sh
+++ b/tools/require_tool.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 __require_tool_version_compare ()
 {
   (

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 echo "Removing ~/.oh-my-zsh"
 if [[ -d ~/.oh-my-zsh ]]
 then

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 printf '\033[0;34m%s\033[0m\n' "Upgrading Oh My Zsh"
 cd "$ZSH"
 if git pull --rebase --stat origin master


### PR DESCRIPTION
As far as I can tell, there is no specific need for zsh in these scripts. Adding shebangs ensures portability and facilitates OS packaging.
