### PR TITLE
List files with directories on top

### DIFF
--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -9,6 +9,7 @@ alias la='ls -lAFh'   #long list,show almost all,show type,human readable
 alias lr='ls -tRFh'   #sorted by date,recursive,show type,human readable
 alias lt='ls -ltFh'   #long list,sorted by date,show type,human readable
 alias ll='ls -l'      #long list
+alias lld='ls -l --group-directories-first'      #long list with directories first
 alias ldot='ls -ld .*'
 alias lS='ls -1FSsh'
 alias lart='ls -1Fcart'


### PR DESCRIPTION
Sometimes it really useful to have directories listed on top of every other files.

`lld` just does that with `alias lld='ls -l --group-directories-first'`

Hope it helps! :)
