### PR TITLE
lib: add safe_alias function

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -63,6 +63,32 @@ function try_alias_value() {
 }
 
 #
+# Alias only if not already a command/function/alias
+# Use option ALLOW_OVERRIDE_ALIASES to force overriding
+#
+# Arguments:
+#    1. my_alias='my alias value'
+#       Same argument you would pass to the "alias" built-in
+# Return value:
+#    0 if the alias was safely created, 73 otherwise
+#
+function safe_alias() {
+    emulate -L zsh
+    local cmd lhs rhs
+    cmd=(${(s:=:)1})
+    lhs=$cmd[1]
+    rhs=$cmd[2,-1]
+    if (( $+commands[$lhs] || $+functions[$lhs] || $+aliases[$lhs] )); then
+        if [[ $ALLOW_OVERRIDE_ALIASES = "true" ]]; then
+            >&2 echo "WARN: override \"$lhs\" with alias \"$rhs\""
+        else
+            return 73  # os.EX_CANTCREAT
+        fi
+    fi
+    alias $lhs="$rhs"
+}
+
+#
 # Set variable "$1" to default value "$2" if "$1" is not yet defined.
 #
 # Arguments:

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -37,6 +37,11 @@ ZSH_THEME="robbyrussell"
 # much, much faster.
 # DISABLE_UNTRACKED_FILES_DIRTY="true"
 
+# Uncomment the following line to allow aliases defined in libs and plugins to
+# override existing commands/functions/aliases. A warning will be printed for
+# every alias overriding an existing name.
+# ALLOW_OVERRIDE_ALIASES="true"
+
 # Uncomment the following line if you want to change the command execution time
 # stamp shown in the history command output.
 # The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"


### PR DESCRIPTION
STATUS — **[[NOT READY]]**
### Summary

This PR adds the `safe_alias` function to `lib/functions` in order to prevent aliases defined in libs and plugins from overriding commands/functions/aliases already defined. It also introduces the `$ALLOW_OVERRIDE_ALIASES` config variable to allow overriding with a warning.
### Roadmap
- [ ] Discuss implementation
  - [ ] Fail when called with illegal arguments
  - [ ] Deal with flags of the `alias` built-in
  - [ ] Deal with the consequences of unset aliases, e.g. when used internally by a plugin
- [ ] Handle duplicate aliases
  - [ ] Intentional ones, e.g. reloading `~/.zshrc` with updated aliases
  - [ ] Unintentional ones, e.g. conflicting plugins
- [ ] Make all aliases safe
  - [ ] List the ones meant to be unsafe by design, e.g. `alias mv='nocorrect mv'`
### Contributions

The idea is from @ChrisJefferson, see https://github.com/robbyrussell/oh-my-zsh/issues/3682#issuecomment-78437079 and the discussion that followed

The implementation is from @blueyed, see https://github.com/robbyrussell/oh-my-zsh/pull/3990#issuecomment-111175759 (I only added parentheses to properly declare the `alias` variable as an array)
