### PR TITLE
Timebox git calls in git_prompt_dirty

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -39,6 +39,11 @@ ZSH_THEME_GIT_PROMPT_PREFIX="git:("         # Prefix at the very beginning of th
 ZSH_THEME_GIT_PROMPT_SUFFIX=")"             # At the very end of the prompt
 ZSH_THEME_GIT_PROMPT_DIRTY="*"              # Text to display if the branch is dirty
 ZSH_THEME_GIT_PROMPT_CLEAN=""               # Text to display if the branch is clean
+ZSH_THEME_GIT_PROMPT_TIMEDOUT="?"           # Text to display if status check timed out
+
+# Timeout (in seconds, fractions okay) for SCM (git/hg/etc) info checks done
+# inside prompt
+ZSH_THEME_SCM_CHECK_TIMEOUT=1
 
 # Setup the prompt with pretty colors
 setopt prompt_subst

--- a/themes/robbyrussell.zsh-theme
+++ b/themes/robbyrussell.zsh-theme
@@ -4,4 +4,5 @@ PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(g
 ZSH_THEME_GIT_PROMPT_PREFIX="git:(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_TIMEDOUT="%{$fg[blue]%}) %{$fg[red]%}?%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%})"


### PR DESCRIPTION
This "timeboxes" the calls to `git` inside `git_prompt_dirty` to prevent the prompt from locking up when you're in a slow git repo. If the `git` call takes too long, it aborts it and just puts "?" for the `git_prompt_dirty` status. The timeout length and "timed-out" prompt text are user-configurable.

This only timeboxes the `git` call in `git_prompt_dirty` (aka `parse_git_dirty`, renamed for consistency with the other prompt info functions). `git_prompt_info` uses `git_prompt_dirty`, so this will help its slow `git` calls, too. This does not affect the more detailed `git_prompt_status`. I couldn't figure out how to cleanly timebox its `git` calls, which use more than one line of output.

Fixes #3009.
Fixes #3706.
Supersedes #3725. This is the same logic, rebased and squashed, and only for `git_prompt_dirty`.
