### PR TITLE
Keep composer autocompletion when using global command

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -15,20 +15,16 @@ _composer_get_required_list () {
 }
 
 _composer () {
-  local curcontext="$curcontext" state line
-  typeset -A opt_args
-  _arguments \
-    '1: :->command'\
-    '*: :->args'
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+    _arguments \
+        '*:: :->subcmds'
 
-  case $state in
-    command)
-      compadd $(_composer_get_command_list)
-      ;;
-    *)
-      compadd $(_composer_get_required_list)
-      ;;
-  esac
+    if (( CURRENT == 1 )) || ( ((CURRENT == 2)) && [ "$words[1]" = "global" ] ) ; then
+        compadd $(_composer_get_command_list)
+    else
+        compadd $(_composer_get_required_list)
+    fi
 }
 
 compdef _composer composer


### PR DESCRIPTION
`composer global *` and `composer *` should have the same autocompletion.