### PR TITLE
Do not initialize RBENV_ROOT to early

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -10,9 +10,6 @@ FOUND_RBENV=0
 rbenvdirs=("$HOME/.rbenv" "/usr/local/rbenv" "/opt/rbenv")
 if _homebrew-installed && _rbenv-from-homebrew-installed ; then
     rbenvdirs=($(brew --prefix rbenv) "${rbenvdirs[@]}")
-    if [[ $RBENV_ROOT = '' ]]; then 
-      RBENV_ROOT="$HOME/.rbenv"
-    fi
 fi
 
 for rbenvdir in "${rbenvdirs[@]}" ; do


### PR DESCRIPTION
I'm not sure, why it broke for me just right now after an upgrade (which I'm doing frequently). 

Since $RBENV_ROOT gets initialized with the rbenv installation dir in $HOME on line 14  it cannot be empty for the check on line 21. So its fixed on $HOME/.rbenv.
Here is a patch removing the conditional and initialization on lines 13 to 15, so that the for loop can do the detection as I guess was intended.

Kind regards, Thomas
