### PR TITLE
Improve the regex used by git-prompt to extract tagname

### DIFF
--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -17,7 +17,7 @@ def get_tagname_or_hash():
     if m:
         hash_ = output[:m.start()-1]
     # get tagname
-    m = re.search('tag: .*[,\)]', output)
+    m = re.search('tag: .*?[,\)]', output)
     if m:
         tagname = 'tags/' + output[m.start()+len('tag: '): m.end()-1]
 


### PR DESCRIPTION
To get the name of the current checked out tag the gitstatus.py script
calls `git log -1 --format="%h%d"`.  Ordinarily this will output
something similar to `(HEAD, tag: foo)`.  Then the regex grabs
everything from `tag:` to the closing `)` and then drops the last
character to give the tag name.  This causes a problem when the current
tag is equal to another tag or branch and the output looks like this:
`(HEAD, tag: foo, origin/master)` and  the tagname gets set to
`tag: foo, origin/master`.  This breaks the whole script because its
output is space delimited and GIT_AHEAD which is supposed to be an
integer gets set to `origin/master` (branch also get set to `foo,`
instead of `foo`, but it's not as big of a problem).  To fix this we
change the regex to be nongreedy so that it will only grab one item from
the list and let the closing match either `,`(comma space) or `)`.  We
also have to use a lookahead since we can't just drop 1 character (`,`
is 2 characters).
