### PR TITLE
Fixed gitignore plugin due to website change from http to https

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,7 +1,7 @@
-function gi() { curl http://www.gitignore.io/api/$@ ;}
+function gi() { curl https://www.gitignore.io/api/$@ ;}
 
 _gitignireio_get_command_list() {
-  curl -s http://www.gitignore.io/api/list | tr "," "\n"
+  curl -s https://www.gitignore.io/api/list | tr "," "\n"
 }
 
 _gitignireio () {


### PR DESCRIPTION
`gitignore.io` changed to using `https` so any request using the old `http` protocol generated a 301 error.
