### PR TITLE
[Composer] Add Composer's global binaries to PATH

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -46,3 +46,6 @@ alias cdu='composer dump-autoload'
 
 # install composer in the current directory
 alias cget='curl -s https://getcomposer.org/installer | php'
+
+# Add Composer's global binaries to PATH
+export PATH=$PATH:~/.composer/vendor/bin


### PR DESCRIPTION
Composer can install global vendor packages and binaries:

```
composer global require phpunit/phpunit:~4.4.1
```

This installs [PHPUnit](http://phpunit.de) to `~/.composer/vendor/bin/phpunit`.

Taking that into consideration, we should add Composer's global binaries to the `PATH` so that one can then run this now globally installed phpunit.
