### PR TITLE
Fix gitignore curl, should follow redirects

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,4 +1,4 @@
-function gi() { curl http://www.gitignore.io/api/$@ ;}
+function gi() { curl -L http://www.gitignore.io/api/$@ ;}
 
 _gitignireio_get_command_list() {
   curl -s http://www.gitignore.io/api/list | tr "," "\n"


### PR DESCRIPTION
Old url now is 301ed to other places.

```
# gi python
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>cloudflare-nginx</center>
</body>
</html>
```
