### PR TITLE
Add support for choosing the method of seting terminal titles.

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -13,13 +13,37 @@ function title {
   # if it is set and empty, leave it as is
   : ${2=$1}
 
-  if [[ "$TERM" == screen* ]]; then
-    print -Pn "\ek$1:q\e\\" #set screen hardstatus, usually truncated at 20 chars
-  elif [[ "$TERM" == xterm* ]] || [[ "$TERM" == rxvt* ]] || [[ "$TERM" == ansi ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
-    print -Pn "\e]2;$2:q\a" #set window name
-    print -Pn "\e]1;$1:q\a" #set icon (=tab) name
-  fi
+  case $ZSH_THEME_TERM_TITLE_TYPE in
+    screen)
+      print -Pn "\ek$1:q\e\\" #set screen title string, usually truncated at 20 chars
+      ;;
+    screenlong)
+      print -Pn "\ek$2:q\e\\"
+      ;;
+    xterm)
+      print -Pn "\e]2;$2:q\a" #set window name
+      print -Pn "\e]1;$1:q\a" #set icon (=tab) name
+      ;;
+    both)
+      print -Pn "\ek$1:q\e\\"
+      print -Pn "\e]2;$2:q\a"
+      print -Pn "\e]1;$1:q\a"
+      ;;
+    bothlong)
+      print -Pn "\ek$2:q\e\\"
+      print -Pn "\e]2;$2:q\a"
+      print -Pn "\e]1;$1:q\a"
+      ;;
+  esac
 }
+
+if [[ -z $ZSH_THEME_TERM_TITLE_TYPE ]] then;
+  if [[ "$TERM" == screen* ]]; then
+    ZSH_THEME_TERM_TITLE_TYPE=screen
+  elif [[ "$TERM" == xterm* ]] || [[ "$TERM" == rxvt* ]] || [[ "$TERM" == ansi ]] || [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+    ZSH_THEME_TERM_TITLE_TYPE=xterm
+  fi
+fi
 
 ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD
 ZSH_THEME_TERM_TITLE_IDLE="%n@%m: %~"

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -41,6 +41,14 @@ ZSH_THEME="robbyrussell"
 # Would you like to use another custom folder than $ZSH/custom?
 # ZSH_CUSTOM=/path/to/new-custom-folder
 
+# Change the default terminal title setting behavior
+# xterm: Default for most cases, uses \e]1 and \e]2.
+# screen: Default for screen and tmux. Uses \ek with a truncated string.
+# screenlong: A non-truncated version of the screen option.
+# both: Combines the xterm and screen options.
+# bothlong: As both, but do not truncate the string passed to \ek.
+# ZSH_THEME_TERM_TITLE_TYPE = xterm
+
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)


### PR DESCRIPTION
This patch preserves the current behavior, but also allows a user to set
the method they want used. This is useful in certain tmux setups that
use both screen and xterm methods, at the very least.
