### PR TITLE
Fix typo in docker plugin

### DIFF
--- a/plugins/docker/_docker
+++ b/plugins/docker/_docker
@@ -214,7 +214,7 @@ __save() {
 __start() {
     _arguments \
         '(-a,--attach=)'{-a,--attach=}'[Attach container''s stdout/stderr and forward all signals to the process]' \
-        '(-i,--interactive=)'{-i, --interactive=}'[Attach container''s stdin]'
+        '(-i,--interactive=)'{-i,--interactive=}'[Attach container''s stdin]'
     __docker_containers
 }
 


### PR DESCRIPTION
The extra space caused an error when auto completing.
