### PR TITLE
removed a hardcoded 'origin' in git.zsh and added new function for number of commits ahead of remote

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -62,7 +62,8 @@ function git_prompt_ahead() {
 # Gets the number of commits ahead from remote
 function git_commits_ahead() {
   if $(echo "$(command git log @{upstream}..HEAD 2> /dev/null)" | grep '^commit' &> /dev/null); then
-    echo "$(command git log @{upstream}..HEAD | grep '^commit' | wc -l | tr -d ' ')"
+    COMMITS=$(command git log @{upstream}..HEAD | grep '^commit' | wc -l | tr -d ' ')
+    echo "$ZSH_THEME_GIT_COMMITS_AHEAD_PREFIX$COMMITS$ZSH_THEME_GIT_COMMITS_AHEAD_SUFFIX"
   fi
 }
 


### PR DESCRIPTION
There was a hardcoded 'origin' to get the remote branch, but this won't work for all setups. Therefor added @{upstream} which will automatically get the upstream branch. Works since git 1.7.0.
Additionally added a function which returns the exact number of commits ahead of the upstream branch.
