### PR TITLE
Fix for Python3

### DIFF
--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -16,7 +16,7 @@ symbols = {
 }
 
 output, error = Popen(
-    ['git', 'status'], stdout=PIPE, stderr=PIPE).communicate()
+    ['git', 'status'], stdout=PIPE, stderr=PIPE, universal_newlines=True).communicate()
 
 if error:
     import sys


### PR DESCRIPTION
In Python3 without universal_newlines set to True
output from Popen was byte-encoded.
