### PR TITLE
Fix currentWindowId

### DIFF
--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -23,7 +23,7 @@ currentWindowId () {
   if hash osascript 2>/dev/null; then #osx
     osascript -e 'tell application (path to frontmost application as text) to id of front window' 2&> /dev/null || echo "0"
   elif hash notify-send 2>/dev/null; then #ubuntu!
-    xprop -root | awk '/NET_ACTIVE_WINDOW/ { print $5; exit }'
+    xprop -root | awk '/^_NET_ACTIVE_WINDOW/ { print $5; exit }'
   else
     echo $EPOCHSECONDS #fallback for windows
   fi


### PR DESCRIPTION
On my system xmonad on Ubuntu 14.04, the xprop -root call has an earlier ocurence of NET_ACTIVE_WINDOW that makes this function fail. I guess someone who knows more about xprop should rewrite this function in a less brittle way, but for now my fix should do.
