### PR TITLE
Add support for jira-prefix configuration file

### DIFF
--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -29,15 +29,23 @@ open_jira_issue () {
     return 0
   fi
 
+  if [ -f .jira-prefix ]; then
+    jira_prefix=$(cat .jira-prefix)
+  elif [ -f ~/.jira-prefix ]; then
+    jira_prefix=$(cat ~/.jira-prefix)
+  else
+    jira_prefix=""
+  fi
+
   if [ -z "$1" ]; then
     echo "Opening new issue"
     $open_cmd "$jira_url/secure/CreateIssue!default.jspa"
   else
     echo "Opening issue #$1"
     if [[ "x$JIRA_RAPID_BOARD" = "xtrue" ]]; then
-      $open_cmd  "$jira_url/issues/$1"
+      $open_cmd  "$jira_url/issues/$jira_prefix$1"
     else
-      $open_cmd  "$jira_url/browse/$1"
+      $open_cmd  "$jira_url/browse/$jira_prefix$1"
     fi
   fi
 }


### PR DESCRIPTION
This adds the option of an extra configuration file for specifying a prefix for JIRA issues. Matching the pattern of the existing plugin, this configuration file can be system-wide or project specific.

This would allow you to just type the numeric ID of an issue rather than including the project prefix. E.g. "jira 123" rather than "jira CHROME-123".

Note that this will conflict with PR2898 if that was merged first, but resolving on either side would be trivial.
