### PR TITLE
context prompt needs to respect light/dark config

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -89,7 +89,7 @@ prompt_end() {
 # Context: user@hostname (who am I and where am I)
 prompt_context() {
   if [[ "$USER" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
-    prompt_segment black default "%(!.%{%F{yellow}%}.)%n@%m"
+    prompt_segment $CURRENT_FG default "%(!.%{%F{yellow}%}.)%n@%m"
   fi
 }
 


### PR DESCRIPTION
Changed the hard-coded black to a variable respecting the config whether one uses Solarized light or dark. Previous version was barely readable when using Solarized Light.