### PR TITLE
Add README file to rake-fast plugin

### DIFF
--- a/plugins/rake-fast/README.md
+++ b/plugins/rake-fast/README.md
@@ -1,0 +1,23 @@
+# rake-fast
+
+Fast rake autocompletion plugin.
+
+This script caches the output for later usage and significantly speeds it up. It generates a .rake_tasks cache file in parallel to the Rakefile. It also checks the file modification dates to see if it needs to regenerate the cache file.
+
+This is entirely based on [this pull request by Ullrich Schäfer](https://github.com/robb/.dotfiles/pull/10/), which is inspired by [this Ruby on Rails trick from 2006](http://weblog.rubyonrails.org/2006/3/9/fast-rake-task-completion-for-zsh/).
+
+Think about that. 2006.
+
+## Installation
+
+Just add the plugin to your `.zshrc`:
+
+```bash
+plugins=(foo bar rake-fast)
+```
+
+You might consider adding `.rake_tasks` to your [global .gitignore](https://help.github.com/articles/ignoring-files#global-gitignore)
+
+## Usage
+
+`rake`, then press tab

--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -1,20 +1,3 @@
-# rake-fast
-# Fast rake autocompletion plugin for oh-my-zsh
-
-# This script caches the output for later usage and significantly speeds it up.
-# It generates a .rake_tasks file in parallel to the Rakefile.
-
-# You'll want to add `.rake_tasks` to your global .git_ignore file:
-# https://help.github.com/articles/ignoring-files#global-gitignore
-
-# You can force .rake_tasks to refresh with:
-# $ rake_refresh
-
-# This is entirely based on Ullrich Schäfer's work
-# (https://github.com/robb/.dotfiles/pull/10/),
-# which is inspired by this Ruby on Rails trick from 2006:
-# http://weblog.rubyonrails.org/2006/3/9/fast-rake-task-completion-for-zsh/
-
 _rake_refresh () {
   if [ -f .rake_tasks ]; then
     rm .rake_tasks


### PR DESCRIPTION
Following the discussion in https://github.com/robbyrussell/oh-my-zsh/issues/2640#issuecomment-38394258, I moved the instructions out of the plugin to a dedicated README.md file which renders nicely when you browse the directory on GitHub: https://github.com/KevinBongart/oh-my-zsh/tree/add-readme-to-rake-fast/plugins/rake-fast
