### PR TITLE
Fix Yosemite broken zsh

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -47,12 +47,12 @@ ZSH_THEME="robbyrussell"
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(git)
 
-source $ZSH/oh-my-zsh.sh
-
 # User configuration
 
 export PATH=$HOME/bin:/usr/local/bin:$PATH
 # export MANPATH="/usr/local/man:$MANPATH"
+
+source $ZSH/oh-my-zsh.sh
 
 # You may need to manually set your language environment
 # export LANG=en_US.UTF-8


### PR DESCRIPTION
Fix Yosemite broken zsh where $PATH var does not get appended correctly.
- Move the source statement to the end of .zshrc template (The source statement should go at least after ZSH_THEME and plugins are defined. @mcornella)
#3255
