### PR TITLE
Update update_terminalapp_cwd to urlencode the hostname

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -90,13 +90,10 @@ if [[ "$TERM_PROGRAM" == "Apple_Terminal" ]] && [[ -z "$INSIDE_EMACS" ]]; then
   function update_terminalapp_cwd() {
     emulate -L zsh
 
-    # Percent-encode the pathname.
-    local URL_PATH="$(omz_urlencode -P $PWD)"
-    [[ $? != 0 ]] && return 1
-    
-    # Percent-encode the hostname.
-    local URL_HOST="$(omz_urlencode -P $HOST)"
-    [[ $? != 0 ]] && return 1
+    # Percent-encode the host and path names.
+    local URL_HOST URL_PATH
+    URL_HOST="$(omz_urlencode -P $HOST)" || return 1
+    URL_PATH="$(omz_urlencode -P $PWD)" || return 1
 
     # Undocumented Terminal.app-specific control sequence
     printf '\e]7;%s\a' "file://$URL_HOST$URL_PATH"

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -93,9 +93,13 @@ if [[ "$TERM_PROGRAM" == "Apple_Terminal" ]] && [[ -z "$INSIDE_EMACS" ]]; then
     # Percent-encode the pathname.
     local URL_PATH="$(omz_urlencode -P $PWD)"
     [[ $? != 0 ]] && return 1
+    
+    # Percent-encode the hostname.
+    local URL_HOST="$(omz_urlencode -P $HOST)"
+    [[ $? != 0 ]] && return 1
 
     # Undocumented Terminal.app-specific control sequence
-    printf '\e]7;%s\a' "file://$HOST$URL_PATH"
+    printf '\e]7;%s\a' "file://$URL_HOST$URL_PATH"
   }
 
   # Use a precmd hook instead of a chpwd hook to avoid contaminating output


### PR DESCRIPTION
Apple's Terminal doesn't open a new tab in your current directory if your hostname has UTF-8 characters in it. Percent encoding the host in addition to the path in update_terminalapp_cwd appears to solve this issue.