### PR TITLE
git_prompt_info: Ignore errors produced by `git config`

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -1,6 +1,6 @@
 # get the name of the branch we are on
 function git_prompt_info() {
-  if [[ "$(git config --get oh-my-zsh.hide-status)" != "1" ]]; then
+  if [[ "$(git config --get oh-my-zsh.hide-status 2>/dev/null)" != "1" ]]; then
     ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
     echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"


### PR DESCRIPTION
The function `git_prompt_info` calls `git config` for its stdout output,
but doesn't handle the stderr output.  This can lead to problems,
e.g. if the git config file is unreadable for some reason (permissions
etc).

This fixes the issue by simply ignoring the stderr output.
