### PR TITLE
plugins/emacs: depend on emacs 25, not emacs 24

### DIFF
--- a/plugins/emacs/emacs.plugin.zsh
+++ b/plugins/emacs/emacs.plugin.zsh
@@ -10,7 +10,7 @@
 # - Configuration changes made at runtime are applied to all frames.
 
 
-if "$ZSH/tools/require_tool.sh" emacs 24 2>/dev/null ; then
+if "$ZSH/tools/require_tool.sh" emacs 25 2>/dev/null ; then
     export EMACS_PLUGIN_LAUNCHER="$ZSH/plugins/emacs/emacsclient.sh"
 
     # set EDITOR if not already defined.


### PR DESCRIPTION
The emacsclient.sh script invokes emacsclient with --alternate-editor '', which is not supported by Emacs v24. (At least, not by Emacs 24.5 on Windows, but I doubt this is platform-specific.)

This may be the cause of issue #3305. The alternative fix, if you want to keep support for Emacs 24, is to remove the --alternate-editor '' from emacsclient.sh, but that looks like useful functionality.