### PR TITLE
Add gcs! (Git plugin aliasses) - amend and sign commit 

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -85,6 +85,7 @@ alias gcp='git cherry-pick'
 alias gcpa='git cherry-pick --abort'
 alias gcpc='git cherry-pick --continue'
 alias gcs='git commit -S'
+alias gcs!='git commit -S --amend'
 
 alias gd='git diff'
 alias gdca='git diff --cached'


### PR DESCRIPTION
Add a git alias that allows amending commits and signing them. 
