### PR TITLE
Ditch smkx in favor of custom bindkey extension

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -223,3 +223,13 @@ function omz_urldecode {
 
   echo -E "$decoded"
 }
+
+# Print input iff $_OMZ_DEBUG is enabled (>0)
+# All arguments are passed verbatim to print()
+function _omz_dbg_print() {
+  if ! (( $_OMZ_DEBUG )); then
+    return
+  fi
+  print "$@"
+}
+

--- a/lib/key-binding-support.zsh
+++ b/lib/key-binding-support.zsh
@@ -1,0 +1,200 @@
+# http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html
+# http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Zle-Builtins
+# http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Standard-Widgets
+
+zmodload -i zsh/zutil
+
+# OMZ takes over zle-line-init/finish, to:
+#  a) provide hooks for multiple init/finish functions, like $precmd_functions does
+#  b) disable [sr]mkx on the few systems whose system zsh configuration enables it
+typeset -g -a zle_line_init_functions zle_line_finish_functions
+function zle-line-init() {
+  local fcn
+  for fcn in "${zle_line_init_functions[@]}"; do
+    $fcn
+  done
+}
+function zle-line-finish() {
+  local fcn
+  for fcn in "${zle_line_finish_functions[@]}"; do
+    $fcn
+  done
+}
+zle -N zle-line-init
+zle -N zle-line-finish
+
+# DEBUG: This is the old stuff we used to do to put the keypads in application mode
+# during command line editing. It's included here to make it easy to test the
+# new key binding logic under both normal and application modes. This should
+# go away once the modeless key binding stuff is tested.
+# Note: This breaks the zle-line-init/finish hooks from above.
+if (( $_OMZ_DEBUG_SMKX )); then
+  if (( ${+terminfo[smkx]} )) && (( ${+terminfo[rmkx]} )); then
+    function zle-line-init() {
+      echoti smkx
+    }
+    function zle-line-finish() {
+      echoti rmkx
+    }
+    zle -N zle-line-init
+    zle -N zle-line-finish
+  fi
+fi
+# end old keypad-mode stuff
+
+
+# Extra portability cursor key mappings for local-mode keypad and terminals
+# which deviate from typical terminfo entries. Supplements $terminfo.
+# Maps capability names to |-delimited lists of character sequences.
+# Reflects the capabilities of the $TERM defined at startup.
+typeset -AHg _omz_terminfo_extra
+_omz_terminfo_extra=(
+  # Start with the basic Xterm local-mode sequences. (Some people call 
+  # these "ANSI" key sequences.)
+  kcuu1   "\e[A"  # up
+  kcud1   "\e[B"  # down
+  kcuf1   "\e[C"  # right ("forward")
+  kcub1   "\e[D"  # left ("backward")
+  khome   "\e[H"  # home
+  kend    "\e[F"  # end
+  )
+# Portability entries for terminals we can't recognize from $TERM
+# Putty and others may send the VT220 editing keypad sequences for
+# Home/End. Bind those too, since there's no collision risk AFAIK.
+# TODO: Should we alias the whole 6-key VT220 editing keypad?
+_omz_terminfo_extra[khome]="$_omz_terminfo_extra[khome]|\e[1~"
+_omz_terminfo_extra[kend]="$_omz_terminfo_extra[kend]|\e[4~"
+# Do *not* bind '\e[Ow' here, which Putty may also send for End, because
+# it collides with application-mode numeric keypad sequences.
+
+# Terminal-specific portability entries for the current terminal, for
+# terminals whose local-mode sequences are known to differ from Xterm's
+case "$TERM" in
+  rxvt-unicode*)
+    # rxvt-unicde local-cursor sequences that differ from xterm
+    _omz_terminfo_extra[khome]="$_omz_terminfo_extra[khome]|\e[7~"
+    _omz_terminfo_extra[kend]="$_omz_terminfo_extra[kend]|\e[8~"
+esac
+
+# omz_bindkey - an extension to bindkey
+#
+# omz_bindkey [options] -t <capability> <command>
+# omz_bindkey -c <modifier> <cursor-key> <command>
+# omz_bindkey [...normal bindkey arguments...]
+#
+# Adds the following features on top of bindkey:
+# 1) Logging
+# 2) -t: binds a key, using terminfo and OMZ portability mappings
+# 3) -c: binds an Xterm-style modified cursor key sequence
+#
+# Returns:
+#   0 if a binding was made
+#   1 if no binding was made
+#   2 if an error occurred
+function omz_bindkey() {
+  emulate -L zsh
+  # Note: "seq" is short for "sequence" in these functions
+  # We must capture all of bindkey's options to get ordering right when calling it
+  local -a omz_opts bindkey_opts
+  omz_opts=()
+  bindkey_opts=()
+  local -A optvals
+  zparseopts -a bindkey_opts -A optvals -D -E t:=omz_opts c=omz_opts M:
+  if [[ -n ${omz_opts[(r)-t]} ]]; then
+    # OMZ terminfo-based binding
+    local cap=${optvals[-t]}
+    local retval=1 seq seqs
+    seqs=()
+    if [[ -n "${terminfo[$cap]}" ]]; then
+      seqs=("$seqs[@]" "${terminfo[$cap]}")
+    fi
+    if [[ -n "${_omz_terminfo_extra[$cap]}" ]]; then
+      seqs=("$seqs[@]" "${(s:|:)_omz_terminfo_extra[$cap]}")
+    fi
+    # Done with a while loop because for seems to break here
+    local ix=0
+    while (( ++ix <= $#seqs )); do
+      seq="${seqs[$ix]}"
+      _omz_dbg_print -r "omz_bindkey: terminfo: $cap '${(q)seq}' $@"
+      bindkey "${bindkey_opts[@]}" $seq "$@"
+      retval=0
+    done
+    return $retval
+  elif [[ -n ${omz_opts[(r)-c]} ]]; then
+    # "-c" for "composed modified-cursor" keys
+    _omz_dbg_print -r "omz_bindkey: modified-cursor: '$1' '$2' '$3'"
+    _omz_bindkey_modified_cursor_key_xterm "$1" "$2" "$3"
+  else
+    _omz_dbg_print -r "omz_bindkey: passthrough: ${(q)@}"
+    bindkey "${bindkey_opts[@]}" "$@"
+  fi
+}
+
+# Xterm style function key modifier codes
+typeset -Ag _omz_ti_modifiers
+_omz_ti_modifiers=(
+  'shift'           2
+  'alt'             3
+  'alt-shift'       4
+  'ctrl'            5
+  'ctrl-shift'      6
+  'ctrl-alt'        7
+  'ctrl-alt-shift'  8
+  'meta'            9
+  'meta-shift'      10
+  'meta-alt'        11
+  'meta-alt-shift'  12
+  'meta-ctrl'       13
+  'meta-ctrl-shift' 14
+  'meta-ctrl-alt'   15
+  'meta-ctrl-alt-shift' 16
+  )
+
+# Binds a modified cursor key sequence
+# Uses xterm modifier mask codes,
+# per http://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-PC-Style-Function-Keys
+# When used in combination, modifier keys must be supplied in the following canonical order:
+#  meta ctrl alt shift
+function _omz_bindkey_modified_cursor_key_xterm() {
+  emulate -L zsh
+  local opts
+  opts=()
+  zparseopts -a opts -D -E M:
+  local modifier=$1 key=$2 widget=$3
+  local CSI='\e['  # Control Sequence Introducer
+  local seq modified_seq
+  local -A modifiers keys
+  set -A modifiers ${(kv)_omz_ti_modifiers}
+  keys=(
+    up    A
+    down  B
+    right C
+    left  D
+    home  H
+    end   F
+    )
+  if [[ -z "$modifiers[$modifier]" ]] || [[ -z "$keys[$key]" ]]; then
+    _omz_dbg_print -r "Invalid modified-cursor-key: modifier=$modifier key=$key"
+    return 1
+  fi
+  seq="${CSI}${keys[$key]}"
+  _omz_bindkey_modified_cursor_seq_xterm_step "$seq" "$modifier"
+  # Wokaround for iTerm2: it reports alt as meta, so bind alt-modified sequences
+  # to the meta-modified variant, too.
+  # See https://gitlab.com/gnachman/iterm2/issues/3753
+  if [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+    if [[ "$modifier" == "alt" ]]; then
+      _omz_bindkey_modified_cursor_seq_xterm_step "$seq" "meta"
+    fi
+  fi
+}
+
+function _omz_bindkey_modified_cursor_seq_xterm_step() {
+  local seq="$1" modifier="$2"
+  local modified_seq
+  local -A modifiers keys
+  set -A modifiers ${(kv)_omz_ti_modifiers}
+  modified_seq="${seq[1,-2]}1;$modifiers[$modifier]${seq[-1,-1]}"
+  omz_bindkey "${opts[@]}" "$modified_seq" "$widget"  
+}
+

--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -1,93 +1,39 @@
-# http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html
-# http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Zle-Builtins
-# http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Standard-Widgets
-
-# Make sure that the terminal is in application mode when zle is active, since
-# only then values from $terminfo are valid
-if (( ${+terminfo[smkx]} )) && (( ${+terminfo[rmkx]} )); then
-  function zle-line-init() {
-    echoti smkx
-  }
-  function zle-line-finish() {
-    echoti rmkx
-  }
-  zle -N zle-line-init
-  zle -N zle-line-finish
-fi
+# Specific key bindings
+# See also key-binding-support.zsh for helper functions used here
 
 bindkey -e                                            # Use emacs key bindings
 
-bindkey '\ew' kill-region                             # [Esc-w] - Kill from the cursor to the mark
-bindkey -s '\el' 'ls\n'                               # [Esc-l] - run command: ls
-bindkey '^r' history-incremental-search-backward      # [Ctrl-r] - Search backward incrementally for a specified string. The string may begin with ^ to anchor the search to the beginning of the line.
-if [[ "${terminfo[kpp]}" != "" ]]; then
-  bindkey "${terminfo[kpp]}" up-line-or-history       # [PageUp] - Up a line of history
-fi
-if [[ "${terminfo[knp]}" != "" ]]; then
-  bindkey "${terminfo[knp]}" down-line-or-history     # [PageDown] - Down a line of history
-fi
+omz_bindkey    '\ew' kill-region                      # [Esc-w] - Kill from the cursor to the mark
+omz_bindkey -s '\el' 'ls\n'                           # [Esc-l] - run command: ls
+omz_bindkey    '^r' history-incremental-search-backward  # [Ctrl-r] - Search backward incrementally for a specified string. 
+                                                      #    The string may begin with ^ to anchor the search to the beginning of the line.
 
-# start typing + [Up-Arrow] - fuzzy find history forward
-if [[ "${terminfo[kcuu1]}" != "" ]]; then
-  autoload -U up-line-or-beginning-search
-  zle -N up-line-or-beginning-search
-  bindkey "${terminfo[kcuu1]}" up-line-or-beginning-search
-fi
-# start typing + [Down-Arrow] - fuzzy find history backward
-if [[ "${terminfo[kcud1]}" != "" ]]; then
-  autoload -U down-line-or-beginning-search
-  zle -N down-line-or-beginning-search
-  bindkey "${terminfo[kcud1]}" down-line-or-beginning-search
-fi
+omz_bindkey -t kpp    up-line-or-history            # [PageUp] - Up a line of history
+omz_bindkey -t knp    down-line-or-history          # [PageDown] - Down a line of history
+omz_bindkey -t kcuu1  up-line-or-search             # start typing + [Up-Arrow] - fuzzy find history forward
+omz_bindkey -t kcud1  down-line-or-search           # start typing + [Down-Arrow] - fuzzy find history backward
+omz_bindkey -t khome  beginning-of-line             # [Home] - Go to beginning of line
+omz_bindkey -t kend   end-of-line                   # [End] - Go to end of line
+omz_bindkey -c ctrl right  forward-word             # [Ctrl-Right] - move forward one word
+omz_bindkey -c ctrl left   backward-word            # [Ctrl-Left] - move backward one word
+  
+omz_bindkey    ' '    magic-space                   # [Space] - do history expansion
 
-if [[ "${terminfo[khome]}" != "" ]]; then
-  bindkey "${terminfo[khome]}" beginning-of-line      # [Home] - Go to beginning of line
-fi
-if [[ "${terminfo[kend]}" != "" ]]; then
-  bindkey "${terminfo[kend]}"  end-of-line            # [End] - Go to end of line
-fi
+omz_bindkey -t kcbt   reverse-menu-complete         # [Shift-Tab] - move through the completion menu backwards
 
-bindkey ' ' magic-space                               # [Space] - do history expansion
-
-bindkey '^[[1;5C' forward-word                        # [Ctrl-RightArrow] - move forward one word
-bindkey '^[[1;5D' backward-word                       # [Ctrl-LeftArrow] - move backward one word
-
-if [[ "${terminfo[kcbt]}" != "" ]]; then
-  bindkey "${terminfo[kcbt]}" reverse-menu-complete   # [Shift-Tab] - move through the completion menu backwards
-fi
-
-bindkey '^?' backward-delete-char                     # [Backspace] - delete backward
-if [[ "${terminfo[kdch1]}" != "" ]]; then
-  bindkey "${terminfo[kdch1]}" delete-char            # [Delete] - delete forward
-else
-  bindkey "^[[3~" delete-char
-  bindkey "^[3;5~" delete-char
-  bindkey "\e[3~" delete-char
+omz_bindkey    '^?'   backward-delete-char          # [Backspace] - delete backward
+omz_bindkey -t kdch1  delete-char                   # [Delete] - delete forward
+if [[ $? != 0 ]]; then
+  # Alternate forward-delete sequences, if not in terminfo
+  omz_bindkey '\e[3~'  delete-char   # VT220 editing keypad Del
+  omz_bindkey '\e3;5~' delete-char   # I don't know what this is, but it was here before -apjanke
 fi
 
 # Edit the current command line in $EDITOR
 autoload -U edit-command-line
 zle -N edit-command-line
-bindkey '\C-x\C-e' edit-command-line
+omz_bindkey '\C-x\C-e' edit-command-line
 
-# file rename magick
-bindkey "^[m" copy-prev-shell-word
+# File rename magick
+omz_bindkey '\em' copy-prev-shell-word
 
-# consider emacs keybindings:
-
-#bindkey -e  ## emacs key bindings
-#
-#bindkey '^[[A' up-line-or-search
-#bindkey '^[[B' down-line-or-search
-#bindkey '^[^[[C' emacs-forward-word
-#bindkey '^[^[[D' emacs-backward-word
-#
-#bindkey -s '^X^Z' '%-^M'
-#bindkey '^[e' expand-cmd-path
-#bindkey '^[^I' reverse-menu-complete
-#bindkey '^X^N' accept-and-infer-next-history
-#bindkey '^W' kill-region
-#bindkey '^I' complete-word
-## Fix weird sequence that rxvt produces
-#bindkey -s '^[[Z' '\t'
-#

--- a/plugins/dircycle/dircycle.plugin.zsh
+++ b/plugins/dircycle/dircycle.plugin.zsh
@@ -44,11 +44,5 @@ insert-cycledright () {
 zle -N insert-cycledright
 
 
-# These sequences work for xterm, Apple Terminal.app, and probably others.
-# Not for rxvt-unicode, but it doesn't seem differentiate Ctrl-Shift-Arrow
-# from plain Shift-Arrow, at least by default.
-# iTerm2 does not have these key combinations defined by default; you will need
-# to add them under "Keys" in your profile if you want to use this. You can do
-# this conveniently by loading the "xterm with Numeric Keypad" preset.
-bindkey "\e[1;6D" insert-cycledleft
-bindkey "\e[1;6C" insert-cycledright
+omz_bindkey -c ctrl-shift left insert-cycledleft
+omz_bindkey -c ctrl-shift right insert-cycledright

--- a/plugins/history-substring-search/history-substring-search.plugin.zsh
+++ b/plugins/history-substring-search/history-substring-search.plugin.zsh
@@ -1,15 +1,14 @@
 0=${(%):-%N}
 source ${0:A:h}/history-substring-search.zsh
 
-
 # Bind terminal-specific up and down keys
 
 if [[ -n "$terminfo[kcuu1]" ]]; then
-  bindkey -M emacs "$terminfo[kcuu1]" history-substring-search-up
-  bindkey -M viins "$terminfo[kcuu1]" history-substring-search-up
+  omz_bindkey -M emacs -t kcuu1 history-substring-search-up
+  omz_bindkey -M viins -t kcuu1 history-substring-search-up
 fi
 if [[ -n "$terminfo[kcud1]" ]]; then
-  bindkey -M emacs "$terminfo[kcud1]" history-substring-search-down
-  bindkey -M viins "$terminfo[kcud1]" history-substring-search-down
+  omz_bindkey -M emacs -t kcud1 history-substring-search-down
+  omz_bindkey -M viins -t kcud1 history-substring-search-down
 fi
 

--- a/plugins/history-substring-search/update-from-upstream.zsh
+++ b/plugins/history-substring-search/update-from-upstream.zsh
@@ -75,14 +75,10 @@ cat >> $plugin_basename.plugin.zsh <<EOF
 
 # Bind terminal-specific up and down keys
 
-if [[ -n "\$terminfo[kcuu1]" ]]; then
-  bindkey -M emacs "\$terminfo[kcuu1]" history-substring-search-up
-  bindkey -M viins "\$terminfo[kcuu1]" history-substring-search-up
-fi
-if [[ -n "\$terminfo[kcud1]" ]]; then
-  bindkey -M emacs "\$terminfo[kcud1]" history-substring-search-down
-  bindkey -M viins "\$terminfo[kcud1]" history-substring-search-down
-fi
+omz_bindkey -M emacs -t kcuu1 history-substring-search-up
+omz_bindkey -M viins -t kcuu1 history-substring-search-up
+omz_bindkey -M emacs -t kcud1 history-substring-search-down
+omz_bindkey -M viins -t kcud1 history-substring-search-down
 
 EOF
 

--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -17,9 +17,10 @@ bindkey -M paste -s '^M' '^J'
 
 zle -N _start_paste
 zle -N _end_paste
-zle -N zle-line-init _zle_line_init
-zle -N zle-line-finish _zle_line_finish
 zle -N paste-insert _paste_insert
+
+zle_line_init_functions+=_omz_safe_paste_line_init
+zle_line_finish_functions+=_omz_safe_paste_line_finish
 
 # switch the active keymap to paste mode
 function _start_paste() {
@@ -41,12 +42,12 @@ function _paste_insert() {
   _paste_content+=$KEYS
 }
 
-function _zle_line_init() {
+function _omz_safe_paste_line_init() {
   # Tell terminal to send escape codes around pastes.
   [[ $TERM == rxvt-unicode || $TERM == xterm || $TERM = xterm-256color || $TERM = screen || $TERM = screen-256color ]] && printf '\e[?2004h'
 }
 
-function _zle_line_finish() {
+function _omz_safe_paste_line_finish() {
   # Tell it to stop when we leave zle, so pasting in other programs
   # doesn't get the ^[[200~ codes around the pasted text.
   [[ $TERM == rxvt-unicode || $TERM == xterm || $TERM = xterm-256color || $TERM = screen || $TERM = screen-256color ]] && printf '\e[?2004l'


### PR DESCRIPTION
## Motivation

More than 2 years ago, Oh My Zsh merged the Pull Request #1355, which introduced a fix to be able to use terminfo sequences to specify key codes to `bindkey`, with the intention to make it standard for everyone and not having to change bindkey sequences all the time. 

**That experiment failed, and it's been obviously clear for quite a while.** Since then lots of issues have popped up where certain combinations of keys didn't work (see list of _Fixes_ below), and the culprit of that is that terminfo databases are not maintained all that well and there is not consistent support among Terminal Emulators.

This is why we're choosing to drop that experiment, and use a custom wrapper around bindkey named `omz_bindkey` were you'll be able to choose whichever modifier keys you want ─ <kbd>CTRL</kbd>, <kbd>ALT</kbd>, <kbd>SHIFT</kbd>, <kbd>META</kbd> ─ instead of having to use an obscure character sequence like `'^[[OH'`.

**Here's where _you_ come into play:** since this is a big change, we need a broad number of users to test in their respective configurations, with as many Terminal Emulators as we can, before we can safely merge this PR knowing that there won't be many users affected.

Thanks for taking the time to read this; in [this GitHub guide](https://help.github.com/articles/checking-out-pull-requests-locally/) you'll find how you can check out this PR locally. After that, restart your terminal or run `exec zsh` to reload Oh My Zsh.

Please report back if there are any keyboard shortcuts broken in your system with the following information:
- Zsh version: run `echo $ZSH_VERSION`.
- Terminal Emulator and its version: _e.g._ iTerm2, Terminal.app, Gnome Terminal, Guake, ...
- TERM variable: run `echo $TERM`.
- The broken keyboard shortcut and its character sequence which you can get [following this tutorial](https://asciinema.org/a/ejxdamcgxew2qlmyb8gdnrxeh) I've made.
- Your current `bindkey` configuration: run `bindkey` and post its output.
- Anything else that you think is relevant.

That is all. Thanks again for participating in this! ─ @mcornella

---
## Description

I think it's time to abandon `smkx`/`rmkx` and stick with "local" keypad mode, even if it requires us to hardcode a few character sequences instead of using terminfo for everything. This PR does so, adding an `omz_bindkey` function that allows us to still use terminfo capability codes in key bindings, and supports cursor keys with modifiers. This should fix a whole slew of these recurring cursor-key terminal issues.

Fixes #4916 – Num Pad can't input 
Fixes #4872 – Home and End not working in MobaXterm
Fixes #4784 – Home and End not working in PhpStorm terminal in Mac OS/X
Fixes #3757 – Home/End broken in PuTTY
Fixes #3733 – Home/End broken in CentOS
Fixes #3495 – Home/End broken in CentOS
Fixes #3061 – Home/End broken in Ubuntu
Probably fixes #2750 – Cursor key bindings broken in urxvt on openSUSE – or at least makes it moot
Fixes #2735 – history-substring-search key bindings broken after terminfo changeover
Fixes #2698 – Home/End broken in gnome-terminal
Fixes #2654 – Num keypad broken on OS X
Fixes #2369 – Change to option-arrow behavior on OS X
Fixes #5149 – Plugin 'safe-paste' messes with 'history-substring-search'
Fixes #5228 – Application mode not working on xterm.js
Fixes #5237 - Safe-paste plugin breaks Home/End
Avoids sourcelair/xterm.js#151 - zsh / oh-my-zsh - no scroll
...and all those other issues about Home/End or the numeric keypad.
## Discussion

Switching to use smkx/rmkx application mode and terminfo for portability was a good idea: you're _supposed_ to use portability libraries for stuff like this. But I think it's time to call it a failed experiment. Not because the implementation in OMZ was bad, but because terminfo and the various terminal programs out there don't have sufficient support for it.

I dug pretty deep in to this issue, and I think that the smkx/rmkx+terminfo solution _cannot_ be made to work for everyone. And you'll continue to see issues reported for it. But local mode with a few hardcoded sequences _can_ work.

The smkx/rmkx approach is defeated by a few factors:
- Terminal emulators [vary in their application mode behavior](https://docs.google.com/spreadsheets/d/1Ue5gb2hLjz058QEtEXwaw8YR7QoVZpSYzbXQKrRcGKk/edit#gid=0), and don't necessarily match `xterm`, which is what most people use for their `$TERM`, even if they're really running a different program
- terminfo conflates the mode setting for cursor keypads and the numeric keypads: [sr]mkx changes both, but we only want the cursor keypads changed
- the program-specific terminfo database entries for PuTTY, Terminal.app, and other programs may not be installed on a given system, or may be incomplete or out of date. We don't want to require custom installation of terminfo entries if we can possibly avoid it.

Using smkx/rmkx is also complicated because:
- Most terminal-related code snippets on forums, StackOverflow, and the rest of the internet are for local mode, so they won't work in OMZ if we use [sr]mkx
- `bash` only supports local mode, so bash cursor code can't be used under [sr]mkx
- Most people don't know about [sr]mkx, so educating people about it becomes part of every bug report for keypad problems
- Using [sr]mkx requires using the `zle-line-init` and `zle-line-finish` hooks, which conflicts with anything else that wants to use them (including some OMZ plugins).
#### zle-line-init/finish hooks

As part of this PR's changes, Oh My Zsh completely takes over the `zle-line-init` and `zle-line-finish` hooks, replacing them with functions that provide support for multiple hook functions to be registered. This is done for two independent reasons. Primarily, it's to clobber and remove any zle-line-init/finish hooks installed by zsh configuration files supplied by the system. Some Linux distributions define hooks which do the [sr]mkx thing, and we need to make sure that doesn't happen. Secondly, it allows for multiple OMZ plugins to install line-init/finish hooks without conflicting with each other.

As part of this, we're essentially having OMZ declare zle-line-init/finish to be completely its territory. I think this is okay.
## Implementation

The terminfo-based key binding code was a lot easier to read, because it used mnemonic terminfo capability codes instead of literal terminal control sequences. So this PR adds an `omz_bindkey` extension on top of `bindkey` that allows you to still use those codes. (It also adds logging support, which would make diagnosing key binding issues a lot easier, because you could see which plugins or user code is doing which binding.) I think this makes the key binding code a lot more readable, both as it is, and in the diffs for future PRs.

The `omz_bindkey` layer keeps a supplemental little database of character sequences based on xterm's local mode behavior (which is not in terminfo), and uses those for cursor keys. It also includes a couple hacks for specific known misbehaving or variant terminal programs. And it has support for binding modifier-key (alt/ctrl/shift) cursor keys, which terminfo doesn't itself provide.
## Future considerations

If you like this approach and merge it, I'll follow it up with a PR for multiple keymap support in the key bindings, which will take care of the issues caused by flipping between the `emacs` and `vi` keymaps during the OMZ startup sequence.
