### PR TITLE
added support for tmux terminal types

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -21,7 +21,7 @@ function title {
       print -Pn "\e]2;$2:q\a" # set window name
       print -Pn "\e]1;$1:q\a" # set tab name
       ;;
-    screen*)
+    screen*|tmux*)
       print -Pn "\ek$1:q\e\\" # set screen hardstatus
       ;;
     *)


### PR DESCRIPTION
This small addition adds support for `TERM=tmux` and `TERM=tmux256color`, which can be used to enable some features like italics in tmux.

https://wiki.archlinux.org/index.php/tmux#256_colors