### PR TITLE
Fix: error messages while getting status of new (no commits) repository on non-english locales

### DIFF
--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -73,7 +73,7 @@ for st in status:
             staged.append(st)
 
 out = ' '.join([
-    branch,
+    branch.replace(' ', '_'), 
     str(ahead),
     str(behind),
     str(len(staged)),


### PR DESCRIPTION
On non-english locales output of gitstatus are corrupted
![before](https://cloud.githubusercontent.com/assets/2860234/20427654/16111a74-ad96-11e6-9425-9c87ca5a9474.png)

Simple fix
![after](https://cloud.githubusercontent.com/assets/2860234/20427653/160fce1c-ad96-11e6-948e-a74d66767e14.png)
