### PR TITLE
Add tmuxconf alias

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -8,6 +8,7 @@ alias ts='tmux new-session -s'
 alias tl='tmux list-sessions'
 alias tksv='tmux kill-server'
 alias tkss='tmux kill-session -t'
+alias tmuxconf='$EDITOR ~/.tmux.conf'
 
 # Only run if tmux is actually installed
 if which tmux &> /dev/null


### PR DESCRIPTION
A handy alias I use quite often and have seem commonly around the web (along with similar such as `zshconf`) for quickly viewing/editing your tmux config file.

This can be combined with re-sourcing your tmux config to update, either manually, or with something like
```
bind-key r source-file ~/.tmux.conf \; display-message "~/.tmux.conf reloaded"
```
(again this is something I have seen a few times around the web and it has been very handy)