### PR TITLE
Fixed alias_value for aliases with hyphens and other characters

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -52,8 +52,8 @@ function open_command() {
 #    1 if it does not exist
 #
 function alias_value() {
-    alias "$1" | sed "s/^$1='\(.*\)'$/\1/"
-    test $(alias "$1")
+	local val=$(alias "$1")
+	test -n "$val" && echo "${val//^$1='\(.*\)'/\1/}"
 }
 
 #


### PR DESCRIPTION
This may still need improvement, but it passes for `alias_value 'grep'` (where `grep`=`grep --color=auto`) and other commands that cause the original `alias_value` to fail. It also replaces a sed command with a bash replacement. 