### PR TITLE
Adding $ or # signs after git indicator

### DIFF
--- a/themes/kafeitu.zsh-theme
+++ b/themes/kafeitu.zsh-theme
@@ -1,4 +1,8 @@
-PROMPT='%{$fg_bold[red]%}➜ %{$fg_bold[green]%}%n%{$fg[cyan]%}@%{$fg_bold[green]%}%m %{$fg_bold[green]%}%p %{$fg[cyan]%}%~ %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%} % %{$reset_color%}'
+function prompt_char {
+    if [ $UID -eq 0 ]; then echo "#"; else echo $; fi
+}
+
+PROMPT='%{$fg_bold[red]%}➜ %{$fg_bold[green]%}%n%{$fg[cyan]%}@%{$fg_bold[green]%}%m %{$fg_bold[green]%}%p %{$fg[cyan]%}%~ %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%} %_$(prompt_char) % %{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="git:(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"


### PR DESCRIPTION
The `prompt_char` function is a copy of the same one by @Bregor for [Gentoo theme](https://github.com/robbyrussell/oh-my-zsh/blob/master/themes/gentoo.zsh-theme).