### PR TITLE
Disable sourcing .profile when checking for available updates

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -22,8 +22,6 @@ if [[ -z "$epoch_target" ]]; then
   epoch_target=13
 fi
 
-[ -f ~/.profile ] && source ~/.profile
-
 # Cancel upgrade if the current user doesn't have write permissions for the
 # oh-my-zsh directory.
 [[ -w "$ZSH" ]] || return 0


### PR DESCRIPTION
Implement once and for all #2431 by @feltnerm

> #### fix(tools/check_for_upgrade): Don't source profile
> 
> Reverts #2296, but mostly #1883.
> 
> There is no need to source ~/.profile when this script is read. oh-my-zsh writes no configuration data in ~/.profile.
> 
> If the user wishes to use data within ~/.profile, then they should source it in another place.
> 
> Fixes #2315

Closes #3411 
