### PR TITLE
Add cabal_sandbox_info function

### DIFF
--- a/plugins/cabal/cabal.plugin.zsh
+++ b/plugins/cabal/cabal.plugin.zsh
@@ -1,3 +1,14 @@
+function cabal_sandbox_info() {
+    cabal_files=(*.cabal(N))
+    if [ $#cabal_files -gt 0 ]; then
+        if [ -f cabal.sandbox.config ]; then
+            echo "%{$fg[green]%}sandboxed%{$reset_color%}"
+        else
+            echo "%{$fg[red]%}not sandboxed%{$reset_color%}"
+        fi
+    fi
+}
+
 function _cabal_commands() {
     local ret=1 state
     _arguments ':subcommand:->subcommand' && ret=0


### PR DESCRIPTION
Reports whether the current working directory is within a
sandbox. Useful to check before installing Cabal packages into the
global registry.
