### PR TITLE
Add itunes shuffle command to OSX plugin.

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -177,12 +177,43 @@ function itunes() {
 		vol)
 			opt="set sound volume to $1" #$1 Due to the shift
 			;;
+		shuf|shuff|shuffle)
+			# The shuffle property of current playlist can't be changed in iTunes 12,
+			# so this workaround uses AppleScript to simulate user input instead.
+			# Defaults to toggling when no options are given.
+			# The toggle option depends on the shuffle button being visible in the Now playing area.
+			# On and off use the menu bar items.
+			local state=$1
+
+			if [[ -n "$state" && ! "$state" =~ "^(on|off|toggle)$" ]]
+			then
+				print "Usage: itunes shuffle [on|off|toggle]. Invalid option."
+				return 1
+			fi
+
+			case "$state" in
+				on|off)
+					# Inspired by: http://stackoverflow.com/a/14675583
+					osascript 1>/dev/null 2>&1 <<-EOF
+					tell application "System Events" to perform action "AXPress" of (menu item "${state}" of menu "Shuffle" of menu item "Shuffle" of menu "Controls" of menu bar item "Controls" of menu bar 1 of application process "iTunes" )
+EOF
+					return 0
+					;;
+				toggle|*)
+					osascript 1>/dev/null 2>&1 <<-EOF
+					tell application "System Events" to perform action "AXPress" of (button 2 of process "iTunes"'s window "iTunes"'s scroll area 1)
+EOF
+					return 0
+					;;
+			esac
+			;;
 		""|-h|--help)
 			echo "Usage: itunes <option>"
 			echo "option:"
 			echo "\tlaunch|play|pause|stop|rewind|resume|quit"
 			echo "\tmute|unmute\tcontrol volume set"
 			echo "\tnext|previous\tplay next or previous track"
+			echo "\tshuf|shuffle [on|off|toggle]\tSet shuffled playback. Default: toggle. Note: toggle doesn't support the MiniPlayer."
 			echo "\tvol\tSet the volume, takes an argument from 0 to 100"
 			echo "\thelp\tshow this message and exit"
 			return 0


### PR DESCRIPTION
Added shuffle functionality to the itunes command in the OSX plugin.
iTunes 12 doesn't support setting the "shuffle" property on the playlist
from what I've read, so this simulates the user interacting with the
iTunes interface. The toggle option "clicks" the shuffle button in the
Now Playing area. This has the effect of toggling the shuffle setting on
whatever is currently playing. The on and off options use the Shuffle
menu bar items.

Usage: itunes shuffle [on|off|toggle]
