### PR TITLE
don't add --exclude-dir to GREP_OPTIONS on FreeBSD

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -3,11 +3,22 @@
 # Examples: http://rubyurl.com/ZXv
 #
 
-# avoid VCS folders
-GREP_OPTIONS=
-for PATTERN in .cvs .git .hg .svn; do
-    GREP_OPTIONS+="--exclude-dir=$PATTERN "
-done
-GREP_OPTIONS+="--color=auto"
+GREP_OPTIONS="--color=auto"
+
+# avoid VCS folders (if the necessary grep flags are available)
+grep-flag-available() {
+    echo | grep $1 "" >/dev/null 2>&1
+}
+if grep-flag-available --exclude-dir=.cvs; then
+    for PATTERN in .cvs .git .hg .svn; do
+        GREP_OPTIONS+=" --exclude-dir=$PATTERN"
+    done
+elif grep-flag-available --exclude=.cvs; then
+    for PATTERN in .cvs .git .hg .svn; do
+        GREP_OPTIONS+=" --exclude=$PATTERN"
+    done
+fi
+unfunction grep-flag-available
+
 export GREP_OPTIONS="$GREP_OPTIONS"
 export GREP_COLOR='1;32'


### PR DESCRIPTION
```
$ grep --exclude-dir='.svn' test ./*
grep: unrecognized option `--exclude-dir=.svn'
Usage: grep [OPTION]... PATTERN [FILE]...
Try `grep --help' for more information.
FAIL: 2
```
