### PR TITLE
Improve template zshrc

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -1,4 +1,4 @@
-# Path to your oh-my-zsh configuration.
+# Path to your oh-my-zsh installation.
 export ZSH=$HOME/.oh-my-zsh
 
 # Set name of the theme to load.


### PR DESCRIPTION
This improves `templates/.zshrc` for two reasons:
- mention that users may need to set `$LANG` (see #1286 and #1823)
- mention that users can use another folder than `$ZSH/custom` (thanks to #525) by setting `$ZSH_CUSTOM` (see #1628, #1989, #2295)

Additionally, I think `$ZSH` should be referred to as "oh-my-zsh _installation_ folder" instead of _configuration_.
