### PR TITLE
fix(screen): respect `DISABLE_AUTO_TITLE`

### DIFF
--- a/plugins/screen/screen.plugin.zsh
+++ b/plugins/screen/screen.plugin.zsh
@@ -30,11 +30,14 @@ if [[ "$TERM" == screen* ]]; then
   # tell GNU screen what the tab window title ($1) and the hardstatus($2) should be
   function screen_set()
   {
-    # set the tab window title (%t) for screen
-    print -nR $'\033k'$1$'\033'\\\
-
     # set hardstatus of tab window (%h) for screen
     print -nR $'\033]0;'$2$'\a'
+
+    if [[ "$DISABLE_AUTO_TITLE" == true ]]; then
+      return
+    fi
+    # set the tab window title (%t) for screen
+    print -nR $'\033k'$1$'\033'\\\
   }
   # called by zsh before executing a command
   function preexec()

--- a/plugins/screen/screen.plugin.zsh
+++ b/plugins/screen/screen.plugin.zsh
@@ -30,14 +30,13 @@ if [[ "$TERM" == screen* ]]; then
   # tell GNU screen what the tab window title ($1) and the hardstatus($2) should be
   function screen_set()
   {
-    # set hardstatus of tab window (%h) for screen
-    print -nR $'\033]0;'$2$'\a'
+    [[ "${DISABLE_AUTO_TITLE:-}" != true ]] || return 0
 
-    if [[ "$DISABLE_AUTO_TITLE" == true ]]; then
-      return
-    fi
     # set the tab window title (%t) for screen
     print -nR $'\033k'$1$'\033'\\\
+
+    # set hardstatus of tab window (%h) for screen
+    print -nR $'\033]0;'$2$'\a'
   }
   # called by zsh before executing a command
   function preexec()


### PR DESCRIPTION
I would like to be able to set title (permanent) for one my tab but can't do this, there is a variable in CORE of OMZ which disable auto titling, I would like same behavior to be adopted by the screen.plugin:
https://github.com/robbyrussell/oh-my-zsh/blob/master/lib/termsupport.zsh#L55
