### PR TITLE
add aliases for vagrant commands frequently needed

### DIFF
--- a/plugins/vagrant/vagrant.plugin.zsh
+++ b/plugins/vagrant/vagrant.plugin.zsh
@@ -1,0 +1,11 @@
+alias vu='vagrant up'
+alias vh='vagrant halt'
+alias vst='vagrant status'
+alias vss='vagrant ssh'
+
+alias vd='vagrant destroy'
+alias vdf='vagrant destroy --force'
+
+alias vbl='vagrant box list'
+alias vbr='vagrant box remove'
+alias vbu='vagrant box update'


### PR DESCRIPTION
the aliases follow a scheme, similar to the those of the git plugin
see https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/git/git.plugin.zsh
