### PR TITLE
Fix osx function: "not valid in this context"

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -139,7 +139,7 @@ function man-preview() {
 
 function trash() {
   local trash_dir="${HOME}/.Trash"
-  local temp_ifs=$IFS
+  local temp_ifs="$IFS"
   IFS=$'\n'
   for item in "$@"; do
     if [[ -e "$item" ]]; then


### PR DESCRIPTION
I have been continually having problems with the "trash" function provided by the osx plugin, getting this error:

```
trash:local:2: not valid in this context:
```

It seems like adding quotes around the assignment in [osx.plugin.zsh#L142](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/osx/osx.plugin.zsh#L142) fixed my problem.

Does this look good to you? Thanks!
