### PR TITLE
Fix gitignore plugin

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,12 +1,12 @@
 function gi() { curl https://www.gitignore.io/api/$@ ;}
 
-_gitignireio_get_command_list() {
+_gitignoreio_get_command_list() {
   curl -s https://www.gitignore.io/api/list | tr "," "\n"
 }
 
-_gitignireio () {
+_gitignoreio () {
   compset -P '*,'
-  compadd -S '' `_gitignireio_get_command_list`
+  compadd -S '' `_gitignoreio_get_command_list`
 }
 
-compdef _gitignireio gi
+compdef _gitignoreio gi


### PR DESCRIPTION
The gitignore.io API now uses HTTPS instead of HTTP. These commits update the gitignore plugin to use the new URL, and fix minor typos in the plugin's function names.
