### PR TITLE
Add alias for db:drop db:migrate db:seed command

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -53,6 +53,7 @@ alias rdd='rake db:drop'
 alias rdtc='rake db:test:clone'
 alias rdtp='rake db:test:prepare'
 alias rdmtc='rake db:migrate db:test:clone'
+alias rddms='rake db:drop db:migrate db:seed'
 
 alias rlc='rake log:clear'
 alias rn='rake notes'


### PR DESCRIPTION
Makes easier to do a full reset on database.

Idea by @lucasbibiano (https://github.com/lucasbibiano)
