### PR TITLE
Vagrant - Add vm_list for suspend and rdp

### DIFF
--- a/plugins/vagrant/_vagrant
+++ b/plugins/vagrant/_vagrant
@@ -121,7 +121,7 @@ case $state in
       (box)
           __vagrant-box
       ;;
-      (up|provision|package|destroy|reload|ssh|ssh-config|halt|resume|status)
+      (up|provision|package|destroy|reload|ssh|ssh-config|halt|resume|status|suspend|rdp)
       _arguments ':feature:__vm_list'
     esac
   ;;


### PR DESCRIPTION
Vagrant - Add autocomplete vm list for subcomands suspend and rpd
