### PR TITLE
Add ability to specify tmux executable path in tmux plugin

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -34,6 +34,8 @@ if which tmux &> /dev/null
 	# Tmux states this should be screen-256color, but you may need to change it on
 	# systems without the proper terminfo
 	[[ -n "$ZSH_TMUX_FIXTERM_WITH_256COLOR" ]] || ZSH_TMUX_FIXTERM_WITH_256COLOR="screen-256color"
+	# Optionally specify which tmux executable to use
+	[[ -n "$ZSH_TMUX_PATH" ]] || ZSH_TMUX_PATH=$(which \tmux)
 
 
 	# Get the absolute path to the current directory
@@ -63,15 +65,15 @@ if which tmux &> /dev/null
 		# We have other arguments, just run them
 		if [[ -n "$@" ]]
 		then
-			\tmux $@
+			$ZSH_TMUX_PATH $@
 		# Try to connect to an existing session.
 		elif [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]]
 		then
-			\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` attach || \tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session
+			$ZSH_TMUX_PATH `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` attach || \tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG` new-session
 			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
 		# Just run tmux, fixing the TERM variable if requested.
 		else
-			\tmux `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG`
+			$ZSH_TMUX_PATH `[[ "$ZSH_TMUX_ITERM2" == "true" ]] && echo '-CC '` `[[ "$ZSH_TMUX_FIXTERM" == "true" ]] && echo '-f '$_ZSH_TMUX_FIXED_CONFIG`
 			[[ "$ZSH_TMUX_AUTOQUIT" == "true" ]] && exit
 		fi
 	}


### PR DESCRIPTION
Have two versions of tmux installed. Don't want to rely on the version that PATH resolves to.
