### PR TITLE
Add config interpolation for git-flow messages

### DIFF
--- a/plugins/git-flow/git-flow.plugin.zsh
+++ b/plugins/git-flow/git-flow.plugin.zsh
@@ -23,9 +23,9 @@
 #Alias
 alias gfl='git flow'
 alias gfli='git flow init'
-alias gcd='git checkout develop'
-alias gch='git checkout hotfix'
-alias gcr='git checkout release'
+alias gcd='git checkout $(git config gitflow.branch.develop)'
+alias gch='git checkout $(git config gitflow.prefix.hotfix)'
+alias gcr='git checkout $(git config gitflow.prefix.release)'
 alias gflf='git flow feature'
 alias gflh='git flow hotfix'
 alias gflr='git flow release'


### PR DESCRIPTION
Changed commands in git-flow plugin:

gcd: uses gitflow.branch.develop to get user-set development branch
gch: uses gitflow.prefix.hotfix to get user-set hotfix prefix
gcr: uses gitflow.prefix.release to get user-set release prefix