### PR TITLE
Cache full fasd initialisation script

### DIFF
--- a/plugins/fasd/fasd.plugin.zsh
+++ b/plugins/fasd/fasd.plugin.zsh
@@ -1,7 +1,8 @@
 if [ $commands[fasd] ]; then # check if fasd is installed
   fasd_cache="${ZSH_CACHE_DIR}/fasd-init-cache"
   if [ "$(command -v fasd)" -nt "$fasd_cache" -o ! -s "$fasd_cache" ]; then
-    fasd --init auto >| "$fasd_cache"
+    fasd --init posix-alias zsh-hook zsh-ccomp zsh-ccomp-install \
+      zsh-wcomp zsh-wcomp-install >| "$fasd_cache"
   fi
   source "$fasd_cache"
   unset fasd_cache


### PR DESCRIPTION
Using `fasd —-init auto` will first detect terminal and then call fasd again to generate the final initialisation script. Caching that gives a more significant performance boost.