### PR TITLE
Bundler plugin: add hanami to list of ruby commands

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -14,6 +14,7 @@ bundled_commands=(
   cucumber
   foodcritic
   guard
+  hanami
   irb
   jekyll
   kitchen


### PR DESCRIPTION
Hello,
I added [hanami](http://hanamirb.org) command to list of bundler commands