### PR TITLE
Switch back to oh-my-zsh.hide-dirty setting again

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -13,7 +13,7 @@ parse_git_dirty() {
   local STATUS=''
   local FLAGS
   FLAGS=('--porcelain')
-  if [[ "$(command git config --get oh-my-zsh.hide-status)" != "1" ]]; then
+  if [[ "$(command git config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
     if [[ $POST_1_7_2_GIT -gt 0 ]]; then
       FLAGS+='--ignore-submodules=dirty'
     fi


### PR DESCRIPTION
Commit 81004dfaba509ff62a13ba303ab941938d619326 reverted the change in 9b811fb625c03c30a766191cdf65a1c7c1fd96b2 when editing the merge conflict from #2928.

This commit fixes that so that we don't make the same mistake again.

First seen in https://github.com/robbyrussell/oh-my-zsh/commit/81004dfaba509ff62a13ba303ab941938d619326#commitcomment-8632329
