### PR TITLE
Remove deprecated brew commands, update core commands

### DIFF
--- a/plugins/brew/_brew
+++ b/plugins/brew/_brew
@@ -19,21 +19,18 @@ _brew_outdated_formulae() {
   outdated_formulae=(`brew outdated`)
 }
 
-_brew_running_services() {
-  running_services=(`brew services list | awk '{print $1}'`)
-}
-
 local -a _1st_arguments
 _1st_arguments=(
   'audit:check formulae for Homebrew coding style'
-  'bundle:look for a Brewfile and run each line as a brew command'
   'cat:display formula file for a formula'
   'cleanup:uninstall unused and old versions of packages'
   'commands:show a list of commands'
   'create:create a new formula'
-  'deps:list dependencies and dependants of a formula'
+  'deps:list dependencies of a formula'
   'doctor:audits your installation for common issues'
   'edit:edit a formula'
+  'fetch:download formula resources to the cache'
+  'gist-logs:generate a gist of the full build logs'
   'home:visit the homepage of a formula or the brew project'
   'info:information about a formula'
   'install:install a formula'
@@ -44,32 +41,24 @@ _1st_arguments=(
   'missing:check all installed formuale for missing dependencies.'
   'outdated:list formulae for which a newer version is available'
   'pin:pin specified formulae'
+  'postinstall:perform post_install for a given formula'
   'prune:remove dead links'
   'remove:remove a formula'
   'search:search for a formula (/regex/ or string)'
-  'server:start a local web app that lets you browse formulae (requires Sinatra)'
-  'services:small wrapper around `launchctl` for supported formulae'
+  'switch:switch linkage between installed versions of a formula'
   'tap:tap a new formula repository from GitHub, or list existing taps'
+  'test-bot:test a formula and build a bottle'
   'uninstall:uninstall a formula'
   'unlink:unlink a formula'
   'unpin:unpin specified formulae'
   'untap:remove a tapped repository'
-  'update:freshen up links'
+  'update:pull latest repository'
   'upgrade:upgrade outdated formulae'
   'uses:show formulae which depend on a formula'
 )
 
-local -a _service_arguments
-_service_arguments=(
-  'cleanup:get rid of stale services and unused plists'
-  'list:list all services managed by `brew services`'
-  'restart:gracefully restart selected service'
-  'start:start selected service'
-  'stop:stop selected service'
-)
-
 local expl
-local -a formulae installed_formulae installed_taps outdated_formulae running_services
+local -a formulae installed_formulae installed_taps outdated_formulae
 
 _arguments \
   '(-v)-v[verbose]' \
@@ -80,6 +69,7 @@ _arguments \
   '(--version)--version[version information]' \
   '(--prefix)--prefix[where brew lives on this system]' \
   '(--cache)--cache[brew cache]' \
+  '(--force)--force[brew force]' \
   '*:: :->subcmds' && return 0
 
 if (( CURRENT == 1 )); then
@@ -109,16 +99,6 @@ case "$words[1]" in
     _arguments \
       '(--macports)--macports[search the macports repository]' \
       '(--fink)--fink[search the fink repository]' ;;
-  services)
-    if [[ -n "$words[2]" ]]; then
-      case "$words[2]" in
-        restart|start|stop)
-          _brew_running_services
-          _wanted running_services expl 'running services' compadd -a running_services ;;
-      esac
-    else
-      _describe -t commands "brew services subcommand" _service_arguments
-    fi ;;
   untap)
     _brew_installed_taps
     _wanted installed_taps expl 'installed taps' compadd -a installed_taps ;;


### PR DESCRIPTION
`brew services`, `server`, and `bundle` were removed and relegated to [homebrew-boneyard](https://github.com/Homebrew/homebrew-boneyard). Added some additional core commands, but not a complete set.
