### PR TITLE
Added support for Bash on Windows

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -31,3 +31,22 @@ if type brew &> /dev/null; then
     eval "$(brew command-not-found-init)";
   fi
 fi
+
+# Bash on Windows support
+# https://github.com/Microsoft/BashOnWindows/issues/423#issuecomment-221627364
+SYS_KERNEL=`cat /proc/sys/kernel/osrelease`
+case "$SYS_KERNEL" in
+    *WSL*|*Microsoft*) command_not_found_handler () {
+        commandsent="$@"
+        buffer=("${(@s/ /)commandsent}")
+        which $buffer[1].exe>/dev/null
+        if [ $? -eq 0 ]; then
+            buffer[1]=$buffer[1].exe
+            $buffer
+            return 0
+        else
+            return 1
+        fi
+    } ;;
+    *) ;;
+esac

--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -39,13 +39,13 @@ case "$SYS_KERNEL" in
     *WSL*|*Microsoft*) command_not_found_handler () {
         commandsent="$@"
         buffer=("${(@s/ /)commandsent}")
-        which $buffer[1].exe>/dev/null
+        which $buffer[1].exe>/dev/null # Does binary exist in path?
         if [ $? -eq 0 ]; then
             buffer[1]=$buffer[1].exe
             $buffer
-            return 0
+            exit # Returns exit code from Windows binary
         else
-            return 1
+            return 1 # Returns 'command not found'
         fi
     } ;;
     *) ;;


### PR DESCRIPTION
Automatically will convert commands to their `.exe` equivalent if one exists and the user is running Bash on Windows. This uses the information [provided by Microsoft](https://github.com/Microsoft/BashOnWindows/issues/423#issuecomment-221627364) to determine if the user is running Windows based on `/proc/sys/kernel/osrelease`'s contents.

Bash on Windows will remap any file paths under `/mnt/c` or  their appropriate drive letter to the Windows equivalent, allowing one to even open files using a Windows binary. 