### PR TITLE
Add a CONTRIBUTING file to instruct people on issues and pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,4 +23,20 @@ See point 1, then go ahead (unless your solution is yet another theme)
 
 ## YOU HAVE FREE TIME TO VOLUNTEER
 
-Cool!
+Cool! Please have a look at the list below to understand how oh-my-zsh categorizes its issues.
+
+Classification of issues and
+
+- Bugs, which may be:
+  - Specific of zsh \*
+  - Regressions, in which we should summon the author of the offending commit once it is located
+
+- Feature requests
+
+- Helpdesk, which may be:
+  - Specific of zsh \*
+  - Everything else
+
+\* In the case of bugs, I see the benefit in going through the trouble of responding to that. After all, oh-my-zsh should be the missing link that makes zsh perfect, and hunting down an upstream bug can lead to a submitted PR.
+In the case of helpdesk, minimal response should be done. That is, provide a link to the wiki with the relevant information, or
+add it to the FAQ of the wiki and point to it afterwards.


### PR DESCRIPTION
### UPDATE

I [converted this issue into a pull request](http://opensoul.org/2012/11/09/convert-a-github-issue-into-a-pull-request/) to start working on the new CONTRIBUTING file. 
I'll keep track of the suggestions you guys make and work on them as I can, using a GFM checklist. This is all there is now:
#### TO DO
- [x] Fill out sections.

---

I just came across that if you have a CONTRIBUTING._something_ file on your project, GitHub will display a notice above the input box. 

![contributing](https://cloud.githubusercontent.com/assets/1441704/2830898/82bc78e4-cfb3-11e3-8d09-69c43d71f9ae.png)

Having one will make some issues to never be submited (like PRs of new themes) and other issues to be more descriptive, therefore driving down the issues number and the time they remain open.

For now I propose having a brief description of what to do (e.g. search before posting) and what not to do (e.g. submit new themes, or duplicate pull requests), and a link to a section in the wiki that can be better modified because it doesn't need to be modified and then merged.
