### PR TITLE
add-zsh-hook not found in prompt_setup_pygmalion

### DIFF
--- a/themes/pygmalion.zsh-theme
+++ b/themes/pygmalion.zsh-theme
@@ -12,7 +12,7 @@ prompt_setup_pygmalion(){
   base_prompt_nocolor=$(echo "$base_prompt" | perl -pe "s/%\{[^}]+\}//g")
   post_prompt_nocolor=$(echo "$post_prompt" | perl -pe "s/%\{[^}]+\}//g")
 
-  add-zsh-hook precmd prompt_pygmalion_precmd
+  precmd_functions+=(prompt_pygmalion_precmd)
 }
 
 prompt_pygmalion_precmd(){


### PR DESCRIPTION
Since this morning update, I get the following error:

```
prompt_setup_pygmalion:12: command not found: add-zsh-hook
```

Applying the same fix as for #748 fixes the issue.
