### PR TITLE
Dropbox CLI completion

### DIFF
--- a/completions/_dropbox
+++ b/completions/_dropbox
@@ -1,0 +1,18 @@
+#compdef dropbox
+
+# Dropbox CLI completion
+ 
+_arguments "1:Command:((
+	status\:'get current status of the dropboxd'
+	help\:'provide help'
+	puburl\:'get public url of a file in your dropbox'
+	stop\:'stop dropboxd'
+	running\:'return whether dropbox is running'
+	update\:'download latest version of dropbox'
+	start\:'start dropboxd'
+	filestatus\:'get current sync status of one or more files'
+	ls\:'list directory contents with current sync status'
+	autostart\:'automatically start dropbox at login'
+	exclude\:'ignores/excludes a directory from syncing'
+	lansync\:'enables or disables LAN sync'
+))"


### PR DESCRIPTION
With this completion function one can use `dropbox <tab>` to see and select all possible options. According to [this source](http://askql.wordpress.com/2011/01/11/zsh-writing-own-completion/), completion function stored in `completions` is the right way it should be implemented, nevertheless maybe it should be plugin instead.

Anyway, this works fine and it's useful.
