### PR TITLE
Proper IPython regarding the activated virtualev

### DIFF
--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -12,3 +12,5 @@ function pyclean() {
 # Grep among .py files
 alias pygrep='grep --include="*.py"'
 
+# Run proper IPython regarding current virtualenv (if any)
+alias ipython="python -c 'import IPython; IPython.terminal.ipapp.launch_new_instance()'"


### PR DESCRIPTION
**Current state:** a user invokes `ipython` and is provided with the IPython instance regarding the `$PATH`.

**Proposed state:** a user invokes `ipython` (which is a new alias in the *python plugin*) and is provided with the proper IPython instance regarding the currently activated virtualenv.

**Example:** the user's default Python is 2.7 with installed IPython 2.7. User activates Python 3.5 virtualenv where he installs IPython 3.5. After activating the environment, one expects `ipython` to run the version of 3.5, which does not happen by default. Instead, IPython 2.7 is used, which in counter-intuitive and often causes problem.

This PR solves this problem.