### PR TITLE
Added VIRTUAL_ENV_DISABLE_PROMPT to steeef.zsh-theme

### DIFF
--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -7,6 +7,8 @@
 # git untracked files modification from Brian Carper:
 # http://briancarper.net/blog/570/git-info-in-your-zsh-prompt
 
+export VIRTUAL_ENV_DISABLE_PROMPT=1
+
 function virtualenv_info {
     [ $VIRTUAL_ENV ] && echo '('$fg[blue]`basename $VIRTUAL_ENV`%{$reset_color%}') '
 }


### PR DESCRIPTION
This stops the virtual env name from being printed before it is actually being
used in the zsh prompt.
