### PR TITLE
[agnoster] add a short path option for the theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -164,7 +164,11 @@ prompt_hg() {
 
 # Dir: current working directory
 prompt_dir() {
-  prompt_segment blue black '%~'
+  # if AGNOSTER_SHORT_PATH is set use %1~ for the path value
+  # that will turn '~/.oh-my-zsh/custom/themes' in to 'themes'
+  [ -n "${AGNOSTER_SHORT_PATH}" ] && AGNOSTER_CURRENT_PATH='%1~'
+
+  prompt_segment blue black "${AGNOSTER_CURRENT_PATH:=%~}"
 }
 
 # Virtualenv: current working virtualenv


### PR DESCRIPTION
This change to the `agnoster` theme adds an option for using the name of
the current directory instead of a relative path. Assume you're in the
following directory: `~/.oh-my-zsh/custom/themes`. If you set
`AGNOSTER_SHORT_PATH=1` in your `.zshrc` file, the path will render only
as `themes` on the command line instead of `~/.oh-my-zsh/custom/themes`.

In the implementation of this option, another was added to give you even
more control if you want it (`AGNOSTER_CURRENT_PATH`). If
`AGNOSTER_SHORT_PATH` is unset and `AGNOSTER_CURRENT_PATH` is set, that
value will be used for the path value on the prompt.