### PR TITLE
prevent preventing headaches to prevent headaches

### DIFF
--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -6,11 +6,6 @@ alias po='popd'
 alias ...='cd ../..'
 alias -- -='cd -'
 
-# Prevent headaches
-alias cp='cp -v'
-alias rm='rm -v'
-alias mv='mv -v'
-
 # Super user
 alias _='sudo'
 alias please='sudo'


### PR DESCRIPTION
There are some verbose aliases for rm et al that are supposed to
"prevent headaches". However, the real headache is when you recursively
rm a directory with a million files in it and have to sit through all of
that output. Fix this by sticking to the tried-and-true default of
non-verbose mode. Users can always ask for verbose output when they want
it.
