### PR TITLE
Various fixes on zsh_reload plugin

### DIFF
--- a/plugins/zsh_reload/zsh_reload.plugin.zsh
+++ b/plugins/zsh_reload/zsh_reload.plugin.zsh
@@ -1,13 +1,12 @@
-zsh_cache=$HOME/.zsh_cache
-mkdir -p $zsh_cache
-
 # reload zshrc
 function src()
 {
   autoload -U compinit zrecompile
-  compinit -d $zsh_cache/zcomp-$HOST
-  for f in $HOME/.zshrc $zsh_cache/zcomp-$HOST; do
-    zrecompile -p $f && rm -f $f.zwc.old
+  compinit -d "$ZSH/cache/zcomp-$HOST"
+
+  for f in ~/.zshrc "$ZSH/cache/zcomp-$HOST"; do
+    zrecompile -p $f && command rm -f $f.zwc.old
   done
+
   source ~/.zshrc
 }


### PR DESCRIPTION
This PR fixes:
- Use `command rm` instead of `rm` which could be aliased.
- Change location of compinit dump files to included `cache` folder inside `$ZSH`. Right now, a dedicated folder is created in the home directory, but it's preferable to use the included with oh-my-zsh.

cc @eMxyzptlk
