### PR TITLE
Added mrm alias to rails

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -52,7 +52,7 @@ alias rdd='rake db:drop'
 alias rdtc='rake db:test:clone'
 alias rdtp='rake db:test:prepare'
 alias rdmtc='rake db:migrate db:test:clone'
-alias rdmrm='rake db:migrate db:rollback && rake db:migrate'
+alias rdmrm='rake db:migrate && rake db:rollback && rake db:migrate'
 
 alias rlc='rake log:clear'
 alias rn='rake notes'

--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -52,6 +52,7 @@ alias rdd='rake db:drop'
 alias rdtc='rake db:test:clone'
 alias rdtp='rake db:test:prepare'
 alias rdmtc='rake db:migrate db:test:clone'
+alias rdmrm='rake db:migrate db:rollback && rake db:migrate'
 
 alias rlc='rake log:clear'
 alias rn='rake notes'


### PR DESCRIPTION
A common workflow in a rails database migrations is to migrate and check
rollback for up/down migration issues.  This helps keep the schema in
check regardless if any part of a migration fails.
