### PR TITLE
Revert "Replace hardcoded key escape sequeneces with dynamic ones from t...

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -20,24 +20,31 @@ bindkey -e                                          # Use emacs key bindings
 bindkey '\ew' kill-region                           # [Esc-w] - Kill from the cursor to the mark
 bindkey -s '\el' 'ls\n'                             # [Esc-l] - run command: ls
 bindkey '^r' history-incremental-search-backward    # [Ctrl-r] - Search backward incrementally for a specified string. The string may begin with ^ to anchor the search to the beginning of the line.
-bindkey "${terminfo[kpp]}" up-line-or-history       # [PageUp] - Up a line of history
-bindkey "${terminfo[knp]}" down-line-or-history     # [PageDown] - Down a line of history
+bindkey '^[[5~' up-line-or-history                  # [PageUp] - Up a line of history
+bindkey '^[[6~' down-line-or-history                # [PageDown] - Down a line of history
 
-bindkey "${terminfo[kcuu1]}" up-line-or-search      # start typing + [Up-Arrow] - fuzzy find history forward
-bindkey "${terminfo[kcud1]}" down-line-or-search    # start typing + [Down-Arrow] - fuzzy find history backward
+bindkey '^[[A' up-line-or-search                    # start typing + [Up-Arrow] - fuzzy find history forward
+bindkey '^[[B' down-line-or-search                  # start typing + [Down-Arrow] - fuzzy find history backward
 
-bindkey "${terminfo[khome]}" beginning-of-line      # [Home] - Go to beginning of line
-bindkey "${terminfo[kend]}"  end-of-line            # [End] - Go to end of line
+bindkey '^[[H' beginning-of-line                    # [Home] - Go to beginning of line
+bindkey '^[[1~' beginning-of-line                   # [Home] - Go to beginning of line
+bindkey '^[OH' beginning-of-line                    # [Home] - Go to beginning of line
+bindkey '^[[F'  end-of-line                         # [End] - Go to end of line
+bindkey '^[[4~' end-of-line                         # [End] - Go to end of line
+bindkey '^[OF' end-of-line                          # [End] - Go to end of line
 
 bindkey ' ' magic-space                             # [Space] - do history expansion
 
 bindkey '^[[1;5C' forward-word                      # [Ctrl-RightArrow] - move forward one word
 bindkey '^[[1;5D' backward-word                     # [Ctrl-LeftArrow] - move backward one word
 
-bindkey "${terminfo[kcbt]}" reverse-menu-complete   # [Shift-Tab] - move through the completion menu backwards
+bindkey '^[[Z' reverse-menu-complete                # [TODO] - Perform menu completion, like menu-complete, except that if a menu completion is already in progress, move to the previous completion rather than the next.
 
-bindkey '^?' backward-delete-char                   # [Backspace] - delete backward
-bindkey "${terminfo[kdch1]}" delete-char            # [Delete] - delete forward
+# Make the delete key (or Fn + Delete on the Mac) work instead of outputting a ~
+bindkey '^?' backward-delete-char                   # [Delete] - delete backward
+bindkey '^[[3~' delete-char                         # [fn-Delete] - delete forward
+bindkey '^[3;5~' delete-char                        # [TODO] - delete forward
+bindkey '\e[3~' delete-char                         # [TODO] - delete forward
 
 # Edit the current command line in $EDITOR
 autoload -U edit-command-line


### PR DESCRIPTION
...erminfo."

This reverts commit 174c9177aa34b4c05bb5a1c6f637e6fa479a8e10.
Fixes #2608, #2617.

Without further research, it seems reasonable to keep hardcoded values for now. Using `$terminfo` seems to be inconsistent between different systems.
