### PR TITLE
[aws plugin] Changed brew cmd to properly report if awscli is installed via homebrew

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -3,19 +3,17 @@ _homebrew-installed() {
 }
 
 _awscli-homebrew-installed() {
-  brew --prefix awscli &> /dev/null
+  brew list awscli &> /dev/null
 }
 
 export AWS_HOME=~/.aws
 
 function agp {
   echo $AWS_DEFAULT_PROFILE
-  
 }
 function asp {
   export AWS_DEFAULT_PROFILE=$1
-    export RPROMPT="<aws:$AWS_DEFAULT_PROFILE>"
-    
+  export RPROMPT="<aws:$AWS_DEFAULT_PROFILE>"
 }
 function aws_profiles {
   reply=($(grep profile $AWS_HOME/config|sed -e 's/.*profile \([a-zA-Z0-9_-]*\).*/\1/'))


### PR DESCRIPTION
As it was previously written, the `brew` command to check if `awscli` was installed would always return true, regardless of whether `awscli` was actually installed via brew. I've updated the command to properly check whether `awscli` is installed. I also cleaned up an indentation and whitespace issue (lines 13, 17-18).  
