### PR TITLE
Refactor syntax to exclude VCS folders from grep commands

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -6,7 +6,7 @@
 GREP_OPTIONS="--color=auto"
 
 # avoid VCS folders (if the necessary grep flags are available)
-local VCS_folders="{.bzr,.cvs,.git,.hg,.svn}"
+VCS_folders="{.bzr,.cvs,.git,.hg,.svn}"
 
 grep-flag-available() {
     echo | command grep $1 "" >/dev/null 2>&1
@@ -16,7 +16,11 @@ if grep-flag-available --exclude-dir=.cvs; then
 elif grep-flag-available --exclude=.cvs; then
     GREP_OPTIONS+=" --exclude=$VCS_folders"
 fi
-unfunction grep-flag-available
 
 export GREP_OPTIONS="$GREP_OPTIONS"
 export GREP_COLOR='1;32'
+
+
+# cleanup
+unset VCS_folders
+unfunction grep-flag-available


### PR DESCRIPTION
This PR implements:
- A simplified version of the syntax to add the exclude argument to the grep command (drop the `for..in`)
- Add `.bzr` folders to the list of folders to ignore (fixes #3028)
- Uses the unaliased command in the grep-flag-available function (by using `command`)
