### PR TITLE
Replace /usr/bin/env with env

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -3,11 +3,11 @@ function zsh_stats() {
 }
 
 function uninstall_oh_my_zsh() {
-  /usr/bin/env ZSH=$ZSH /bin/sh $ZSH/tools/uninstall.sh
+  env ZSH=$ZSH /bin/sh $ZSH/tools/uninstall.sh
 }
 
 function upgrade_oh_my_zsh() {
-  /usr/bin/env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
+  env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
 }
 
 function take() {

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -1,6 +1,6 @@
 # Check for updates on initial load...
 if [ "$DISABLE_AUTO_UPDATE" != "true" ]; then
-  /usr/bin/env ZSH=$ZSH DISABLE_UPDATE_PROMPT=$DISABLE_UPDATE_PROMPT zsh -f $ZSH/tools/check_for_upgrade.sh
+  env ZSH=$ZSH DISABLE_UPDATE_PROMPT=$DISABLE_UPDATE_PROMPT zsh -f $ZSH/tools/check_for_upgrade.sh
 fi
 
 # Initializes Oh My Zsh

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -9,7 +9,7 @@ function _update_zsh_update() {
 }
 
 function _upgrade_zsh() {
-  /usr/bin/env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
+  env ZSH=$ZSH /bin/sh $ZSH/tools/upgrade.sh
   # update the zsh file
   _update_zsh_update
 }

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -10,7 +10,7 @@ if [ -d "$ZSH" ]; then
 fi
 
 echo "\033[0;34mCloning Oh My Zsh...\033[0m"
-hash git >/dev/null 2>&1 && /usr/bin/env git clone https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
+hash git >/dev/null 2>&1 && env git clone https://github.com/robbyrussell/oh-my-zsh.git $ZSH || {
   echo "git not installed"
   exit
 }
@@ -43,5 +43,5 @@ echo "\033[0;32m"'\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/  '"\033[0m
 echo "\033[0;32m"'                        /____/                       ....is now installed!'"\033[0m"
 echo "\n\n \033[0;32mPlease look over the ~/.zshrc file to select plugins, themes, and options.\033[0m"
 echo "\n\n \033[0;32mp.s. Follow us at http://twitter.com/ohmyzsh.\033[0m"
-/usr/bin/env zsh
+env zsh
 . ~/.zshrc


### PR DESCRIPTION
Some environments (such as Android) does not have /usr/bin. There are more changes necessary to get oh-my-zsh working in such an environment, but this is a first step and to get feedback!

Is it safe to just replace /usr/bin/env => env?

If not, would it be ok to fallback to just "env" if /usr/bin/env does not exist, or some other approach maybe?
