### PR TITLE
Fix gradle command option name

### DIFF
--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -71,7 +71,7 @@ function _gradle_arguments() {
     '--quiet[Log errors only]' \
     '--recompile-scripts[Forces scripts to be recompiled, bypassing caching]' \
     '--refresh-dependencies[Refresh the state of dependencies]' \
-    '--rerun-task[Specifies that any task optimization is ignored]' \
+    '--rerun-tasks[Specifies that any task optimization is ignored]' \
     '--settings-file[Specifies the settings file]' \
     '--stacktrace[Print out the stacktrace also for user exceptions]' \
     '--status[Print Gradle Daemon status]' \


### PR DESCRIPTION
It should be `--rerun-tasks`, the original one miss a 's' at the end.

See also: https://docs.gradle.org/current/userguide/command_line_interface.html





