### PR TITLE
Fix gwip alias in git plugin when no files to rm

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -149,7 +149,7 @@ function work_in_progress() {
   fi
 }
 # these alias commit and uncomit wip branches
-alias gwip='git add -A; git ls-files --deleted -z | xargs -0 git rm; git commit -m "--wip--"'
+alias gwip='git add -A; git ls-files --deleted -z | xargs -r0 git rm; git commit -m "--wip--"'
 alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
 
 # these alias ignore changes to file


### PR DESCRIPTION
This fixes a bug in gwip alias in the git plugin, when no files are matched with 'git ls-files --deleted -z'. 

The git rm command complained it had nothing to do. Now the "git rm" is run by xargs only if there is something in the pipe. 
