### PR TITLE
Fixed errors if acpitool isn't installed on linux

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -21,7 +21,7 @@ if [[ $(uname) == "Darwin" ]] ; then
   function plugged_in() {
     [ $(ioreg -rc AppleSmartBattery | grep -c '^.*"ExternalConnected"\ =\ Yes') -eq 1 ]
   }
-  
+
   function battery_pct_remaining() {
     if plugged_in ; then
       echo "External Power"
@@ -31,7 +31,7 @@ if [[ $(uname) == "Darwin" ]] ; then
   }
 
   function battery_time_remaining() {
-  	local smart_battery_status="$(ioreg -rc "AppleSmartBattery")"
+    local smart_battery_status="$(ioreg -rc "AppleSmartBattery")"
     if [[ $(echo $smart_battery_status | grep -c '^.*"ExternalConnected"\ =\ No') -eq 1 ]] ; then
       timeremaining=$(echo $smart_battery_status | grep '^.*"AvgTimeToEmpty"\ =\ ' | sed -e 's/^.*"AvgTimeToEmpty"\ =\ //')
       if [ $timeremaining -gt 720 ] ; then
@@ -59,9 +59,9 @@ if [[ $(uname) == "Darwin" ]] ; then
       echo "∞"
     fi
   }
-  
+
   function battery_is_charging() {
-	  [[ $(ioreg -rc "AppleSmartBattery"| grep '^.*"IsCharging"\ =\ ' | sed -e 's/^.*"IsCharging"\ =\ //') == "Yes" ]]
+    [[ $(ioreg -rc "AppleSmartBattery"| grep '^.*"IsCharging"\ =\ ' | sed -e 's/^.*"IsCharging"\ =\ //') == "Yes" ]]
   }
 
 elif [[ $(uname) == "Linux"  ]] ; then
@@ -71,7 +71,9 @@ elif [[ $(uname) == "Linux"  ]] ; then
   }
 
   function battery_pct() {
-    echo "$(acpi | cut -f2 -d ',' | tr -cd '[:digit:]')" 
+    if (( $+commands[acpi] )) ; then
+      echo "$(acpi | cut -f2 -d ',' | tr -cd '[:digit:]')"
+    fi
   }
 
   function battery_pct_remaining() {
@@ -103,7 +105,7 @@ elif [[ $(uname) == "Linux"  ]] ; then
       echo "∞"
     fi
   }
-  
+
 else
   # Empty functions so we don't cause errors in prompts
   function battery_pct_remaining() {
@@ -136,7 +138,7 @@ function battery_level_gauge() {
   if [[ $battery_remaining_percentage =~ [0-9]+ ]]; then
     local filled=$(((( $battery_remaining_percentage + $gauge_slots - 1) / $gauge_slots)));
     local empty=$(($gauge_slots - $filled));
-	
+
     if [[ $filled -gt $green_threshold ]]; then local gauge_color=$color_green;
     elif [[ $filled -gt $yellow_threshold ]]; then local gauge_color=$color_yellow;
     else local gauge_color=$color_red;
@@ -144,10 +146,9 @@ function battery_level_gauge() {
   else
     local filled=$gauge_slots;
     local empty=0;
-  	filled_symbol=${BATTERY_UNKNOWN_SYMBOL:-'.'};
+    filled_symbol=${BATTERY_UNKNOWN_SYMBOL:-'.'};
   fi
 
-  
   local charging=' ' && battery_is_charging && charging=$charging_symbol;
 
   printf ${charging_color//\%/\%\%}$charging${color_reset//\%/\%\%}${battery_prefix//\%/\%\%}${gauge_color//\%/\%\%}


### PR DESCRIPTION
Currently, when acpitool isn't installed, I get an error every time my prompt tries to call battery_pct:

```
battery_pct:1: command not found: acpi
```

This change fixes the error by guarding the call to acpi with a check that it's actually installed and executable.

(Also include a small amount of whitespace cleanup.)
