### PR TITLE
Added psync(port sync), updated puni, puo

### DIFF
--- a/plugins/macports/macports.plugin.zsh
+++ b/plugins/macports/macports.plugin.zsh
@@ -1,8 +1,9 @@
 #Aliases
 alias pc="sudo port clean --all installed"
 alias pi="sudo port install $1"
+alias psync="sudo port sync"
 alias psu="sudo port selfupdate"
-alias puni="sudo port uninstall inactive"
-alias puo="sudo port upgrade outdated"
+alias puni="sudo port -u uninstall inactive"
+alias puo="sudo port -u upgrade outdated"
 alias pup="psu && puo"
 


### PR DESCRIPTION
Added psync(port sync) to performs a sync operation only on the ports tree of a MacPorts installation, pulling in the latest revision available of the Portfiles from the MacPorts rsync server.
Added -u option to puni,puo so that it uninstall non-active ports when upgrading and uninstalling.
