### PR TITLE
Do not use GREP_OPTIONS to set grep parameters

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -3,6 +3,7 @@
 # Examples: http://rubyurl.com/ZXv
 #
 
+# color grep output
 GREP_OPTIONS="--color=auto"
 
 # avoid VCS folders (if the necessary grep flags are available)
@@ -20,5 +21,8 @@ elif grep-flag-available --exclude=.cvs; then
 fi
 unfunction grep-flag-available
 
-export GREP_OPTIONS="$GREP_OPTIONS"
-export GREP_COLOR='1;32'
+# define grep wrapper (GREP_OPTIONS env var is deprecated)
+eval "function grep {
+    command grep $GREP_OPTIONS \"\$@\"
+}"
+unset GREP_OPTIONS


### PR DESCRIPTION
## STATUS: will merge #3341 for now

From grep version 2.21, using environment variable `GREP_OPTIONS` to set common parameters to grep calls is deprecated.

As an alternative, we use a custom function to pass in our defined `GREP_OPTIONS`, while at the same time preserving any aliases that called grep.

If we choose the alias way as suggested in the grep documentation, we'll overwrite any already defined grep aliases, or get overwritten by any subsequently defined user aliases.

See discussion in #3341.
