### PR TITLE
check system 'reboot-required' then show icon in prompt_status()

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -208,6 +208,7 @@ prompt_status() {
   [[ $RETVAL -ne 0 ]] && symbols+="%{%F{red}%}✘"
   [[ $UID -eq 0 ]] && symbols+="%{%F{yellow}%}⚡"
   [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{cyan}%}⚙"
+  [[ -f /var/run/reboot-required ]] && symbols+="%{%F{yellow}%}↻"
 
   [[ -n "$symbols" ]] && prompt_segment black default "$symbols"
 }


### PR DESCRIPTION
use icon ↻ (U+21BB) to show whether reboot is required
