### PR TITLE
Adding alias to restart bluetooth daemon

### DIFF
--- a/plugins/osx/README.md
+++ b/plugins/osx/README.md
@@ -31,3 +31,4 @@ Original author: [Sorin Ionescu](https://github.com/sorin-ionescu)
 | `hidefiles`     | Hide the hidden files                            |
 | `itunes`        | Control iTunes. User `itunes -h` for usage details |
 | `spotify`       | Control Spotify and search by artist, album, track and etc.|
+| `bt_restart`    | Restart the bluetooth daemon.                     |

--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -543,6 +543,8 @@ function spotify() {
   done
 }
 
+# Bluetooth restart
+alias bt_restart="sudo kextunload -b com.apple.iokit.BroadcomBluetoothHostControllerUSBTransport && sudo kextload -b com.apple.iokit.BroadcomBluetoothHostControllerUSBTransport"
 
 # Show/hide hidden files in the Finder
 alias showfiles="defaults write com.apple.finder AppleShowAllFiles -bool true && killall Finder"


### PR DESCRIPTION
I use theses commands a lot to restart the bluetooth daemon of my osx when it starts to fail. I think it might be useful for other bluetooth device users.