### PR TITLE
Add /usr/bin/subl path for who has linked sublime text there

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -7,6 +7,7 @@ if [[ $('uname') == 'Linux' ]]; then
         "/opt/sublime_text/sublime_text"
         "/usr/bin/sublime_text"
         "/usr/local/bin/sublime_text"
+        "/usr/bin/subl"
     )
     for _sublime_path in $_sublime_linux_paths; do
         if [[ -a $_sublime_path ]]; then


### PR DESCRIPTION
As I comment in my issue, some users use to link sublime text to /usr/bin instead of usr/local/bin.
This is just a little fix for me. Hope to contribute with this.
