### PR TITLE
cursor color changing for vi-MODES

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -44,6 +44,10 @@ zle-line-init () {
   override-vi-mode-zle-line-init
 }; zle -N zle-line-init
 
+zle-line-finish () {
+  zle -K viins
+}; zle -N zle-line-finish
+
 autoload -U select-quoted
 zle -N select-quoted
 for m in visual viopp; do

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -34,12 +34,14 @@ function zle-keymap-select() {
   fi
 }; zle -N zle-keymap-select
 
+eval "override-vi-mode-$(declare -f zle-line-init)"
 zle-line-init () {
   if [ $TERM = "screen" ]; then
     echo -ne $VIM_INSERT_COLOR
   elif [ $TERM != "linux" ]; then
     echo -ne $VIM_INSERT_COLOR
   fi
+  override-vi-mode-zle-line-init
 }; zle -N zle-line-init
 
 autoload -U select-quoted

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -54,7 +54,7 @@ zle -N edit-command-line
 
 bindkey -v
 
-# allow v to edit the command line (standard behaviour)
+# allow v to edit the command line (standard psql)
 autoload -Uz edit-command-line
 bindkey -M vicmd '\e' edit-command-line
 

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -54,7 +54,7 @@ zle -N edit-command-line
 
 bindkey -v
 
-# allow v to edit the command line (standard psql)
+# allow v to edit the command line (psql behaviour)
 autoload -Uz edit-command-line
 bindkey -M vicmd '\e' edit-command-line
 


### PR DESCRIPTION
There is also \e instead of v for editing command line in EDITOR, like you would do it in postgress. Feel free to remove this change.

The bindkey -v were in original file, I'm not sure if it should be moved to user config like @slavaGanzin suggested. Feel free to decide.

@slavaGanzin I can't test what you mentioned about 'eval "override-vi-color-$(declare -f zle-line-init)"', but eval is evil anyway shell it or not. May be it can be fixed in other way?