### PR TITLE
Change sed regex to capture all possible kitchen commands

### DIFF
--- a/plugins/kitchen/_kitchen
+++ b/plugins/kitchen/_kitchen
@@ -67,7 +67,7 @@ _kitchen() {
 _kitchen_commands() {
   local commands
 
-  commands=("${(@f)$(_call_program commands $service help | sed -n 's/^  kitchen \([[:alpha:]]*\).*# \(.*\)$/\1:\2/p')}")
+  commands=("${(@f)$(_call_program commands $service help | sed -n 's/^  kitchen \([[:alpha:]]*\) [ A-Z[].*# \(.*\)$/\1:\2/p')}")
   _describe -t commands 'kitchen commands' commands
 }
 

--- a/plugins/kitchen/_kitchen
+++ b/plugins/kitchen/_kitchen
@@ -67,7 +67,7 @@ _kitchen() {
 _kitchen_commands() {
   local commands
 
-  commands=("${(@f)$(_call_program commands $service help | sed -n 's/^  kitchen \([[:alpha:]]*\) [ [].*# \(.*\)$/\1:\2/p')}")
+  commands=("${(@f)$(_call_program commands $service help | sed -n 's/^  kitchen \([[:alpha:]]*\).*# \(.*\)$/\1:\2/p')}")
   _describe -t commands 'kitchen commands' commands
 }
 


### PR DESCRIPTION
The kitchen plugin was missing some commands, like login, because the regex was expecting brackets on all lines and yet the `kitchen help` command doesn't return that.