### PR TITLE
removed alias irb='bundled_irb'

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -15,7 +15,6 @@ bundled_commands=(
   foodcritic
   guard
   hanami
-  irb
   jekyll
   kitchen
   knife


### PR DESCRIPTION
### bundled irb can lead to LoadError

Executing `irb` and performing some `require` commands inside of the *interactive ruby shell* in a directory, which contains `Gemfile` there is a possibility that it will result in a `LoadError`. This behavior is unexpected because irb is just a plain Ruby console which does not depends on Gemfile.

User who wish like to use only `irb` not `bundle exec irb` in a directory including Gemfile will have to face this potential `LoadError (cannot load such file -- XYZ)`. The fact that the user is not aware of the bundled irb may be very nuisance.

It was added via https://github.com/robbyrussell/oh-my-zsh/pull/2638

If the alias `irb` for bundled irb will be removed, it will be required to execute `be irb` for the bundled irb.