### PR TITLE
Allow the systemd plugin to work when sudo is not installed.

### DIFF
--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -8,4 +8,9 @@ sudo_commands=(
   link load cancel set-environment unset-environment)
 
 for c in $user_commands; do; alias sc-$c="systemctl $c"; done
-for c in $sudo_commands; do; alias sc-$c="sudo systemctl $c"; done
+# Do not use sudo for root user
+if [ "`id -u`" = "0" ]; then
+   for c in $sudo_commands; do; alias sc-$c="systemctl $c"; done
+else
+   for c in $sudo_commands; do; alias sc-$c="sudo systemctl $c"; done
+fi


### PR DESCRIPTION
Problem: The systemd plugin requires sudo to be installed.
The plugin set-up aliases sc-\* for each systemctl command, and
prefix the alias with sudo so they can be used from non-root
account. However, this doesn't work if "sudo" is not installed.

Solution: Do not prefix the alias with "sudo" when they
are created for the root account.

This doesn't change anything for non-root user, but allows
root user to use the plugin even when sudo is not available
on the machine.
