### PR TITLE
Add gap (git add --patch)

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -70,6 +70,7 @@ alias gss='git status -s'
 compdef _git gss=git-status
 alias ga='git add'
 compdef _git ga=git-add
+alias gap='git add --patch'
 alias gm='git merge'
 compdef _git gm=git-merge
 alias grh='git reset HEAD'


### PR DESCRIPTION
Just started using oh-my-zsh. `gap` or `git add --patch` is a shortcut I picked up long ago from someone else. This workflow encourages review of what your committing.
