### PR TITLE
Support themes from ZSH_CUSTOM dir in 'random' mode

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -95,25 +95,39 @@ done
 unset config_file
 
 # Load the theme
+load_theme() {
+  if [ ! "$1" = ""  ]; then
+    if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]; then
+      theme_path="$ZSH_CUSTOM/$1.zsh-theme"
+    elif [ -f "$ZSH_CUSTOM/themes/$1.zsh-theme" ]; then
+      theme_path="$ZSH_CUSTOM/themes/$1.zsh-theme"
+    else
+      theme_path="$ZSH/themes/$1.zsh-theme"
+    fi
+  fi
+
+  source "$theme_path"
+}
+
 if [[ "$ZSH_THEME" == "random" ]]; then
   if [[ "${(t)ZSH_THEME_RANDOM_CANDIDATES}" = "array" ]] && [[ "${#ZSH_THEME_RANDOM_CANDIDATES[@]}" -gt 0 ]]; then
-    themes=($ZSH/themes/${^ZSH_THEME_RANDOM_CANDIDATES}.zsh-theme)
+    themes=(${^ZSH_THEME_RANDOM_CANDIDATES})
+    theme_list_type="names"
   else
-    themes=($ZSH/themes/*zsh-theme)
+    themes=($ZSH/themes/*.zsh-theme $ZSH_CUSTOM/themes/*.zsh-theme)
+    theme_list_type="paths"
   fi
   N=${#themes[@]}
   ((N=(RANDOM%N)+1))
   RANDOM_THEME=${themes[$N]}
-  source "$RANDOM_THEME"
+
+  if [[ "$theme_list_type" == "names" ]]; then
+    load_theme "$RANDOM_THEME"
+  else
+    source "$RANDOM_THEME"
+  fi
+
   echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
 else
-  if [ ! "$ZSH_THEME" = ""  ]; then
-    if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then
-      source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
-    elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
-      source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
-    else
-      source "$ZSH/themes/$ZSH_THEME.zsh-theme"
-    fi
-  fi
+  load_theme $ZSH_THEME
 fi


### PR DESCRIPTION
Currently if you specify themes from ZSH_CUSTOM dir in `ZSH_THEME_RANDOM_CANDIDATES`, they will never be picked up because only `$ZSH/themes` dir is being scanned. 

This PR introduces minor refactoring (extracted theme loading logic to new `load_theme()` function) and adds scanning of both internal and custom theme dirs in 'random' mode.