### PR TITLE
Prevent chsh from running when $SHELL is already zsh

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -32,8 +32,10 @@ sed -i -e "/export PATH=/ c\\
 export PATH=\"$PATH\"
 " ~/.zshrc
 
-echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
-chsh -s `which zsh`
+if [ "$SHELL" != "$(which zsh)" ]; then
+    echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
+    chsh -s `which zsh`
+fi
 
 echo "\033[0;32m"'         __                                     __   '"\033[0m"
 echo "\033[0;32m"'  ____  / /_     ____ ___  __  __   ____  _____/ /_  '"\033[0m"


### PR DESCRIPTION
The chsh command in the install script will prompt the user for a password, which is inconvenient for automated installs of Oh My ZSH.
By setting the default shell before running the install script and running the chsh conditionaly, this allows for fully automated OhmyZSH installs.
