### PR TITLE
Fix chruby plugin to not complain if chruby is *not* installed

### DIFF
--- a/plugins/chruby/chruby.plugin.zsh
+++ b/plugins/chruby/chruby.plugin.zsh
@@ -24,7 +24,7 @@ _homebrew-installed() {
 }
 
 _chruby-from-homebrew-installed() {
-    brew --prefix chruby &> /dev/null
+  [ -r $(brew --prefix chruby)] &> /dev/null
 }
 
 _ruby-build_installed() {
@@ -45,11 +45,11 @@ _source_from_omz_settings() {
     zstyle -s :omz:plugins:chruby path _chruby_path
     zstyle -s :omz:plugins:chruby auto _chruby_auto
 
-    if _chruby_path && [[ -r _chruby_path ]]; then
+    if ${_chruby_path} && [[ -r ${_chruby_path} ]]; then
         source ${_chruby_path}
     fi
 
-    if _chruby_auto && [[ -r _chruby_auto ]]; then
+    if ${_chruby_auto} && [[ -r ${_chruby_auto} ]]; then
         source ${_chruby_auto}
     fi
 }


### PR DESCRIPTION
Fix for the chruby plugin that spits out error messages on shell startup if chruby is not installed (on OS X with homebrew), like this:

```
<omz>/plugins/chruby/chruby.plugin.zsh:source:67: no such file or directory: /usr/local/Cellar/chruby/0.3.9/share/chruby/chruby.sh
<omz>/plugins/chruby/chruby.plugin.zsh:source:68: no such file or directory: /usr/local/Cellar/chruby/0.3.9/share/chruby/auto.sh
```
