### PR TITLE
Added current working anaconda env to agnoster prompt

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -205,7 +205,7 @@ prompt_conda() {
   local conda_env="$CONDA_DEFAULT_ENV"
   if [[ -n $conda_env ]]; then
     if [[ -z $CONDA_PROMPT_MODIFIER ]]; then
-      prompt_segment blue black "($CONDA_DEFAULT_ENV)"
+      prompt_segment blue black "conda:$conda_env"
     fi
   fi
 }

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -205,7 +205,7 @@ prompt_conda() {
   local conda_env="$CONDA_DEFAULT_ENV"
   if [[ -n $conda_env ]]; then
     if [[ -z $CONDA_PROMPT_MODIFIER ]]; then
-      prompt_segment blue black "conda:$conda_env"
+      prompt_segment blue black "conda:$(basename $conda_env)"
     fi
   fi
 }

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -204,8 +204,7 @@ prompt_virtualenv() {
 prompt_conda() {
   local conda_env="$CONDA_DEFAULT_ENV"
   if [[ -n $conda_env ]]; then
-    local conda_changeps1="`conda config --show changeps1`" 
-    if [[ $conda_changeps1 == "changeps1: False" && $conda_env != "base" ]]; then
+    if [[ -z $CONDA_PROMPT_MODIFIER ]]; then
       prompt_segment blue black "($CONDA_DEFAULT_ENV)"
     fi
   fi

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -198,6 +198,19 @@ prompt_virtualenv() {
   fi
 }
 
+# Anaconda: current working conda env
+# To replace the conda modification of PS1 do `conda config --set changeps1 False`
+# or add 'changeps1: False' to your .condarc file.
+prompt_conda() {
+  local conda_env="$CONDA_DEFAULT_ENV"
+  if [[ -n $conda_env ]]; then
+    local conda_changeps1="`conda config --show changeps1`" 
+    if [[ $conda_changeps1 == "changeps1: False" && $conda_env != "base" ]]; then
+      prompt_segment blue black "($CONDA_DEFAULT_ENV)"
+    fi
+  fi
+}
+
 # Status:
 # - was there an error
 # - am I root
@@ -216,6 +229,7 @@ prompt_status() {
 build_prompt() {
   RETVAL=$?
   prompt_status
+  prompt_conda
   prompt_virtualenv
   prompt_context
   prompt_dir


### PR DESCRIPTION
I've attempted to add the current anaconda env to the prompt for the agnoster theme. If someone else could test it or give some feedback it would be much appreciated. This is very similar to the current virualenv part of the prompt. This may also address issue #5703. Possibly related to PR #2508 although the agnoster virtualenv prompt component doesn't appear to use the virtualenv plugin in any way.

The addition only shows the env if not in the base env. This was in an attempt to follow the agnoster goal, "only show you *relevant* information", as if a user has anaconda installed then thier .zshrc or .bashrc will always start in the base env unless an additional conda activate command has been added.

The 'changeps1' option in the anaconda configuration is checked to avoid adding the env to the prompt twice (once unformatted and once formatted for agnoster).

I also noticed that there is an [agnoster repo](https://github.com/agnoster/agnoster-zsh-theme) and was not sure if i should send my pull request over there or here in oh-my-`zsh`.