### PR TITLE
Added v as a keybinding to edit-command-line in vi-mode

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -17,8 +17,14 @@ function zle-keymap-select zle-line-init zle-line-finish {
 zle -N zle-line-init
 zle -N zle-line-finish
 zle -N zle-keymap-select
+zle -N edit-command-line
+
 
 bindkey -v
+
+# allow v to edit the command line (standard behaviour)
+autoload -Uz edit-command-line
+bindkey -M vicmd 'v' edit-command-line
 
 # if mode indicator wasn't setup by theme, define default
 if [[ "$MODE_INDICATOR" == "" ]]; then


### PR DESCRIPTION
taken from [here](http://www.zsh.org/mla/users/2008/msg01013.html)
We want pressing v in command mode to take us to an editor (defined by the $VISUAL or $EDITOR variable or vi) to edit the current contents of the command line which (I believe) is a standard feature of bash vi-mode or other readline prompts (see [here](http://www.catonmat.net/download/bash-vi-editing-mode-cheat-sheet.pdf) and [here](http://www.catonmat.net/blog/bash-vi-editing-mode-cheat-sheet/) for source).
