### PR TITLE
Fix grep.zsh: grep on FreeBSD 10 does not have --exclude-dir option.

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -5,9 +5,12 @@
 
 # avoid VCS folders
 GREP_OPTIONS=
-for PATTERN in .cvs .git .hg .svn; do
-    GREP_OPTIONS+="--exclude-dir=$PATTERN "
-done
+if [ $(uname) != "FreeBSD" ]
+then
+    for PATTERN in .cvs .git .hg .svn; do
+        GREP_OPTIONS+="--exclude-dir=$PATTERN "
+    done
+fi
 GREP_OPTIONS+="--color=auto"
 export GREP_OPTIONS="$GREP_OPTIONS"
 export GREP_COLOR='1;32'


### PR DESCRIPTION
The default grep configuration breaks on FreeBSD 10, not sure about older versions.
