### PR TITLE
Fix gwip alias for some BSD flavors of xargs

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -148,7 +148,8 @@ function work_in_progress() {
     echo "WIP!!"
   fi
 }
-# these alias commit and uncomit wip branches
+
+# these aliases commit and uncommit wip branches
 # first though, check xargs flavor for -r flag
 echo | xargs -r &>/dev/null && XARGS_OPTS="-r"
 alias gwip="git add -A; git ls-files --deleted -z | xargs ${XARGS_OPTS} -0 git rm; git commit -m \"--wip--\""


### PR DESCRIPTION
**Status: Ready** (but testing cannot hurt)

Some BSD flavors of the `xargs` command (_eg_ on Mac OSX) do not support the `-r` flag — which is actually a non-standard flag introduced by the GNU flavor of `xargs`. This breaks the `gwip` alias in [the current `git` plugin](https://github.com/robbyrussell/oh-my-zsh/blob/a869ec9bc848a011a3068fbaed52b4cbd04681aa/plugins/git/git.plugin.zsh). See #2692 and #2713.

The bug was introduced by a869ec9bc848a011a3068fbaed52b4cbd04681aa. The original intention was to take care of the possibility that `git ls-files --deleted -z` would not send anything in the pipe. However, the author @bdubertret failed to see that, in that case, only the GNU flavor of `xarg` fails.

This is because the GNU flavor does not follow the `xargs` standard, and fails on empty input instead of returning 0 silently: it requires the `-r` flag in order to adopt the standard behavior. Apparently, all BSD flavors abide by the standard, and thus need not the `-r` flag; some of them (_eg_ FreeBSD) still silently support the flag for the sake of compatibility, but others (_eg_ Mac OSX) do not and fail in case they see it. Hence this PR.
