### PR TITLE
[minikube plugin] cache command completions

### DIFF
--- a/plugins/minikube/minikube.plugin.zsh
+++ b/plugins/minikube/minikube.plugin.zsh
@@ -1,6 +1,13 @@
 # Autocompletion for Minikube.
 #
+if (( $+commands[minikube] )); then
+    __MINICUBE_COMPLETION_FILE="${ZSH_CACHE_DIR}/minicube_completion"
 
-if [ $commands[minikube] ]; then
-  source <(minikube completion zsh)
+    if [[ ! -f $__MINICUBE_COMPLETION_FILE ]]; then
+        minikube completion zsh >! $__MINICUBE_COMPLETION_FILE
+    fi
+
+    [[ -f $__MINICUBE_COMPLETION_FILE ]] && source $__MINICUBE_COMPLETION_FILE
+
+    unset __MINICUBE_COMPLETION_FILE
 fi


### PR DESCRIPTION
Add caching of completions for **minikube** plugin in the same manner as for **kubectl**.