### PR TITLE
autojump installed from github has mv the autojump.zsh to $HOME/.autojum...

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -1,6 +1,8 @@
 if [ $commands[autojump] ]; then # check if autojump is installed
   if [ -f $HOME/.autojump/etc/profile.d/autojump.zsh ]; then # manual user-local installation
     . $HOME/.autojump/etc/profile.d/autojump.zsh
+  elif [ -f $HOME/.autojump/share/autojump/autojump.zsh ]; then # another manual user-local installation
+    . $HOME/.autojump/share/autojump/autojump.zsh
   elif [ -f $HOME/.nix-profile/etc/profile.d/autojump.zsh ]; then # nix installation
     . $HOME/.nix-profile/etc/profile.d/autojump.zsh
   elif [ -f /usr/share/autojump/autojump.zsh ]; then # debian and ubuntu package


### PR DESCRIPTION
I installed autojump manually, and I found the autojump plugin not work well. With some digging, I found the autojump has move the autojump.zhs from $HOME/.autojump/etc/profile.d/autojump.zsh to $HOME/.autojump/share/autojump/autojump.zsh
