### PR TITLE
z plugin: allow usage while in sudo mode

### DIFF
--- a/plugins/z/Makefile
+++ b/plugins/z/Makefile
@@ -1,4 +1,2 @@
-readme:
-	@groff -man -Tascii z.1 | col -bx
-
-.PHONY: readme
+README: z.1
+	@groff -man -Tascii z.1 | col -bx > README

--- a/plugins/z/README
+++ b/plugins/z/README
@@ -118,9 +118,12 @@ ENVIRONMENT
        directories to exclude from tracking. $HOME is always excluded.  Direc-
        tories must be full paths without trailing slashes.
 
+       The  environment  variable  $_Z_OWNER  can  be set if you want to use z
+       while `sudo -s' and $HOME variable was kept.
+
 FILES
-       Data  is  stored  in  $HOME/.z.  This  can be overridden by setting the
-       $_Z_DATA environment variable. When initialized, z will raise an  error
+       Data is stored in $HOME/.z. This  can  be  overridden  by  setting  the
+       $_Z_DATA  environment variable. When initialized, z will raise an error
        if this path is a directory, and not function correctly.
 
        A man page (z.1) is provided.

--- a/plugins/z/z.1
+++ b/plugins/z/z.1
@@ -141,6 +141,9 @@ handle \fBPROMPT_COMMAND\fR or \fBprecmd\fR yourself.
 The environment variable \fB$_Z_EXCLUDE_DIRS\fR can be set to an array of
 directories to exclude from tracking. \fB$HOME\fR is always excluded.
 Directories must be full paths without trailing slashes.
+.P
+The environment variable \fB$_Z_OWNER\fR can be set if you want to use z
+while `sudo -s' and \fB$HOME\fR variable was kept.
 .SH
 FILES
 Data is stored in \fB$HOME/.z\fR. This can be overridden by setting the

--- a/plugins/z/z.sh
+++ b/plugins/z/z.sh
@@ -13,6 +13,7 @@
 #     set $_Z_NO_RESOLVE_SYMLINKS to prevent symlink resolution.
 #     set $_Z_NO_PROMPT_COMMAND if you're handling PROMPT_COMMAND yourself.
 #     set $_Z_EXCLUDE_DIRS to an array of directories to exclude.
+#     set $_Z_OWNER to your username if you want use z while sudo with $HOME kept
 #
 # USE:
 #   * z foo     # cd to most frecent dir matching foo
@@ -36,7 +37,7 @@ _z() {
  local datafile="${_Z_DATA:-$HOME/.z}"
 
  # bail out if we don't own ~/.z (we're another user but our ENV is still set)
- [ -f "$datafile" -a ! -O "$datafile" ] && return
+ [ -z "$_Z_OWNER" -a -f "$datafile" -a ! -O "$datafile" ] && return
 
  # add entries
  if [ "$1" = "--add" ]; then
@@ -54,6 +55,7 @@ _z() {
   # maintain the file
   local tempfile
   tempfile="$(mktemp "$datafile.XXXXXX")" || return
+  [ -n "$_Z_OWNER" ] && chown $_Z_OWNER:$(id -ng $_Z_OWNER) $tempfile
   while read line; do
    [ -d "${line%%\|*}" ] && echo $line
   done < "$datafile" | awk -v path="$*" -v now="$(date +%s)" -F"|" '


### PR DESCRIPTION
$HOME directory is kept in my sudo environment and I'm able to use all my usual commands, scripts and settings after sudo -s. Z plugin makes some checks and terminates if user is not owner of _Z_DATA file.
This pull request adds _Z_OWNER variable. When it set to your main username (_Z_OWNER=dan for example) it's possible to use the power of Z while rooted.
