### PR TITLE
Add tilingaware plugin

### DIFF
--- a/plugins/tilingaware/tilingaware.plugin.zsh
+++ b/plugins/tilingaware/tilingaware.plugin.zsh
@@ -1,0 +1,10 @@
+DIRSTACKSIZE=9
+DIRSTACKFILE=~/.zdirs
+if [[ -f $DIRSTACKFILE ]] && [[ $#dirstack -eq 0 ]]; then
+	dirstack=( ${(f)"$(< $DIRSTACKFILE)"} )
+	[[ -d $dirstack[1] ]] && cd $dirstack[1]
+fi
+
+function chpwd() {
+	print -l $PWD ${(u)dirstack}> $DIRSTACKFILE
+}


### PR DESCRIPTION
This plugin will allow the pwd to be consistent over different zsh sessions.
All new sessions will start in the last opened directory.

There is a function chpwd that will save the current directory as the working directory for all new sessions.
