### PR TITLE
Added the installer plugin

### DIFF
--- a/plugins/installer/README.md
+++ b/plugins/installer/README.md
@@ -1,0 +1,15 @@
+A simple aliasing scheme for the different kinds of systems
+that have command line app installers.
+
+On Mac systems, it's assumed the installer is brew
+On Suse based sysetms, it's zypper
+On Redhat, it's yum
+On Debian/Ubuntu it's apt-get
+
+include the installer as a plugin in your ~/.zshrc
+
+to install a new app run
+install <app>
+
+you can upgrade an app with
+upgrade <app>

--- a/plugins/installer/README.md
+++ b/plugins/installer/README.md
@@ -9,7 +9,7 @@ On Debian/Ubuntu it's apt-get
 include the installer as a plugin in your ~/.zshrc
 
 to install a new app run
-install <app>
+in <app>
 
 you can upgrade an app with
-upgrade <app>
+up <app>

--- a/plugins/installer/core.sh
+++ b/plugins/installer/core.sh
@@ -1,0 +1,77 @@
+#!/bin/zsh
+lowercase(){
+    echo "$1" | sed "y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/"
+}
+
+####################################################################
+# Get System Info
+####################################################################
+shootProfile(){
+    OS=`lowercase \`uname\``
+    KERNEL=`uname -r`
+    MACH=`uname -m`
+
+    if [ "${OS}" = "windowsnt" ]; then
+        OS=windows
+    elif [ "${OS}" = "darwin" ]; then
+        OS=mac
+        DIST="apple"
+        DistroBasedOn='RedHat'
+        REV=`sw_vers | grep ProductVersion | awk '{ print $2 }'`
+    else
+        OS=`uname`
+        if [ "${OS}" = "SunOS" ] ; then
+            OS=Solaris
+            ARCH=`uname -p`
+            OSSTR="${OS} ${REV}(${ARCH} `uname -v`)"
+        elif [ "${OS}" = "AIX" ] ; then
+            OSSTR="${OS} `oslevel` (`oslevel -r`)"
+        elif [ "${OS}" = "Linux" ] ; then
+            if [ -f /etc/redhat-release ] ; then
+                DistroBasedOn='RedHat'
+                DIST=`cat /etc/redhat-release |sed s/\ release.*//`
+                PSEUDONAME=`cat /etc/redhat-release | sed s/.*\(// | sed s/\)//`
+                REV=`cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//`
+            elif [ -f /etc/SuSE-release ] ; then
+                DIST='suse'
+                DistroBasedOn='SuSe'
+                PSEUDONAME=`lsb_release -a | grep Description | cut -f2-`
+                REV=`lsb_release -a | grep Release | cut -f2-`
+            elif [ -f /etc/mandrake-release ] ; then
+                DistroBasedOn='Mandrake'
+                PSEUDONAME=`cat /etc/mandrake-release | sed s/.*\(// | sed s/\)//`
+                REV=`cat /etc/mandrake-release | sed s/.*release\ // | sed s/\ .*//`
+            elif [ -f /etc/debian_version ] ; then
+                DistroBasedOn='Debian'
+                if [ -f /etc/lsb-release ] ; then
+                        DIST=`cat /etc/lsb-release | grep '^DISTRIB_ID' | awk -F=  '{ print $2 }'`
+                            PSEUDONAME=`cat /etc/lsb-release | grep '^DISTRIB_CODENAME' | awk -F=  '{ print $2 }'`
+                            REV=`cat /etc/lsb-release | grep '^DISTRIB_RELEASE' | awk -F=  '{ print $2 }'`
+                        fi
+            fi
+            if [ -f /etc/UnitedLinux-release ] ; then
+                DIST="${DIST}[`cat /etc/UnitedLinux-release | tr "\n" ' ' | sed s/VERSION.*//`]"
+            fi
+            OS=`lowercase $OS`
+            DIST=`lowercase $DIST`
+            DistroBasedOn=`lowercase $DistroBasedOn`
+            readonly OS
+            readonly DIST
+            readonly DistroBasedOn
+            readonly PSEUDONAME
+            readonly REV
+            readonly KERNEL
+            readonly MACH
+        fi
+
+    fi
+}
+shootProfile
+#echo "OS: $OS"
+#echo "DIST: $DIST"
+#echo "PSUEDONAME: $PSUEDONAME"
+#echo "REV: $REV"
+#echo "DistroBasedOn: $DistroBasedOn"
+#echo "KERNEL: $KERNEL"
+#echo "MACH: $MACH"
+#echo "========"

--- a/plugins/installer/installer.plugin.zsh
+++ b/plugins/installer/installer.plugin.zsh
@@ -11,7 +11,7 @@
 source "${0:h}/core.sh"
 
 case $OS in
-    'mac') 
+    'mac')
         alias in='brew install'
         alias up='brew upgrade'
         ;;

--- a/plugins/installer/installer.plugin.zsh
+++ b/plugins/installer/installer.plugin.zsh
@@ -1,0 +1,31 @@
+#!/bin/zsh
+#
+# System agnostic installer aliasing
+#
+# Assumes if you are on a mac, brew is used
+# Suse = zypper
+# ubuntu/debian = apt
+# Redhat = yum
+#
+
+source "${0:h}/core.sh"
+
+case $OS in
+    'mac') 
+        alias in='brew install'
+        alias up='brew upgrade'
+        ;;
+    'linux')
+        if [[ "$DIST" == "ubuntu" ]]; then
+            alias in="sudo -E apt-get install"
+            alias up="sudo -E apt-get upgrade"
+        elif [[ "$DIST" == "suse" ]]; then
+            alias in="sudo -E zypper in"
+            alias up="sudo -E zypper up"
+        elif [[ "$DIST" == "redhat" ]]; then
+            alias in="sudo -E yum install"
+            alias up="sudo -E yup upgrade"
+        fi
+        ;;
+    *) ;;
+esac


### PR DESCRIPTION
This plugin creates 2 aliases "in and up" that are system
and distro agnostic.   For example,
on Mac in = brew install
on SUSE in = sudo -E zypper install
on Debian in = sudo -E apt-get install
on RedHat in = sudo -E yum install

add the 'installer' to your plugin list in ~/.zshrc
source ~/.zshrc

now you can run
'in wget'
'up curl'