### PR TITLE
[colored-man] squeeze blank lines

### DIFF
--- a/plugins/colored-man/colored-man.plugin.zsh
+++ b/plugins/colored-man/colored-man.plugin.zsh
@@ -25,7 +25,7 @@ man() {
 	  LESS_TERMCAP_so=$(printf "\e[1;44;33m") \
 	  LESS_TERMCAP_ue=$(printf "\e[0m") \
 	  LESS_TERMCAP_us=$(printf "\e[1;32m") \
-	  PAGER=/usr/bin/less \
+	  PAGER="/usr/bin/less -s" \
 	  _NROFF_U=1 \
 	  PATH=${HOME}/bin:${PATH} \
 	  			   man "$@"


### PR DESCRIPTION
Like **man**(1) does by default, use `less -s` as pager to squeeze blank
lines.
