### PR TITLE
Allowing path with spaces in pow plugin

### DIFF
--- a/plugins/pow/pow.plugin.zsh
+++ b/plugins/pow/pow.plugin.zsh
@@ -21,8 +21,8 @@
 
 rack_root(){
   setopt chaselinks
-  local orgdir=$(pwd)
-  local basedir=$(pwd)
+  local orgdir="$(pwd)"
+  local basedir="$(pwd)"
 
   while [[ $basedir != '/' ]]; do
     test -e "$basedir/config.ru" && break
@@ -30,7 +30,7 @@ rack_root(){
     basedir="$(pwd)"
   done
 
-  builtin cd $orgdir 2>/dev/null
+  builtin cd "$orgdir" 2>/dev/null
   [[ ${basedir} == "/" ]] && return 1
   echo $basedir
 }
@@ -56,19 +56,19 @@ kapow(){
 compctl -W ~/.pow -/ kapow
 
 powit(){
-  local basedir=$(pwd)
+  local basedir="$(pwd)"
   local vhost=$1
   [ ! -n "$vhost" ] && vhost=$(rack_root_detect)
   if [ ! -h ~/.pow/$vhost ]
   then
     echo "pow: Symlinking your app with pow. ${vhost}"
-    [ ! -d ~/.pow/${vhost} ] && ln -s $basedir ~/.pow/$vhost
+    [ ! -d ~/.pow/${vhost} ] && ln -s "$basedir" ~/.pow/$vhost
     return 1
   fi
 }
 
 powed(){
-  local basedir=$(rack_root)
+  local basedir="$(rack_root)"
   find ~/.pow/ -type l -lname "*$basedir*" -exec basename {}'.dev' \;
 }
 


### PR DESCRIPTION
This commit allows for paths with spaces to be symlinked
in Pow.

If an application is located in a folder like `/some path/to the/app`
the powit command would fail when it shouldn't. It's not the case
anymore.
