### PR TITLE
Removes the support for screen TERMs in termsupport.zsh

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -6,9 +6,7 @@ function title {
   if [[ "$DISABLE_AUTO_TITLE" == "true" ]] || [[ "$EMACS" == *term* ]]; then
     return
   fi
-  if [[ "$TERM" == screen* ]]; then
-    print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
-  elif [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ $TERM == ansi ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+  if [[ "$TERM" == xterm* ]] || [[ $TERM == rxvt* ]] || [[ $TERM == ansi ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
     print -Pn "\e]2;$2:q\a" #set window name
     print -Pn "\e]1;$1:q\a" #set icon (=tab) name (will override window name on broken terminal)
   fi


### PR DESCRIPTION
Without this fix, it is not possible to have fixed window titles in
screen, zsh always makes automatic titles.

This fixes #2015 and #1491

Users should now use the screen plugin to get an automatic windowtitle.
