### PR TITLE
vi-mode: Allow an insert mode indicator to be set.

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -26,13 +26,19 @@ bindkey -v
 autoload -Uz edit-command-line
 bindkey -M vicmd 'v' edit-command-line
 
-# if mode indicator wasn't setup by theme, define default
+# if command mode indicator wasn't setup by theme, define default
 if [[ "$MODE_INDICATOR" == "" ]]; then
   MODE_INDICATOR="%{$fg_bold[red]%}<%{$fg[red]%}<<%{$reset_color%}"
 fi
 
+# if insert mode indicator wasn't setup by theme, define an empty default
+# to preserve existing behaviour
+if [[ "$INS_MODE_INDICATOR" == "" ]]; then
+  INS_MODE_INDICATOR=""
+fi
+
 function vi_mode_prompt_info() {
-  echo "${${KEYMAP/vicmd/$MODE_INDICATOR}/(main|viins)/}"
+  echo "${${KEYMAP/vicmd/$MODE_INDICATOR}/(main|viins)/$INS_MODE_INDICATOR}"
 }
 
 # define right prompt, if it wasn't defined by a theme


### PR DESCRIPTION
Set INS_MODE_INDICATOR to set what will be shown in the prompt during
insert mode.
