### PR TITLE
git_prompt_info: display tags when available

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -3,7 +3,11 @@ function git_prompt_info() {
   local ref
   if [[ "$(command git config --get oh-my-zsh.hide-status 2>/dev/null)" != "1" ]]; then
     ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
-    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
+    ref=$(command git tag --points-at HEAD 2> /dev/null | head -1) || return 0
+
+    if [[ -z $ref ]]; then
+      ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
+    fi
     echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
   fi
 }


### PR DESCRIPTION
As of now, the `git_prompt_info` method just prints the branch, and if there isn't any, it prints the SHA. I think printing a tag, when there is one, is pretty helpful.

This PR implements just that.