### PR TITLE
Added a function to the core GIT library to allow use for Cygwin users

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -7,6 +7,13 @@ function git_prompt_info() {
   fi
 }
 
+function git_cygwin_prompt_info_quick() {
+  ref=$(command git symbolic-ref -q --short HEAD 2> /dev/null)
+  if [[ "${ref}" != "" ]]; then
+    echo "git:${ref}"
+  fi
+}
+
 
 # Checks if working tree is dirty
 parse_git_dirty() {


### PR DESCRIPTION
(Designed to be used by custom themes)

The prompt info for GIT takes an extensive time to return in Cygwin, due to the way Cygwin has to handle c++ forks.

This small addition means that the basic status is able to be displayed, but not taking an extensive amount of time to do so. 
