### PR TITLE
Fix aws.plugins.zsh check rule

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -22,7 +22,10 @@ function aws_profiles {
 compctl -K aws_profiles asp
 
 if _homebrew-installed && _awscli-homebrew-installed ; then
-  source $(brew --prefix)/opt/awscli/libexec/bin/aws_zsh_completer.sh
+  _aws_zsh_completer_path=$(brew --prefix)/opt/awscli/libexec/bin/aws_zsh_completer.sh
 else
-  source `which aws_zsh_completer.sh`
+  _aws_zsh_completer_path=$(which aws_zsh_completer.sh)
 fi
+
+[ -x $_aws_zsh_completer_path ] && source $_aws_zsh_completer_path
+unset _aws_zsh_completer_path


### PR DESCRIPTION
Check aws_zsh_completer.sh had exist or not

When aws_zsh_completer.sh is not exist, this will got error like this
`~/.oh-my-zsh/plugins/aws/aws.plugin.zsh:source:27: no such file or directory: aws_zsh_completer.sh`

I check it path, let it can work all the time.
