### PR TITLE
Fixed sublime plugin behaviors.

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -1,25 +1,32 @@
 # Sublime Text 2 Aliases
 
-local _sublime_darwin_paths > /dev/null 2>&1
-_sublime_darwin_paths=(
-    "/usr/local/bin/subl"
-    "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
-    "/Applications/Sublime Text 3.app/Contents/SharedSupport/bin/subl"
-    "/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
-    "$HOME/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
-    "$HOME/Applications/Sublime Text 3.app/Contents/SharedSupport/bin/subl"
-    "$HOME/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
-)
-
 if [[ $('uname') == 'Linux' ]]; then
-    if [ -f '/opt/sublime_text/sublime_text' ]; then
-        st_run() { /opt/sublime_text/sublime_text $@ &| }
-    else
-        st_run() { /usr/bin/sublime-text $@ &| }
-    fi
-    alias st=st_run
+    local _sublime_linux_paths > /dev/null 2>&1
+    _sublime_linux_paths=(
+        "$HOME/bin/sublime_text"
+        "/opt/sublime_text/sublime_text"
+        "/usr/bin/sublime_text"
+        "/usr/local/bin/sublime_text"
+    )
+    for _sublime_path in $_sublime_linux_paths; do
+        if [[ -a $_sublime_path ]]; then
+            st_run() { $_sublime_path $@ >/dev/null 2>&1 &| }
+            alias st=st_run
+            break
+        fi
+    done
 
 elif  [[ $('uname') == 'Darwin' ]]; then
+    local _sublime_darwin_paths > /dev/null 2>&1
+    _sublime_darwin_paths=(
+        "/usr/local/bin/subl"
+        "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
+        "/Applications/Sublime Text 3.app/Contents/SharedSupport/bin/subl"
+        "/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
+        "$HOME/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
+        "$HOME/Applications/Sublime Text 3.app/Contents/SharedSupport/bin/subl"
+        "$HOME/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
+    )
 
     for _sublime_path in $_sublime_darwin_paths; do
         if [[ -a $_sublime_path ]]; then


### PR DESCRIPTION
- Fixed subl search path order in Mac because Sublime Text 3 is named
  Sublime Text.app by default instead of Sublime Text 3.app and they are
  mostly likely to be placed in /Applications instead of
  $HOME/Applications.
- Fixed sublime text binary path in Linux. The sublime_text binary
  installed by Ubuntu installer is placed in /opt/sublime_text/sublime_text
  instead of /usr/bin/sublime_text.
- Use zsh's built-in process detach syntax instead of nohup.
