### PR TITLE
Fix Symfony2 autocomplete

### DIFF
--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -5,7 +5,7 @@ _symfony_console () {
 }
 
 _symfony2_get_command_list () {
-   `_symfony_console` --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
+   `_symfony_console` --no-ansi | sed "1,/Available commands/d" | awk '{ print $1 }' | grep ':'
 }
 
 _symfony2 () {


### PR DESCRIPTION
The old `awk` was probably using an old output format.
I changed it to reflect the current format.
