### PR TITLE
Plugin zsh_reload: make sure cache dir exists

### DIFF
--- a/cache/.easter-egg
+++ b/cache/.easter-egg
@@ -1,0 +1,4 @@
+This file is only here so that Git will keep a cache directory as .gitignore is ignoring all the files within it.
+
+Feel free to add love notes for people here.
+

--- a/plugins/zsh_reload/zsh_reload.plugin.zsh
+++ b/plugins/zsh_reload/zsh_reload.plugin.zsh
@@ -1,10 +1,11 @@
 # reload zshrc
 function src()
 {
+  local cache="$ZSH/cache"
   autoload -U compinit zrecompile
-  compinit -d "$ZSH/cache/zcomp-$HOST"
+  compinit -d "$cache/zcomp-$HOST"
 
-  for f in ~/.zshrc "$ZSH/cache/zcomp-$HOST"; do
+  for f in ~/.zshrc "$cache/zcomp-$HOST"; do
     zrecompile -p $f && command rm -f $f.zwc.old
   done
 


### PR DESCRIPTION
The [`zsh_reload`](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/zsh_reload) plugin uses the `$ZSH/cache` directory, which does not exist on a fresh OMZ install. Hence the `src` function will fail to recompile the compdump:

```
re-compiling /home/ncanceill/.oh-my-zsh/cache/zcomp-epsilon.zwc: zrecompile:zcompile:133: can't write zwc file: /home/ncanceill/.oh-my-zsh/cache/zcomp-epsilon.zwc
re-compiling /home/ncanceill/.oh-my-zsh/cache/zcomp-epsilon.zwc: failed
```

This PR adds a check for it.

@mcornella @eMxyzptlk any objections?
