### PR TITLE
Update osx.plugin.zsh : "pfd" was not working in the case where the frontmost Finder window was not in the same desktop as the current terminal window.

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -142,7 +142,7 @@ EOF
 function pfd() {
   osascript 2>/dev/null <<EOF
     tell application "Finder"
-      return POSIX path of (target of window 1 as alias)
+      return POSIX path of (insertion location as alias)
     end tell
 EOF
 }


### PR DESCRIPTION
The functions "pfd" and "cdf" need that the frontmost Finder window lies in the same desktop as the current Terminal (or iTerm2) window. With the proposed update, it works whatever desktop (and display) is the frontmost tab of the frontmost Finder window.