### PR TITLE
Improved kclean command

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -66,9 +66,9 @@ if [[ $use_sudo -eq 1 ]]; then
     alias di='sudo dpkg -i'
 
     # Remove ALL kernel images and headers EXCEPT the one in use
-    alias kclean='sudo aptitude remove -P ?and(~i~nlinux-(ima|hea) \
-        ?not(~n`uname -r`))'
-
+    alias kclean='sudo aptitude remove -P "?and(~i~nlinux-(ima|hea),\
+        ?not(?or(~n`uname -r | cut -d'\''-'\'' -f-2`,\
+        ~n(linux-(virtual|headers-virtual|headers-generic|image-virtual|image-generic)))))"'
 
 # commands using su #########
 else
@@ -106,8 +106,9 @@ else
     alias di='su -lc "dpkg -i" root'
 
     # Remove ALL kernel images and headers EXCEPT the one in use
-    alias kclean='su -lc '\''aptitude remove -P ?and(~i~nlinux-(ima|hea) \
-        ?not(~n`uname -r`))'\'' root'
+    alias kclean='su -lc '\''aptitude remove -P "?and(~i~nlinux-(ima|hea),\
+        ?not(?or(~n`uname -r | cut -d'\''-'\'' -f-2`,\
+        ~n(linux-(virtual|headers-virtual|headers-generic|image-virtual|image-generic)))))"'\'' root'
 fi
 
 # Completion ################################################################

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -68,7 +68,7 @@ if [[ $use_sudo -eq 1 ]]; then
     # Remove ALL kernel images and headers EXCEPT the one in use
     alias kclean='sudo aptitude remove -P "?and(~i~nlinux-(ima|hea),\
         ?not(?or(~n`uname -r | cut -d'\''-'\'' -f-2`,\
-        ~n(linux-(virtual|headers-virtual|headers-generic|image-virtual|image-generic)))))"'
+        ~n(linux-(virtual|headers-virtual|headers-generic|image-virtual|image-generic|image-`dpkg --print-architecture`)))))"'
 
 # commands using su #########
 else
@@ -108,7 +108,7 @@ else
     # Remove ALL kernel images and headers EXCEPT the one in use
     alias kclean='su -lc '\''aptitude remove -P "?and(~i~nlinux-(ima|hea),\
         ?not(?or(~n`uname -r | cut -d'\''-'\'' -f-2`,\
-        ~n(linux-(virtual|headers-virtual|headers-generic|image-virtual|image-generic)))))"'\'' root'
+        ~n(linux-(virtual|headers-virtual|headers-generic|image-virtual|image-generic|image-`dpkg --print-architecture`)))))"'\'' root'
 fi
 
 # Completion ################################################################


### PR DESCRIPTION
The original kclean returned 'zsh: no matches found: '  in some machines
and in others requested to remove the current headers to resolve unmet
dependencies.
So I optimized it a little, now it should work seamlessly in most debian/ubuntu 
machines.
