### PR TITLE
Fix broken reverse-menu-complete keybinding.

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -46,8 +46,8 @@ bindkey ' ' magic-space                               # [Space] - do history exp
 bindkey '^[[1;5C' forward-word                        # [Ctrl-RightArrow] - move forward one word
 bindkey '^[[1;5D' backward-word                       # [Ctrl-LeftArrow] - move backward one word
 
-if [[ "${terminfo[kdch1]}" != "" ]]; then
-  bindkey "${terminfo[kdch1]}" reverse-menu-complete  # [Shift-Tab] - move through the completion menu backwards
+if [[ "${terminfo[kcbt]}" != "" ]]; then
+  bindkey "${terminfo[kcbt]}" reverse-menu-complete   # [Shift-Tab] - move through the completion menu backwards
 fi
 
 bindkey '^?' backward-delete-char                     # [Backspace] - delete backward


### PR DESCRIPTION
Since e537ee9, the reverse-menu-complete keybinding has no longer been properly bound.

Specifically, it seems to be accidentally bound to ${terminfo[kdch1]} (delete) instead of ${terminfo[kcbt]} (back-tab).

This commit ensures that reverse-menu-complete is properly bound to back-tab.
