### PR TITLE
Add 'gfp' alias for 'git' plugin.

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -13,6 +13,7 @@ alias gl='git pull'
 compdef _git gl=git-pull
 alias gup='git pull --rebase'
 compdef _git gup=git-fetch
+alias gfp='git fetch --prune'
 alias gp='git push'
 compdef _git gp=git-push
 alias gd='git diff'


### PR DESCRIPTION
We use 'git fetch --prune' often in our workflow.  I thought it might be useful as a general alias for the community.
