### PR TITLE
Add alias to Django plugin for manage.py

### DIFF
--- a/plugins/django/django.plugin.zsh
+++ b/plugins/django/django.plugin.zsh
@@ -401,3 +401,5 @@ compdef _managepy django
 compdef _managepy django-admin
 compdef _managepy django-admin.py
 compdef _managepy django-manage
+
+alias pm='python manage.py'


### PR DESCRIPTION
Add `pm`, a simple alias for `python manage.py`.