### PR TITLE
Fixed minimal.zsh-theme's check for in_hg.

### DIFF
--- a/themes/minimal.zsh-theme
+++ b/themes/minimal.zsh-theme
@@ -14,7 +14,7 @@ ZSH_THEME_HG_PROMPT_CLEAN=$ZSH_THEME_GIT_PROMPT_CLEAN
 vcs_status() {
     if [[ $(whence in_svn) != "" ]] && in_svn; then
         svn_prompt_info
-    elif [[ $(whence in_hg) != "" ]] && in_hg; then
+    elif [[ $(whence in_hg) != "" && $(in_hg) == 1 ]]; then
         hg_prompt_info
     else
         git_prompt_info


### PR DESCRIPTION
I experienced an issue with the minimal theme [a while ago](https://github.com/robbyrussell/oh-my-zsh/pull/3821). Turns out I've had a local version of the file checked out since.

The function `in_svn` uses exit codes, and the function `in_hg` echo's 1 if successful. I think the best solution would be to make `in_hg` behave the same way as `in_svn` - But I'm afraid such drastic measures will break too much.

This is only tested on my macOS 10.11.6 box.