### PR TITLE
Add helper function to get the mercurial bookmark.

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -63,3 +63,9 @@ function hgic() {
 function hgoc() {
     hg outgoing "$@" | grep "changeset" | wc -l
 }
+
+function hg_get_bookmark_name() {
+  if [ $(in_hg) ]; then
+    echo $(hg id -B)
+  fi
+}


### PR DESCRIPTION
Add a new function to get the current mercurial bookmark which can be
used in the theme prompts for example.
