### PR TITLE
Add quoting to nvm.sh

### DIFF
--- a/lib/nvm.zsh
+++ b/lib/nvm.zsh
@@ -1,6 +1,6 @@
 # get the node.js version
 function nvm_prompt_info() {
-  [ -f $HOME/.nvm/nvm.sh ] || return
+  [ -f "$HOME/.nvm/nvm.sh" ] || return
   local nvm_prompt
   nvm_prompt=$(node -v 2>/dev/null)
   [[ "${nvm_prompt}x" == "x" ]] && return


### PR DESCRIPTION
Quotes the path to nvm.sh in `lib/nvm.zsh` in case the path to the user's home directory has a space in it.  
