### PR TITLE
add bower commands aliases

### DIFF
--- a/plugins/bower/bower.plugin.zsh
+++ b/plugins/bower/bower.plugin.zsh
@@ -1,4 +1,6 @@
 alias bi="bower install"
+alias bisd="bower install --save-dev"
+alias bis="bower install --save"
 alias bl="bower list"
 alias bs="bower search"
 


### PR DESCRIPTION
Add the following frequently used bower command aliases:

bis: installs a package and adds it to package.json under dependencies (bower install)
bisd: installs a package and adds it to package.json under devDependencies (bower list)

original pr https://github.com/robbyrussell/oh-my-zsh/pull/1614
