### PR TITLE
git-prompt (gitstatus.py) plugin fix

### DIFF
--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -67,7 +67,7 @@ if bline.find('Not currently on any branch') != -1:
         '--short',
         'HEAD'], stdout=PIPE).communicate()[0][:-1]
 else:
-    branch = bline.split(' ')[3]
+    branch = bline.split(' ')[-1]
     bstatusline = lines[1]
     match = behead_re.match(bstatusline)
     if match:


### PR DESCRIPTION
Git v1.9 has a slightly different output for branch name and the call in `gitstatus.py` to get the branch name relies on it being at a certain index. After some testing, I found that regardless of version (tested v1.8 & 1.9), the branch name is always the last item in the list. So rather than rely on a specific index it's easier to just return the last item in the list.

Also gave this file some much needed PEP8 love. Moved imports to the top of the file where they belong and it actually passes a linter now.

``` python
branch = bline.split(' ')[3]  # Bad
branch = bline.split(' ')[-1]  # Good
```
