### PR TITLE
[Agnoster theme] Add the prompt view customization ability

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -29,6 +29,20 @@
 # jobs are running in this shell will all be displayed automatically when
 # appropriate.
 
+### Segments of the prompt default order declaration
+
+typeset -aHg AGNOSTER_PROMPT=(
+    prompt_status
+    prompt_virtualenv
+    prompt_aws
+    prompt_context
+    prompt_dir
+    prompt_git
+    prompt_bzr
+    prompt_hg
+    prompt_end
+)
+
 ### Segment drawing
 # A few utility functions to make it easy and re-usable to draw segmented prompts
 
@@ -239,15 +253,9 @@ prompt_aws() {
 ## Main prompt
 build_prompt() {
   RETVAL=$?
-  prompt_status
-  prompt_virtualenv
-  prompt_aws
-  prompt_context
-  prompt_dir
-  prompt_git
-  prompt_bzr
-  prompt_hg
-  prompt_end
+  for prompt_segment in "${AGNOSTER_PROMPT[@]}"; do
+    [[ -n $prompt_segment ]] && $prompt_segment
+  done
 }
 
 PROMPT='%{%f%b%k%}$(build_prompt) '

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -31,7 +31,7 @@
 
 ### Segments of the prompt default order declaration
 
-typeset -aHg AGNOSTER_PROMPT=(
+typeset -aHg AGNOSTER_PROMPT_SEGMENTS=(
     prompt_status
     prompt_virtualenv
     prompt_aws
@@ -253,7 +253,7 @@ prompt_aws() {
 ## Main prompt
 build_prompt() {
   RETVAL=$?
-  for prompt_segment in "${AGNOSTER_PROMPT[@]}"; do
+  for prompt_segment in "${AGNOSTER_PROMPT_SEGMENTS[@]}"; do
     [[ -n $prompt_segment ]] && $prompt_segment
   done
 }


### PR DESCRIPTION
By default prompt has these segments: `prompt_status`, `prompt_context`, `prompt_virtualenv`, `prompt_dir`, `prompt_git`, `prompt_end` in that particular order.

If you want to add, change the order or remove some segments of the prompt, you can use array environment variable named `AGNOSTER_PROMPT`.

Examples:
- Show all segments of the prompt with indices:
```
echo "${(F)AGNOSTER_PROMPT[@]}" | cat -n
```
- Add the new segment of the prompt to the beginning:
```
AGNOSTER_PROMPT=("prompt_git" "${AGNOSTER_PROMPT[@]}")
```
- Add the new segment of the prompt to the end:
```
AGNOSTER_PROMPT+="prompt_end"
```
- Insert the new segment of the prompt = `PROMPT_SEGMENT_NAME` on the particular position = `PROMPT_SEGMENT_POSITION`:
```
PROMPT_SEGMENT_POSITION=5 PROMPT_SEGMENT_NAME="prompt_end";\
AGNOSTER_PROMPT=("${AGNOSTER_PROMPT[@]:0:$PROMPT_SEGMENT_POSITION-1}" "$PROMPT_SEGMENT_NAME" "${AGNOSTER_PROMPT[@]:$PROMPT_SEGMENT_POSITION-1}");\
unset PROMPT_SEGMENT_POSITION PROMPT_SEGMENT_NAME
```
- Swap segments 4th and 5th:
```
SWAP_SEGMENTS=(4 5);\
TMP_VAR="$AGNOSTER_PROMPT[$SWAP_SEGMENTS[1]]"; AGNOSTER_PROMPT[$SWAP_SEGMENTS[1]]="$AGNOSTER_PROMPT[$SWAP_SEGMENTS[2]]"; AGNOSTER_PROMPT[$SWAP_SEGMENTS[2]]="$TMP_VAR"
unset SWAP_SEGMENTS TMP_VAR
```
- Remove the 5th segment:
```
AGNOSTER_PROMPT[5]=
```

A small demo of the dummy custom prompt segment, which has been created with help of the built-in `prompt_segment()` function from Agnoster theme:
```
# prompt_segment() - Takes two arguments, background and foreground.
# Both can be omitted, rendering default background/foreground.

customize_agnoster() {
  prompt_segment 'red' '' ' ⚙ ⚡⚡⚡ ⚙  '
}
```
![Customization demo](https://github.com/apodkutin/agnoster-zsh-theme/raw/customize-prompt/agnoster_customization.gif)