### PR TITLE
Adding scu-* commands to alias for 'systemctl --user'

### DIFF
--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -8,8 +8,11 @@ sudo_commands=(
   link load cancel set-environment unset-environment
   edit)
 
+all_commands=($user_commands $sudo_commands)
+
 for c in $user_commands; do; alias sc-$c="systemctl $c"; done
 for c in $sudo_commands; do; alias sc-$c="sudo systemctl $c"; done
+for c in $all_commands; do; alias scu-$c="systemctl --user $c"; done
 
 alias sc-enable-now="sc-enable --now"
 alias sc-disable-now="sc-disable --now"


### PR DESCRIPTION
Unless there's something I'm missing, the current plugin doesn't allow to run commands for user services. Say "redshift" is a user service in ~/.config/systemd/user, then "sc-start redshift" would actually "sudo systemctl start redshift" which isn't what I want. Even "sc-start --user redshift" would alias to "sudo systemctl start --user redshift" which isn't what I want either.

As far as I understand, in the case of user service, we want to run all_commands as the user, and we want to always use the --user option.

I think there's very little risk that scu-* conflicts with anything.