### PR TITLE
[NOT SAFE TO MERGE] Add warning if npm is not in $PATH

### DIFF
--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -1,1 +1,4 @@
-eval "$(npm completion 2>/dev/null)"
+# If NPM is not found don't silently fail.
+(( $+commands[npm] )) && eval "$(npm completion 2>/dev/null)" || {
+  echo "oh-my-zsh (npm plugin): npm not found. Make sure you have it in your \$PATH"
+}


### PR DESCRIPTION
## NEEDS TESTING

When `npm` is not found in the PATH, the `eval` statement in the npm plugin silently fails, leaving the user puzzled because npm completion doesn't work even though the npm command works fine.

This also goes hand in hand with the fact that the default zshrc has an `export PATH` statement _after_ having sourced oh-my-zsh.

With this pull request, the plugin will fail to init with an explicit error, so the user knows he has to add `npm` to the PATH.

Related: #2458 #2791 
