### PR TITLE
Spring plugin

### DIFF
--- a/plugins/spring/spring.plugin.zsh
+++ b/plugins/spring/spring.plugin.zsh
@@ -1,0 +1,31 @@
+spring_commands=(rails rake rspec)
+
+_spring_installed() {
+  which spring > /dev/null 2>&1
+}
+
+_within_springified_rails_project() {
+  local check_dir=$PWD
+  while [ $check_dir != "/" ]; do
+    [ -f "$check_dir/bin/spring" ] && return
+    check_dir="$(dirname $check_dir)"
+  done
+  false
+}
+
+_run_with_spring() {
+  if _spring_installed && _within_springified_rails_project; then
+    spring $@
+  else
+    $@
+  fi
+}
+
+for cmd in $spring_commands; do
+  eval "function springified_$cmd () { _run_with_spring $cmd \$@}"
+  alias $cmd=springified_$cmd
+
+  if which _$cmd > /dev/null 2>&1; then
+    compdef _$cmd springified_$cmd=$cmd
+  fi
+done


### PR DESCRIPTION
Ruby on Rails now ships with [spring](https://github.com/rails/spring) which makes common commands run much faster by preloading the environment.

This plugin automatically prepends `rails`, `rake` and `rspec` commands with `spring` when possible, just like the [bundler plugin](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/bundler/bundler.plugin.zsh) does.
