### PR TITLE
Fix error using compass search alias

### DIFF
--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -118,7 +118,7 @@ alias jquery='frontend jquery'
 alias mdn='frontend mdn'
 
 # pre processors frameworks
-alias compass='frontend compass'
+alias compassdoc='frontend compass'
 
 # important links
 alias html5please='frontend html5please'


### PR DESCRIPTION
When you create a search using `compass` alias  is showed an error because it the compass commands are supresseds
