### PR TITLE
Display tag instead of commit revision

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -3,7 +3,7 @@ function git_prompt_info() {
   local ref
   if [[ "$(command git config --get oh-my-zsh.hide-status 2>/dev/null)" != "1" ]]; then
     ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
-    ref="tag/$(command git describe --exact-match $(command git rev-parse HEAD) 2> /dev/null)" || \
+    ref="tag/$(command git describe --exact-match HEAD 2> /dev/null)" || \
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
     echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
   fi

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -3,6 +3,7 @@ function git_prompt_info() {
   local ref
   if [[ "$(command git config --get oh-my-zsh.hide-status 2>/dev/null)" != "1" ]]; then
     ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
+    ref="tag/$(command git describe --exact-match $(command git rev-parse HEAD) 2> /dev/null)" || \
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
     echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
   fi


### PR DESCRIPTION
When a tag is checkout, display `tag/[tag-name]` instead of `[commit-sha]`