### PR TITLE
Unbreak vi's visual mode

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -17,7 +17,6 @@ bindkey -v
 
 # allow v to edit the command line (standard behaviour)
 autoload -Uz edit-command-line
-bindkey -M vicmd 'v' edit-command-line
 
 # allow ctrl-p, ctrl-n for navigate history (standard behaviour)
 bindkey '^P' up-history


### PR DESCRIPTION
Vi (and zsh's vi mode) a few modes, one of them being visual mode, which is triggered by pressing <kbd>v</kbd>.

Entering it using <kbd>v</kbd> is the default on vi/vim/nvim, and also on zsh when using `bindkey -v`.

However, the `vi-mode` plugin overrides this with a custom action, effectively making this mode inaccessible and breaking vi mode.

This PR undoes that, since it seems to be a huge oversight when mapping that particular key, and makes vi's visual mode accessible when using the `vi-mode` plugin.