### PR TITLE
Feature/skip update when no connectivity

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -31,6 +31,12 @@ whence git >/dev/null || return 0
 
 # Skip when no internet connectivity, depends on curl
 REMOTE=$(cd "$ZSH" && git remote get-url --all origin)
+echo "$REMOTE" | grep -qa 'git@'
+if [ $? -eq 0 ]
+then
+  # convert the remote protocol to https
+  REMOTE=$(echo $REMOTE | tr ':' '/' | sed -e "s#git@#https://#")
+fi
 # -L follow redirect, -s silent,
 # --max-time overall operation timeout, -I only download headers
 whence curl > /dev/null && curl -L -s --max-time 3 -I ${REMOTE} || return 0

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -39,7 +39,7 @@ then
 fi
 # -L follow redirect, -s silent,
 # --max-time overall operation timeout, -I only download headers
-whence curl > /dev/null && curl -L -s --max-time 3 -I ${REMOTE} || return 0
+whence curl > /dev/null && curl -L -s --max-time 3 -I ${REMOTE} > /dev/null || return 0
 
 if mkdir "$ZSH/log/update.lock" 2>/dev/null; then
   if [ -f ~/.zsh-update ]; then

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -29,6 +29,12 @@ fi
 # Cancel upgrade if git is unavailable on the system
 whence git >/dev/null || return 0
 
+# Skip when no internet connectivity, depends on curl
+REMOTE=$(cd "$ZSH" && git remote get-url --all origin)
+# -L follow redirect, -s silent,
+# --max-time overall operation timeout, -I only download headers
+whence curl > /dev/null && curl -L -s --max-time 3 -I ${REMOTE} || return 0
+
 if mkdir "$ZSH/log/update.lock" 2>/dev/null; then
   if [ -f ~/.zsh-update ]; then
     . ~/.zsh-update

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -23,6 +23,9 @@ function _upgrade_zsh() {
   # -L follow redirect, -s silent,
   # --max-time overall operation timeout, -I only download headers
   whence curl > /dev/null && curl -L -s --max-time 3 -I ${REMOTE} > /dev/null || return 0
+  # the curl call could be replaced by:
+  # `ping -q -c 1 -W 1 8.8.8.8 >/dev/null` without DNS resolution
+  # or `ping -q -c 1 -W 1 github.com >/dev/null`
   env ZSH=$ZSH sh $ZSH/tools/upgrade.sh
   # update the zsh file
   _update_zsh_update


### PR DESCRIPTION
This is an attempt in order to fix the long waiting time (git pull timeout) when one oh-my-zsh user has no/bad internet connectivity.
Thanks to review or improve this PR.

Note: the commit `6afbbe8` is for people forking the oh-my-zsh repo and cloning it via ssh protocol.

I did some testing with both https://github.com and git@github.com remote types.

```
UPDATE_ZSH_DAYS=0 source .zshrc
```

Cheers
Eric