### PR TITLE
Don't override ZSH_COMPDUMP if already set.

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -46,7 +46,9 @@ else
 fi
 
 # Save the location of the current completion dump file.
-ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+if [ -z "$ZSH_COMPDUMP" ]; then
+  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+fi
 
 # Load and run compinit
 autoload -U compinit


### PR DESCRIPTION
This allows customization via .zshenv if wanted. This is helpful for zsh
developers and people who want to move it out of $HOME

For example, developers may want to have granularity higher than just the version.
