### PR TITLE
Make Jira plugin work under cygwin.

### DIFF
--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -14,6 +14,8 @@ open_jira_issue () {
   local open_cmd
   if [[ $(uname -s) == 'Darwin' ]]; then
     open_cmd='open'
+  elif [[ $(uname -o) == 'Cygwin' ]]; then
+    open_cmd='cygstart'
   else
     open_cmd='xdg-open'
   fi


### PR DESCRIPTION
- Cygwin does not have the xdg-open command, this change uses cygstart which is capable of opening urls.
