### PR TITLE
Also set the `grep` options for `egrep` and `fgrep`

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -19,8 +19,10 @@ elif grep-flag-available --exclude=.cvs; then
     GREP_OPTIONS+=" --exclude=$VCS_FOLDERS"
 fi
 
-# export grep settings
+# export grep, egrep and fgrep settings
 alias grep="grep $GREP_OPTIONS"
+alias egrep="egrep $GREP_OPTIONS"
+alias fgrep="fgrep $GREP_OPTIONS"
 
 # clean up
 unset GREP_OPTIONS


### PR DESCRIPTION
Both BSD and GNU bundle together `grep`, `egrep` and `fgrep`, so it make sense IMO to export the `grep` options for `egrep` and `fgrep` as well.

Note that BSD also bundles `zgrep`, `zegrep`, and `zfgrep`, so we could conditionnally export the same options for the compression-compatible utilities as well, but that's probably a separate PR.