### PR TITLE
fix chsh

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -35,7 +35,6 @@ export PATH=\"$PATH\"
 echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
 sudo chsh -s `which zsh` $USER
 
-
 echo "\033[0;32m"'         __                                     __   '"\033[0m"
 echo "\033[0;32m"'  ____  / /_     ____ ___  __  __   ____  _____/ /_  '"\033[0m"
 echo "\033[0;32m"' / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \ '"\033[0m"


### PR DESCRIPTION
Currently the chsh in the script does not work because chsh demands a password if you are not root, and the script does not stop to ask for user input. This change fixes that by running the command as root.
