### PR TITLE
Fixed outputting message of "composer.plugin.zsh"

### DIFF
--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -52,4 +52,4 @@ alias cgrm='composer global remove'
 alias cget='curl -s https://getcomposer.org/installer | php'
 
 # Add Composer's global binaries to PATH
-export PATH=$PATH:$(composer global config bin-dir --absolute 2>/dev/null)
+export PATH=$PATH:"$(composer global config bin-dir --absolute 2>/dev/null)"


### PR DESCRIPTION
# WHAT IS THIS

Hi, I found that Composer Plugin output this message.
I fixed it using double quote.

```
~/.oh-my-zsh/plugins/composer/composer.plugin.zsh:export:55: not valid in this context: Warning:
```

Thanks 👍 