### PR TITLE
Don't add nonexistant paths to fpath

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -16,9 +16,6 @@ fi
 
 # Initializes Oh My Zsh
 
-# add a function path
-fpath=($ZSH/functions $ZSH/completions $fpath)
-
 # Load all stock functions (from $fpath files) called below.
 autoload -U compaudit compinit
 


### PR DESCRIPTION
Oh-my-zsh adds the following two paths to `fpath`, but neither currently exists in the project:
`$ZSH/functions`
`$ZSH/completions`