### PR TITLE
Fix missing add-zsh-hook in pygmalion.zsh-theme

### DIFF
--- a/themes/pygmalion.zsh-theme
+++ b/themes/pygmalion.zsh-theme
@@ -12,7 +12,7 @@ prompt_setup_pygmalion(){
   base_prompt_nocolor=$(echo "$base_prompt" | perl -pe "s/%\{[^}]+\}//g")
   post_prompt_nocolor=$(echo "$post_prompt" | perl -pe "s/%\{[^}]+\}//g")
 
-  add-zsh-hook precmd prompt_pygmalion_precmd
+  precmd_functions+=(prompt_pygmalion_precmd)
 }
 
 prompt_pygmalion_precmd(){


### PR DESCRIPTION
Fix "prompt_setup_pygmalion:12: command not found: add-zsh-hook" error since #3053 removes `autoload -U add-zsh-hook` line.

For people love the pygmalion theme:)
