### PR TITLE
Support dynamically defined Vagrant machines

### DIFF
--- a/plugins/vagrant/_vagrant
+++ b/plugins/vagrant/_vagrant
@@ -57,6 +57,7 @@ __box_list ()
 __vm_list ()
 {
     _wanted application expl 'command' compadd $(command grep Vagrantfile -oe '^[^#]*\.vm\.define *[:"]\([a-zA-Z0-9_-]\+\)' 2>/dev/null | awk '{print substr($2, 2)}')
+    _wanted application expl 'command' compadd $(command ls .vagrant/machines/ 2>/dev/null)
 }
 
 __vagrant-box ()


### PR DESCRIPTION
When defining multiple Vagrant machines in Ruby, the machine names need to be collected in a different way than before:

```
  config.vm.define opts[:name] do |node|
    # do something
  end
```

As it would not be efficient to parse the Vagrantfile just to find out these names, we're looking up for created machines in the .vagrant/machines/ folder.

See also #2810.
