### PR TITLE
[plugins/archlinux] add alias for pikaur

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -52,6 +52,31 @@
 | yasu    | yaourt -Syua --no-confirm          | Same as `yaupg`, but without confirmation                           |
 | upgrade | yaourt -Syu                        | Sync with repositories before upgrading packages                    |
 
+#### PIKAUR
+
+| Alias   | Command                            | Description                                                         |
+|---------|------------------------------------|---------------------------------------------------------------------|
+| piconf  | pikaur -C                          | Fix all configuration files with vimdiff                            |
+| piin    | pikaur -S                          | Install packages from the repositories                              |
+| piins   | pikaur -U                          | Install a package from a local file                                 |
+| piinsd  | pikaur -S --asdeps                 | Install packages as dependencies of another package                 |
+| piloc   | pikaur -Qi                         | Display information about a package in the local database           |
+| pilocs  | pikaur -Qs                         | Search for packages in the local database                           |
+| pilst   | pikaur -Qe                         | List installed packages including from AUR (tagged as "local")      |
+| pimir   | pikaur -Syy                        | Force refresh of all package lists after updating mirrorlist        |
+| piorph  | pikaur -Qtd                        | Remove orphans using pikaur                                         |
+| pire    | pikaur -R                          | Remove packages, keeping its settings and dependencies              |
+| pirem   | pikaur -Rns                        | Remove packages, including its settings and unneeded dependencies   |
+| pirep   | pikaur -Si                         | Display information about a package in the repositories             |
+| pireps  | pikaur -Ss                         | Search for packages in the repositories                             |
+| piupd   | pikaur -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases             |
+| piupd   | pikaur -Sy && sudo abs             | Update and refresh the local package and ABS databases              |
+| piupd   | pikaur -Sy && sudo aur             | Update and refresh the local package and AUR databases              |
+| piupd   | pikaur -Sy                         | Update and refresh the local package database                       |
+| piupg   | pikaur -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
+| pisu    | pikaur -Syua --noconfirm           | Same as `piupg`, but without confirmation                           |
+| upgrade | pikaur -Syu                        | Sync with repositories before upgrading packages                    |
+
 #### PACAUR
 
 | Alias   | Command                            | Description                                                         |
@@ -124,3 +149,4 @@
 - Juraj Fiala - doctorjellyface@riseup.net
 - Majora320 (Moses Miller) - Majora320@gmail.com
 - Ybalrid (Arthur Brainville) - ybalrid@ybalrid.info
+- Byeonghoon Yoo - bh322yoo@gmail.com

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -83,6 +83,35 @@ if (( $+commands[pacaur] )); then
   fi
 fi
 
+if (( $+commands[pikaur] )); then
+  alias piconf='pikaur -C'
+  alias piupg='pikaur -Syua'
+  alias pisu='pikaur -Syua --noconfirm'
+  alias piin='pikaur -S'
+  alias piins='pikaur -U'
+  alias pire='pikaur -R'
+  alias pirem='pikaur -Rns'
+  alias pirep='pikaur -Si'
+  alias pireps='pikaur -Ss'
+  alias piloc='pikaur -Qi'
+  alias pilocs='pikaur -Qs'
+  alias pilst='pikaur -Qe'
+  alias piorph='pikaur -Qtd'
+  alias piinsd='pikaur -S --asdeps'
+  alias pimir='pikaur -Syy'
+
+
+  if (( $+commands[abs] && $+commands[aur] )); then
+    alias piupd='pikaur -Sy && sudo abs && sudo aur'
+  elif (( $+commands[abs] )); then
+    alias piupd='pikaur -Sy && sudo abs'
+  elif (( $+commands[aur] )); then
+    alias piupd='pikaur -Sy && sudo aur'
+  else
+    alias piupd='pikaur -Sy'
+  fi
+fi
+
 if (( $+commands[trizen] )); then
   function upgrade() {
     trizen -Syu
@@ -94,6 +123,10 @@ elif (( $+commands[pacaur] )); then
 elif (( $+commands[yaourt] )); then
   function upgrade() {
     yaourt -Syu
+  }
+elif (( $+commands[pikaur] )); then
+  function upgrade() {
+    pikaur -Syu
   }
 else
   function upgrade() {


### PR DESCRIPTION
According to [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers), [pikaur](https://github.com/actionless/pikaur) is a substitute for *yaourt* with many functions.

So I alias pikaur with prefix `pi`

Example:
`piin` is same as `pikaur -S`