### PR TITLE
git_prompt_status now uses hash lookups instead of multiple greps

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -179,8 +179,8 @@ function git_prompt_status() {
     return 1
   fi
 
-  if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
-    statuses_seen['STASHED']=1
+  if command git rev-parse --verify refs/stash &>/dev/null; then
+    statuses_seen[STASHED]=1
   fi
 
   local status_lines=("${(@f)${status_text}}");


### PR DESCRIPTION
Switches git_prompt_status to using hash lookups instead of multiple greps.  This gives a significant improvement (6-8x+) in performance on operating systems with slow fork(), and a moderate improvement on other systems (2x).

Tests and comparisons exist at https://github.com/TheDauthi/git-prompt-status.  If I missed a use case, I'd love to know.

Also of note is that at the end of the function, the count of ahead/behind/diverged commits, as well as a count of each type of divergence (ADDED, MODIFIED, DELETED, UNTRACKED, etc) between current and head are tracked  They are not used or exported currently, but I can think of several reasons to do so.

Closes #5486.

I've tested a great deal, but more testing would be encouraged.
