### PR TITLE
feat(plugins): add `term_tab` plugin to complete other zsh sessions' directories

### DIFF
--- a/plugins/term_tab/README
+++ b/plugins/term_tab/README
@@ -7,7 +7,7 @@ What it does:
 This plugin allows to complete the 'cwd' of other Zsh sessions. Sounds
 complicated but is rather simple. E.g. if you have three zsh sessions open, in
 each session you are in a different folder, you can hit Ctrl+v in one session
-to show you the pathes the other zsh sessions are in.
+to show you the current working directory of the other open zsh sessions.
 
 How it works:
 *************

--- a/plugins/term_tab/README
+++ b/plugins/term_tab/README
@@ -1,0 +1,16 @@
+
+term_tab - 'cwd' for all open zsh sessions
+******************************************
+
+What it does:
+*************
+This plugin allows to complete the 'cwd' of other Zsh sessions. Sounds
+complicated but is rather simple. E.g. if you have three zsh sessions open, in
+each session you are in a different folder, you can hit Ctrl+v in one session
+to show you the pathes the other zsh sessions are in.
+
+How it works:
+*************
+* It uses 'pidof zsh' to determine all zsh PIDs
+* It reads procfs to get the current working directory of this session
+* Everything is fed into zsh's completion magic

--- a/plugins/term_tab/term_tab.plugin.zsh
+++ b/plugins/term_tab/term_tab.plugin.zsh
@@ -18,13 +18,12 @@ function _term_list(){
   local -a w
 
   for SESSION in $(pidof  zsh); do
-    PA=$(readlink -n /proc/${SESSION}/cwd)
-    w+=(${(D)PA})
+    w+=${(D)$(readlink -n /proc/${SESSION}/cwd)}
   done
 
   compadd -aQ w
 }
 
-zle -C term_list complete-word _generic
+zle -C term_list menu-complete _generic
 bindkey "^v" term_list
 zstyle ':completion:term_list:*' completer _term_list

--- a/plugins/term_tab/term_tab.plugin.zsh
+++ b/plugins/term_tab/term_tab.plugin.zsh
@@ -17,11 +17,8 @@
 function _term_list(){
   local -a w
 
-  for SESSION in $(ps -eo pid,fname | grep zsh | awk '{print $1}'); do
-    SPATH="$(readlink -n /proc/${SESSION}/cwd)"
-    if [ x != x${SPATH} ]; then
-      w+=${SPATH}
-    fi
+  for SESSION in $(pidof  zsh); do
+    w+=$(readlink -n /proc/${SESSION}/cwd)
   done
 
   compadd -a w

--- a/plugins/term_tab/term_tab.plugin.zsh
+++ b/plugins/term_tab/term_tab.plugin.zsh
@@ -18,10 +18,11 @@ function _term_list(){
   local -a w
 
   for SESSION in $(pidof  zsh); do
-    w+=$(readlink -n /proc/${SESSION}/cwd)
+    PA=$(readlink -n /proc/${SESSION}/cwd)
+    w+=(${(D)PA})
   done
 
-  compadd -a w
+  compadd -aQ w
 }
 
 zle -C term_list complete-word _generic

--- a/plugins/term_tab/term_tab.plugin.zsh
+++ b/plugins/term_tab/term_tab.plugin.zsh
@@ -1,0 +1,32 @@
+# Copyright (C) 2014 Julian Vetter <death.jester@web.de>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+function _term_list(){
+  local -a w
+
+  for SESSION in $(ps -eo pid,fname | grep zsh | awk '{print $1}'); do
+    SPATH="$(readlink -n /proc/${SESSION}/cwd)"
+    if [ x != x${SPATH} ]; then
+      w+=${SPATH}
+    fi
+  done
+
+  compadd -a w
+}
+
+zle -C term_list complete-word _generic
+bindkey "^v" term_list
+zstyle ':completion:term_list:*' completer _term_list

--- a/plugins/term_tab/term_tab.plugin.zsh
+++ b/plugins/term_tab/term_tab.plugin.zsh
@@ -21,7 +21,7 @@ function _term_list(){
     w+=${(D)$(readlink -n /proc/${SESSION}/cwd)}
   done
 
-  compadd -aQ w
+  compadd -aQS '' w
 }
 
 zle -C term_list menu-complete _generic


### PR DESCRIPTION
This plugin allows the user to complete other zsh session pathes by hitting 'CTRL+v'. 
