### PR TITLE
new plugin: virtual-insert

### DIFF
--- a/plugins/virtual-insert/virtual-insert.plugin.zsh
+++ b/plugins/virtual-insert/virtual-insert.plugin.zsh
@@ -1,0 +1,70 @@
+zle -N user-complete
+bindkey "\t" user-complete
+
+zle -N user-ret
+bindkey "\r" user-ret
+
+zle -N user-del
+bindkey "^W" user-del        
+
+cdpath=".."
+
+user-complete()
+{
+    case $BUFFER in
+        "" )
+            BUFFER="cd "
+            zle end-of-line
+            zle expand-or-complete
+            ;;
+        cd\ \ * )
+            BUFFER=${BUFFER/\ \ /\ ~}
+            zle end-of-line
+            zle expand-or-complete
+            ;;
+        " " )
+            BUFFER="z "
+            zle end-of-line
+            zle expand-or-complete
+            ;;
+        "cd --" )
+            BUFFER="cd +"
+            zle end-of-line
+            zle expand-or-complete
+            ;;
+        "cd +-" )
+            BUFFER="cd -"
+            zle end-of-line
+            zle expand-or-complete
+            ;;
+        * )
+            zle expand-or-complete
+            ;;
+    esac
+}
+
+user-ret()
+{
+    if [[ $BUFFER = "" ]] ;then
+        BUFFER="ls"
+        zle end-of-line
+        zle accept-line
+    elif [[ $BUFFER =~ "^cd\ \.\.\.+$" ]] ;then
+        BUFFER=${${BUFFER//\./\.\.\/}/\.\.\//}
+        zle end-of-line
+        zle accept-line
+    else
+        zle accept-line
+    fi
+}
+
+user-del()
+{
+    if [[ $BUFFER = "" ]] ; then
+        BUFFER="cd .."
+        zle end-of-line
+        zle accept-line
+    else
+        zle backward-kill-word
+    fi
+}


### PR DESCRIPTION
```
about Tab:
    when current line is blank, type TAB, string “cd " will be put in the line, and the menu of "cd" 's candidates appeared.
    when current line is "cd "(notice that there is two space), in other words, type TAB SPACE in a blank line, it will be replace with "cd ~", and the menu of named directory's candidates appeared.
    when current line is "cd --", it will be replace with "cd +"---- i consider that it was not quite utility

about Enter:
    when current line is blank, type ENTER, it will put ls in the line, then performance ENTER. so you can just type ENTER instead l, s, ENTER.
    when current line is cd ....., type ENTER, the line will replace this to cd ../../../../, then performance ENTER， whether there was how many "."

for example:
    you can type TAB . . . ENTER, it will performance cd ../../

about C-w:
when current line is blank, type C-w to uplevel path
else backward delete word
```
