### PR TITLE
[Plugin: gitignore] Several fixes in the plugin

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,7 +1,7 @@
-function gi() { curl -L https://www.gitignore.io/api/$@ ;}
+function gi() { curl -sL https://www.gitignore.io/api/$@ ;}
 
 _gitignoreio_get_command_list() {
-  curl -s https://www.gitignore.io/api/list | tr "," "\n"
+  curl -sL https://www.gitignore.io/api/list | tr "," "\n"
 }
 
 _gitignoreio () {


### PR DESCRIPTION
This pull request puts together these 4 fixes:
- Changing the API URL from `http` to `https`, as [has](https://github.com/robbyrussell/oh-my-zsh/pull/3106) [been](https://github.com/robbyrussell/oh-my-zsh/pull/3114) [asked](https://github.com/robbyrussell/oh-my-zsh/pull/3118) [for](https://github.com/robbyrussell/oh-my-zsh/pull/3144) [a](https://github.com/robbyrussell/oh-my-zsh/pull/3171) [lot](https://github.com/robbyrussell/oh-my-zsh/pull/3172) [of](https://github.com/robbyrussell/oh-my-zsh/pull/3173) [times](https://github.com/robbyrussell/oh-my-zsh/pull/3180) [already](https://github.com/robbyrussell/oh-my-zsh/pull/3205). The commit used is the one in #3105, provided by @gugu, for being the first to submit the fix.
- Fixing a misspelling in the `_gitignoreio_get_command_list` function. Fix provided by @ashaindlin in #3225.
- Using the follow-redirects flag (`-L`) in case the URL changes again. Fix provided by @wooparadog in #3203.
- Using the silent flag in `gi()` too, as was asked by @yachi in https://github.com/robbyrussell/oh-my-zsh/pull/3105#issuecomment-58313493. 

All in all, the plugin now uses curl in `follow-redirects` and `silent` mode **in both calls**. This should satisfy all submitted user requests, as well as prevent the need to update it in the future.

Thank you all involved.

Close #3105.
Close #3203.
Close #3225.

Close #3231.
Close #3242.
