### PR TITLE
Fix escaping of $CMD of automatic title

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -26,8 +26,11 @@ function omz_termsupport_precmd {
 function omz_termsupport_preexec {
   emulate -L zsh
   setopt extended_glob
-  local CMD=${1[(wr)^(*=*|sudo|ssh|rake|-*)]} #cmd name only, or if this is sudo or ssh, the next cmd
+
+  # cmd name only, or if this is sudo or ssh, the next cmd
+  local CMD=${1[(wr)^(*=*|sudo|ssh|rake|-*)]:gs/%/%%}
   local LINE="${2:gs/%/%%}"
+
   title '$CMD' '%100>...>$LINE%<<'
 }
 


### PR DESCRIPTION
Fixes formatting on some rare cases when a percent ends up in the `$CMD` variable, examples below:
- When assigning a variable, $CMD ends up with the second parameter;
  in this case, $CMD will contain **+%s%N**, messing with the syntax:
  
  ``` sh
  a=`date +%s%N` 
  ```
- A function (or command in general) that contains a percent symbol:
  
  ``` sh
  to\%() { echo $(( $1 * 100 / $3))\% }
  # $CMD will equal to "to%()"
  to% 2 of 10
  # $CMD will equal to "to%"
  ```
