### PR TITLE
Fix origin of .gitignore

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,7 +1,7 @@
-function gi() { curl http://www.gitignore.io/api/$@ ;}
+function gi() { curl -L https://www.gitignore.io/api/$@ ;}
 
 _gitignireio_get_command_list() {
-  curl -s http://www.gitignore.io/api/list | tr "," "\n"
+  curl -s -L https://www.gitignore.io/api/list | tr "," "\n"
 }
 
 _gitignireio () {


### PR DESCRIPTION
.gitignore.io is currently provided at https://gitignore.io/, but gitignore plugin still refers http://gitignore.io.  http://gitignroe.io/ returns html with 301 http response code, so this plugin outputs html unexpectedly.  This PR is fix this problem and follow future moving with response code means redirect.
