### PR TITLE
ignore any grep aliases that might be defined

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -123,10 +123,10 @@ prompt_hg() {
       st=""
       rev=$(hg id -n 2>/dev/null | sed 's/[^-0-9]//g')
       branch=$(hg id -b 2>/dev/null)
-      if `hg st | grep -Eq "^\?"`; then
+      if `hg st | command grep -Eq "^\?"`; then
         prompt_segment red black
         st='±'
-      elif `hg st | grep -Eq "^(M|A)"`; then
+      elif `hg st | command grep -Eq "^(M|A)"`; then
         prompt_segment yellow black
         st='±'
       else


### PR DESCRIPTION
I have alias `grep="grep -P"` which conflicts with the `-E` switch when used in mercurial repos
