### PR TITLE
Add Lotus.rb bin to bundled commands

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -17,6 +17,7 @@ bundled_commands=(
   jekyll
   kitchen
   knife
+  lotus
   middleman
   nanoc
   pry


### PR DESCRIPTION
[Lotus Web Framework](http://lotusrb.org) is provided with a `lotus` command which has to be run using `bundle exec` when used in bundler context.

This PR adds `lotus` bin to auto bundled commands.
