### PR TITLE
Allow user to blacklist themes from random selector.

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -81,6 +81,10 @@ unset config_file
 # Load the theme
 if [ "$ZSH_THEME" = "random" ]; then
   themes=($ZSH/themes/*zsh-theme)
+  for theme ($ZSH_BLACKLISTED_THEMES) do
+    themes=(${themes:#$ZSH/themes/${theme}.zsh-theme})
+  done
+
   N=${#themes[@]}
   ((N=(RANDOM%N)+1))
   RANDOM_THEME=${themes[$N]}

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -4,8 +4,10 @@ export ZSH=$HOME/.oh-my-zsh
 # Set name of the theme to load.
 # Look in ~/.oh-my-zsh/themes/
 # Optionally, if you set this to "random", it'll load a random theme each
-# time that oh-my-zsh is loaded.
+# time that oh-my-zsh is loaded, except for themes included in 
+# ZSH_BLACKLISTED_THEMES
 ZSH_THEME="robbyrussell"
+#ZSH_BLACKLISTED_THEMES=()
 
 # Uncomment the following line to use case-sensitive completion.
 # CASE_SENSITIVE="true"


### PR DESCRIPTION
If user adds themes they don't want to see to ZSH_BLACKLISTED_THEMES they won't be picked by the random theme selector.

Fixes #3704 
