### PR TITLE
recent versions of zsh flag functions declared w/o explicit 'function'…

### DIFF
--- a/plugins/colored-man-pages/colored-man-pages.plugin.zsh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.zsh
@@ -16,7 +16,7 @@ EOF
 	fi
 fi
 
-man() {
+function man() {
 	env \
 		LESS_TERMCAP_mb=$(printf "\e[1;31m") \
 		LESS_TERMCAP_md=$(printf "\e[1;31m") \


### PR DESCRIPTION
… specifier as defined based on an alias, causing a parsing error and disabling the function in the shell upon launch.  Explicit 'function' specifier added, and problem is fixed