### PR TITLE
Added atom plugin for cygwin

### DIFF
--- a/plugins/atom-cygwin/README.md
+++ b/plugins/atom-cygwin/README.md
@@ -1,0 +1,17 @@
+## atom-cygwin
+
+This plugin allows invoking the Atom Editor from Cygwin using the `atom` command.
+For this purpose, it uses `cygpath` to convert between Unix and Windows paths.
+
+### Requirements
+
+ * [Atom](https://atom.io/)
+ * [Cygwin](https://www.cygwin.com/)
+
+### Usage
+
+Same as the original CLI script (pointed by `${LOCALAPPDATA}/atom/bin/atom`).
+
+ * If `atom` command is called without an argument, launch Atom
+ * If `atom` is passed a directory, open it in Atom
+ * If `atom` is passed a file, open it in Atom

--- a/plugins/atom-cygwin/atom-cygwin.plugin.zsh
+++ b/plugins/atom-cygwin/atom-cygwin.plugin.zsh
@@ -1,0 +1,18 @@
+if [[ "$OSTYPE" == "cygwin" ]]; then
+    local _atom_path > /dev/null 2>&1
+
+    _atom_path=${LOCALAPPDATA}/atom/bin/atom
+
+    if [[ -a $_atom_path ]]; then
+        cyg_open_atom()
+        {
+            if [[ -n $1 ]]; then
+                ${_atom_path} `cygpath -w -a $1`
+            else
+                ${_atom_path}
+            fi
+        }
+
+        alias atom=cyg_open_atom
+    fi
+fi


### PR DESCRIPTION
Although the original atom plugin is now obsolete (as it adds no extra functionality over the default command line tool provided when installing Atom.io), this plugin helps using the tool on cygwin by translating Linux-like paths to Windows-like paths before calling the original script.
