### PR TITLE
Inclusion of aliases for sign git commits and tags

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -77,6 +77,18 @@ alias grhh='git reset HEAD --hard'
 alias gclean='git reset --hard && git clean -dfx'
 alias gwc='git whatchanged -p --abbrev-commit --pretty=medium'
 
+# Sign and verify commits with GPG
+alias gcs='git commit -S'
+compdef _git gcs=git-commit
+alias gsps='git show --pretty=short --show-signature'
+compdef _git gsps=git-show
+
+# Sign and verify tags with GPG
+alias gts='git tag -s'
+compdef _git gts=git-tag
+alias gvt='git verify-tag'
+compdef _git gvt=git verify-tag
+
 #remove the gf alias
 #alias gf='git ls-files | grep'
 


### PR DESCRIPTION
To test this PR with GPG installed and configured:
1. Change any file and stage it
2. _gcs -m "sign my commit"_

Expected output

```
You need a passphrase to unlock the secret key for
user: "Bruno Oliveira da Silva <bruno@abstractj.org>"
2048-bit RSA key, ID 84DC9914, created 2012-04-18

[myproject 672ba9c] sign
 1 file changed, 1 insertion(+), 1 deletion(-)
```
1. _git log_ and get the commit id
2. _gsps 672ba9cfa1566d1380f47b36acade5c04fcd249c_

Expected output:

```
commit 672ba9cfa1566d1380f47b36acade5c04fcd249c
gpg: Signature made Sat Aug  9 12:32:12 2014 BRT using RSA key ID 84DC9914
gpg: Good signature from "Bruno Oliveira da Silva <bruno@abstractj.org>"

    sign my commit

diff --git a/README.md b/README.md
index 9e760d7..4b14553 100644
--- a/README.md
+++ b/README.md
@@ -1 +1 @@
```
1.  _gts -m "Sign my tag" 0.2.1_

Expected output

```
You need a passphrase to unlock the secret key for
user: "Bruno Oliveira da Silva <bruno@abstractj.org>"
2048-bit RSA key, ID 84DC9914, created 2012-04-18
```
1. _gvt 0.2.1_

Expected output

```
gpg: Signature made Sat Aug  9 12:33:06 2014 BRT using RSA key ID 84DC9914
gpg: Good signature from "Bruno Oliveira da Silva <bruno@abstractj.org>"
```
