### PR TITLE
Better read command syntax

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -42,9 +42,7 @@ if mkdir "$ZSH/log/update.lock" 2>/dev/null; then
       if [ "$DISABLE_UPDATE_PROMPT" = "true" ]; then
         _upgrade_zsh
       else
-        echo "[Oh My Zsh] Would you like to check for updates? [Y/n]: \c"
-        read line
-        if [[ "$line" == Y* ]] || [[ "$line" == y* ]] || [ -z "$line" ]; then
+        if read -q line\?"[Oh My Zsh] Would you like to check for updates? [Y/n]: " && echo; then
           _upgrade_zsh
         else
           _update_zsh_update


### PR DESCRIPTION
This syntax is more concise. The read command can be placed into question mode, which causes it to behave like a normal Y/n prompt. The read command, in question mode, will also return 0 if the user type y (or Y), which allows it to be used directly in an if statement.