### PR TITLE
feat(plugins): `octozen` shows an Octocat zen quote on startup

### DIFF
--- a/plugins/octozen/README.md
+++ b/plugins/octozen/README.md
@@ -1,5 +1,11 @@
 # Octozen plugin
 
-Displays a zen quote of octocat on start up.
+Displays a zen quote from GitHub's octocat on start up.
 
-Internet connection is required.
+To use it, add `octozen` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... octozen)
+```
+
+NOTE: Internet connection is required (will time out if not fetched in 2 seconds).

--- a/plugins/octozen/README.md
+++ b/plugins/octozen/README.md
@@ -1,6 +1,6 @@
 # Octozen plugin
 
-Displays a zen quote from GitHub's octocat on start up.
+Displays a zen quote from GitHub's Octocat on start up.
 
 To use it, add `octozen` to the plugins array in your zshrc file:
 
@@ -8,4 +8,5 @@ To use it, add `octozen` to the plugins array in your zshrc file:
 plugins=(... octozen)
 ```
 
+It defines a `display_octozen` function that fetches a GitHub Octocat zen quote.
 NOTE: Internet connection is required (will time out if not fetched in 2 seconds).

--- a/plugins/octozen/README.md
+++ b/plugins/octozen/README.md
@@ -1,0 +1,5 @@
+# Octozen plugin
+
+Displays a zen quote of octocat on start up.
+
+Internet connection is required.

--- a/plugins/octozen/octozen.plugin.zsh
+++ b/plugins/octozen/octozen.plugin.zsh
@@ -4,6 +4,9 @@
 #
 function display_octozen() {
   curl -m 2 -fsL "https://api.github.com/octocat"
+  add-zsh-hook -d precmd display_octozen
 }
 
-display_octozen
+# Display the octocat on the first precmd, after the whole starting process has finished
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd display_octozen

--- a/plugins/octozen/octozen.plugin.zsh
+++ b/plugins/octozen/octozen.plugin.zsh
@@ -1,7 +1,6 @@
 # octozen plugin
 
-# Displays a zen from octocat 
-#
+# Displays a zen quote from octocat
 function display_octozen() {
   curl -m 2 -fsL "https://api.github.com/octocat"
   add-zsh-hook -d precmd display_octozen

--- a/plugins/octozen/octozen.plugin.zsh
+++ b/plugins/octozen/octozen.plugin.zsh
@@ -3,11 +3,7 @@
 # Displays a zen from octocat 
 #
 function display_octozen() {
-  local command="curl -s https://api.github.com/octocat"	
-  local zen=$(eval ${command})
-  if [ "$zen" != "" ]; then
-    printf '%s\n' ${zen}
-  fi
+  curl -m 2 -fsL "https://api.github.com/octocat"
 }
 
 display_octozen

--- a/plugins/octozen/octozen.plugin.zsh
+++ b/plugins/octozen/octozen.plugin.zsh
@@ -1,0 +1,13 @@
+# octozen plugin
+
+# Displays a zen from octocat 
+#
+function display_octozen() {
+  local command="curl -s https://api.github.com/octocat"	
+  local zen=$(eval ${command})
+  if [ "$zen" != "" ]; then
+    printf '%s\n' ${zen}
+  fi
+}
+
+display_octozen


### PR DESCRIPTION
Added a plugin which `curls` `https://api.github.com/octocat` on startup and displays the returned message.