### PR TITLE
Update half-life.zsh-theme

### DIFF
--- a/themes/half-life.zsh-theme
+++ b/themes/half-life.zsh-theme
@@ -51,8 +51,8 @@ zstyle ':vcs_info:*:prompt:*' check-for-changes true
 PR_RST="%{${reset_color}%}"
 FMT_BRANCH=" on %{$turquoise%}%b%u%c${PR_RST}"
 FMT_ACTION=" performing a %{$limegreen%}%a${PR_RST}"
-FMT_UNSTAGED="%{$orange%}●"
-FMT_STAGED="%{$limegreen%}●"
+FMT_UNSTAGED="%{$orange%} ●"
+FMT_STAGED="%{$limegreen%} ●"
 
 zstyle ':vcs_info:*:prompt:*' unstagedstr   "${FMT_UNSTAGED}"
 zstyle ':vcs_info:*:prompt:*' stagedstr     "${FMT_STAGED}"
@@ -83,7 +83,7 @@ function steeef_precmd {
         # check for untracked files or updated submodules, since vcs_info doesn't
         if [[ ! -z $(git ls-files --other --exclude-standard 2> /dev/null) ]]; then
             PR_GIT_UPDATE=1
-            FMT_BRANCH="${PM_RST} on %{$turquoise%}%b%u%c%{$hotpink%}●${PR_RST}"
+            FMT_BRANCH="${PM_RST} on %{$turquoise%}%b%u%c%{$hotpink%} ●${PR_RST}"
         else
             FMT_BRANCH="${PM_RST} on %{$turquoise%}%b%u%c${PR_RST}"
         fi
@@ -95,5 +95,4 @@ function steeef_precmd {
 }
 add-zsh-hook precmd steeef_precmd
 
-PROMPT=$'
-%{$purple%}%n%{$reset_color%} in %{$limegreen%}%~%{$reset_color%}$(rvm-prompt " with%{$fg[red]%} " v g "%{$reset_color%}")$vcs_info_msg_0_%{$orange%} λ%{$reset_color%} '
+PROMPT=$'%{$purple%}%n%{$reset_color%} in %{$limegreen%}%~%{$reset_color%}$(rvm-prompt " with%{$fg[red]%} " v g "%{$reset_color%}")$vcs_info_msg_0_%{$orange%} λ%{$reset_color%} '


### PR DESCRIPTION
Add spaces before bullet-points to more easily distinguish them from one another and the rest of the prompt when using smaller font-sizes and do not add a blank line prior to prompt output; if there's a desire for spacing, one can use their terminal's line-height to achieve this.
