### PR TITLE
add docker aliases to docker plugin

### DIFF
--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -1,0 +1,22 @@
+#
+# Aliases
+# (sorted alphabetically)
+#
+
+alias dk='docker'
+
+alias dkb='docker build'
+
+alias dkex='docker exec'
+alias dkexit='docker exec -it'
+
+alias dknet='docker network'
+
+alias dkps='docker ps'
+alias dkpsa='docker ps -a'
+
+alias dkr='docker run'
+alias dkrit='docker run -it'
+
+alias dkv='docker version'
+alias dkvol='docker volume'


### PR DESCRIPTION
use dk as base

it is tedious to write `docker` and its commands and parameters out while tinkering with docker containers.
These aliases are simplifying my workflows tremendously. Perhaps it is also useful for other people. Anybody is welcome to add more aliases so it fit also to own workflows and commands.