### PR TITLE
Plugin: Rake-fast: Support both *nix and Darwin

### DIFF
--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -27,8 +27,13 @@ _rake_refresh () {
 _rake_does_task_list_need_generating () {
   if [ ! -f .rake_tasks ]; then return 0;
   else
-    accurate=$(stat -f%m .rake_tasks)
-    changed=$(stat -f%m Rakefile)
+    if [[ $(uname -s) == 'Darwin' ]]; then
+      accurate=$(stat -f%m .rake_tasks)
+      changed=$(stat -f%m Rakefile)
+    else
+      accurate=$(stat -c%Y .rake_tasks)
+      changed=$(stat -c%Y Rakefile)
+    fi
     return $(expr $accurate '>=' $changed)
   fi
 }


### PR DESCRIPTION
Syntax for stat is different on *nix and Darwin (BSD)

BSD syntax: 
http://www.freebsd.org/cgi/man.cgi?query=stat&sektion=1&n=1

Darwin Syntax:
https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/stat.1.html

*nix syntax:
http://linux.die.net/man/1/stat

This pull request makes rake-fast work on both *nix and bsd platforms.
