### PR TITLE
Removing mentions of $PATH, using zsh $path instead

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -48,4 +48,4 @@ alias cdu='composer dump-autoload'
 alias cget='curl -s https://getcomposer.org/installer | php'
 
 # Add Composer's global binaries to PATH
-export PATH=$PATH:~/.composer/vendor/bin
+path+=(~/.composer/vendor/bin)

--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -16,7 +16,7 @@ for pyenvdir in "${pyenvdirs[@]}" ; do
     if [ -d $pyenvdir/bin -a $FOUND_PYENV -eq 0 ] ; then
         FOUND_PYENV=1
         export PYENV_ROOT=$pyenvdir
-        export PATH=${pyenvdir}/bin:$PATH
+        path=(${pyenvdir}/bin $path)
         eval "$(pyenv init --no-rehash - zsh)"
 
         function pyenv_prompt_info() {

--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -19,7 +19,7 @@ for rbenvdir in "${rbenvdirs[@]}" ; do
       RBENV_ROOT=$rbenvdir
     fi
     export RBENV_ROOT
-    export PATH=${rbenvdir}/bin:$PATH
+    path=(${rbenvdir}/bin $path)
     eval "$(rbenv init --no-rehash - zsh)"
 
     alias rubies="rbenv versions"

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -51,7 +51,7 @@ source $ZSH/oh-my-zsh.sh
 
 # User configuration
 
-export PATH=$HOME/bin:/usr/local/bin:$PATH
+path=($HOME/bin /usr/local/bin $path)
 # export MANPATH="/usr/local/man:$MANPATH"
 
 # You may need to manually set your language environment


### PR DESCRIPTION
In ZSH, there is an array variable called `$path` that mirrors the bash `$PATH`, and zsh automatically exports the `$path` to `$PATH` when initializing the environment. Several plugins `export $PATH` directly instead of adding to the `$path` variable, which makes things like `typeset -U path` to remove duplicates from the `$PATH` impossible. This patch moves all mentions of `$PATH` to `$path`.
