### PR TITLE
Mercurial: changed prompt_info to hg_get_id

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -26,9 +26,7 @@ function in_hg() {
 }
 
 function hg_get_branch_name() {
-  if [ $(in_hg) ]; then
     echo $(hg branch)
-  fi
 }
 
 function hg_prompt_info {
@@ -41,7 +39,6 @@ $ZSH_THEME_REPO_NAME_COLOR$_DISPLAY$ZSH_PROMPT_BASE_COLOR$ZSH_PROMPT_BASE_COLOR$
 }
 
 function hg_dirty_choose {
-  if [ $(in_hg) ]; then
     hg status 2> /dev/null | command grep -Eq '^\s*[ACDIM!?L]'
     if [ $pipestatus[-1] -eq 0 ]; then
       # Grep exits with 0 when "One or more lines were selected", return "dirty".
@@ -50,7 +47,6 @@ function hg_dirty_choose {
       # Otherwise, no lines were found, or an error occurred. Return clean.
       echo $2
     fi
-  fi
 }
 
 function hg_dirty {

--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -29,9 +29,13 @@ function hg_get_branch_name() {
     echo $(hg branch)
 }
 
+function hg_get_id() {
+    echo $(hg id -i -b -B -t)
+}
+
 function hg_prompt_info {
   if [ $(in_hg) ]; then
-    _DISPLAY=$(hg_get_branch_name)
+    _DISPLAY=$(hg_get_id)
     echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_HG_PROMPT_PREFIX\
 $ZSH_THEME_REPO_NAME_COLOR$_DISPLAY$ZSH_PROMPT_BASE_COLOR$ZSH_PROMPT_BASE_COLOR$(hg_dirty)$ZSH_THEME_HG_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR"
     unset _DISPLAY


### PR DESCRIPTION
I propose this pull request since it allows for more mercurial repository details and allows to run slightly faster than before. 

When using the mercurial plugin, it tended to have certain slowdowns with retrieval of (heavy) branch status. This was due both to the multiple check calls of `$(in_hg)`, when using `$(hg_prompt_info)`, and to the programming of the `hg branch` command in mercurial.

The `hg id` command has a tendency to be quicker in the callback and, as a bonus, allows for greater detail to a mercurial repository status. I think the `$(hg_get_id)` is better suited for mercurial branching since the command can allow for multiple status outputs like `changeset`, `branch`, and `bookmarks`. It also gives a quick status reference change to the repository when in use.

As such, I took the liberty to truncate the multiple check calls and to also replace the `$(hg_get_branch_name)` function with `$(hg_get_id)` for `$(hg_prompt_info)`.
