### PR TITLE
Don't set RBENV_ROOT to "$HOME/.rbenv" when using Homebrew rbenv

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -10,9 +10,6 @@ FOUND_RBENV=0
 rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv")
 if _homebrew-installed && _rbenv-from-homebrew-installed ; then
     rbenvdirs=($(brew --prefix rbenv) "${rbenvdirs[@]}")
-    if [[ $RBENV_ROOT = '' ]]; then 
-      RBENV_ROOT="$HOME/.rbenv"
-    fi
 fi
 
 for rbenvdir in "${rbenvdirs[@]}" ; do


### PR DESCRIPTION
Hard setting RBENV_ROOT to "$HOME/.rbenv" when using Homebrew's rbenv
will breaks it. It has to be set to $(brew --prefix rbenv).
