### PR TITLE
Add lein aliases plugin that shows aliases from project.clj in autosuggestions

### DIFF
--- a/plugins/lein-aliases/lein-aliases.plugin.zsh
+++ b/plugins/lein-aliases/lein-aliases.plugin.zsh
@@ -1,0 +1,37 @@
+__LEIN_ALIASES_DIR="${0:A:h}"
+
+function _lein_aliases() {
+    unset _LEIN_ALIASES_STR
+    unset _LEIN_ALIASES
+
+    local ret=1 state
+    _arguments ':aliases:->aliases' && ret=0
+
+    case $state in
+      aliases)
+        _LEIN_ALIASES_STR=$(_read_lein_aliases)
+        _LEIN_ALIASES=("${(@s:;:)${_LEIN_ALIASES_STR}}")
+        _describe -t _LEIN_ALIASES 'leiningen aliases' _LEIN_ALIASES && ret=0
+        _include_lein_commands_if_exists
+        ;;
+      *) _files
+    esac
+
+    return ret
+}
+
+compdef _lein_aliases lein
+
+function _read_lein_aliases() {
+    unset __LEIN_ALIASES_STR
+
+    local lein_aliases="$__LEIN_ALIASES_DIR/lein-aliases.py"
+    __LEIN_ALIASES_STR=$(python ${lein_aliases} 2>/dev/null)
+    echo $__LEIN_ALIASES_STR
+}
+
+function _include_lein_commands_if_exists() {
+    if whence -w _lein > /dev/null; then
+      _lein
+    fi
+}

--- a/plugins/lein-aliases/lein-aliases.py
+++ b/plugins/lein-aliases/lein-aliases.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import re
+
+def readFile(filename):
+  try:
+    file = open(filename, 'r')
+    content = file.read()
+    file.close()
+    return content
+  except IOError as e:
+    print('', end='')
+
+def parse_key_and_values(raw):
+  no_double_quotes = raw.replace('"', '')
+  no_last_bracket = re.sub(r']\s*$','', no_double_quotes)
+  key_value_strings = no_last_bracket.split(']')
+  return map(key_value_string_to_pair, key_value_strings)
+
+def key_value_string_to_pair(key_value_str):
+  key_and_value = key_value_str.split('[')
+  return key_and_value[0].strip() + ":ALIAS: " + key_and_value[1]
+
+def read_aliases(filename):
+  keys_and_commands = re.search('(?<=:aliases {").*?(?=})', readFile(filename).replace('\n', ''))
+
+  if keys_and_commands is None:
+    return []
+  else:
+    keys_and_commands_raw = keys_and_commands.group(0)
+    return parse_key_and_values(keys_and_commands_raw)
+
+aliases_from_project = read_aliases('project.clj')
+
+out = ';'.join(aliases_from_project)
+print(out, end='')


### PR DESCRIPTION
Extends lein plugin if it is enabled.
"lein" should be before "lein-aliases" in `$plugins`

There is still a problem with one of my testers (macOS Yosemite). `lein <tab>` fails with:
`_lein_aliases:7: number expected`
And I can't figure out why. Updating to latest zsh wasn't helping.

But it works on El Capitan, Sierra and Xubuntu 16.10.