### PR TITLE
change color blue+black -> blue+white

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -187,14 +187,14 @@ prompt_hg() {
 
 # Dir: current working directory
 prompt_dir() {
-  prompt_segment blue black '%~'
+  prompt_segment blue white '%~'
 }
 
 # Virtualenv: current working virtualenv
 prompt_virtualenv() {
   local virtualenv_path="$VIRTUAL_ENV"
   if [[ -n $virtualenv_path && -n $VIRTUAL_ENV_DISABLE_PROMPT ]]; then
-    prompt_segment blue black "(`basename $virtualenv_path`)"
+    prompt_segment blue white "(`basename $virtualenv_path`)"
   fi
 }
 


### PR DESCRIPTION
I am an avid fan of the agnoster theme.
However, the blue + black combination of prompts is often visually inadequate to make mistakes.
So I modified it as follows.

before:
![](https://s22.postimg.cc/3uznyrb75/screenshot_5.png)

after:
![](https://s22.postimg.cc/kwsi11d9d/screenshot_6.png)