### PR TITLE
Update battery plugin to show calculating - OSX

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -30,7 +30,11 @@ if [[ $(uname) == "Darwin" ]] ; then
   	local smart_battery_status="$(ioreg -rc "AppleSmartBattery")"
     if [[ $(echo $smart_battery_status | grep -c '^.*"ExternalConnected"\ =\ No') -eq 1 ]] ; then
       timeremaining=$(echo $smart_battery_status | grep '^.*"AvgTimeToEmpty"\ =\ ' | sed -e 's/^.*"AvgTimeToEmpty"\ =\ //')
-      echo "~$((timeremaining / 60)):$((timeremaining % 60))"
+      if [ $timeremaining -gt 720 ] ; then
+        echo "::"
+      else
+        echo "~$((timeremaining / 60)):$((timeremaining % 60))"
+      fi
     else
       echo "∞"
     fi


### PR DESCRIPTION
Instantly after removing the charger, I have found that the "AvgTimeToEmpty" value can swing to ridiculous values. Apple's current claim is that the max battery life is 12 hours, so any value larger than this is considered a "time is being calculated" value.
