### PR TITLE
Added list alias for npm plugin

### DIFF
--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -17,3 +17,6 @@ alias npmD="npm i -D "
 # Execute command from node_modules folder based on current directory
 # i.e npmE gulp
 alias npmE='PATH="$(npm bin)":"$PATH"'
+
+# List all packages installed at root level
+alias npmL='npm ls --depth=0'


### PR DESCRIPTION
Added the alias npmL for listing installed packages at root level (not showing sub-dependencies).
It also works with the global -g option.
