### PR TITLE
terminal party show exit status with color

### DIFF
--- a/themes/terminalparty.zsh-theme
+++ b/themes/terminalparty.zsh-theme
@@ -1,4 +1,4 @@
-PROMPT='%{$fg[green]%} %% '
+PROMPT='%(?,%{$fg[green]%},%{$fg[red]%}) %% '
 # RPS1='%{$fg[blue]%}%~%{$reset_color%} '
 RPS1='%{$fg[white]%}%2~$(git_prompt_info) %{$fg_bold[blue]%}%m%{$reset_color%}'
 
@@ -6,4 +6,3 @@ ZSH_THEME_GIT_PROMPT_PREFIX=" %{$fg[yellow]%}("
 ZSH_THEME_GIT_PROMPT_SUFFIX=")%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[red]%} ⚡%{$fg[yellow]%}"
-


### PR DESCRIPTION
Rather than the `%` prompt always being green, make it red if the last command exited badly.
