### PR TITLE
Add plugin iterm2-touch-bar-status

### DIFF
--- a/plugins/iterm2-touch-bar-status/README.md
+++ b/plugins/iterm2-touch-bar-status/README.md
@@ -1,0 +1,20 @@
+# iTerm2 Touch Bar Status Plugin
+
+This plugin allows you to set the text of the Status button on the MacBook Pro Touch Bar when using [iTerm2](https://www.iterm2.com/).
+
+To setup, follow the instructions:
+
+1. Install iTerm2 Shell Integration and Utilities by going to `iTerm2 -> Install Shell Integration` and selecting `Install Shell Integration & Utilities`. The default installation location is `~/.iterm2` but you can override this by setting `$ITERM2_DIR` in your `.zshrc`.
+
+2. Add the Status button to the Touch Bar by going to `View -> Customize Touch Bar` and draging the "Status/Your Message Here" button to the Touch Bar.
+
+3. Enable this plugin in your `.zshrc` file:
+```
+plugins=(... iterms-touch-bar-status)
+```
+
+4. While the text defaults to your current working directory, you can set it to anything you like by setting `$ITERM2_TOUCH_BAR_STATUS` in your `.zshrc` (or anywhere else actually).
+
+## Contributors
+
+- [Jeff Erickson](https://github.com/jefferickson)

--- a/plugins/iterm2-touch-bar-status/README.md
+++ b/plugins/iterm2-touch-bar-status/README.md
@@ -10,7 +10,7 @@ To setup, follow the instructions:
 
 3. Enable this plugin in your `.zshrc` file:
 ```
-plugins=(... iterms-touch-bar-status)
+plugins=(... iterm2-touch-bar-status)
 ```
 
 4. While the text defaults to your current working directory, you can set it to anything you like by setting `$ITERM2_TOUCH_BAR_STATUS` in your `.zshrc` (or anywhere else actually).

--- a/plugins/iterm2-touch-bar-status/iterm2-touch-bar-status.plugin.zsh
+++ b/plugins/iterm2-touch-bar-status/iterm2-touch-bar-status.plugin.zsh
@@ -1,0 +1,16 @@
+function _iterm2_touch_bar_status(){
+	if [ -z $ITERM2_TOUCH_BAR_STATUS ];
+	then
+		ITERM2_TOUCH_BAR_STATUS='"$(pwd)"';
+	fi
+
+	if [ -z $ITERM2_DIR ];
+	then
+		ITERM2_DIR="$HOME/.iterm2"
+	fi	
+		
+	$ITERM2_DIR/it2setkeylabel set status "$(eval echo $ITERM2_TOUCH_BAR_STATUS)"
+}
+
+autoload -U add-zsh-hook
+add-zsh-hook precmd _iterm2_touch_bar_status


### PR DESCRIPTION
This plugin allows for custom text to be set on the Macbook Pro Touch Bar when using iTerm2. Defaults to the current working directory.