### PR TITLE
Fix completion for Laravel 5 (previously 4.3)

### DIFF
--- a/plugins/laravel4/laravel4.plugin.zsh
+++ b/plugins/laravel4/laravel4.plugin.zsh
@@ -1,6 +1,6 @@
 # Laravel4 basic command completion
 _laravel4_get_command_list () {
-	php artisan --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
+	php artisan --no-ansi | sed "1,/Available commands/d" | awk '/^  ?[a-z]+/ { print $1 }'
 }
 
 _laravel4 () {


### PR DESCRIPTION
Laravel changed the output out when listing commands.

This change makes the `laravel4` plugin compatible with both Laravel 4 and Laravel 5.
