### PR TITLE
Fixed output issues webith websearch plugin.

### DIFF
--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -37,8 +37,7 @@ function web_search() {
   done
 
   url="${url%?}" # remove the last '+'
-  nohup $open_cmd "$url" 
- 	rm nohup.out	
+  nohup $open_cmd "$url" >/dev/null 2&>1
 }
 
 


### PR DESCRIPTION
- if user has rm set as an alias to 'rm -i' user is prompted to whether to
  remove the nohup.out file.
  
  $ ddg fools
    nohup: ignoring input and appending output to ‘nohup.out’
    rm: remove regular empty file ‘nohup.out’?
- if output redirected to a file nohup will not create nohup.out and rm is
  unecessary.
