### PR TITLE
Edit due to pygmalion sending add-zsh-hook not found.

### DIFF
--- a/themes/pygmalion.zsh-theme
+++ b/themes/pygmalion.zsh-theme
@@ -1,6 +1,7 @@
 # Yay! High voltage and arrows!
 
 prompt_setup_pygmalion(){
+  autoload -U add-zsh-hook
   ZSH_THEME_GIT_PROMPT_PREFIX="%{$reset_color%}%{$fg[green]%}"
   ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
   ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[yellow]%}⚡%{$reset_color%}"


### PR DESCRIPTION
Recently while testing themes pygmalion sent me this error:

> prompt_setup_pygmalion:12: command not found: add-zsh-hook

Made a quick correction and checked the other themes.
