### PR TITLE
Fixed which output at each new shell creation

### DIFF
--- a/themes/gallois.zsh-theme
+++ b/themes/gallois.zsh-theme
@@ -11,19 +11,11 @@ git_custom_status() {
   fi
 }
 
-#RVM and git settings
-if [[ -s ~/.rvm/scripts/rvm ]] ; then
-  RPS1='$(git_custom_status)%{$fg[red]%}[`~/.rvm/bin/rvm-prompt`]%{$reset_color%} $EPS1'
-else
-  if which rbenv &> /dev/null; then
-    RPS1='$(git_custom_status)%{$fg[red]%}[`rbenv version | sed -e "s/ (set.*$//"`]%{$reset_color%} $EPS1'
-  else
-    if [[ -n `which chruby_prompt_info &> /dev/null` && -n `chruby_prompt_info` ]]; then
-      RPS1='$(git_custom_status)%{$fg[red]%}[`chruby_prompt_info`]%{$reset_color%} $EPS1'
-    else
-      RPS1='$(git_custom_status) $EPS1'
-    fi
-  fi
-fi
+# RVM component of prompt
+ZSH_THEME_RVM_PROMPT_PREFIX="%{$fg[red]%}["
+ZSH_THEME_RVM_PROMPT_SUFFIX="]%{$reset_color%}"
+
+# Combine it all into a final right-side prompt
+RPS1='$(git_custom_status)$(ruby_prompt_info) $EPS1'
 
 PROMPT='%{$fg[cyan]%}[%~% ]%(?.%{$fg[green]%}.%{$fg[red]%})%B$%b '


### PR DESCRIPTION
After #2619, I'm seeing the following each time I open a new shell:

```
/usr/bin/which: no chruby_prompt_info in (/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/bin:/home/daniel/bin:/usr/local/sbin:/usr/sbin)
```

That change removed a redirect to /dev/null that had been suppressing this output. I simply re-added that redirect.
