### PR TITLE
Feature: Check vagrant status of current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
   <img src="https://s3.amazonaws.com/ohmyzsh/oh-my-zsh-logo.png" alt="Oh My Zsh">
 </p>
 
+##Whats different?
+
+This fork of Oh My Zsh adds a status symbol to the agnoster theme to show if there is a vagrant box running for your currect directory.
+
+
+
 Oh My Zsh is an open source, community-driven framework for managing your [zsh](http://www.zsh.org/) configuration. That sounds boring. Let's try this again.
 
 __Oh My Zsh is a way of life!__ Once installed, your terminal prompt will become the talk of the town _or your money back!_ Each time you interact with your command prompt, you'll be able to take advantage of the hundreds of bundled plugins and pretty themes. Strangers will come up to you in cafés and ask you, _"that is amazing. are you some sort of genius?"_ Finally, you'll begin to get the sort of attention that you always felt that you deserved. ...or maybe you'll just use the time that you saved to start flossing more often.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-<p align="center">
-  <img src="https://s3.amazonaws.com/ohmyzsh/oh-my-zsh-logo.png" alt="Oh My Zsh">
-</p>
 
 ##Whats different?
 
 This fork of Oh My Zsh adds a status symbol to the agnoster theme to show if there is a vagrant box running for your currect directory.
+
+<p align="center">
+  <img src="https://s3.amazonaws.com/ohmyzsh/oh-my-zsh-logo.png" alt="Oh My Zsh">
+</p>
+
 
 
 

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -208,6 +208,12 @@ prompt_status() {
   [[ $RETVAL -ne 0 ]] && symbols+="%{%F{red}%}✘"
   [[ $UID -eq 0 ]] && symbols+="%{%F{yellow}%}⚡"
   [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{cyan}%}⚙"
+  
+  if [[ -d ./.vagrant/machines ]]; then
+    if [[ $(VBoxManage list runningvms | grep -c $(/bin/cat .vagrant/machines/*/*/id)) -gt 0 ]]; then
+      symbols+="%{%F{red}%}⚙"
+    fi
+  fi
 
   [[ -n "$symbols" ]] && prompt_segment black default "$symbols"
 }


### PR DESCRIPTION
I added a status symbol to show when a vagrant box was running in your current directory. This only runs when `.vagrant/machines` is found in the current working directory.
