### PR TITLE
feat(branch): Better support for branch name

### DIFF
--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -62,7 +62,12 @@ function jira() {
     # but `branch` is a special case that will parse the current git branch
     if [[ "$action" == "branch" ]]; then
       local issue_arg=$(git rev-parse --abbrev-ref HEAD)
-      local issue="${jira_prefix}${issue_arg}"
+      issue_arg=($(echo $issue_arg | cut -d'_' -f1)) 
+      if [[ $(echo ${issue_arg} | grep ${jira_prefix}) ]]; then
+        local issue="${issue_arg}"
+      else
+        local issue="${jira_prefix}${issue_arg}"
+      fi
     else
       local issue_arg=$action
       local issue="${jira_prefix}${issue_arg}"


### PR DESCRIPTION
I wanted to add support for custom branch name to work with the command `jira branch`

What this does is you can name your branch starting with the issue number (with or without the prefix) and user an underscore "_" delimiter to add a human friendly name to your branch. This way one still have the issue number, and one can also have a human friendly name for the branch tu remember what it is about.

Many examples of working name could be for the issue MP-1234 about general conf:
* MP-1234_configuration
* 1234_configuration
* 1234
* MP-1234