### PR TITLE
Fix for the profile plugin.

### DIFF
--- a/plugins/profiles/profiles.plugin.zsh
+++ b/plugins/profiles/profiles.plugin.zsh
@@ -2,7 +2,7 @@
 
 # This will look for a custom profile for the local machine and each domain or
 # subdomain it belongs to. (e.g. com, example.com and foo.example.com)
-parts=(${(s:.:)$HOST})
+parts=(${(s:.:)HOST})
 for i in {${#parts}..1}; do
   profile=${(j:.:)${parts[$i,${#parts}]}}
   file=$ZSH_CUSTOM/profiles/$profile


### PR DESCRIPTION
An error was introduced with 7f75bb9, which lead to this output

```
$HOME/.ohmyzsh/plugins/profiles/profiles.plugin.zsh:5: bad substitution
```

This is a simple fix for that.
