### PR TITLE
List ZSH_CACHE_DIR in default .zshrc template and ensure the directory exists

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -25,6 +25,11 @@ if [[ -z "$ZSH_CACHE_DIR" ]]; then
   ZSH_CACHE_DIR="$ZSH/cache"
 fi
 
+# Create the ZSH_CACHE_DIR if it doesn't exist
+if [[ ! -d $ZSH_CACHE_DIR ]]; then
+  mkdir -p $ZSH_CACHE_DIR
+fi
+
 
 # Load all of the config files in ~/oh-my-zsh that end in .zsh
 # TIP: Add files you don't want in git to .gitignore

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -47,6 +47,9 @@ ZSH_THEME="robbyrussell"
 # Would you like to use another custom folder than $ZSH/custom?
 # ZSH_CUSTOM=/path/to/new-custom-folder
 
+# Would you like to use different cache directory? (Default is $ZSH/cache)
+# ZSH_CACHE_DIR=/path/to/new-cache-directory
+
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)


### PR DESCRIPTION
Two part PR inspired by the [patch](https://aur.archlinux.org/cgit/aur.git/tree/0001-zshrc.patch?h=oh-my-zsh-git) applied to the oh-my-zsh [AUR package](https://aur.archlinux.org/packages/oh-my-zsh-git/).

I kept each part as separate commits, but feel free to squash if you want to.

Firstly, list `ZSH_CACHE_DIR` in the `.zshrc` template file to make it easier for users to find and distributes to modify. I tried to position it close to similar variables like `ZSH_CUSTOM`.

Secondly, ensure that `$ZSH_CACHE_DIR` actually exists before loading plugins (etc) since AFAIK plugins do not check the directory exists before making use of it.