### PR TITLE
Don't clobber $HISTSIZE and $SAVEHIST

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -3,10 +3,10 @@ if [ -z "$HISTFILE" ]; then
     HISTFILE=$HOME/.zsh_history
 fi
 if [ -z "$HISTSIZE" ]; then
-	HISTSIZE=10000
+    HISTSIZE=10000
 fi
 if [ -z "$SAVEHIST" ]; then
-	SAVEHIST=10000
+    SAVEHIST=10000
 fi
 
 setopt extended_history


### PR DESCRIPTION
The existing code was clobbering $HISTSIZE and $SAVEHIST, switch to only setting them if they're unset
