### PR TITLE
Use shrink_path in agnoster theme if available

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -187,7 +187,11 @@ prompt_hg() {
 
 # Dir: current working directory
 prompt_dir() {
-  prompt_segment blue black '%~'
+  if type shrink_path &>/dev/null; then
+    prompt_segment blue black "$(shrink_path -t -l)"
+  else
+    prompt_segment blue black '%~'
+  fi
 }
 
 # Virtualenv: current working virtualenv

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -187,7 +187,7 @@ prompt_hg() {
 
 # Dir: current working directory
 prompt_dir() {
-  if type shrink_path &>/dev/null; then
+  if (( $+functions[shrink_path] )); then
     prompt_segment blue black "$(shrink_path -t -l)"
   else
     prompt_segment blue black '%~'


### PR DESCRIPTION
This makes the prompt shorter if the user tried to load the shrink_path module and will leave it alone if they didn't.

I left off `-s` because it makes any dir starting with a . turn into just a dot which can be really confusing.