### PR TITLE
Use $OSTYPE instead of uname to speed things up

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -8,7 +8,7 @@
 # Modified to add support for Apple Mac   #
 ###########################################
 
-if [[ $(uname) == "Darwin" ]] ; then
+if [[ "$OSTYPE" = darwin* ]] ; then
 
   function battery_pct() {
     local smart_battery_status="$(ioreg -rc "AppleSmartBattery")"

--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -54,7 +54,7 @@ bundle_install() {
   if _bundler-installed && _within-bundled-project; then
     local bundler_version=`bundle version | cut -d' ' -f3`
     if [[ $bundler_version > '1.4.0' || $bundler_version = '1.4.0' ]]; then
-      if [[ "$(uname)" == 'Darwin' ]]
+      if [[ "$OSTYPE" = darwin* ]]
       then
         local cores_num="$(sysctl hw.ncpu | awk '{print $2}')"
       else

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -12,7 +12,7 @@
 #        jira ABC-123   # Opens an existing issue
 open_jira_issue () {
   local open_cmd
-  if [[ $(uname -s) == 'Darwin' ]]; then
+  if [[ "$OSTYPE" = darwin* ]]; then
     open_cmd='open'
   else
     open_cmd='xdg-open'

--- a/plugins/node/node.plugin.zsh
+++ b/plugins/node/node.plugin.zsh
@@ -3,7 +3,7 @@
 function node-docs {
   # get the open command
   local open_cmd
-  if [[ $(uname -s) == 'Darwin' ]]; then
+  if [[ "$OSTYPE" = darwin* ]]; then
     open_cmd='open'
   else
     open_cmd='xdg-open'

--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -10,7 +10,7 @@ _rake_refresh () {
 _rake_does_task_list_need_generating () {
   if [ ! -f .rake_tasks ]; then return 0;
   else
-    if [[ $(uname -s) == 'Darwin' ]]; then
+    if [[ "$OSTYPE" = darwin* ]]; then
       accurate=$(stat -f%m .rake_tasks)
       changed=$(stat -f%m Rakefile)
     else

--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -17,7 +17,7 @@ if [[ $('uname') == 'Linux' ]]; then
         fi
     done
 
-elif  [[ $('uname') == 'Darwin' ]]; then
+elif  [[ "$OSTYPE" = darwin* ]]; then
     local _sublime_darwin_paths > /dev/null 2>&1
     _sublime_darwin_paths=(
         "/usr/local/bin/subl"

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -4,7 +4,7 @@ function web_search() {
 
   # get the open command
   local open_cmd
-  if [[ $(uname -s) == 'Darwin' ]]; then
+  if [[ "$OSTYPE" = darwin* ]]; then
     open_cmd='open'
   else
     open_cmd='xdg-open'


### PR DESCRIPTION
The $OSTYPE variable is set at ZSH compile time and can be safely used to
determine the OS of the system. e.g. darwin (os x)
