### PR TITLE
Added cd to active Xcode project to osx plugin

### DIFF
--- a/plugins/osx/README.md
+++ b/plugins/osx/README.md
@@ -24,6 +24,7 @@ Original author: [Sorin Ionescu](https://github.com/sorin-ionescu)
 | `pfd`           | Return the path of the frontmost Finder window   |
 | `pfs`           | Return the current Finder selection              |
 | `cdf`           | `cd` to the current Finder directory             |
+| `cdx`           | `cd` to the current Xcode project directory      |
 | `pushdf`        | `pushd` to the current Finder directory          |
 | `quick-look`    | Quick-Look a specified file                      |
 | `man-preview`   | Open a specified man page in Preview app         |

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -160,7 +160,7 @@ function pfs() {
 EOF
 }
 
-function xcodeprojdir() {
+function pxd() {
   dirname $(osascript 2>/dev/null <<EOF
     tell application "Xcode"
       return path of active workspace document
@@ -178,7 +178,7 @@ function pushdf() {
 }
 
 function cdx() {
-  cd "$(xcodeprojdir)"
+  cd "$(pxd)"
 }
 
 function quick-look() {

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -162,9 +162,11 @@ EOF
 
 function pxd() {
   dirname $(osascript 2>/dev/null <<EOF
-    tell application "Xcode"
-      return path of active workspace document
-    end tell
+    if application "Xcode" is running then
+	  tell application "Xcode"
+	    return path of active workspace document
+	  end tell
+	end if
 EOF
 ) 2>/dev/null
 }

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -160,12 +160,25 @@ function pfs() {
 EOF
 }
 
+function xcodeprojdir() {
+  dirname $(osascript 2>/dev/null <<EOF
+    tell application "Xcode"
+      return path of active workspace document
+    end tell
+EOF
+) 2>/dev/null
+}
+
 function cdf() {
   cd "$(pfd)"
 }
 
 function pushdf() {
   pushd "$(pfd)"
+}
+
+function cdx() {
+  cd "$(xcodeprojdir)"
 }
 
 function quick-look() {


### PR DESCRIPTION
Added `cdx` function to osx plugin.

`cdx` will change the current working directory to the containing directory of the front-most project in Xcode. If no projects are active, no directory change takes place. If all projects are minimized, the last minimized project is considered active.

Particularly useful for jumping to the project dir to use git in the terminal.