### PR TITLE
update "themes" plugin

### DIFF
--- a/plugins/themes/_theme
+++ b/plugins/themes/_theme
@@ -1,3 +1,3 @@
 #compdef theme
 
-_arguments "1: :($(lstheme | tr "\n" " "))"
+_arguments "1: :($(lstheme | tr "\n\t" " "))"

--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -1,24 +1,28 @@
 function theme
 {
     if [ -z "$1" ] || [ "$1" = "random" ]; then
-	themes=($ZSH/themes/*zsh-theme)
-	N=${#themes[@]}
-	((N=(RANDOM%N)+1))
-	RANDOM_THEME=${themes[$N]}
-	source "$RANDOM_THEME"
-	echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+        themes=($ZSH/themes/*.zsh-theme)
+        N=${#themes[@]}
+        ((N=(RANDOM%N)+1))
+        RANDOM_THEME=${themes[$N]}
+        source "$RANDOM_THEME"
+        RANDOM_THEME_NAME=`echo "$RANDOM_THEME"|xargs -d '\n' -n 1 basename|sed 's/\(.*\)\..*/\1/'`
+        echo "[oh-my-zsh] Random theme '$RANDOM_THEME_NAME' loaded."
     else
-	if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]
-	then
-	    source "$ZSH_CUSTOM/$1.zsh-theme"
-	else
-	    source "$ZSH/themes/$1.zsh-theme"
-	fi
+        if [ -f "$ZSH_CUSTOM/themes/$1.zsh-theme" ]; then
+            source "$ZSH_CUSTOM/themes/$1.zsh-theme"
+        elif [ -f "$ZSH/themes/$1.zsh-theme" ]; then
+            source "$ZSH/themes/$1.zsh-theme"
+        else
+            echo "[oh-my-zsh] Theme '$1' not found."
+        fi
     fi
 }
 
 function lstheme
 {
-    cd $ZSH/themes
-    ls *zsh-theme | sed 's,\.zsh-theme$,,'
+    ls -1 $ZSH/themes/*.zsh-theme $ZSH_CUSTOM/themes/*.zsh-theme \
+    | xargs -d '\n' -n 1 basename \
+    | sed 's/\(.*\)\..*/\1/' \
+    | uniq | sort | column
 }

--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -1,7 +1,7 @@
 function theme
 {
     if [ -z "$1" ] || [ "$1" = "random" ]; then
-        themes=($ZSH/themes/*.zsh-theme)
+        themes=($(find $ZSH_CUSTOM $ZSH_CUSTOM/themes/ $ZSH/themes -name '*.zsh-theme'))
         N=${#themes[@]}
         ((N=(RANDOM%N)+1))
         RANDOM_THEME=${themes[$N]}
@@ -9,7 +9,9 @@ function theme
         RANDOM_THEME_NAME=`echo "$RANDOM_THEME"|xargs -d '\n' -n 1 basename|sed 's/\(.*\)\..*/\1/'`
         echo "[oh-my-zsh] Random theme '$RANDOM_THEME_NAME' loaded."
     else
-        if [ -f "$ZSH_CUSTOM/themes/$1.zsh-theme" ]; then
+	    if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]; then
+            source "$ZSH_CUSTOM/$1.zsh-theme"
+        elif [ -f "$ZSH_CUSTOM/themes/$1.zsh-theme" ]; then
             source "$ZSH_CUSTOM/themes/$1.zsh-theme"
         elif [ -f "$ZSH/themes/$1.zsh-theme" ]; then
             source "$ZSH/themes/$1.zsh-theme"
@@ -21,8 +23,8 @@ function theme
 
 function lstheme
 {
-    ls -1 $ZSH/themes/*.zsh-theme $ZSH_CUSTOM/themes/*.zsh-theme \
+    find $ZSH_CUSTOM $ZSH_CUSTOM/themes/ $ZSH/themes -name '*.zsh-theme' \
     | xargs -d '\n' -n 1 basename \
     | sed 's/\(.*\)\..*/\1/' \
-    | uniq | sort | column
+    | sort -u | column
 }

--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -9,7 +9,7 @@ function theme
         RANDOM_THEME_NAME=`echo "$RANDOM_THEME"|xargs -d '\n' -n 1 basename|sed 's/\(.*\)\..*/\1/'`
         echo "[oh-my-zsh] Random theme '$RANDOM_THEME_NAME' loaded."
     else
-	    if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]; then
+        if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]; then
             source "$ZSH_CUSTOM/$1.zsh-theme"
         elif [ -f "$ZSH_CUSTOM/themes/$1.zsh-theme" ]; then
             source "$ZSH_CUSTOM/themes/$1.zsh-theme"


### PR DESCRIPTION
Now support custom themes (the old code is broken)
this looks in both $ZSH_CUSTOM and $ZSH_CUSTOM/themes according to #4605
and prettified output of lstheme command (split to column instead of one theme per line)

i don't think just removing this plugin is a good idea, with this plugin i can preview themes easily