### PR TITLE
Fix autocompletion of Docker containers

### DIFF
--- a/plugins/docker/_docker
+++ b/plugins/docker/_docker
@@ -10,7 +10,7 @@
 # Output a selectable list of all running docker containers
 __docker_containers() {
     declare -a cont_cmd
-    cont_cmd=($(docker ps | awk 'NR>1{print $1":[CON("$1")"$2"("$3")]"}'))
+    cont_cmd=($(docker ps -a | awk 'NR>1{print $NF}'))
     _describe 'containers' cont_cmd
 }
 


### PR DESCRIPTION
Since version 0.6.5, Docker ensures that new containers are named by generating it if not passed.
This commit fixes the container autocompletion by referring to the NAMES column given by `docker ps -a`.

```
❯ zsh --version
zsh 5.0.6 (x86_64-apple-darwin13.3.0)
```

```
❯ docker --version
Docker version 1.2.0, build fa7b24f
```

```
❯ docker ps -a
CONTAINER ID        IMAGE                     COMMAND                CREATED             STATUS                         PORTS               NAMES
ca2bf5c5339c        jpetazzo/nsenter:latest   "/bin/sh -c /install   3 hours ago         Exited (0) 2 hours ago                             sleepy_thompson
5fb4c4583bad        ubuntu:latest             "bash"                 3 hours ago         Exited (0) 2 hours ago                             lonely_brown
```

```
❯ docker ps | awk 'NR>1{print $1":[CON("$1")"$2"("$3")]"}'

```

```
❯ docker ps -a | awk 'NR>1{print $NF}'
sleepy_thompson
lonely_brown
```

Before:

```
❯ docker logs <TAB>
-follow
-f
-- Follow log output
```

After:

```
❯ docker logs
-follow  -f  -- Follow log output
lonely_brown                                                       sleepy_thompson
```
