### PR TITLE
systemadmin plugin: Fix head line sorting

### DIFF
--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -37,8 +37,8 @@ alias mkdir='mkdir -pv'
 alias psmem='ps -e -orss=,args= | sort -b -k1,1n'
 alias psmem10='ps -e -orss=,args= | sort -b -k1,1n| head -10'
 # get top process eating cpu if not work try excute : export LC_ALL='C'
-alias pscpu='ps -e -o pcpu,cpu,nice,state,cputime,args|sort -k1 -nr'
-alias pscpu10='ps -e -o pcpu,cpu,nice,state,cputime,args|sort -k1 -nr | head -10'
+alias pscpu='ps -e -o pcpu,cpu,nice,state,cputime,args|sort -k1,1n -nr'
+alias pscpu10='ps -e -o pcpu,cpu,nice,state,cputime,args|sort -k1,1n -nr | head -10'
 # top10 of the history
 alias hist10='print -l ${(o)history%% *} | uniq -c | sort -nr | head -n 10'
 


### PR DESCRIPTION
Inside `pscpu` and `pscpu10` aliases, remove sorting of the head line