### PR TITLE
Fix for systems with grep below version 2.5.3

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -5,9 +5,6 @@
 
 # avoid VCS folders
 GREP_OPTIONS=
-for PATTERN in .cvs .git .hg .svn; do
-    GREP_OPTIONS+="--exclude-dir=$PATTERN "
-done
 GREP_OPTIONS+="--color=auto"
 export GREP_OPTIONS="$GREP_OPTIONS"
 export GREP_COLOR='1;32'


### PR DESCRIPTION
Versions of grep below 2.5.3 do not support the `--exclude-dir` option.
