### PR TITLE
Add default hostname check to Agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -79,7 +79,8 @@ prompt_end() {
 
 # Context: user@hostname (who am I and where am I)
 prompt_context() {
-  if [[ "$USER" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
+  if [[ "$USER" != "$DEFAULT_USER" || \
+        ( -n "$SSH_CLIENT" && "$HOSTNAME" != "$DEFAULT_HOSTNAME" ) ]]; then
     prompt_segment black default "%(!.%{%F{yellow}%}.)$USER@%m"
   fi
 }


### PR DESCRIPTION
This adds the ability to have a DEFAULT_HOSTNAME variable for folks that have a primary remote host.