### PR TITLE
Random theme functionality encapsulated in a theme.

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -70,21 +70,12 @@ done
 unset config_file
 
 # Load the theme
-if [ "$ZSH_THEME" = "random" ]; then
-  themes=($ZSH/themes/*zsh-theme)
-  N=${#themes[@]}
-  ((N=(RANDOM%N)+1))
-  RANDOM_THEME=${themes[$N]}
-  source "$RANDOM_THEME"
-  echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
-else
-  if [ ! "$ZSH_THEME" = ""  ]; then
-    if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then
-      source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
-    elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
-      source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
-    else
-      source "$ZSH/themes/$ZSH_THEME.zsh-theme"
-    fi
+if [ ! "$ZSH_THEME" = ""  ]; then
+  if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then
+    source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
+  elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
+    source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
+  else
+    source "$ZSH/themes/$ZSH_THEME.zsh-theme"
   fi
 fi

--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -1,19 +1,14 @@
 function theme
 {
-    if [ -z "$1" ] || [ "$1" = "random" ]; then
-	themes=($ZSH/themes/*zsh-theme)
-	N=${#themes[@]}
-	((N=(RANDOM%N)+1))
-	RANDOM_THEME=${themes[$N]}
-	source "$RANDOM_THEME"
-	echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+    if [ -z "$1" ]; then
+        1="random"
+    fi
+
+    if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]
+    then
+        source "$ZSH_CUSTOM/$1.zsh-theme"
     else
-	if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]
-	then
-	    source "$ZSH_CUSTOM/$1.zsh-theme"
-	else
-	    source "$ZSH/themes/$1.zsh-theme"
-	fi
+        source "$ZSH/themes/$1.zsh-theme"
     fi
 }
 

--- a/themes/random.zsh-theme
+++ b/themes/random.zsh-theme
@@ -1,0 +1,6 @@
+themes=($ZSH/themes/*zsh-theme)
+N=${#themes[@]}
+((N=(RANDOM%N)+1))
+RANDOM_THEME=${themes[$N]}
+source "$RANDOM_THEME"
+echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."


### PR DESCRIPTION
Hello!
The statements for selecting a random theme in oh-my-zsh.sh and the themes plugin are duplicate. Most people eventually settle on a theme, making those lines in oh-my-zsh.sh superfluous. To address those points, it may make sense to put the random theme functionality into a theme of its own (since themes are just zsh-script).  I understand this could conflict with other PRs like #2902, I'm happy to edit this PR as needed if other changes happen first.  Thoughts?
