### PR TITLE
Add irb to the list of bundled commands

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -6,7 +6,7 @@ alias bu="bundle update"
 
 # The following is based on https://github.com/gma/bundler-exec
 
-bundled_commands=(annotate berks cap capify cucumber foodcritic foreman guard jekyll kitchen knife mailcatcher middleman nanoc rackup rainbows rake rspec ruby shotgun spec spin spork strainer tailor taps thin thor unicorn unicorn_rails puma irb)
+bundled_commands=(annotate berks cap capify cucumber foodcritic foreman guard irb jekyll kitchen knife mailcatcher middleman nanoc puma rackup rainbows rake rspec ruby shotgun spec spin spork strainer tailor taps thin thor unicorn unicorn_rails)
 
 # Remove $UNBUNDLED_COMMANDS from the bundled_commands list
 for cmd in $UNBUNDLED_COMMANDS; do


### PR DESCRIPTION
Sometimes it's useful to use `irb`, it would be great to run it with `bundle exec` automatically.
