### PR TITLE
systemd: refactor and add latest commands

### DIFF
--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -1,9 +1,14 @@
 user_commands=(
   cat
+  get-default
   help
   is-active
   is-enabled
+  is-failed
+  is-system-running
+  list-dependencies
   list-jobs
+  list-sockets
   list-timers
   list-unit-files
   list-units
@@ -12,23 +17,46 @@ user_commands=(
   status)
 
 sudo_commands=(
+  add-requires
+  add-wants
   cancel
+  daemon-reexec
+  daemon-reload
+  default
   disable
   edit
+  emergency
   enable
+  halt
+  hibernate
+  hybrid-sleep
+  import-environment
   isolate
+  kexec
   kill
   link
+  list-machines
   load
   mask
+  poweroff
   preset
+  preset-all
+  reboot
   reenable
   reload
+  reload-or-restart
   reset-failed
+  rescue
   restart
+  revert
+  set-default
   set-environment
+  set-property
   start
   stop
+  suspend
+  switch-root
+  try-reload-or-restart
   try-restart
   unmask
   unset-environment)

--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -1,12 +1,37 @@
 user_commands=(
-  list-units is-active status show help list-unit-files
-  is-enabled list-jobs show-environment cat list-timers)
+  cat
+  help
+  is-active
+  is-enabled
+  list-jobs
+  list-timers
+  list-unit-files
+  list-units
+  show
+  show-environment
+  status)
 
 sudo_commands=(
-  start stop reload restart try-restart isolate kill
-  reset-failed enable disable reenable preset mask unmask
-  link load cancel set-environment unset-environment
-  edit)
+  cancel
+  disable
+  edit
+  enable
+  isolate
+  kill
+  link
+  load
+  mask
+  preset
+  reenable
+  reload
+  reset-failed
+  restart
+  set-environment
+  start
+  stop
+  try-restart
+  unmask
+  unset-environment)
 
 for c in $user_commands; do; alias sc-$c="systemctl $c"; done
 for c in $sudo_commands; do; alias sc-$c="sudo systemctl $c"; done


### PR DESCRIPTION
Including the latest `systemctl` commands and making the systemd plugin easier to maintain.