### PR TITLE
Fix alias in Ubuntu plugin

### DIFF
--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -51,7 +51,7 @@ alias agug='sudo apt-get upgrade' # ag
 alias aguu='sudo apt-get update && sudo apt-get upgrade'      #adg
 alias agar='sudo apt-get autoremove'
 
-compdef _ag apg='sudo apt-get'
+compdef _apg apg='sudo apt-get'
 compdef _aga aga='sudo apt-get autoclean'
 compdef _agb agb='sudo apt-get build-dep'
 compdef _agc agc='sudo apt-get clean'


### PR DESCRIPTION
It looks like the `_ag` compdef name was not changed when `ag` was changed to `apg`.