### PR TITLE
Add ability to have multiple auto-connected sessions

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -70,6 +70,11 @@ if which tmux &> /dev/null
 		[[ -n $INACTIVE_SESSIONS ]] && echo $INACTIVE_SESSIONS
 	}
 
+	function _all_sessions {
+		ALL_SESSIONS=`tmux ls | grep "$ZSH_TMUX_SESSION_NAME_PREFIX" | cut -d: -f1`
+		[[ -n $ALL_SESSIONS ]] && echo $ALL_SESSIONS
+	}
+
 	# Wrapper function for tmux.
 	function _zsh_tmux_plugin_run()
 	{
@@ -85,7 +90,7 @@ if which tmux &> /dev/null
 			then
 				\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` attach -t `_inactive_sessions | head -n1`
 			else
-				\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session -s "$ZSH_TMUX_SESSION_NAME_PREFIX`_inactive_sessions | tail -n1 | cut -d- -f4 | _incr`"
+				\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session -s "$ZSH_TMUX_SESSION_NAME_PREFIX`_incr $(_all_sessions | tail -n1 | cut -d- -f4)`"
 			fi
 			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
 		# Just run tmux, fixing the TERM variable if requested.


### PR DESCRIPTION
As of now, if you turn on autoconnect and open a new terminal, it will connect you back to your an existing session, even if it's currently attached to by another terminal. This changeset changes the aforementioned behavior so that autoconnect sessions have special names. We use these like so: first we examine existing unattached sessions matching the autoconnect naming scheme, if we find one attach to it, else create a new one.

I don't see why anyone would want two terminal sessions with the same tmux session by default, so I didn't make it configurable. Maybe I'm horribly wrong via oversight, if so I would appreciate it if you let me know which use case I've overlooked. I want this badly and didn't see anything like it with the tmux tag in the issue tracker.
