### PR TITLE
Tag support for detached branche in git_prompt_info

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -3,6 +3,7 @@ function git_prompt_info() {
   local ref
   if [[ "$(command git config --get oh-my-zsh.hide-status 2>/dev/null)" != "1" ]]; then
     ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
+    ref=$(command git describe --tags --exact-match HEAD 2> /dev/null) || \
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
     echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
   fi


### PR DESCRIPTION
If the HEAD is not a symbolic ref (e.g. refs/heads/master) but it points to a commit ID (branch is detached), the git_prompt_info shows commit ID even if the commit ID points has a tag. This patch allows to display the tag version if there is a tag for the HEAD commit ID.
