### PR TITLE
Add github url shortener

### DIFF
--- a/plugins/github/github.plugin.zsh
+++ b/plugins/github/github.plugin.zsh
@@ -84,5 +84,14 @@ exist_gh() { # [DIRECTORY]
     git push -u origin master
 }
 
+# git.io "GitHub URL"
+#
+# Shorten GitHub url, example:
+#   https://github.com/nvogel/dotzsh    >   http://git.io/8nU25w  
+# source: https://github.com/nvogel/dotzsh
+# documentation: https://github.com/blog/985-git-io-github-url-shortener
+#
+git.io() {curl -i -s http://git.io -F "url=$1" | grep "Location" | cut -f 2 -d " "}
+
 # End Functions #############################################################
 


### PR DESCRIPTION
git.io() function shortens any GitHub URL using git.io server, e.g.:

```
> git.io https://github.com/blog/985-git-io-github-url-shortener
http://git.io/help
```
