### PR TITLE
Load completions from custom config folder

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -5,14 +5,14 @@ fi
 
 # Initializes Oh My Zsh
 
-# add a function path
-fpath=($ZSH/functions $ZSH/completions $fpath)
-
 # Set ZSH_CUSTOM to the path where your custom config files
 # and plugins exists, or else we will use the default custom/
 if [[ -z "$ZSH_CUSTOM" ]]; then
     ZSH_CUSTOM="$ZSH/custom"
 fi
+
+# add a function path
+fpath=($ZSH/functions $ZSH/completions $ZSH_CUSTOM/completions $fpath)
 
 # Set ZSH_CACHE_DIR to the path where cache files should be created
 # or else we will use the default cache/


### PR DESCRIPTION
The present setup loads custom completions from `$ZSH/completions` which is against what everything else is doing. Plugins and profiles are both loaded from the custom folder. The user should be able to store their all custom modifications in `$ZSH_CUSTOM`.
