### PR TITLE
Add poetry plugin, and encapsulate compinit logic

### DIFF
--- a/lib/compfix.zsh
+++ b/lib/compfix.zsh
@@ -42,3 +42,19 @@ function handle_completion_insecurities() {
 
 EOD
 }
+
+
+# Load zsh completions according to the user's security preferences.
+update_completions() {
+  if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
+    # If completion insecurities exist, warn the user
+    if ! compaudit &>/dev/null; then
+      handle_completion_insecurities
+    fi
+    # Load only from secure directories
+    compinit -i -d "${ZSH_COMPDUMP}"
+  else
+    # If the user wants it, load from all found directories
+    compinit -u -d "${ZSH_COMPDUMP}"
+  fi
+}

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -66,18 +66,7 @@ fi
 if [ -z "$ZSH_COMPDUMP" ]; then
   ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
-
-if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
-  # If completion insecurities exist, warn the user
-  if ! compaudit &>/dev/null; then
-    handle_completion_insecurities
-  fi
-  # Load only from secure directories
-  compinit -i -d "${ZSH_COMPDUMP}"
-else
-  # If the user wants it, load from all found directories
-  compinit -u -d "${ZSH_COMPDUMP}"
-fi
+update_completions
 
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do

--- a/plugins/poetry/README.md
+++ b/plugins/poetry/README.md
@@ -1,0 +1,9 @@
+Poetry Plugin
+===
+
+This plugin automatically installs [Poetry's](https://poetry.eustace.io/) completions for you, and keeps them up to date as your Poetry version changes.
+
+To install, simply add the plugin to the plugins array in your `.zshrc` file:
+```
+plugins=(... poetry)
+```

--- a/plugins/poetry/poetry.plugin.zsh
+++ b/plugins/poetry/poetry.plugin.zsh
@@ -1,0 +1,16 @@
+# Return immediately if poetry is not found
+if ! $(command -v poetry >/dev/null) ; then
+  return
+fi
+
+local directory=${0:h}
+
+# Create completion file if it does not exist,
+# # or if poetry version changes
+if ! [[ -e "$directory/_poetry" && 
+        -e "$directory/VERSION.lock" &&
+        "$(poetry -V)" == "$(<$directory/VERSION.lock)" ]]; then
+  poetry -V > $directory/VERSION.lock
+  poetry completions zsh > $directory/_poetry
+  update_completions  # Defined in Oh My Zsh core, in lib/compfix.zsh
+fi


### PR DESCRIPTION
This PR does two things:
1. Add a basic plugin to manage tab completions for the Python `poetry` package manager.
2. Moves the `compinit` logic in Oh My Zsh's entry point into its own lib function, so other developers can easily respect the user's security preferences if they ever need to run `compinit` again.