### PR TITLE
Add support for 'vaulted' shells in agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -198,6 +198,23 @@ prompt_virtualenv() {
   fi
 }
 
+# vaulted: current vaulted shell
+prompt_vaulted() {
+  if [[ -z $VAULTED_ENV ]]; then
+    return
+  fi
+  local exp=$(echo $VAULTED_ENV_EXPIRATION | sed 's/Z/+0000/')
+  local valid_until=$(date -j -f %Y-%m-%dT%H:%M:%S%z $exp +%s)
+  local bg=009 #orange
+  local fg=black
+  if [[ $valid_until -lt $(date +%s) ]]; then
+    fg=blue
+  fi
+  if [[ -n $VAULTED_ENV ]]; then
+    prompt_segment $bg $fg "$VAULTED_ENV"
+  fi
+}
+
 # Status:
 # - was there an error
 # - am I root
@@ -217,6 +234,7 @@ build_prompt() {
   RETVAL=$?
   prompt_status
   prompt_virtualenv
+  prompt_vaulted
   prompt_context
   prompt_dir
   prompt_git

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -198,13 +198,24 @@ prompt_virtualenv() {
   fi
 }
 
+epoch_date() {
+  unamestr=`uname`
+  if [[ "$unamestr" == 'Linux' ]]; then
+    echo $(date -d $1 +%s)
+  elif [[ "$unamestr" == 'Darwin' ]]; then
+    echo $(date -j -f %Y-%m-%dT%H:%M:%S%z $1 +%s)
+  else # TODO - other platforms?
+    echo $(date -j -f %Y-%m-%dT%H:%M:%S%z $1 +%s)
+  fi
+}
+
 # vaulted: current vaulted shell
 prompt_vaulted() {
   if [[ -z $VAULTED_ENV ]]; then
     return
   fi
   local exp=$(echo $VAULTED_ENV_EXPIRATION | sed 's/Z/+0000/')
-  local valid_until=$(date -j -f %Y-%m-%dT%H:%M:%S%z $exp +%s)
+  local valid_until=$(epoch_date $exp)
   local bg=009 #orange
   local fg=black
   if [[ $valid_until -lt $(date +%s) ]]; then


### PR DESCRIPTION
If a user is currently in a [vaulted](https://github.com/miquella/vaulted) shell, they
will now have an indication of this in the agnoster prompt, not unlike the
virtualenv prompt. The foreground color will switch if the timer expires (which
usually signifies that the temporary Amazon keys generated by vaulted will be
invalid).