### PR TITLE
Fix pygmalion theme: add 'autoload "add-zsh-hook"'

### DIFF
--- a/themes/pygmalion.zsh-theme
+++ b/themes/pygmalion.zsh-theme
@@ -12,6 +12,7 @@ prompt_setup_pygmalion(){
   base_prompt_nocolor=$(echo "$base_prompt" | perl -pe "s/%\{[^}]+\}//g")
   post_prompt_nocolor=$(echo "$post_prompt" | perl -pe "s/%\{[^}]+\}//g")
 
+  autoload "add-zsh-hook"
   add-zsh-hook precmd prompt_pygmalion_precmd
 }
 


### PR DESCRIPTION
Currently with `ZSH_THEME="pygmalion"` in my `~/.zshrc`, I get the following error message:
`prompt_setup_pygmalion:12: command not found: add-zsh-hook`

This PR fixes it, but I'm not sure, whether I placed the `autoload` command in the correct file and line.
