### PR TITLE
Made install file compatible w/ Standard Sed

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -23,14 +23,14 @@ fi
 
 echo "\033[0;34mUsing the Oh My Zsh template file and adding it to ~/.zshrc\033[0m"
 cp $ZSH/templates/zshrc.zsh-template ~/.zshrc
-sed -i -e "/^ZSH=/ c\\
+sed -e "/^ZSH=/ c\\
 ZSH=$ZSH
-" ~/.zshrc
+" ~/.zshrc | tee ~/.zshrc
 
 echo "\033[0;34mCopying your current PATH and adding it to the end of ~/.zshrc for you.\033[0m"
-sed -i -e "/export PATH=/ c\\
+sed -e "/export PATH=/ c\\
 export PATH=\"$PATH\"
-" ~/.zshrc
+" ~/.zshrc | tee ~/.zshrc
 
 if [ "$SHELL" != "$(which zsh)" ]; then
     echo "\033[0;34mTime to change your default shell to zsh!\033[0m"


### PR DESCRIPTION
Standard Sed is found on systems like OpenBSD and NetBSD

Great work, love me some oh-my-zsh!

...and I misspelled compatible in the commit message, wonderful...
