### PR TITLE
Speed up the mercurial plugin for large repositories

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -20,7 +20,7 @@ alias hgca='hg qimport -r tip ; hg qrefresh -e ; hg qfinish tip'
 alias hgun='hg resolve --list'
 
 function in_hg() {
-  if [[ -d .hg ]] || $(hg summary > /dev/null 2>&1); then
+  if [[ -d .hg ]] || $(hg root > /dev/null 2>&1); then
     echo 1
   fi
 }
@@ -42,13 +42,20 @@ $ZSH_THEME_REPO_NAME_COLOR$_DISPLAY$ZSH_PROMPT_BASE_COLOR$ZSH_PROMPT_BASE_COLOR$
 
 function hg_dirty_choose {
   if [ $(in_hg) ]; then
-    hg status 2> /dev/null | command grep -Eq '^\s*[ACDIM!?L]'
-    if [ $pipestatus[-1] -eq 0 ]; then
-      # Grep exits with 0 when "One or more lines were selected", return "dirty".
-      echo $1
-    else
-      # Otherwise, no lines were found, or an error occurred. Return clean.
+    # Allow turning off the 'hg status' call. Useful in large repos where that
+    # can take a while. Mirror the functionality of the git plugin by just
+    # showing the "clean" prompt in this case.
+    if [[ "$(command hg config oh-my-zsh.hide-dirty)" = "1" ]]; then
       echo $2
+    else
+      hg status 2> /dev/null | command grep -Eq '^\s*[ACDIM!?L]'
+      if [ $pipestatus[-1] -eq 0 ]; then
+        # Grep exits with 0 when "One or more lines were selected", return "dirty".
+        echo $1
+      else
+        # Otherwise, no lines were found, or an error occurred. Return clean.
+        echo $2
+      fi
     fi
   fi
 }

--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -26,22 +26,24 @@ function in_hg() {
 }
 
 function hg_get_branch_name() {
-  if [ $(in_hg) ]; then
+  if [ $_INHG ]; then
     echo $(hg branch)
   fi
 }
 
 function hg_prompt_info {
-  if [ $(in_hg) ]; then
+  _INHG=$(in_hg)
+  if [ $_INHG ]; then
     _DISPLAY=$(hg_get_branch_name)
     echo "$ZSH_PROMPT_BASE_COLOR$ZSH_THEME_HG_PROMPT_PREFIX\
 $ZSH_THEME_REPO_NAME_COLOR$_DISPLAY$ZSH_PROMPT_BASE_COLOR$ZSH_PROMPT_BASE_COLOR$(hg_dirty)$ZSH_THEME_HG_PROMPT_SUFFIX$ZSH_PROMPT_BASE_COLOR"
     unset _DISPLAY
   fi
+  unset _INHG
 }
 
 function hg_dirty_choose {
-  if [ $(in_hg) ]; then
+  if [ $_INHG ]; then
     # Allow turning off the 'hg status' call. Useful in large repos where that
     # can take a while. Mirror the functionality of the git plugin by just
     # showing the "clean" prompt in this case.


### PR DESCRIPTION
In very large repositories, certain hg commands can take a very long time. Two of those used in the mercurial plugin are particularly bad - `hg status` and `hg summary`. I removed the `hg summary` call by replacing it with `hg root`, which gives us similar information much faster.

`hg status` was a different beast, and since there is no "faster" replacement I ended up just mirroring the functionality of the git plugin. If you're unfamiliar, the git plugin simply shows the clean prompt if a certain config flag is set (`oh-my-zsh.hide-dirty`). This approach has multiple benefits, the most important being that you can configure it per-repository.

Finally, the multiple `in_hg` calls ended up calling `hg root` a lot. These were not super long calls on their own, but when we do it often we end up spending quite a bit of time calculating an answer we already know. To fix this I saved it in a local variable at the beginning of the `hg_prompt_info` call and remove it at the end.
