### PR TITLE
feat(plugins): add completion plugin for `invoke`

### DIFF
--- a/plugins/invoke/README.md
+++ b/plugins/invoke/README.md
@@ -1,0 +1,10 @@
+# Invoke plugin
+
+This plugin adds completion for [invoke](https://github.com/pyinvoke/invoke).
+
+To use it, add `invoke` to the plugins array in your `~/.zshrc` file:
+
+```zsh
+plugins=(... invoke)
+```
+

--- a/plugins/invoke/invoke.plugin.zsh
+++ b/plugins/invoke/invoke.plugin.zsh
@@ -1,0 +1,5 @@
+# Autocompletion for invoke.
+#
+if [ $commands[invoke] ]; then
+  source <(invoke --print-completion-script=zsh)
+fi


### PR DESCRIPTION
This gives completion for the `inv` / `invoke` commands.
https://github.com/pyinvoke/invoke

There already is a PR for invoke (https://github.com/robbyrussell/oh-my-zsh/pull/3471) but it is outdated. Invoke since added a command to generate a completion script.
This PR  simply uses this command.
http://docs.pyinvoke.org/en/latest/invoke.html#tab-completion

Note: [pyinvoke](https://pypi.org/project/pyinvoke/) is a python package that has nothing to do with invoke, but the website for invoke is http://www.pyinvoke.org/.

Closes #3471