### PR TITLE
[web-search plugin] Redirect output from $open_cmd to /dev/null

### DIFF
--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -37,8 +37,7 @@ function web_search() {
   done
 
   url="${url%?}" # remove the last '+'
-  nohup $open_cmd "$url" 
- 	rm nohup.out	
+  nohup $open_cmd "$url"&> /dev/null& 
 }
 
 


### PR DESCRIPTION
This will remove the somewhat unnecessary "appending to nohup.out" message.
