### PR TITLE
Export LS_COLORS for linux

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -3,6 +3,7 @@ autoload -U colors && colors
 
 # Enable ls colors
 export LSCOLORS="Gxfxcxdxbxegedabagacad"
+export LS_COLORS="di=1;36:ln=35:so=32:pi=33:ex=31:bd=34;46:cd=34;43:su=30;41:sg=30;46:tw=30;42:ow=30;43"
 
 # TODO organise this chaotic logic
 


### PR DESCRIPTION
Problem:
On Linux oh-my-zsh's default coloring of `ls` is not taken into account.

Solution:
The BSD version of `ls` uses a variable called `LSCOLORS` to set the coloring of output of `ls`. The Linux version uses `LS_COLORS` which is not set beautifully as `LSCOLORS` for BSD. So this PR sets `LS_COLORS` (valid for Linux) equal to `LSCOLORS` (valid for Mac), according to this conversion: https://geoff.greer.fm/lscolors/