### PR TITLE
Add Sudo option to npm -g

### DIFF
--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -2,6 +2,7 @@ eval "$(npm completion 2>/dev/null)"
 
 # Install dependencies globally
 alias npmg="npm i -g "
+alias snpmg="sudo npm i -g "
 
 # npm package names are lowercase
 # Thus, we've used camelCase for the following aliases:


### PR DESCRIPTION
All sudo to be used with NPM -g option.
Follows pattern for other plugins
