### PR TITLE
Fix missing add-zsh-hook

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -34,6 +34,5 @@ function omz_termsupport_preexec {
   title '$CMD' '%100>...>$LINE%<<'
 }
 
-autoload -U add-zsh-hook
-add-zsh-hook precmd  omz_termsupport_precmd
-add-zsh-hook preexec omz_termsupport_preexec
+precmd_functions+=(omz_termsupport_precmd)
+preexec_functions+=(omz_termsupport_preexec)


### PR DESCRIPTION
In older version of zsh, `add-zsh-hook` is not available, causing issues like:

```
/Users/hugo/.oh-my-zsh/lib/termsupport.zsh:32: add-zsh-hook: function definition file not found
/Users/hugo/.oh-my-zsh/lib/termsupport.zsh:33: add-zsh-hook: function definition file not found
```

See https://github.com/robbyrussell/oh-my-zsh/issues/748. This patch pulls in the changes suggested in https://github.com/robbyrussell/oh-my-zsh/issues/748#issuecomment-37862691 by @mcornella and I have tested it on RHEL 5.
