### PR TITLE
Add aliases for `git rebase` and `git rebase --skip`

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -13,7 +13,6 @@ alias gup='git pull --rebase'
 compdef _git gup=git-fetch
 alias gp='git push'
 compdef _git gp=git-push
-alias gd='git diff'
 gdv() { git diff -w "$@" | view - }
 compdef _git gdv=git-diff
 alias gc='git commit -v'


### PR DESCRIPTION
These two are somehow missing from the existing list of `grb*` aliases in the git plugin.

Marten
