### PR TITLE
Fixed calculation for battery percentage plugin

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -91,7 +91,7 @@ elif [[ $(uname) == "Linux"  ]] ; then
   }
 
   function battery_pct_prompt() {
-    b=$(battery_pct_remaining) 
+    b=$(battery_pct_remaining)
     if [[ $(acpi 2&>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
       if [ $b -gt 50 ] ; then
         color='green'
@@ -136,7 +136,7 @@ function battery_level_gauge() {
   local battery_remaining_percentage=$(battery_pct);
 
   if [[ $battery_remaining_percentage =~ [0-9]+ ]]; then
-    local filled=$(((( $battery_remaining_percentage + $gauge_slots - 1) / $gauge_slots)));
+    local filled=$(((( $battery_remaining_percentage * $gauge_slots) / 100)));
     local empty=$(($gauge_slots - $filled));
 
     if [[ $filled -gt $green_threshold ]]; then local gauge_color=$color_green;

--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -14,7 +14,7 @@ if [[ "$OSTYPE" = darwin* ]] ; then
     local smart_battery_status="$(ioreg -rc "AppleSmartBattery")"
     typeset -F maxcapacity=$(echo $smart_battery_status | grep '^.*"MaxCapacity"\ =\ ' | sed -e 's/^.*"MaxCapacity"\ =\ //')
     typeset -F currentcapacity=$(echo $smart_battery_status | grep '^.*"CurrentCapacity"\ =\ ' | sed -e 's/^.*CurrentCapacity"\ =\ //')
-    integer i=$(((currentcapacity/maxcapacity) * 100))
+    local integer i=$(((currentcapacity/maxcapacity) * 100))
     echo $i
   }
 
@@ -33,7 +33,7 @@ if [[ "$OSTYPE" = darwin* ]] ; then
   function battery_time_remaining() {
     local smart_battery_status="$(ioreg -rc "AppleSmartBattery")"
     if [[ $(echo $smart_battery_status | grep -c '^.*"ExternalConnected"\ =\ No') -eq 1 ]] ; then
-      timeremaining=$(echo $smart_battery_status | grep '^.*"AvgTimeToEmpty"\ =\ ' | sed -e 's/^.*"AvgTimeToEmpty"\ =\ //')
+      local timeremaining=$(echo $smart_battery_status | grep '^.*"AvgTimeToEmpty"\ =\ ' | sed -e 's/^.*"AvgTimeToEmpty"\ =\ //')
       if [ $timeremaining -gt 720 ] ; then
         echo "::"
       else
@@ -46,13 +46,13 @@ if [[ "$OSTYPE" = darwin* ]] ; then
 
   function battery_pct_prompt () {
     if [[ $(ioreg -rc AppleSmartBattery | grep -c '^.*"ExternalConnected"\ =\ No') -eq 1 ]] ; then
-      b=$(battery_pct_remaining)
+      local b=$(battery_pct_remaining)
       if [ $b -gt 50 ] ; then
-        color='green'
+        local color='green'
       elif [ $b -gt 20 ] ; then
-        color='yellow'
+        local color='yellow'
       else
-        color='red'
+        local color='red'
       fi
       echo "%{$fg[$color]%}[$(battery_pct_remaining)%%]%{$reset_color%}"
     else
@@ -91,14 +91,14 @@ elif [[ $(uname) == "Linux"  ]] ; then
   }
 
   function battery_pct_prompt() {
-    b=$(battery_pct_remaining)
+    local b=$(battery_pct_remaining)
     if [[ $(acpi 2&>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
       if [ $b -gt 50 ] ; then
-        color='green'
+        local color='green'
       elif [ $b -gt 20 ] ; then
-        color='yellow'
+        local color='yellow'
       else
-        color='red'
+        local color='red'
       fi
       echo "%{$fg[$color]%}[$(battery_pct_remaining)%%]%{$reset_color%}"
     else


### PR DESCRIPTION
Fixed the calculation for the bars to be filled in for the battery plugin. The old formula didn't work if `BATTERY_GAUGE_SLOTS` was changed to be anything other than `10`, the new formula generalizes to any size battery bar. 
