### PR TITLE
Support whitespace characters in username in agnoster

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -60,7 +60,7 @@ prompt_end() {
 
 # Context: user@hostname (who am I and where am I)
 prompt_context() {
-  local user=`whoami`
+  local user="$(whoami)"
 
   if [[ "$user" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
     prompt_segment black default "%(!.%{%F{yellow}%}.)$user@%m"


### PR DESCRIPTION
Support whitespace characters in username in **agnoster** theme by doing `"$(whoami)"` instead of ``whoami``.

In some environments like **Cygwin**, username can contains whitespace characters.
