### PR TITLE
Disable Travis build on temporary commit.

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -147,8 +147,8 @@ function work_in_progress() {
   fi
 }
 # these alias commit and uncomit wip branches
-alias gwip='git add -A; git ls-files --deleted -z | xargs -0 git rm; git commit -m "--wip--"'
-alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
+alias gwip='git add -A; git ls-files --deleted -z | xargs -0 git rm; git commit -m "--wip-- [skip ci]"'
+alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\- \[skip ci\]" && git reset HEAD~1'
 
 # these alias ignore changes to file
 alias gignore='git update-index --assume-unchanged'


### PR DESCRIPTION
When pushing a commit, with the git `gwip` command, it should not be build by Travis.
