### PR TITLE
Add curl plugin

### DIFF
--- a/plugins/curl/README.md
+++ b/plugins/curl/README.md
@@ -1,0 +1,5 @@
+# Curl aliases plugin
+
+## Functions explained
+
+## Aliases explained

--- a/plugins/curl/README.md
+++ b/plugins/curl/README.md
@@ -2,4 +2,11 @@
 
 ## Functions explained
 
+ * curlj - pretty json (require Python 2.6)
+
 ## Aliases explained
+
+ * curlh - show header only
+ * curls - download filename
+ * curlt - show response time in milliseconds
+ * curlrc - show http code

--- a/plugins/curl/curl.plugin.zsh
+++ b/plugins/curl/curl.plugin.zsh
@@ -1,0 +1,5 @@
+alias jcurl=jsoncurl
+function jsoncurl()
+{
+    curl -s $1 |python -m json.tool
+}

--- a/plugins/curl/curl.plugin.zsh
+++ b/plugins/curl/curl.plugin.zsh
@@ -1,5 +1,10 @@
-alias jcurl=jsoncurl
+alias curlj=jsoncurl
 function jsoncurl()
 {
     curl -s $1 |python -m json.tool
 }
+
+alias curlh="curl -siv -o /dev/null"
+alias curls="curl -O"
+alias curlt="curl -o /dev/null -s -w %{time_total}'\\n'"
+alias curlrc="curl -s -o /dev/null -w %{http_code}'\\n'"


### PR DESCRIPTION
# Curl aliases plugin
## Functions explained
- curlj - pretty json (require Python 2.6)
## Aliases explained
- curlh - show header only
- curls - download filename
- curlt - show response time in milliseconds
- curlrc - show http code
