### PR TITLE
Hide git_prompt_status when hide-status is set

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -120,50 +120,52 @@ function git_prompt_long_sha() {
 
 # Get the status of the working tree
 function git_prompt_status() {
-  local INDEX STATUS
-  INDEX=$(command git status --porcelain -b 2> /dev/null)
-  STATUS=""
-  if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
+  if [[ "$(command git config --get oh-my-zsh.hide-status 2>/dev/null)" != "1" ]]; then
+    local INDEX STATUS
+    INDEX=$(command git status --porcelain -b 2> /dev/null)
+    STATUS=""
+    if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
+    elif $(echo "$INDEX" | grep '^M  ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^ M ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+    elif $(echo "$INDEX" | grep '^AM ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+    elif $(echo "$INDEX" | grep '^ T ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^R  ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_RENAMED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^ D ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
+    elif $(echo "$INDEX" | grep '^D  ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
+    elif $(echo "$INDEX" | grep '^AD ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
+    fi
+    if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_STASHED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^UU ' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_UNMERGED$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^## .*ahead' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_AHEAD$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^## .*behind' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_BEHIND$STATUS"
+    fi
+    if $(echo "$INDEX" | grep '^## .*diverged' &> /dev/null); then
+      STATUS="$ZSH_THEME_GIT_PROMPT_DIVERGED$STATUS"
+    fi
+    echo $STATUS
   fi
-  if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
-  elif $(echo "$INDEX" | grep '^M  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_ADDED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^ M ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  elif $(echo "$INDEX" | grep '^AM ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  elif $(echo "$INDEX" | grep '^ T ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^R  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_RENAMED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^ D ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
-  elif $(echo "$INDEX" | grep '^D  ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
-  elif $(echo "$INDEX" | grep '^AD ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DELETED$STATUS"
-  fi
-  if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_STASHED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^UU ' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_UNMERGED$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^## .*ahead' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_AHEAD$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^## .*behind' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_BEHIND$STATUS"
-  fi
-  if $(echo "$INDEX" | grep '^## .*diverged' &> /dev/null); then
-    STATUS="$ZSH_THEME_GIT_PROMPT_DIVERGED$STATUS"
-  fi
-  echo $STATUS
 }
 
 # Compares the provided version of git to the version installed and on path


### PR DESCRIPTION
On very large repos executing `git status` can take really long time. Setting hide-status had effect only on `git_prompt_info()` but not on `git_prompt_status()`. This makes `git_prompt_status()`check for hide-status as well.
