### PR TITLE
Fix plugins/pass completion to allow for multiple pass repos

### DIFF
--- a/plugins/pass/_pass
+++ b/plugins/pass/_pass
@@ -6,11 +6,18 @@
 #    Brian Mattern <rephorm@rephorm.com>
 #    Jason A. Donenfeld <Jason@zx2c4.com>.
 # All Rights Reserved.
-#
 # This file is licensed under the GPLv2+.
 # Please visit http://git.zx2c4.com/password-store/tree/COPYING for more information.
 #
 # Oh my zsh plugin maintainer: Santiago Borrazás <sanbor@gmail.com>
+
+# If you use multiple repositories, you can configure completion like this:
+#
+# compdef _pass workpass
+# zstyle ':completion::complete:workpass::' prefix "$HOME/work/pass"
+# workpass() {
+#   PASSWORD_STORE_DIR=$HOME/work/pass pass $@
+# }
 
 
 _pass () {
@@ -117,8 +124,9 @@ _pass_cmd_show () {
 }
 _pass_complete_entries_helper () {
 	local IFS=$'\n'
-	local prefix="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
-	_values -C 'passwords' ${$(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print 2>/dev/null | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' | sort):-""}
+	local prefix
+	zstyle -s ":completion:${curcontext}:" prefix prefix || prefix="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
+	_values -C 'passwords' ${$(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print 2>/dev/null | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' -e 's#\\#\\\\#' | sort):-""}
 }
 
 _pass_complete_entries_with_subdirs () {


### PR DESCRIPTION
 - see upstream:
   https://git.zx2c4.com/password-store/tree/src/completion/pass.zsh-completion

this fix has been in the upstream zsh completion for a while now. Took my quite a while to find out why completion did not work for me anymore.

However - this is an easy one for you guys I guess.


Thanks,
Sven