### PR TITLE
plugin rake-fast: show task descriptions in autocomplete

### DIFF
--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -12,7 +12,12 @@ _rake_does_task_list_need_generating () {
 }
 
 _rake_generate () {
-  rake --silent --tasks | cut -d " " -f 2 > .rake_tasks
+  rake --silent --tasks \
+    | sed "s/^rake //"  \
+    | sed "s/\:/\\\:/g" \
+    | sed "s/\[.*\]//g" \
+    | sed "s/ *# /\:/"  \
+    > .rake_tasks
 }
 
 _rake () {
@@ -21,7 +26,9 @@ _rake () {
       echo "\nGenerating .rake_tasks..." > /dev/stderr
       _rake_generate
     fi
-    compadd `cat .rake_tasks`
+    local -a rake_options
+    rake_options=( "${(f)mapfile[.rake_tasks]}" )
+    _describe 'values' rake_options
   fi
 }
 


### PR DESCRIPTION
This PR adds rake task descriptions to the autocomplete.

**Before:**
<img width="1434" alt="screenshot 2015-12-21 13 17 26" src="https://cloud.githubusercontent.com/assets/792845/11945640/f68dd592-a806-11e5-9444-e9bd1eb12b15.png">

**After:**
<img width="1418" alt="screenshot 2015-12-21 17 15 13" src="https://cloud.githubusercontent.com/assets/792845/11945644/feda9aa0-a806-11e5-8950-fab94adbdda8.png">

It saves both task names and descriptions to the .rake_tasks file, in a format that [_describe](http://zsh.sourceforge.net/Doc/Release/Completion-System.html#index-_005fdescribe) can understand.

Mind taking a look, @KevinBongart?
