### PR TITLE
New alias for git plugin: gbr == git branch --remote

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -51,6 +51,7 @@ alias gb='git branch'
 compdef _git gb=git-branch
 alias gba='git branch -a'
 compdef _git gba=git-branch
+alias gbr='git branch --remote'
 alias gcount='git shortlog -sn'
 compdef gcount=git
 alias gcl='git config --list'


### PR DESCRIPTION
New alias for git plugin "gbr"  for "git branch --remote" to list remote branches.
- gb lists local branches
- gba lists both local and remote branches
- gbr lists remote branches [this PR]
