### PR TITLE
Fix `rbenv_prompt_info` prefix/suffix

### DIFF
--- a/plugins/rbenv/rbenv.plugin.zsh
+++ b/plugins/rbenv/rbenv.plugin.zsh
@@ -44,9 +44,9 @@ for rbenvdir in "${rbenvdirs[@]}" ; do
 
     function rbenv_prompt_info() {
       if [[ -n $(current_gemset) ]] ; then
-        echo "$(current_ruby)@$(current_gemset)"
+        echo "${ZSH_THEME_RVM_PROMPT_PREFIX:=(}$(current_ruby)@$(current_gemset)${ZSH_THEME_RVM_PROMPT_SUFFIX:=)}"
       else
-        echo "$(current_ruby)"
+        echo "${ZSH_THEME_RVM_PROMPT_PREFIX:=(}$(current_ruby)${ZSH_THEME_RVM_PROMPT_SUFFIX:=)}"
       fi
     }
   fi
@@ -56,5 +56,5 @@ unset rbenvdir
 if [ $FOUND_RBENV -eq 0 ] ; then
   alias rubies='ruby -v'
   function gemsets() { echo 'not supported' }
-  function rbenv_prompt_info() { echo "system: $(ruby -v | cut -f-2 -d ' ')" }
+  function rbenv_prompt_info() { echo "${ZSH_THEME_RVM_PROMPT_PREFIX:=(}system: $(ruby -v | cut -f-2 -d ' ')${ZSH_THEME_RVM_PROMPT_SUFFIX:=)}" }
 fi

--- a/themes/jonathan.zsh-theme
+++ b/themes/jonathan.zsh-theme
@@ -12,7 +12,7 @@ function theme_precmd {
     PR_PWDLEN=""
 
     local promptsize=${#${(%):---(%n@%m:%l)---()--}}
-    local rubyprompt=`rvm_prompt_info || rbenv_prompt_info`
+    local rubyprompt="`rvm_prompt_info || rbenv_prompt_info`"
     local rubypromptsize=${#${rubyprompt}}
     local pwdsize=${#${(%):-%~}}
 


### PR DESCRIPTION
Result of rbenv_prompt_info should be the same as rvm_prompt_info.

before:

![150410-0002](https://cloud.githubusercontent.com/assets/1144712/7090163/f726028e-dfdb-11e4-8ec7-0aca2252426d.png)

after:

![150410-0001](https://cloud.githubusercontent.com/assets/1144712/7090168/0120ebdc-dfdc-11e4-89db-eaece584cf29.png)
