### PR TITLE
Fix awesomepanda theme wrap on new line.

### DIFF
--- a/themes/awesomepanda.zsh-theme
+++ b/themes/awesomepanda.zsh-theme
@@ -1,6 +1,6 @@
 # the svn plugin has to be activated for this to work.
 local ret_status="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ %s)"
-PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%}$(svn_prompt_info)%{$reset_color%}'
+PROMPT='%{${ret_status}%}%{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%}$(svn_prompt_info)%{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="git:(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"


### PR DESCRIPTION
This fixes terminal text jumping around when a command spills to a new line for the awesomepanda theme. The same issue is in robbyrussell theme, could be fixed in the same way. See also: https://github.com/robbyrussell/oh-my-zsh/issues/2314