### PR TITLE
just command runner oh-my-zsh plugin

### DIFF
--- a/plugins/just/README.md
+++ b/plugins/just/README.md
@@ -1,0 +1,33 @@
+Just command runner oh-my-zsh plugin
+======================================
+
+Just is a command runner and handy way to save and run project-specific commands.
+Commands are stored in a file called justfile or Justfile with syntax inspired by make:
+
+```
+# build the project
+build:
+    cc *.c -o main
+
+# test everything
+test-all: build
+    ./test --all
+
+# run a specific test
+test TEST: build
+    ./test --test {{TEST}}
+```
+
+With oh-my-zsh plugin support, all recipes could be completed by press tab like following:
+
+```
+just<tab>
+command
+build     --  build the project
+test      --  run a specific test
+test-all  --  test everything
+```
+
+# References
+
+* Just Home: https://github.com/casey/just

--- a/plugins/just/_just
+++ b/plugins/just/_just
@@ -1,0 +1,16 @@
+#compdef just
+#autload
+
+alias justl="\just --list"
+alias juste="\just --evaluate"
+
+local subcmds=()
+
+while read -r line ; do
+   if [[ ! $line == Available* ]] ;
+   then
+      subcmds+=(${line/[[:space:]]*\#/:})
+   fi
+done < <(just --list)
+
+_describe 'command' subcmds


### PR DESCRIPTION
Just is a popular command runner to supply a handy way to save and run project-specific commands.
With oh-my-zsh integration, and it's easy to implement code completion for recipes. https://github.com/casey/just 