### PR TITLE
Add jtriley-light theme for light background

### DIFF
--- a/themes/jtriley-light.zsh-theme
+++ b/themes/jtriley-light.zsh-theme
@@ -1,0 +1,8 @@
+#PROMPT='%{$fg_bold[red]%}➜ %{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%} % %{$reset_color%}'
+PROMPT="%{$fg_bold[blue]%}%T%{$fg_bold[green]%} %{$fg_bold[black]%}%n%{$fg[magenta]%}@%{$fg_bold[black]%}%m %{$fg_bold[green]%}%d
+%{$fg_bold[magenta]%}%% %{$reset_color%}"
+
+#ZSH_THEME_GIT_PROMPT_PREFIX="git:(%{$fg[red]%}"
+#ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
+#ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗%{$reset_color%}"
+#ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%})"


### PR DESCRIPTION
Add a jtriley-light theme, which is modified from jtriley to be suitable on light background.

![screen shot 2014-02-20 at 3 24 36 pm](https://f.cloud.github.com/assets/1191434/2215988/17e5c1da-9a00-11e3-95a1-f501de4e3ba4.png)
