### PR TITLE
Add support for local aur databases

### DIFF
--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -21,7 +21,7 @@ if [[ -x `which yaourt` ]]; then
   alias yalst='yaourt -Qe'         # List installed packages, even those installed from AUR (they're tagged as "local")
   alias yaorph='yaourt -Qtd'       # Remove orphans using yaourt
   # Additional yaourt alias examples
-  if [[ -x `which abs` && -x `which aur` '']]; then
+  if [[ -x `which abs` && -x `which aur` ]]; then
     alias yaupd='yaourt -Sy && sudo abs && sudo aur'  # Update and refresh the local package, ABS and AUR databases against repositories
   elif [[ -x `which abs` ]]; then
     alias yaupd='yaourt -Sy && sudo abs'   # Update and refresh the local package and ABS databases against repositories


### PR DESCRIPTION
With these simple changes the plugin checks for the local AUR database and updates the aliases so it can update it when you issue a `pacupd` or `yaupd`.
