### PR TITLE
Make the upgrade script rebase from upstream remote if it exists

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -22,7 +22,7 @@ fi
 
 printf "${BLUE}%s${NORMAL}\n" "Updating Oh My Zsh"
 cd "$ZSH"
-if git pull --rebase --stat origin master
+if [ -d .git/refs/upsteam ] git pull --rebase --stat upstream master || git pull --rebase --stat origin master
 then
   printf '%s' "$GREEN"
   printf '%s\n' '         __                                     __   '


### PR DESCRIPTION
This should be helpful for people on a fork that want a happy path to upgrade.

It definitely comes with a complexity cost, but I totally think it's worth it.