### PR TITLE
Improve cp-plugin: Show overall time & percentage.

### DIFF
--- a/plugins/cp/cp.plugin.zsh
+++ b/plugins/cp/cp.plugin.zsh
@@ -1,4 +1,4 @@
 cpv() {
-    rsync -pogbr -hhh --backup-dir=/tmp/rsync -e /dev/null --progress "$@"
+    rsync -pogbr -hhh --backup-dir=/tmp/rsync -e /dev/null --info=progress2 "$@"
 }
 compdef _files cpv


### PR DESCRIPTION
Displays the overall time & percentage in a single self-updating line while copying with `cpv`.

Until now, `cpv` has shown that for individual files only instead of the whole operation, when copying recursively.

E.g.:

```
> cpv phone /media/user/Backup/phone
[...]
phone/DCIM/Camera/IMG_20150410_124506.dng
         16.37M 100%   14.88MB/s    0:00:01 (xfr#6035, ir-chk=2539/8915)
phone/DCIM/Camera/IMG_20150410_124506.jpg
          1.66M 100%    4.77MB/s    0:00:00 (xfr#6036, ir-chk=2538/8915)
phone/DCIM/Camera/IMG_20150410_124528.dng
         16.37M 100%   16.93MB/s    0:00:00 (xfr#6037, ir-chk=2537/8915)
phone/DCIM/Camera/IMG_20150410_124528.jpg
          1.68M 100%    1.40MB/s    0:00:01 (xfr#6038, ir-chk=2536/8915)
phone/DCIM/Camera/IMG_20150411_115839.dng
         16.37M 100%   31.31MB/s    0:00:00 (xfr#6039, ir-chk=2535/8915)
[... scrolling and scrolling ...]
```

vs. in simply one line updating itself:

```
> cpv phone /media/user/Backup/phone
         10.89G  26%   27.12MB/s    0:06:51 (xfr#8042, ir-chk=2174/10561)^C
```

See http://unix.stackexchange.com/a/65222 for details.