### PR TITLE
Plugin jump: autocompletion for numbers and dots

### DIFF
--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -39,7 +39,7 @@ marks() {
 
 _completemarks() {
 	if [[ $(ls "${MARKPATH}" | wc -l) -gt 1 ]]; then
-		reply=($(ls $MARKPATH/**/*(-) | grep : | sed -E 's/(.*)\/([_\da-zA-Z\-]*):$/\2/g'))
+		reply=($(ls $MARKPATH/**/*(-) | grep : | sed -E 's/(.*)\/([_a-zA-Z0-9\.\-]*):$/\2/g'))
 	else
 		if readlink -e "${MARKPATH}"/* &>/dev/null; then
 			reply=($(ls "${MARKPATH}"))


### PR DESCRIPTION
This change fixes the autocompletion for marks which contain numbers or dots.

Fixes #2578
