### PR TITLE
Fix Emacs plugin

### DIFF
--- a/plugins/emacs/emacsclient.sh
+++ b/plugins/emacs/emacsclient.sh
@@ -3,7 +3,7 @@
 # get list of available X windows.
 x=`emacsclient --alternate-editor '' --eval '(x-display-list)' 2>/dev/null`
 
-if [ -z "$x" ] ;then
+if [ -z "$x" ] || [ "$x" = "nil" ] ;then
     # Create one if there is no X window yet.
     emacsclient --alternate-editor "" --create-frame "$@"
 else


### PR DESCRIPTION
With Emacs 24.3 on Mac OS X the command `emacsclient --alternate-editor '' --eval '(x-display-list)' 2>/dev/null` returns `nil`, what makes absolutely sense from a LISP point of view, but breaks the script.
### What went wrong before?

The `e` alias from the plugin triggered a start of Emacs server as expected, but since `nil` was returned, the `--create-frame` option was not provided. Without an existing open frame / window, this results in opening Emacs client in the terminal. Since the alias adds the `--no-wait` option, the Emacs client in the terminal was immediately closed again. The user might think, Emacs is crashing 😉.
