### PR TITLE
Prevent screen plugin title being overwritten by omz core

### DIFF
--- a/plugins/screen/screen.plugin.zsh
+++ b/plugins/screen/screen.plugin.zsh
@@ -1,6 +1,10 @@
 # if using GNU screen, let the zsh tell screen what the title and hardstatus
 # of the tab window should be.
 if [[ "$TERM" == screen* ]]; then
+  # Unset title() function defined in lib/termsupport.zsh to prevent
+  # overwriting our screen titles
+  title(){}
+
   if [[ $_GET_PATH == '' ]]; then
     _GET_PATH='echo $PWD | sed "s/^\/Users\//~/;s/^\/home\//~/;s/^~$USER/~/"'
   fi


### PR DESCRIPTION
lib/termsupport.zsh creates titles for screen which take precedence over
titles set by the screen plugin. Unsetting the title() function within
the screen plugin prevent this "race-condition".
