### PR TITLE
add support for randomly selecting from a list of specific themes

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -92,6 +92,13 @@ for config_file ($ZSH_CUSTOM/*.zsh(N)); do
 done
 unset config_file
 
+if [[ "$(declare -p ZSH_THEME) 2>/dev/null" =~ "(declare|typeset) -a" ]]; then
+  # Choose randomly from multiple specified themes
+  THEME_COUNT=${#ZSH_THEME[@]}
+  ((THEME_N=(RANDOM%THEME_COUNT)+1))
+  ZSH_THEME=${ZSH_THEME[$THEME_N]}
+fi
+
 # Load the theme
 if [ "$ZSH_THEME" = "random" ]; then
   themes=($ZSH/themes/*zsh-theme)

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -3,9 +3,12 @@ export ZSH=$HOME/.oh-my-zsh
 
 # Set name of the theme to load.
 # Look in ~/.oh-my-zsh/themes/
-# Optionally, if you set this to "random", it'll load a random theme each
-# time that oh-my-zsh is loaded.
 ZSH_THEME="robbyrussell"
+# Optionally, if you set this to "random", it'll load a random non-custom
+# theme each time that oh-my-zsh is loaded.
+# ZSH_THEME="random"
+# This can also be a list of specific themes to be chosen between at random
+# ZSH_THEME=(arrow gallifrey robbyrussell smt wedisagree)
 
 # Uncomment the following line to use case-sensitive completion.
 # CASE_SENSITIVE="true"


### PR DESCRIPTION
As a new oh-my-zsh user I set my theme to random to try out a bunch of themes. I found a few that I like, and now I want to just have it pick between those until I decide which one to stick with. This patch allows ZSH_THEME to optionally be an array instead of a string.
