### PR TITLE
Add aliases for systemd --user start/stop/enable/..

### DIFF
--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -3,7 +3,7 @@ user_commands=(
   is-enabled list-jobs show-environment cat)
 
 dash_user_commands=(
-  start stop status enable disable edit
+  start stop restart status enable disable edit cat
   )
 
 sudo_commands=(

--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -2,6 +2,10 @@ user_commands=(
   list-units is-active status show help list-unit-files
   is-enabled list-jobs show-environment cat)
 
+dash_user_commands=(
+  start stop status enable disable edit
+  )
+
 sudo_commands=(
   start stop reload restart try-restart isolate kill
   reset-failed enable disable reenable preset mask unmask
@@ -9,6 +13,7 @@ sudo_commands=(
   edit)
 
 for c in $user_commands; do; alias sc-$c="systemctl $c"; done
+for c in $dash_user_commands; do; alias sc-user-$c="systemctl --user $c"; done
 for c in $sudo_commands; do; alias sc-$c="sudo systemctl $c"; done
 
 alias sc-enable-now="sc-enable --now"

--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -19,3 +19,4 @@ for c in $sudo_commands; do; alias sc-$c="sudo systemctl $c"; done
 alias sc-enable-now="sc-enable --now"
 alias sc-disable-now="sc-disable --now"
 alias sc-mask-now="sc-mask --now"
+alias sc-user-dr="systemctl --user daemon-reload"


### PR DESCRIPTION
Added new aliases: 

`sc-user-start <service>` means `systemctl --user start <service>`

Avaliable actions: `start`, `stop`, `status`, `enable`, `disable`, `edit`
