### PR TITLE
Use zsh's default for ':completion:*:hosts'

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -31,22 +31,6 @@ zstyle ':completion:*:*:*:*:processes' command "ps -u `whoami` -o pid,user,comm 
 zstyle ':completion:*:cd:*' tag-order local-directories directory-stack path-directories
 cdpath=(.)
 
-# use /etc/hosts and known_hosts for hostname completion
-[ -r /etc/ssh/ssh_known_hosts ] && _global_ssh_hosts=(${${${${(f)"$(</etc/ssh/ssh_known_hosts)"}:#[\|]*}%%\ *}%%,*}) || _global_ssh_hosts=()
-[ -r ~/.ssh/known_hosts ] && _ssh_hosts=(${${${${(f)"$(<$HOME/.ssh/known_hosts)"}:#[\|]*}%%\ *}%%,*}) || _ssh_hosts=()
-[ -r ~/.ssh/config ] && _ssh_config=($(cat ~/.ssh/config | sed -ne 's/Host[=\t ]//p')) || _ssh_config=()
-[ -r /etc/hosts ] && : ${(A)_etc_hosts:=${(s: :)${(ps:\t:)${${(f)~~"$(</etc/hosts)"}%%\#*}##[:blank:]#[^[:blank:]]#}}} || _etc_hosts=()
-hosts=(
-  "$_ssh_config[@]"
-  "$_global_ssh_hosts[@]"
-  "$_ssh_hosts[@]"
-  "$_etc_hosts[@]"
-  "$HOST"
-  localhost
-)
-zstyle ':completion:*:hosts' hosts $hosts
-zstyle ':completion:*' users off
-
 # Use caching so that commands like apt and dpkg complete are useable
 zstyle ':completion::complete:*' use-cache 1
 zstyle ':completion::complete:*' cache-path $ZSH/cache/


### PR DESCRIPTION
The manual configuration of ':completion:*:hosts' causes some problems
(e.g. issue #1337), and misses useful information (especially from
~/.ssh/known_hosts; issue #690 and issue #1009).

The best option appears to be using zsh's default configuration for
':completion:*:hosts'.

While rebasing this for a new pull request (#1498 got closed by accident
and then requests to re-open it got ignored), it also drops the `users
off` setting: completion of user names can be useful, and the commit
adding it (c4434d2) does not state why.

/cc @essembeh: you had introduced `users off` - do you happen to remember why?
