### PR TITLE
added support for GNU version of `date`

### DIFF
--- a/plugins/emoji-clock/emoji-clock.plugin.zsh
+++ b/plugins/emoji-clock/emoji-clock.plugin.zsh
@@ -8,21 +8,25 @@
 # -----------------------------------------------------------------------------
 
 function emoji-clock() {
-  hour=$(date -v '+15M' '+%I')
-  minutes=$(date -v '+15M' '+%M')
+  # Add 15 minutes to the current time and save the value as $minutes.
+  (( minutes = $(date '+%M') + 15 ))
+  (( hour = $(date '+%I') + minutes / 60 ))
+  # make sure minutes and hours don't exceed 60 nor 12 respectively
+  (( minutes %= 60 )); (( hour %= 12 ))
+
   case $hour in
-    01) clock="🕐"; [ $minutes -ge 30 ] && clock="🕜";;
-    02) clock="🕑"; [ $minutes -ge 30 ] && clock="🕝";;
-    03) clock="🕒"; [ $minutes -ge 30 ] && clock="🕞";;
-    04) clock="🕓"; [ $minutes -ge 30 ] && clock="🕟";;
-    05) clock="🕔"; [ $minutes -ge 30 ] && clock="🕠";;
-    06) clock="🕕"; [ $minutes -ge 30 ] && clock="🕡";;
-    07) clock="🕖"; [ $minutes -ge 30 ] && clock="🕢";;
-    08) clock="🕗"; [ $minutes -ge 30 ] && clock="🕣";;
-    09) clock="🕘"; [ $minutes -ge 30 ] && clock="🕤";;
+     0) clock="🕛"; [ $minutes -ge 30 ] && clock="🕧";;
+     1) clock="🕐"; [ $minutes -ge 30 ] && clock="🕜";;
+     2) clock="🕑"; [ $minutes -ge 30 ] && clock="🕝";;
+     3) clock="🕒"; [ $minutes -ge 30 ] && clock="🕞";;
+     4) clock="🕓"; [ $minutes -ge 30 ] && clock="🕟";;
+     5) clock="🕔"; [ $minutes -ge 30 ] && clock="🕠";;
+     6) clock="🕕"; [ $minutes -ge 30 ] && clock="🕡";;
+     7) clock="🕖"; [ $minutes -ge 30 ] && clock="🕢";;
+     8) clock="🕗"; [ $minutes -ge 30 ] && clock="🕣";;
+     9) clock="🕘"; [ $minutes -ge 30 ] && clock="🕤";;
     10) clock="🕙"; [ $minutes -ge 30 ] && clock="🕥";;
     11) clock="🕚"; [ $minutes -ge 30 ] && clock="🕦";;
-    12) clock="🕛"; [ $minutes -ge 30 ] && clock="🕧";;
      *) clock="⌛";;
   esac
   echo $clock


### PR DESCRIPTION
`emoji-clock` used `date -v` which is only supported on OSX version of `date`. Added support for GNU version, so that `emoji-clock` plugin can, now, be used everywhere.
