### PR TITLE
Add exclude-dir option only if grep supports it

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -5,7 +5,7 @@
 
 # avoid VCS folders if grep supports it
 GREP_OPTIONS=
-if [[ "$(man grep | grep -q exclude-dir)" != "1" ]]; then
+if [[ "$(grep --help | grep -q exclude-dir)" != "1" ]]; then
     for PATTERN in .cvs .git .hg .svn; do
         GREP_OPTIONS+="--exclude-dir=$PATTERN "
     done


### PR DESCRIPTION
Older versions of grep pre 2.5.2 did not have this option. Providing it
breaks grep use under oh-my-zsh on these systems. This patch adds a
check to ensure the option is only used if the manpages list it.
