### PR TITLE
Updated gitignore.io url to use https

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,4 +1,4 @@
-function gi() { curl http://www.gitignore.io/api/$@ ;}
+function gi() { curl https://www.gitignore.io/api/$@ ;}
 
 _gitignireio_get_command_list() {
   curl -s http://www.gitignore.io/api/list | tr "," "\n"


### PR DESCRIPTION
Previous use with only http returns 301 Moved Permanently. Changing to https fixes this bug.
