### PR TITLE
This alias is conflict cause

### DIFF
--- a/lib/aliases.zsh
+++ b/lib/aliases.zsh
@@ -30,7 +30,6 @@ alias lsa='ls -lah'
 alias l='ls -lah'
 alias ll='ls -lh'
 alias la='ls -lAh'
-alias sl=ls # often screw this up
 
 alias afind='ack-grep -il'
 


### PR DESCRIPTION
this `alias sl=ls` alias is conflict cause.
ex: `sl` steam train command
ex: `subl` for SublimeText command
ex: `sudo ls` etc...

So I want to delete.

May I delete this alias?

@robbyrussell 
