### PR TITLE
Update curl install script

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -15,7 +15,7 @@ You can install this via the command line with either @curl@ or @wget@.
 
 h4. via @curl@
 
-@curl -L http://install.ohmyz.sh | sh@
+@curl -L https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh | sh@
 
 h4. via @wget@
 


### PR DESCRIPTION
For me, the curl command doesn't get the redirect page's script

The install script is [here](https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh),
but the current curl command only returns 

```
<a href="https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh">Moved Permanently</a>.
```

for me. This edit works out though.
