### PR TITLE
[plugins/archlinux] add alias for aurman

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -76,6 +76,30 @@
 | pasu    | pacaur -Syua --no-confirm          | Same as `paupg`, but without confirmation                           |
 | upgrade | pacaur -Syu                        | Sync with repositories before upgrading packages                    |
 
+#### PACAUR
+
+| Alias   | Command                            | Description                                                         |
+|---------|------------------------------------|---------------------------------------------------------------------|
+| auin    | aurman -S                          | Install packages from the repositories                              |
+| auins   | aurman -U                          | Install a package from a local file                                 |
+| auinsd  | aurman -S --asdeps                 | Install packages as dependencies of another package                 |
+| auloc   | aurman -Qi                         | Display information about a package in the local database           |
+| aulocs  | aurman -Qs                         | Search for packages in the local database                           |
+| aulst   | aurman -Qe                         | List installed packages including from AUR (tagged as "local")      |
+| aumir   | aurman -Syy                        | Force refresh of all package lists after updating mirrorlist        |
+| auorph  | aurman -Qtd                        | Remove orphans using aurman                                         |
+| aure    | aurman -R                          | Remove packages, keeping its settings and dependencies              |
+| aurem   | aurman -Rns                        | Remove packages, including its settings and unneeded dependencies   |
+| aurep   | aurman -Si                         | Display information about a package in the repositories             |
+| aureps  | aurman -Ss                         | Search for packages in the repositories                             |
+| auupd   | aurman -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases             |
+| auupd   | aurman -Sy && sudo abs             | Update and refresh the local package and ABS databases              |
+| auupd   | aurman -Sy && sudo aur             | Update and refresh the local package and AUR databases              |
+| auupd   | aurman -Sy                         | Update and refresh the local package database                       |
+| auupg   | aurman -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
+| ausu    | aurman -Syua --no-confirm          | Same as `auupg`, but without confirmation                           |
+| upgrade | aurman -Syu                        | Sync with repositories before upgrading packages                    |
+
 #### PACMAN
 
 | Alias        | Command                                 | Description                                                  |

--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -76,7 +76,7 @@
 | pasu    | pacaur -Syua --no-confirm          | Same as `paupg`, but without confirmation                           |
 | upgrade | pacaur -Syu                        | Sync with repositories before upgrading packages                    |
 
-#### PACAUR
+#### AURMAN
 
 | Alias   | Command                            | Description                                                         |
 |---------|------------------------------------|---------------------------------------------------------------------|

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -83,7 +83,38 @@ if (( $+commands[pacaur] )); then
   fi
 fi
 
-if (( $+commands[trizen] )); then
+if (( $+commands[aurman] )); then
+  alias auupg='aurman -Syu'
+  alias ausu='aurman -Syu --noconfirm'
+  alias auin='aurman -S'
+  alias auins='aurman -U'
+  alias aure='aurman -R'
+  alias aurem='aurman -Rns'
+  alias aurep='aurman -Si'
+  alias aureps='aurman -Ss'
+  alias auloc='aurman -Qi'
+  alias aulocs='aurman -Qs'
+  alias aulst='aurman -Qe'
+  alias auorph='aurman -Qtd'
+  alias auinsd='aurman -S --asdeps'
+  alias aumir='aurman -Syy'
+
+  if (( $+commands[abs] && $+commands[aur] )); then
+    alias auupd='aurman -Sy && sudo abs && sudo aur'
+  elif (( $+commands[abs] )); then
+    alias auupd='aurman -Sy && sudo abs'
+  elif (( $+commands[aur] )); then
+    alias auupd='aurman -Sy && sudo aur'
+  else
+    alias auupd='aurman -Sy'
+  fi
+fi
+
+if (( $+commands[aurman] )); then
+  function upgrade() {
+    aurman -Syu
+  }
+elif (( $+commands[trizen] )); then
   function upgrade() {
     trizen -Syu
   }


### PR DESCRIPTION
According to [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers), [pikaur](https://github.com/polygamma/aurman) is a substitute for *yaourt* with many functions.

So I alias aurman with prefix `au`

Example:
`auin` is same as `aurman -S`