### PR TITLE
Don't show useless '[]' when chruby_prompt_info is empty

### DIFF
--- a/themes/gallois.zsh-theme
+++ b/themes/gallois.zsh-theme
@@ -18,7 +18,7 @@ else
   if which rbenv &> /dev/null; then
     RPS1='$(git_custom_status)%{$fg[red]%}[`rbenv version | sed -e "s/ (set.*$//"`]%{$reset_color%} $EPS1'
   else
-    if which chruby_prompt_info &> /dev/null; then
+    if [[ -n `which chruby_prompt_info` && -n `chruby_prompt_info` ]]; then
       RPS1='$(git_custom_status)%{$fg[red]%}[`chruby_prompt_info`]%{$reset_color%} $EPS1'
     else
       RPS1='$(git_custom_status) $EPS1'


### PR DESCRIPTION
A recent update added some Ruby info to the gallois theme. I don't use Ruby, and I don't see any reason to have a useless `[]` on the right side of my prompt at all times.

This commit only put's the Ruby status there if `ruby_prompt_info` actually returns something.
