### PR TITLE
Fix grep.zsh library

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -16,9 +16,9 @@ elif grep-flag-available --exclude=.cvs; then
 fi
 
 # export grep settings
-export GREP_OPTIONS="$GREP_OPTIONS"
-export GREP_COLOR='1;32'
+alias grep="grep $GREP_OPTIONS"
 
 # clean up
+unset GREP_OPTIONS
 unset VCS_FOLDERS
 unfunction grep-flag-available


### PR DESCRIPTION
This PR merges 2 pull requests together:
- #3341: solves the `GREP_OPTIONS deprecated` message
- #3402: tidies up the part to exclude VCS folders and adds `.bzr` folder to the list of folders to ignore

Fixes #3341, fixes #3402, fixes #3028.
Closes #3343, closes #3382, closes #3388.
