### PR TITLE
virtualenvwrapper: Support pyenv

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -1,7 +1,27 @@
 virtualenvwrapper='virtualenvwrapper.sh'
 virtualenvwrapper_lazy='virtualenvwrapper_lazy.sh'
+pyenv_virtualenvwrapper_lazy='pyenv-virtualenvwrapper_lazy'
+pyenv_virtualenvwrapper='pyenv-virtualenvwrapper'
 
-if (( $+commands[$virtualenvwrapper_lazy] )); then
+if (( ${+PYENV_SHELL} )); then
+  if (( $+commands[$pyenv_virtualenvwrapper_lazy] )); then
+    function {
+      setopt local_options
+      unsetopt equals
+      pyenv virtualenvwrapper_lazy
+    }
+  elif (( $+commands[$pyenv_virtualenvwrapper] )); then
+    function {
+      setopt local_options
+      unsetopt equals
+      pyenv virtualenvwrapper
+    }
+  else
+    print "[oh-my-zsh] You need pyenv-virtualenvwrapper to use virtualenvwrapper with pyenv.\n"\
+          "Please see: https://github.com/pyenv/pyenv-virtualenvwrapper" >&2
+    return
+  fi
+elif (( $+commands[$virtualenvwrapper_lazy] )); then
   function {
     setopt local_options
     unsetopt equals


### PR DESCRIPTION
Add support to `pyenv` using [`pyenv-virtualenvwrapper`](https://github.com/pyenv/pyenv-virtualenvwrapper).

* Determine that `pyenv` is in use if `PYENV_SHELL` is exported
* Run `pyenv virtualenvwrapper_lazy` (else `pyenv virtualenvwrapper`)

Closes #2927