### PR TITLE
Add `rdmd` and `rdmu` aliases to Rails plugin

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -49,7 +49,9 @@ alias rsp='rails server --port'
 
 # Rake aliases
 alias rdm='rake db:migrate'
+alias rdmd='rake db:migrate:down'
 alias rdms='rake db:migrate:status'
+alias rdmu='rake db:migrate:up'
 alias rdr='rake db:rollback'
 alias rdc='rake db:create'
 alias rds='rake db:seed'


### PR DESCRIPTION
This adds `rdmd` (`rake db:migrate:down`) and `rdmu` (`rake db:migrate:up`) aliases to Rails plugin to be able to run specific migrations.

/cc @robbyrussell 