### PR TITLE
Meaningful author in template used by hgsl alias coming from Mercurial plugin

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -13,7 +13,7 @@ alias hglr='hg pull --rebase'
 alias hgo='hg outgoing'
 alias hgp='hg push'
 alias hgs='hg status'
-alias hgsl='hg log --limit 20 --template "{node|short} | {date|isodatesec} | {author|user}: {desc|strip|firstline}\n" '
+alias hgsl='hg log --limit 20 --template "{node|short} | {date|isodatesec} | {author|person}: {desc|strip|firstline}\n" '
 # this is the 'git commit --amend' equivalent
 alias hgca='hg qimport -r tip ; hg qrefresh -e ; hg qfinish tip'
 # list unresolved files (since hg does not list unmerged files in the status command)


### PR DESCRIPTION
Mercurial plugin embed some aliases to ease typing of the most useful commands.

One of them is `hgsl` which is intended to display latest commits log messages with some info including commit's authors. For now it's only displaying the user part of the email which doesn't bring much informations.

This PR changes the behavior to display the real author name. For instance let say I have the following string configured as my username "Nicolas Cavigneaux <me@domain.com>".

Rather than displaying "me" as the author of the commit it will display "Nicolas Cavigneaux". Much better IMO.
