### PR TITLE
Legacy grep breaks on --exclude-dir option

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -5,9 +5,14 @@
 
 # avoid VCS folders
 GREP_OPTIONS=
-for PATTERN in .cvs .git .hg .svn; do
-    GREP_OPTIONS+="--exclude-dir=$PATTERN "
-done
+# --exclude-dir is only available on 2.5.3 and later versions of grep
+if ! grep --version | head -n 1 | egrep " [0-2]\.[0-5]\.[0-2]" 2>&1 >/dev/null;
+then
+    for PATTERN in .cvs .git .hg .svn; do
+        GREP_OPTIONS+="--exclude-dir=$PATTERN "
+    done
+fi
+
 GREP_OPTIONS+="--color=auto"
 export GREP_OPTIONS="$GREP_OPTIONS"
 export GREP_COLOR='1;32'


### PR DESCRIPTION
This patch matches enables --exclude-dir iff the grep version is less than 2.5.3.
Tested on RHEL5 and OSX mavericks.
## RHEL 5

```
➜  lib git:(master) grep --version
grep (GNU grep) 2.5.1

Copyright 1988, 1992-1999, 2000, 2001 Free Software Foundation, Inc.
This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

➜  lib git:(master) grep --version | head -n 1 | egrep " [0-2]\.[0-5]\.[0-2]"
grep (GNU grep) 2.5.1
```
## OSX

```
 % grep --version                                                                                                               
grep (BSD grep) 2.5.1-FreeBSD

% grep --version | head -n 1 | egrep " [0-2]\.[0-5]\.[0-2]"                                                                
grep (BSD grep) 2.5.1-FreeBSD
```
