### PR TITLE
allow overriding lib/*.zsh in custom/lib

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -8,17 +8,19 @@ fi
 # add a function path
 fpath=($ZSH/functions $ZSH/completions $fpath)
 
-# Load all of the config files in ~/oh-my-zsh that end in .zsh
-# TIP: Add files you don't want in git to .gitignore
-for config_file ($ZSH/lib/*.zsh); do
-  source $config_file
-done
-
 # Set ZSH_CUSTOM to the path where your custom config files
 # and plugins exists, or else we will use the default custom/
 if [[ -z "$ZSH_CUSTOM" ]]; then
     ZSH_CUSTOM="$ZSH/custom"
 fi
+
+# Load all of the config files in ~/oh-my-zsh that end in .zsh
+# TIP: Add files you don't want in git to .gitignore
+for config_file ($ZSH/lib/*.zsh); do
+  custom_config_file="${ZSH_CUSTOM}/lib/${config_file:t}"
+  [ -f "${custom_config_file}" ] && config_file=${custom_config_file}
+  source $config_file
+done
 
 
 is_plugin() {


### PR DESCRIPTION
Allow explicitly overriding `lib/*.zsh` with files of the same name in `$ZSH_CUSTOM/lib/`

Rationale: all those aliases in directories.zsh!
