### PR TITLE
Update pass completion and fix syntax and autoloading

### DIFF
--- a/plugins/pass/_pass
+++ b/plugins/pass/_pass
@@ -118,7 +118,7 @@ _pass_cmd_show () {
 _pass_complete_entries_helper () {
 	local IFS=$'\n'
 	local prefix="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
-	_values -C 'passwords' $(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' | sort)
+	_values -C 'passwords' ${$(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print 2>/dev/null | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' | sort):-""}
 }
 
 _pass_complete_entries_with_subdirs () {
@@ -134,3 +134,5 @@ _pass_complete_keys () {
 	# Extract names and email addresses from gpg --list-keys
 	_values 'gpg keys' $(gpg2 --list-secret-keys --with-colons | cut -d : -f 10 | sort -u | sed '/^$/d')
 }
+
+_pass


### PR DESCRIPTION
**STATUS:** TESTED, WAITING FOR INPUT.

Fixes #2846, closes #1480.
/cc @sanbor @christianschmidt

---

This pull request fixes the copyright notice (by @sanbor) and updates the zsh pass completion to the current one on the upstream project. 

It also fixes the errors that appear in #2846 and the first TAB completion. 
Refer to https://github.com/mcornella/oh-my-zsh/commit/4bf87c2282f577ac69b50cf7638608d3cc59889b for more information.
