### PR TITLE
fancy-ctrl-z: ensure widgets are called with full context

### DIFF
--- a/plugins/fancy-ctrl-z/fancy-ctrl-z.plugin.zsh
+++ b/plugins/fancy-ctrl-z/fancy-ctrl-z.plugin.zsh
@@ -1,10 +1,10 @@
 fancy-ctrl-z () {
   if [[ $#BUFFER -eq 0 ]]; then
     BUFFER="fg"
-    zle accept-line
+    zle accept-line -w
   else
-    zle push-input
-    zle clear-screen
+    zle push-input -w
+    zle clear-screen -w
   fi
 }
 zle -N fancy-ctrl-z


### PR DESCRIPTION
According to [this helpful analysis](https://github.com/tarruda/zsh-autosuggestions/issues/82#issuecomment-181133379) in tarruda/zsh-autosuggestions#82 plugin fancy-ctrl-z could be made a better citizen when it calls potentially intercepted/overridden widgets. I do not understand the fix fully (scrutiny welcome), but it does fix the issue on my end.
