### PR TITLE
Remove mailcatcher from the bundler plugin.

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -6,7 +6,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate berks cap capify cucumber foodcritic foreman guard jekyll kitchen knife middleman nanoc rackup rainbows rake rspec ruby shotgun spec spin spork strainer tailor taps thin thor unicorn unicorn_rails puma)
+bundled_commands=(annotate berks cap capify cucumber foodcritic foreman guard jekyll kitchen knife mailcatcher middleman nanoc rackup rainbows rake rspec ruby shotgun spec spin spork strainer tailor taps thin thor unicorn unicorn_rails puma)
 
 # Remove $UNBUNDLED_COMMANDS from the bundled_commands list
 for cmd in $UNBUNDLED_COMMANDS; do


### PR DESCRIPTION
Recommended by @sj26 per https://github.com/sj26/mailcatcher#bundler.
