### PR TITLE
Fix symfony auto-completion for version 2.6+

### DIFF
--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -5,7 +5,7 @@ _symfony_console () {
 }
 
 _symfony2_get_command_list () {
-   `_symfony_console` --no-ansi | sed "1,/Available commands/d" | awk '/^  [a-z]+/ { print $1 }'
+   `_symfony_console` --no-ansi | sed "1,/Available commands/d" | awk '/^[ ]+[a-z]+/ { print $1 }'
 }
 
 _symfony2 () {


### PR DESCRIPTION
The previous plugin assumes that command list has 2 spaces before each command. Symfony 2.6 has only one space for commands. This bug prevents autocomplete for Symfony 2.6+.
