### PR TITLE
Add ganpa alias for untracked files

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -43,6 +43,7 @@ alias g='git'
 alias ga='git add'
 alias gaa='git add --all'
 alias gapa='git add --patch'
+alias ganpa='git add --intent-to-add . && git add --patch'
 alias gau='git add --update'
 alias gap='git apply'
 


### PR DESCRIPTION
Building off @lapanti's #6871 and https://stackoverflow.com/a/45640990/1268612, this adds an alias that adds all untracked files via `--intent-to-add` before entering patch mode.