### PR TITLE
Fix for command autocomplete for Symfony 2.6.x

### DIFF
--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -5,7 +5,7 @@ _symfony_console () {
 }
 
 _symfony2_get_command_list () {
-   `_symfony_console` --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
+   `_symfony_console` --no-ansi | sed "1,/Available commands/d" | awk '/^  ?[a-z]+/ { print $1 }'
 }
 
 _symfony2 () {


### PR DESCRIPTION
The command list in Symfony 2.6.x has a single space from the start of the line as a delimiter, instead of 2 spaces as in previous version. This breaks the autocomplete.

It is a small fix that makes one space optional and is backward compatible.
