### PR TITLE
Source custom files after theme files

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -86,12 +86,6 @@ for plugin ($plugins); do
   fi
 done
 
-# Load all of your custom configurations from custom/
-for config_file ($ZSH_CUSTOM/*.zsh(N)); do
-  source $config_file
-done
-unset config_file
-
 # Load the theme
 if [ "$ZSH_THEME" = "random" ]; then
   themes=($ZSH/themes/*zsh-theme)
@@ -111,3 +105,9 @@ else
     fi
   fi
 fi
+
+# Load all of your custom configurations from custom/
+for config_file ($ZSH_CUSTOM/*.zsh(N)); do
+  source $config_file
+done
+unset config_file


### PR DESCRIPTION
I use oh-my-zsh on a embedded board and would like to monitor the CPU temperature via r-prompt. Tried to do that by appending temperature to r-prompt in custom file, but because theme files are sourced last, this approach won't work.

So I moved source custom files to the end of .zshrc. This will allow user to do minor customization to prompts by simply appending instead of creating a new theme.