### PR TITLE
vagrant: add common aliases

### DIFF
--- a/plugins/vagrant/vagrant.plugin.zsh
+++ b/plugins/vagrant/vagrant.plugin.zsh
@@ -1,0 +1,31 @@
+alias vgi="vagrant init"
+
+alias vup="vagrant up"
+alias vd="vagrant destroy"
+alias vdf="vagrant destroy -f"
+
+alias vssh="vagrant ssh"
+alias vrdp="vagrant rdp"
+
+alias vh="vagrant halt"
+alias vssp="vagrant suspend"
+alias vst="vagrant status"
+alias vre="vagrant resume"
+
+alias vpr="vagrant provision"
+alias vr="vagrant reload"
+alias vrp="vagrant reload --provision"
+
+alias vp="vagrant push"
+alias vsh="vagrant share"
+
+alias vba="vagrant box add"
+alias vbr="vagrant box remove"
+alias vbl="vagrant box list"
+alias vbo="vagrant box outdated"
+alias vbu="vagrant box update"
+
+alias vpli="vagrant plugin install"
+alias vpll="vagrant plugin list"
+alias vplun="vagrant plugin uninstall"
+alias vplu="vagrant plugin update"

--- a/plugins/vagrant/vagrant.plugin.zsh
+++ b/plugins/vagrant/vagrant.plugin.zsh
@@ -5,12 +5,14 @@ alias vd="vagrant destroy"
 alias vdf="vagrant destroy -f"
 
 alias vssh="vagrant ssh"
+alias vsshc="vagrant ssh-config"
 alias vrdp="vagrant rdp"
 
 alias vh="vagrant halt"
 alias vssp="vagrant suspend"
 alias vst="vagrant status"
 alias vre="vagrant resume"
+alias vgs="vagrant global-status"
 
 alias vpr="vagrant provision"
 alias vr="vagrant reload"


### PR DESCRIPTION
I found it strange these were missing.  I ran through them all to check that they weren't conflicting with any commands on my system and they were all good.

Almost made `vagrant init` alias to `vi` lol (used `vgi` instead).

Closes #3140
Closes #3312