### PR TITLE
Add sublime-merge plugin

### DIFF
--- a/plugins/sublime-merge/README.md
+++ b/plugins/sublime-merge/README.md
@@ -1,4 +1,4 @@
-## sublime
+## sublime-merge
 
 Plugin for Sublime Merge, a cross platform text and code editor, available for Linux, Mac OS X, and Windows.
 
@@ -10,8 +10,8 @@ Plugin for Sublime Merge, a cross platform text and code editor, available for L
 
  * If `sm` command is called without an argument, launch Sublime Merge
 
- * If `sm` is passed a directory, `cd` to it and open it in Sublime Merge
+ * If `sm` is passed a directory, `cd` to it and open the existing git repository in Sublime Merge
 
- * If `ssm` command is called, it is equivalent to `sm .`, opening the current folder in Sublime Merge
+ * If `smt` command is called, it is equivalent to `sm .`, opening the existing git repository in the current folder in Sublime Merge
 
- * If `ssm` command is called, it is like `sudo sm`, opening the file or folder in Sublime Merge. Useful for editing system protected files.
+ * If `ssm` command is called, it is like `sudo sm`, opening the git repository in Sublime Merge. Useful for editing system protected repositories.

--- a/plugins/sublime-merge/README.md
+++ b/plugins/sublime-merge/README.md
@@ -1,0 +1,17 @@
+## sublime
+
+Plugin for Sublime Merge, a cross platform text and code editor, available for Linux, Mac OS X, and Windows.
+
+### Requirements
+
+ * [Sublime Merge](https://www.sublimemerge.com)
+
+### Usage
+
+ * If `sm` command is called without an argument, launch Sublime Merge
+
+ * If `sm` is passed a directory, `cd` to it and open it in Sublime Merge
+
+ * If `ssm` command is called, it is equivalent to `sm .`, opening the current folder in Sublime Merge
+
+ * If `ssm` command is called, it is like `sudo sm`, opening the file or folder in Sublime Merge. Useful for editing system protected files.

--- a/plugins/sublime-merge/sublime-merge.plugin.zsh
+++ b/plugins/sublime-merge/sublime-merge.plugin.zsh
@@ -1,0 +1,53 @@
+# Sublime Merge Aliases
+
+() {
+
+	if [[ "$OSTYPE" == linux* ]]; then
+		local _sublime_linux_paths
+		_sublime_linux_paths=(
+			"$HOME/bin/sublime_merge"
+			"/opt/sublime_merge/sublime_merge"
+			"/usr/bin/sublime_merge"
+			"/usr/local/bin/sublime_merge"
+			"/usr/bin/sublime_merge"
+			)
+		for _sublime_merge_path in $_sublime_linux_paths; do
+			if [[ -a $_sublime_merge_path ]]; then
+				sm_run() { $_sublime_merge_path "$@" >/dev/null 2>&1 &| }
+				ssm_run_sudo() {sudo $_sublime_merge_path "$@" >/dev/null 2>&1}
+				alias ssm=ssm_run_sudo
+				alias sm=sm_run
+				break
+			fi
+		done
+	elif  [[ "$OSTYPE" = darwin* ]]; then
+		local _sublime_darwin_paths
+		_sublime_darwin_paths=(
+			"/usr/local/bin/sublime_merge"
+			"/Applications/Sublime Merge.app/Contents/MacOS/sublime_merge"
+			"$HOME/Applications/Sublime Merge.app/Contents/MacOS/sublime_merge"
+			)
+		for _sublime_merge_path in $_sublime_darwin_paths; do
+			if [[ -a $_sublime_merge_path ]]; then
+				subm () { "$_sublime_merge_path" "$@" }
+				alias sm=subm
+				break
+			fi
+		done
+	elif [[ "$OSTYPE" = 'cygwin' ]]; then
+		local sublime_merge_cygwin_paths
+		sublime_merge_cygwin_paths=(
+			"$(cygpath $ProgramW6432/Sublime\ Merge)/sublime_merge.exe"
+			)
+		for _sublime_merge_path in $_sublime_merge_cygwin_paths; do
+			if [[ -a $_sublime_merge_path ]]; then
+				subm () { "$_sublime_merge_path" "$@" }
+				alias sm=subm
+				break
+			fi
+		done
+	fi
+
+}
+
+alias smt='sm .'

--- a/plugins/sublime-merge/sublime-merge.plugin.zsh
+++ b/plugins/sublime-merge/sublime-merge.plugin.zsh
@@ -10,6 +10,8 @@
 			"/usr/bin/sublime_merge"
 			"/usr/local/bin/sublime_merge"
 			"/usr/bin/sublime_merge"
+			"/usr/local/bin/smerge"
+			"/usr/bin/smerge"
 			)
 		for _sublime_merge_path in $_sublime_linux_paths; do
 			if [[ -a $_sublime_merge_path ]]; then
@@ -23,9 +25,9 @@
 	elif  [[ "$OSTYPE" = darwin* ]]; then
 		local _sublime_darwin_paths
 		_sublime_darwin_paths=(
-			"/usr/local/bin/sublime_merge"
-			"/Applications/Sublime Merge.app/Contents/MacOS/sublime_merge"
-			"$HOME/Applications/Sublime Merge.app/Contents/MacOS/sublime_merge"
+			"/usr/local/bin/smerge"
+			"/Applications/Sublime Merge.app/Contents/SharedSupport/bin/smerge"
+			"$HOME/Applications/Sublime Merge.app/Contents/SharedSupport/bin/smerge"
 			)
 		for _sublime_merge_path in $_sublime_darwin_paths; do
 			if [[ -a $_sublime_merge_path ]]; then


### PR DESCRIPTION
I've tried to put together a plugin similar to [`sublime`](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/sublime) but for [Sublime Merge](https://www.sublimemerge.com). I've used the `sublime` as the base and adjusted it with Sublime Merge. In the process, I've changed the `$*` to `"@*"` as I read that it's more robust. It shouldn't be very relevant in the case of Sublime Merge, but I thought why not?

P.S. I'm not a `zsh` expert! Please let me know if I'm missing something, or in any way I can improve this :-)