### PR TITLE
Stash before pull when upgrading

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,5 +1,6 @@
 printf '\033[0;34m%s\033[0m\n' "Upgrading Oh My Zsh"
 cd "$ZSH"
+git stash
 if git pull --rebase --stat origin master
 then
   printf '\033[0;32m%s\033[0m\n' '         __                                     __   '
@@ -13,4 +14,4 @@ then
 else
   printf '\033[0;31m%s\033[0m\n' 'There was an error updating. Try again later?'
 fi
-
+git stash apply


### PR DESCRIPTION
Avoid this annoying message when upgrading :
« Type Y to update oh-my-zsh: Y
Upgrading Oh My Zsh
Cannot pull with rebase: You have unstaged changes.
Please commit or stash them.
There was an error updating. Try again later? »
