### PR TITLE
Plugins: vi-mode: extra vi-like bindings, vi-like commands clipboard 

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -63,3 +63,45 @@ function vi_mode_prompt_info() {
 if [[ "$RPS1" == "" && "$RPROMPT" == "" ]]; then
   RPS1='$(vi_mode_prompt_info)'
 fi
+
+
+# Allow Copy/Paste with the system clipboard
+# behave as expected with vim commands ( y/p/d/c/s )
+[[ -n $DISPLAY ]] && (( $+commands[xclip] )) && {
+
+  function cutbuffer() {
+    zle .$WIDGET
+    echo $CUTBUFFER | xclip -selection clipboard
+  }
+
+  zle_cut_widgets=(
+    vi-backward-delete-char
+    vi-change
+    vi-change-eol
+    vi-change-whole-line
+    vi-delete
+    vi-delete-char
+    vi-kill-eol
+    vi-substitute
+    vi-yank
+    vi-yank-eol
+  )
+  for widget in $zle_cut_widgets
+  do
+    zle -N $widget cutbuffer
+  done
+
+  function putbuffer() {
+    zle copy-region-as-kill "$(xclip -o)"
+    zle .$WIDGET
+  }
+
+  zle_put_widgets=(
+    vi-put-after
+    vi-put-before
+  )
+  for widget in $zle_put_widgets
+  do
+    zle -N $widget putbuffer
+  done
+}

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -44,6 +44,12 @@ bindkey '^?' backward-delete-char
 bindkey '^h' backward-delete-char
 bindkey '^w' backward-kill-word
 
+# Some extra vim like bindings
+bindkey -a 'gg' beginning-of-buffer-or-history
+bindkey -a 'G' end-of-buffer-or-history
+bindkey -a 'u' undo
+bindkey -a '^R' redo
+
 # if mode indicator wasn't setup by theme, define default
 if [[ "$MODE_INDICATOR" == "" ]]; then
   MODE_INDICATOR="%{$fg_bold[red]%}<%{$fg[red]%}<<%{$reset_color%}"

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -34,9 +34,10 @@ bindkey -v
 autoload -Uz edit-command-line
 bindkey -M vicmd 'v' edit-command-line
 
-# allow ctrl-p, ctrl-n for navigate history (standard behaviour)
+# allow ctrl-p, ctrl-n, ctrl-r for navigate history (standard behaviour)
 bindkey '^P' up-history
 bindkey '^N' down-history
+bindkey '^r' history-incremental-search-backward
 
 # allow ctrl-h, ctrl-w, ctrl-? for char and word deletion (standard behaviour)
 bindkey '^?' backward-delete-char

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -92,7 +92,7 @@ fi
   done
 
   function putbuffer() {
-    zle copy-region-as-kill "$(xclip -o)"
+    zle copy-region-as-kill "$(xclip -selection clipboard -o)"
     zle .$WIDGET
   }
 


### PR DESCRIPTION
- Added standard `ctrl-r` for incremental history searching
- Added `G` `gg` `u` `^-R` vim commands behavior
- Added X clipboard interaction with standard vim commands ( y/p/d/c )
- From zsh wiki vim bindings [examples|suggestions?]
