### PR TITLE
Fixed ls alias issue for Mac OSX while maintaining support for Linux distros

### DIFF
--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -3,7 +3,11 @@
 #
 
 # ls, the common ones I use a lot shortened for rapid fire usage
-alias ls='ls -G' #I like color
+if [[ $(uname -s) == 'Darwin' ]]; then
+  alias ls='ls -G' # Mac OSX support
+else
+  alias ls='ls --color' #I like color
+fi
 alias l='ls -lFh'     #size,show type,human readable
 alias la='ls -lAFh'   #long list,show almost all,show type,human readable
 alias lr='ls -tRFh'   #sorted by date,recursive,show type,human readable


### PR DESCRIPTION
Hi Robby

Just noticed and fixed an ls alias issue which caused the ls command to return a syntax error on my Mac.

I have not tested it on Linux environments however I think most distros support the uname command.

Regards
Dion
