### PR TITLE
List runnable NPM scripts alias

### DIFF
--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -44,3 +44,5 @@ alias npmst="npm start"
 # Run npm test
 alias npmt="npm test"
 
+# List run scripts
+alias npmr="npm run"


### PR DESCRIPTION
Added this alias for short-hand way for getting list of run script targets, usage:
$ npmr                    # lists available scripts
$ npmr myScript    # runs myScript

GTM?