### PR TITLE
Fix problem with redirect on http.

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,4 +1,4 @@
-function gi() { curl http://www.gitignore.io/api/$@ ;}
+function gi() { curl https://www.gitignore.io/api/$@ ;}
 
 _gitignireio_get_command_list() {
   curl -s http://www.gitignore.io/api/list | tr "," "\n"


### PR DESCRIPTION
gitignore.io now redirects from http to https. Make https the default now.
