### PR TITLE
Prevent duplicate hooks in termsupport.zsh when reloading config

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -75,8 +75,9 @@ function omz_termsupport_preexec {
   title '$CMD' '%100>...>$LINE%<<'
 }
 
-precmd_functions+=(omz_termsupport_precmd)
-preexec_functions+=(omz_termsupport_preexec)
+autoload -U add-zsh-hook
+add-zsh-hook precmd omz_termsupport_precmd
+add-zsh-hook preexec omz_termsupport_preexec
 
 
 # Keep Apple Terminal.app's current working directory updated
@@ -99,7 +100,7 @@ if [[ "$TERM_PROGRAM" == "Apple_Terminal" ]] && [[ -z "$INSIDE_EMACS" ]]; then
   }
 
   # Use a precmd hook instead of a chpwd hook to avoid contaminating output
-  precmd_functions+=(update_terminalapp_cwd)
+  add-zsh-hook precmd update_terminalapp_cwd
   # Run once to get initial cwd set
   update_terminalapp_cwd
 fi


### PR DESCRIPTION
Is it time to revert #3053 with this PR?

RHEL5 uses an old version of zsh but is now EOL as of 2017-03-31. I'm not sure if there is demand for other distros that use zsh before `add-zsh-hook` was added in 4.3.4. RHEL5 users should upgrade to RHEL7 or at least RHEL6 with zsh 4.3.11 which includes `add-zsh-hook`.

Using the `+=` method appends the hook whenever the zsh config is reloaded. This is ok in normal zsh usage but `source ~/.zshrc` is often run many times when testing new zsh configs. A hook function is called as many times as it appears in the array which can eventually affect performance.

```
# initial environment
% echo $precmd_functions
omz_termsupport_precmd

# reload config (appends hook)
% source ~/.zshrc
% echo $precmd_functions
omz_termsupport_precmd omz_termsupport_precmd

# reload config again (appends another hook)
% source ~/.zshrc
% echo $precmd_functions
omz_termsupport_precmd omz_termsupport_precmd omz_termsupport_precmd
```

Using `add-zsh-hook` only adds the hook if it isn't already in the array which is expected.

Let me know if support for zsh before 4.3.4 without `add-zsh-hook` is still required and I'll adjust the patch to check the array to see whether the hook exists in the array before running `+=`.