### PR TITLE
fix parse_git_dirty() to work on Solaris

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -20,7 +20,7 @@ function parse_git_dirty() {
     if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" == "true" ]]; then
       FLAGS+='--untracked-files=no'
     fi
-    STATUS=$(command git status ${FLAGS} 2> /dev/null | tail -n1)
+    STATUS=$(command git status ${FLAGS} 2> /dev/null | tail -1)
   fi
   if [[ -n $STATUS ]]; then
     echo "$ZSH_THEME_GIT_PROMPT_DIRTY"


### PR DESCRIPTION
We need this as Solaris's tail doesn't support `-n` option. However it does support old `-[n]` format so we can simply use `tail -1` instead of `tail -n1`

Tested on Linux, Solaris 11.1 and FreeBSD 11.3. Haven't test it under MacOS as I don't have such machine 