### PR TITLE
Feature: mtab for osx plugin

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -12,7 +12,7 @@ EOF
   echo "$the_app"
 }
 
-function tab() {
+function _tab() {
   # Must not have trailing semicolon, for iTerm compatibility
   local command="cd \\\"$PWD\\\"; clear"
   (( $# > 0 )) && command="${command}; $*"
@@ -521,6 +521,20 @@ function spotify() {
         showHelp;
         break ;;
     esac
+  done
+}
+
+function tab() {
+  _tab "$PWD/${1-}"
+}
+
+function mtab() {
+  counter=0
+  limit=$1
+  while [ "$counter" -lt "$limit" ]
+  do
+    _tab "$PWD/${2-}"
+    counter=$(($counter+1))
   done
 }
 


### PR DESCRIPTION
Hi!

This is a change I've ended up making to the osx plugin, and it's a source of near continuous merge conflict when I update oh-my-zsh. I find it super helpful to be able to open up multiple tabs in a give directory, so maybe others would find this useful too!