### PR TITLE
Update path for the iOS simulator.

### DIFF
--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -16,4 +16,9 @@ function xcsel {
 
 alias xcb='xcodebuild'
 alias xcp='xcode-select --print-path'
-alias simulator='open $(xcode-select -p)/Applications/iOS\ Simulator.app'
+
+if [[ -d $(xcode-select -p)/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone\ Simulator.app ]]; then
+  alias simulator='open $(xcode-select -p)/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone\ Simulator.app'
+else
+  alias simulator='open $(xcode-select -p)/Applications/iOS\ Simulator.app'
+fi


### PR DESCRIPTION
Xcode 6 changed the path for the iOS simulator. This commit fixes it.
