### PR TITLE
make plugin compatible with gpg (v2.2.10) on macOS

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -1,7 +1,7 @@
 # Enable gpg-agent if it is not running-
 # --use-standard-socket will work from version 2 upwards
 
-AGENT_SOCK=$(gpgconf --list-dirs | grep agent-socket | cut -d : -f 2)
+AGENT_SOCK=$(gpgconf --list-dirs | grep agent-ssh-socket | cut -d : -f 2)
 
 if [[ ! -S $AGENT_SOCK ]]; then
   gpg-agent --daemon --use-standard-socket &>/dev/null
@@ -11,6 +11,6 @@ export GPG_TTY=$TTY
 # Set SSH to use gpg-agent if it's enabled
 GNUPGCONFIG="${GNUPGHOME:-"$HOME/.gnupg"}/gpg-agent.conf"
 if [[ -r $GNUPGCONFIG ]] && command grep -q enable-ssh-support "$GNUPGCONFIG"; then
-  export SSH_AUTH_SOCK="$AGENT_SOCK.ssh"
+  export SSH_AUTH_SOCK="$AGENT_SOCK"
   unset SSH_AGENT_PID
 fi


### PR DESCRIPTION
GPG Version 2.2.10 on macOS do not know `agent-socket` 

`gpgconf --list-dirs` output:
```sysconfdir:/usr/local/etc/gnupg
bindir:/usr/local/Cellar/gnupg/2.2.10/bin
libexecdir:/usr/local/Cellar/gnupg/2.2.10/libexec
libdir:/usr/local/Cellar/gnupg/2.2.10/lib/gnupg
datadir:/usr/local/Cellar/gnupg/2.2.10/share/gnupg
localedir:/usr/local/Cellar/gnupg/2.2.10/share/locale
socketdir:/Users/test/.gnupg
dirmngr-socket:/Users/test/.gnupg/S.dirmngr
agent-ssh-socket:/Users/test/.gnupg/S.gpg-agent.ssh
agent-extra-socket:/Users/test/.gnupg/S.gpg-agent.extra
agent-browser-socket:/Users/test/.gnupg/S.gpg-agent.browser
agent-socket:/Users/test/.gnupg/S.gpg-agent
homedir:/Users/test/.gnupg```