### PR TITLE
Correct redirection of stderr

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -10,7 +10,7 @@ if [ -d "$ZSH" ]; then
 fi
 
 echo "\033[0;34mCloning Oh My Zsh...\033[0m"
-hash git >/dev/null && /usr/bin/env git clone https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
+hash git >/dev/null 2>&1 && /usr/bin/env git clone https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
   echo "git not installed"
   exit
 }


### PR DESCRIPTION
The intention of the redirection to /dev/null is to hide the output
'hash: no such command: git' since we rely on the exit status.

However, the output goes to stderr, so it's stderr that needs to be
redirected.

Example:

  [~]$ hash git > /dev/null
  [~]$ PATH=''
  [~]$ hash git > /dev/null
  hash: no such command: git
  [~]$ hash git 2> /dev/null
  [~]$
