### PR TITLE
Disable the npm plugin on cygwin

### DIFF
--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -1,1 +1,4 @@
+if [ Cygwin = "$(uname -o 2>/dev/null)" ]; then
+    return
+fi
 eval "$(npm completion 2>/dev/null)"


### PR DESCRIPTION
npm doesn't work on cygwin, and will add a `npm-debug.log` on oh-my-zsh startup, which is rather annoying.
