### PR TITLE
Added minimum length and ellipsis symbol options for the shrink-path plugin.

### DIFF
--- a/plugins/shrink-path/README.md
+++ b/plugins/shrink-path/README.md
@@ -20,6 +20,8 @@ here are the results of calling `shrink_path <option> /home/me/foo/bar/quux`:
     -s|--short    /h/m/f/b/q
     -t|--tilde    ~/f/ba/q
     -f|--fish     ~/f/b/quux
+    -3            /hom/me/foo/bar/quu
+    -e '$' -3     /ho$/me/foo/bar/qu$
 ```
 
 
@@ -38,10 +40,13 @@ The following options are available:
 ```
     -f, --fish       fish simulation, equivalent to -l -s -t.
     -l, --last       Print the last directory's full name.
-    -s, --short      Truncate directory names to the first character. Without
+    -s, --short      Truncate directory names to the number of characters given by -. Without
                      -s, names are truncated without making them ambiguous.
     -t, --tilde      Substitute ~ for the home directory.
     -T, --nameddirs  Substitute named directories as well.
+    -#               Truncate each directly to at least this many characters inclusive of the
+                     ellipsis character(s) (defaulting to 1).
+    -e SYMBOL        Postfix symbol(s) to indicate that a directory name had been truncated.
 ```
 
 The long options can also be set via zstyle, like
@@ -56,6 +61,7 @@ supported.
 ## License
 
 Copyright (C) 2008 by Daniel Friesel <derf@xxxxxxxxxxxxxxxxxx>
+Copyright (C) 2018-2020 by Pavel N. Krivitsky
 
 License: WTFPL <http://www.wtfpl.net>
 

--- a/plugins/shrink-path/shrink-path.plugin.zsh
+++ b/plugins/shrink-path/shrink-path.plugin.zsh
@@ -57,11 +57,11 @@ shrink_path () {
         zstyle -t ':prompt:shrink_path' tilde && tilde=1
 
         while [[ $1 == -* ]]; do
-            case $1 in
-                --)
-                    shift
-                    break
-                    ;;
+                case $1 in
+                        --)
+                                shift
+                                break
+                        ;;
                         -f|--fish)
                                 lastfull=1
                                 short=1
@@ -88,14 +88,14 @@ shrink_path () {
                         -T|--nameddirs)
                                 tilde=1
                                 named=1
-                                ;;
+                        ;;
                         -[0-9]|-[0-9][0-9])
-                            length=${1/-/}
-                            ;;
+                                length=${1/-/}
+                        ;;
                         -e)
-                            shift
-                            ellipsis="$1"
-                            ;;
+                                shift
+                                ellipsis="$1"
+                        ;;
                 esac
                 shift
         done
@@ -130,7 +130,7 @@ shrink_path () {
                         expn=(a b)
                         part=''
                         i=0
-                        until [[ $i -gt 99 || ( $i -ge $((length - ellen)) || $dir == $part ) && ( (( ${#expn} == 1 )) || $dir = $expn ) ]];  do
+                        until [[ $i -gt 99 || ( $i -ge $((length - ellen)) || $dir == $part ) && ( (( ${#expn} == 1 )) || $dir = $expn ) ]]; do
                                 (( i++ ))
                                 part+=$dir[$i]
                                 expn=($(echo ${part}*(-/)))

--- a/plugins/shrink-path/shrink-path.plugin.zsh
+++ b/plugins/shrink-path/shrink-path.plugin.zsh
@@ -38,7 +38,7 @@ shrink_path () {
         typeset -i tilde=0
         typeset -i named=0
         typeset -i length=1
-	typeset ellipsis=""
+        typeset ellipsis=""
 
         if zstyle -t ':prompt:shrink_path' fish; then
                 lastfull=1
@@ -55,10 +55,10 @@ shrink_path () {
 
         while [[ $1 == -* ]]; do
             case $1 in
-		--)
-		    shift
-		    break
-		    ;;
+                --)
+                    shift
+                    break
+                    ;;
                         -f|--fish)
                                 lastfull=1
                                 short=1
@@ -72,7 +72,7 @@ shrink_path () {
                                 print ' -t, --tilde     Substitute ~ for the home directory'
                                 print ' -T, --nameddirs Substitute named directories as well'
                                 print ' -#              Truncate each directly to at least this many characters (defaulting to 1).'
-				print ' -e SYMBOL       Postfix symbol to indicate that a directory name had been truncated.'
+                                print ' -e SYMBOL       Postfix symbol to indicate that a directory name had been truncated.'
                                 print 'The long options can also be set via zstyle, like'
                                 print '  zstyle :prompt:shrink_path fish yes'
                                 return 0
@@ -83,14 +83,14 @@ shrink_path () {
                         -T|--nameddirs)
                                 tilde=1
                                 named=1
-				;;
-			-[0-9]|-[0-9][0-9])
-			    length=${1/-/}
-			    ;;
-			-e)
-			    shift
-			    ellipsis="$1"
-			    ;;
+                                ;;
+                        -[0-9]|-[0-9][0-9])
+                            length=${1/-/}
+                            ;;
+                        -e)
+                            shift
+                            ellipsis="$1"
+                            ;;
                 esac
                 shift
         done
@@ -131,17 +131,17 @@ shrink_path () {
                                 (( short )) && [[ $i -ge $length ]] && break
                         done
 
-			typeset -i dif="(( ${#dir} - ${#part} ))"
-			case $dif in
-			    0)
-			    ;;
-			    1)
-				(( i++ ))
-			    	part+="$dir[$i]"
-				;;
-			    *)
-				part+="$ellipsis"
-			esac
+                        typeset -i dif="(( ${#dir} - ${#part} ))"
+                        case $dif in
+                            0)
+                            ;;
+                            1)
+                                (( i++ ))
+                                    part+="$dir[$i]"
+                                ;;
+                            *)
+                                part+="$ellipsis"
+                        esac
                         result+="/$part"
                         cd -q $dir
                         shift tree


### PR DESCRIPTION
This PR adds two additional arguments to `shrink_path`, one to specify the (unconditional) minimum length of each truncated path element and the other to specify the symbol indicating truncation if one occurred. For example, here's the old behaviour:
```
$ shrink_path -t  -l ~/.oh-my-zsh/plugins/shrink-path
~/.o/p/shrink-path
```
Here's the new behaviour, with indication of whether an element was truncated:
```
$ shrink_path -t -3 -e '$' -l ~/.oh-my-zsh/plugins/shrink-path
~/.oh$/plu$/shrink-path

$ shrink_path -t -6 -e '$' -l ~/.oh-my-zsh/plugins/shrink-path
~/.oh-my$/plugins/shrink-path
```

This makes the path much more readable, while still saving a lot of space.