### PR TITLE
Don't set auto_name_dirs because it messes up prompts

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -1,5 +1,4 @@
 # Changing/making/removing directory
-setopt auto_name_dirs
 setopt auto_pushd
 setopt pushd_ignore_dups
 setopt pushdminus


### PR DESCRIPTION
## Quick test:

Run in order: 

``` sh
PROMPT="%~ $ "
unsetopt auto_name_dirs
mkdir longnameddirectory
cd longnameddirectory
dir="$PWD"
```

afterwards, run: 

``` sh
setopt auto_name_dirs
dir="$PWD"
```

Which should look like this: 

``` sh
> PROMPT="%~ $ "
~ $ unsetopt auto_name_dirs
~ $ mkdir longnameddirectory
~ $ cd longnameddirectory
~/longnameddirectory $ dir="$PWD"
~/longnameddirectory $ # prompt doesn't change
~/longnameddirectory $ setopt auto_name_dirs
~/longnameddirectory $ dir="$PWD"
~dir $ # prompt now uses ~dir instead
```

---

From http://zsh.sourceforge.net/Doc/Release/Options.html#Completion-4

> AUTO_NAME_DIRS
> Any parameter that is set to the absolute name of a directory immediately
> becomes a name for that directory, that will be used by the ‘%~’ and
> related prompt sequences, and will be available when completion is performed
> on a word starting with ‘~’.
> (Otherwise, the parameter must be used in the form ‘~param’ first.)

Explained in more detail in
https://github.com/wayneeseguin/rvm/issues/3091#issuecomment-60083194

Related issues:
https://github.com/robbyrussell/oh-my-zsh/issues/2857
https://github.com/robbyrussell/oh-my-zsh/issues/3238
https://github.com/wayneeseguin/rvm/issues/3091

Fix #3238, close #3244.
