### PR TITLE
Made spectrum_{,b}ls wide.

### DIFF
--- a/lib/spectrum.zsh
+++ b/lib/spectrum.zsh
@@ -21,15 +21,18 @@ done
 
 # Show all 256 colors with color number
 function spectrum_ls() {
-  for code in {000..255}; do
-    print -P -- "$code: %F{$code}Test%f"
+  typeset -a colors
+  for i in {000..255}; do
+    colors+="%F{$i}███ Color $i ███%f    "
   done
+  print -P -c -- $colors
 }
 
 # Show all 256 colors where the background is set to specific color
 function spectrum_bls() {
-  for code in {000..255}; do
-    ((cc = code + 1))
-    print -P -- "$BG[$code]$code: Test %{$reset_color%}"
+  typeset -a colors
+  for i in {000..255}; do
+    colors+="$BG[$i]    Color $i    %{$reset_color%}    "
   done
+  print -P -c -- $colors
 }


### PR DESCRIPTION
Small tweak to make `spectrum_ls` and `spectrum_bls` output more readable. I debated making them separate functions but thought it wouldn't be worth it in the end.
