### PR TITLE
Fix for recusion limit hit for _rake_command alias

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -6,7 +6,7 @@ function _rails_command () {
   elif [ -e "script/server" ]; then
     ruby script/$@
   else
-    rails $@
+    command rails $@
   fi
 }
 
@@ -14,7 +14,7 @@ function _rake_command () {
   if [ -e "bin/rake" ]; then
     bin/rake $@
   else
-    rake $@
+    command rake $@
   fi
 }
 


### PR DESCRIPTION
Inserted ZSH precommand modifier for the _rails_command and _rake_command functions. 

Otherwise, a recursion limit will be hit when rake or rails are called after a user sources the .zshrc file for instance.

Fixes #2550 
