### PR TITLE
[battery plugin] Support multiple batteries

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -72,7 +72,7 @@ elif [[ $(uname) == "Linux"  ]] ; then
 
   function battery_pct() {
     if (( $+commands[acpi] )) ; then
-      echo "$(acpi | cut -f2 -d ',' | tr -cd '[:digit:]')"
+      echo "$(acpi | grep '^Battery.*Discharging' | cut -f2 -d ',' | tr -cd '[:digit:]')"
     fi
   }
 
@@ -86,7 +86,7 @@ elif [[ $(uname) == "Linux"  ]] ; then
 
   function battery_time_remaining() {
     if [[ $(acpi 2&>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
-      echo $(acpi | cut -f3 -d ',')
+      echo $(acpi | grep '^Battery.*Discharging' | cut -f3 -d ',')
     fi
   }
 

--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -72,15 +72,15 @@ elif [[ $(uname) == "Linux"  ]] ; then
 
   function battery_pct() {
     if (( $+commands[acpi] )) ; then
-      echo "$(acpi | grep '^Battery.*Discharging' | cut -f2 -d ',' | tr -cd '[:digit:]')"
+      echo "$(acpi | egrep '^Battery.*(Disc|C)harging' | cut -f2 -d ',' | tr -cd '[:digit:]')"
     fi
   }
 
   function battery_pct_remaining() {
-    if [ ! $(battery_is_charging) ] ; then
-      battery_pct
-    else
+    if battery_is_charging ; then
       echo "External Power"
+    else
+      battery_pct
     fi
   }
 


### PR DESCRIPTION
On a system with multiple batteries (like thinkpads) report percentage
and time remaining only for the active battery (the one being
discharged).

Ideally we should report all batteries, but acpi only shows time remaining
for the active battery. Also callers of these functions expect a single
return value. This is still better than reporting 596% remaining (like it
did on my laptop).

For the reference, the output of acpi command with multiple batteries looks
like this:

```
Battery 0: Unknown, 5%
Battery 1: Discharging, 86%, 03:14:04 remaining
```
