### PR TITLE
Added budspencer theme.

### DIFF
--- a/themes/budspencer.zsh-theme
+++ b/themes/budspencer.zsh-theme
@@ -78,7 +78,7 @@ prompt_git() {
     if [[ -n $dirty ]]; then
       prompt_segment 160 0
     else
-      prompt_segment 64 254
+      prompt_segment 64 0
     fi
 
     if [[ -e "${repo_path}/BISECT_LOG" ]]; then
@@ -110,7 +110,7 @@ prompt_hg() {
     if $(hg prompt >/dev/null 2>&1); then
       if [[ $(hg prompt "{status|unknown}") = "?" ]]; then
         # if files are not added
-        prompt_segment 160 230
+        prompt_segment 160 0
         st='±'
       elif [[ -n $(hg prompt "{status|modified}") ]]; then
         # if any modification


### PR DESCRIPTION
This theme is for people working in vi mode and want to see, at a glance,
whether they are in INSERT or NORMAL mode. In addition, budspencer theme
provides a noticeable prompt in order to find commands quickly when
scrolling back within the terminal.

Feel free to merge it.

![scrot-2014-05-12-121025](https://cloud.githubusercontent.com/assets/2333069/2943079/f7692fa2-d9bd-11e3-890b-1936e8dba1f5.png)
