### PR TITLE
Fix URL to gi (gitignore) function

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,4 +1,4 @@
-function gi() { curl http://gitignore.io/api/$@ ;}
+function gi() { curl http://www.gitignore.io/api/$@ ;}
 
 _gitignireio_get_command_list() {
   curl -s http://gitignore.io/api/list | tr "," "\n"


### PR DESCRIPTION
Previous URL doesn't seem to work because the host requires a www
prefix.
