### PR TITLE
Display command return code in the half-life theme

### DIFF
--- a/themes/half-life.zsh-theme
+++ b/themes/half-life.zsh-theme
@@ -94,3 +94,6 @@ function steeef_precmd {
 add-zsh-hook precmd steeef_precmd
 
 PROMPT=$'%{$purple%}%n%{$reset_color%} in %{$limegreen%}%~%{$reset_color%}$(ruby_prompt_info " with%{$fg[red]%} " v g "%{$reset_color%}")$vcs_info_msg_0_%{$orange%} λ%{$reset_color%} '
+
+local return_code="%(?..%{$fg_bold[red]%} %? Λ%{$reset_color%})"
+RPS1="${return_code}"


### PR DESCRIPTION
If the previous command returns an error code, it is displayed right-aligned, along with the big lambda character **Λ** which can have 2 meanings:
- Looks like an _up arrow_ to indicate which command returned the error code.
- Looks like The iconic Half Life logo, but in CAPS (Λ vs λ) to emphasise the error.

![image](https://cloud.githubusercontent.com/assets/506532/18775425/4eb00d20-816a-11e6-926a-019f40b4e8ca.png)
