### PR TITLE
Add local Python package files to completion for pip install

### DIFF
--- a/plugins/pip/_pip
+++ b/plugins/pip/_pip
@@ -89,6 +89,7 @@ case "$words[1]" in
       if [[ "$state" == packages ]]; then
         _pip_all
         _wanted piplist expl 'packages' compadd -a piplist
+        _files -g "*.(tar.gz|whl)"
       fi ;;
   uninstall)
     _pip_installed


### PR DESCRIPTION
It's often useful to `pip install` a package that is found locally on the filesystem (e.g. when testing a package before releasing on `pypi`). This allows such files to be options for completion for the `pip install` command.

It would be useful if https://github.com/robbyrussell/oh-my-zsh/pull/6986 is merged first.