### PR TITLE
ignore any grep aliases that might be defined

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -78,7 +78,7 @@ function git_prompt_long_sha() {
 git_prompt_status() {
   INDEX=$(command git status --porcelain -b 2> /dev/null)
   STATUS=""
-  if $(echo "$INDEX" | grep -E '^\?\? ' &> /dev/null); then
+  if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
     STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
   fi
   if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then

--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -42,7 +42,7 @@ $ZSH_THEME_REPO_NAME_COLOR$_DISPLAY$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_HG_PROMPT_SU
 
 function hg_dirty_choose {
   if [ $(in_hg) ]; then
-    hg status 2> /dev/null | grep -Eq '^\s*[ACDIM!?L]'
+    hg status 2> /dev/null | command grep -Eq '^\s*[ACDIM!?L]'
     if [ $pipestatus[-1] -eq 0 ]; then
       # Grep exits with 0 when "One or more lines were selected", return "dirty".
       echo $1

--- a/plugins/svn-fast-info/svn-fast-info.plugin.zsh
+++ b/plugins/svn-fast-info/svn-fast-info.plugin.zsh
@@ -63,11 +63,11 @@ function svn_current_revision() {
 function svn_status_info() {
   local svn_status_string="$ZSH_THEME_SVN_PROMPT_CLEAN"
   local svn_status="$(svn status 2> /dev/null)";
-  if grep -E '^\s*A' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_ADDITIONS:-+}"; fi
-  if grep -E '^\s*D' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_DELETIONS:-✖}"; fi
-  if grep -E '^\s*M' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_MODIFICATIONS:-✎}"; fi
-  if grep -E '^\s*[R~]' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_REPLACEMENTS:-∿}"; fi
-  if grep -E '^\s*\?' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_UNTRACKED:-?}"; fi
-  if grep -E '^\s*[CI!L]' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_DIRTY:-'!'}"; fi
+  if command grep -E '^\s*A' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_ADDITIONS:-+}"; fi
+  if command grep -E '^\s*D' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_DELETIONS:-✖}"; fi
+  if command grep -E '^\s*M' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_MODIFICATIONS:-✎}"; fi
+  if command grep -E '^\s*[R~]' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_REPLACEMENTS:-∿}"; fi
+  if command grep -E '^\s*\?' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_UNTRACKED:-?}"; fi
+  if command grep -E '^\s*[CI!L]' &> /dev/null <<< $svn_status; then svn_status_string="$svn_status_string ${ZSH_THEME_SVN_PROMPT_DIRTY:-'!'}"; fi
   echo $svn_status_string
 }

--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -61,7 +61,7 @@ function svn_get_rev_nr() {
 function svn_dirty_choose() {
   if in_svn; then
     root=`svn info 2> /dev/null | sed -n 's/^Working Copy Root Path: //p'`
-    if $(svn status $root 2> /dev/null | grep -Eq '^\s*[ACDIM!?L]'); then
+    if $(svn status $root 2> /dev/null | command grep -Eq '^\s*[ACDIM!?L]'); then
       # Grep exits with 0 when "One or more lines were selected", return "dirty".
       echo $1
     else
@@ -78,7 +78,7 @@ function svn_dirty() {
 function svn_dirty_choose_pwd () {
   if in_svn; then
     root=$PWD
-    if $(svn status $root 2> /dev/null | grep -Eq '^\s*[ACDIM!?L]'); then
+    if $(svn status $root 2> /dev/null | command grep -Eq '^\s*[ACDIM!?L]'); then
       # Grep exits with 0 when "One or more lines were selected", return "dirty".
       echo $1
     else

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -123,10 +123,10 @@ prompt_hg() {
       st=""
       rev=$(hg id -n 2>/dev/null | sed 's/[^-0-9]//g')
       branch=$(hg id -b 2>/dev/null)
-      if `hg st | grep -Eq "^\?"`; then
+      if `hg st | grep -q "^\?"`; then
         prompt_segment red black
         st='±'
-      elif `hg st | grep -Eq "^(M|A)"`; then
+      elif `hg st | grep -q "^(M|A)"`; then
         prompt_segment yellow black
         st='±'
       else

--- a/themes/bureau.zsh-theme
+++ b/themes/bureau.zsh-theme
@@ -31,7 +31,7 @@ bureau_git_status () {
   if $(echo "$_INDEX" | grep '^.[MTD] ' &> /dev/null); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNSTAGED"
   fi
-  if $(echo "$_INDEX" | grep -E '^\?\? ' &> /dev/null); then
+  if $(echo "$_INDEX" | command grep -E '^\?\? ' &> /dev/null); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED"
   fi
   if $(echo "$_INDEX" | grep '^UU ' &> /dev/null); then

--- a/themes/mortalscumbag.zsh-theme
+++ b/themes/mortalscumbag.zsh-theme
@@ -10,12 +10,12 @@ function my_git_prompt() {
   fi
 
   # is anything staged?
-  if $(echo "$INDEX" | grep -E -e '^(D[ M]|[MARC][ MD]) ' &> /dev/null); then
+  if $(echo "$INDEX" | command grep -E -e '^(D[ M]|[MARC][ MD]) ' &> /dev/null); then
     STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_STAGED"
   fi
 
   # is anything unstaged?
-  if $(echo "$INDEX" | grep -E -e '^[ MARC][MD] ' &> /dev/null); then
+  if $(echo "$INDEX" | command grep -E -e '^[ MARC][MD] ' &> /dev/null); then
     STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UNSTAGED"
   fi
 
@@ -25,7 +25,7 @@ function my_git_prompt() {
   fi
 
   # is anything unmerged?
-  if $(echo "$INDEX" | grep -E -e '^(A[AU]|D[DU]|U[ADU]) ' &> /dev/null); then
+  if $(echo "$INDEX" | command grep -E -e '^(A[AU]|D[DU]|U[ADU]) ' &> /dev/null); then
     STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UNMERGED"
   fi
 


### PR DESCRIPTION
I use `alias grep="grep -P"` which conflicts with the `-E` switch any time it's used
using `command` ignores any aliases
