### PR TITLE
Fix #3126 - parse_git_dirty() always returns dirty if branch = 1 on .gitconfig

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -18,9 +18,9 @@ parse_git_dirty() {
           SUBMODULE_SYNTAX="--ignore-submodules=dirty"
     fi
     if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" == "true" ]]; then
-        GIT_STATUS=$(command git status -s ${SUBMODULE_SYNTAX} -uno 2> /dev/null | grep -v '^##' | tail -n1)
+        GIT_STATUS=$(command git status --porcelain ${SUBMODULE_SYNTAX} -uno 2> /dev/null | tail -n1)
     else
-        GIT_STATUS=$(command git status -s ${SUBMODULE_SYNTAX} 2> /dev/null | grep -v '^##' | tail -n1)
+        GIT_STATUS=$(command git status --porcelain ${SUBMODULE_SYNTAX} 2> /dev/null | tail -n1)
     fi
     if [[ -n $GIT_STATUS ]]; then
       echo "$ZSH_THEME_GIT_PROMPT_DIRTY"


### PR DESCRIPTION
This fixes the issue by grepping out the branch information.
