### PR TITLE
Asynchronous RPROMPT plugin

### DIFF
--- a/plugins/async-prompt/async-prompt.plugin.zsh
+++ b/plugins/async-prompt/async-prompt.plugin.zsh
@@ -18,6 +18,7 @@ function precmd() {
     }
 
     # do not clear RPROMPT, let it persist
+    RPROMPT="${ZSH_THEME_ASYNC_PROMPT_OLD_PREFIX}${RPROMPT}${ZSH_THEME_ASYNC_PROMPT_OLD_SUFFIX}"
 
     # kill child if necessary
     if [[ "${ASYNC_PROC}" != 0 ]]; then

--- a/plugins/async-prompt/async-prompt.plugin.zsh
+++ b/plugins/async-prompt/async-prompt.plugin.zsh
@@ -4,6 +4,10 @@
 # To use in your theme, define an `rprompt` function that echoes whatever you
 # want to have on the right-hand-side prompt.
 #
+# Copyright
+#	2015, Anish Athalye (initial idea and code)
+#	2018, Olivier Mehani <shtrom+zsh@ssji.net> (this plugin), MIT licensed
+#
 setopt prompt_subst # enable command substition in prompt
 
 local _RPROMPT_FILE=$(umask 7077; mktemp /tmp/zsh_async_prompt.$$.XXXXXX)

--- a/plugins/async-prompt/async-prompt.plugin.zsh
+++ b/plugins/async-prompt/async-prompt.plugin.zsh
@@ -1,0 +1,41 @@
+# Asynchronous prompt heavily based on Anish Athalye's [0]
+# [0[ https://www.anishathalye.com/2015/02/07/an-asynchronous-shell-prompt/
+#
+# To use in your theme, define an `rprompt` function that echoes whatever you
+# want to have on the right-hand-side prompt.
+#
+setopt prompt_subst # enable command substition in prompt
+
+ASYNC_PROC=0
+function precmd() {
+    function async() {
+
+        # save to temp file
+	printf "%s" "$(rprompt)" > "/tmp/zsh_prompt_$$"
+
+        # signal parent
+        kill -s USR1 $$
+    }
+
+    # do not clear RPROMPT, let it persist
+
+    # kill child if necessary
+    if [[ "${ASYNC_PROC}" != 0 ]]; then
+        kill -s HUP $ASYNC_PROC >/dev/null 2>&1 || :
+    fi
+
+    # start background computation
+    async &!
+    ASYNC_PROC=$!
+}
+
+function TRAPUSR1() {
+    # read from temp file
+    RPROMPT="$(cat /tmp/zsh_prompt_$$)"
+
+    # reset proc number
+    ASYNC_PROC=0
+
+    # redisplay
+    zle && zle reset-prompt
+}

--- a/plugins/async-prompt/async-prompt.plugin.zsh
+++ b/plugins/async-prompt/async-prompt.plugin.zsh
@@ -38,7 +38,7 @@ function precmd() {
 
 function TRAPUSR1() {
     # read from temp file
-    RPROMPT="$(cat ${_RPROMPT_FILE})"
+    RPROMPT="$(cat ${_RPROMPT_FILE} 2>/dev/null)"
 
     # reset proc number
     ASYNC_PROC=0
@@ -48,7 +48,7 @@ function TRAPUSR1() {
 }
 
 function async_zshexit() {
-	rm ${_RPROMPT_FILE}
+	rm -f ${_RPROMPT_FILE}
 }
 
 autoload -U add-zsh-hook


### PR DESCRIPTION
Asynchronous prompt heavily based on Anish Athalye's  https://www.anishathalye.com/2015/02/07/an-asynchronous-shell-prompt/

To use in your theme, define an `rprompt` function that echoes whatever you
want to have on the right-hand-side prompt.

I also have a branch with a simple theme using it, over at https://github.com/shtrom/oh-my-zsh/blob/shtrom-theme/themes/shtrom.zsh-theme, based on `alanpeabody`'s.