### PR TITLE
Enable using 'gls' on any OS for ls coloring

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -6,17 +6,18 @@ export LSCOLORS="Gxfxcxdxbxegedabagacad"
 if [ "$DISABLE_LS_COLORS" != "true" ]
 then
   # Find the option for using colors in ls, depending on the version: Linux or BSD
-  if [[ "$(uname -s)" == "NetBSD" ]]; then
-    # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors);
-    # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
-    gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty'
-  elif [[ "$(uname -s)" == "OpenBSD" ]]; then
+  # Allow any system with "gls" to use that if available.
+  if [[ "$(uname -s)" == "OpenBSD" ]]; then
     # On OpenBSD, "gls" (ls from GNU coreutils) and "colorls" (ls from base, 
     # with color and multibyte support) are available from ports.  "colorls"  
     # will be installed on purpose and can't be pulled in by installing 
     # coreutils, so prefer it to "gls".
     gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty'
     colorls -G -d . &>/dev/null 2>&1 && alias ls='colorls -G'
+  elif [[ "$(uname -s)" == "NetBSD" || $+commands[gls] ]]; then
+    # On NetBSD, test if "gls" (GNU ls) is installed (this one supports colors);
+    # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
+    gls --color -d . &>/dev/null 2>&1 && alias ls='gls --color=tty'
   else
     ls --color -d . &>/dev/null 2>&1 && alias ls='ls --color=tty' || alias ls='ls -G'
   fi


### PR DESCRIPTION
New adopter to omz. I noticed it had aliased `ls` to `ls --color=tty` despite the check to ensure that this doesn't error-out. 

In debugging I found that I had already setup `ls` as an alias `alias ls="gls -F --color"`, so the check passes (since the check uses the aliased `ls`), and then re-aliases `ls` and wipes out the `gls`. Tricky.

At any rate it seems "more correct" to use `gls` if it's available no matter the OS. I moved the OpenBSD check first to keep the same behavior.

I don't have a NetBSD or OpenBSD to test, but I tried with and without `gls` installed on my mac and `ls` is properly aliased and colored.
