### PR TITLE
[symfony2 plugin] fix compatibility with symfony 2.6

### DIFF
--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -5,7 +5,7 @@ _symfony_console () {
 }
 
 _symfony2_get_command_list () {
-   `_symfony_console` --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
+   `_symfony_console` --no-ansi | sed "1,/Available commands/d" | awk '/^\s+[a-z]+/ { print $1 }'
 }
 
 _symfony2 () {


### PR DESCRIPTION
fix compatibility with symfony 2.6 : now use 1 space instead of 2 for command listing
