### PR TITLE
rounding to emoji clock

### DIFF
--- a/plugins/emoji-clock/emoji-clock.plugin.zsh
+++ b/plugins/emoji-clock/emoji-clock.plugin.zsh
@@ -8,8 +8,8 @@
 # -----------------------------------------------------------------------------
 
 function emoji-clock() {
-  hour=$(date '+%I')
-  minutes=$(date '+%M')
+  hour=$(date -v '+15M' '+%I')
+  minutes=$(date -v '+15M' '+%M')
   case $hour in
     01) clock="🕐"; [ $minutes -ge 30 ] && clock="🕜";;
     02) clock="🕑"; [ $minutes -ge 30 ] && clock="🕝";;


### PR DESCRIPTION
Let `emoji-clock` round to the nearest half-hour.
As it is more sensible to show 7:28 with :clock730: instead of :clock7:
