### PR TITLE
Trust but verify 'scutil' to return ComputerName

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -38,9 +38,9 @@ for plugin ($plugins); do
 done
 
 # Figure out the SHORT hostname
-if [ -n "$commands[scutil]" ]; then
-  # OS X
-  SHORT_HOST=$(scutil --get ComputerName)
+if [[ "$OSTYPE" = darwin* ]]; then
+  # OS X's $HOST changes with dhcp, etc. Use ComputerName if possible.
+  SHORT_HOST=$(scutil --get ComputerName 2>/dev/null) || SHORT_HOST=${HOST/.*/}
 else
   SHORT_HOST=${HOST/.*/}
 fi


### PR DESCRIPTION
Apparently, it is possible to set up a Mac such that
`scutil --get ComputerName` hasn't been set.

This change checks if that fails and falls back to the original mechanism.

Closes #2155
Closes #2183
