### PR TITLE
Use low level command to detect branches behind

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -54,7 +54,7 @@ git_remote_status() {
 
 # Checks if there are commits ahead from remote
 function git_prompt_ahead() {
-  if $(echo "$(command git log origin/$(current_branch)..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
+  if [[ -n "$(command git rev-list origin/$(current_branch)..HEAD 2> /dev/null)" ]]; then
     echo "$ZSH_THEME_GIT_PROMPT_AHEAD"
   fi
 }


### PR DESCRIPTION
Using `git log` + `grep` is subject to formatting in `.gitconfig`, which can be overridden and will break this function. Relying on `rev-list` is much more stable.
