### PR TITLE
jhbuild: Add shell alias

### DIFF
--- a/plugins/jhbuild/jhbuild.plugin.zsh
+++ b/plugins/jhbuild/jhbuild.plugin.zsh
@@ -23,6 +23,8 @@ alias jhu='jhbuild update'
 alias jhuo='jhbuild updateone'
 # Uninstall
 alias jhun='jhbuild uninstall'
+# Shell
+alias jhsh='jhbuild shell'
 
 
 


### PR DESCRIPTION
This adds "jhsh" as an alias for "jhbuild shell" to the JHBuild plugin.
