### PR TITLE
Add `cda` alias for composer dump-autoload

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -42,6 +42,7 @@ alias cr='composer require'
 alias ci='composer install'
 alias ccp='composer create-project'
 alias cdu='composer dump-autoload'
+alias cda='composer dump-autoload'
 alias cgu='composer global update'
 alias cgr='composer global require'
 


### PR DESCRIPTION
This catches me out all the time. Surely the alias should be `cda`, not `cdu`

I've left `cdu` in there for people that are used to typing that now.
