### PR TITLE
Plugin "debian": Switch order of "apt" and "aptitude" for detection

### DIFF
--- a/plugins/debian/README.md
+++ b/plugins/debian/README.md
@@ -10,7 +10,7 @@ plugins=(... debian)
 
 ## Settings
 
-- `$apt_pref`: use apt or aptitude if installed, fallback is apt-get.
+- `$apt_pref`: use aptitude or apt if installed, fallback is apt-get.
 - `$apt_upgr`: use upgrade or safe-upgrade (for aptitude).
 
 Set `$apt_pref` and `$apt_upgr` to whatever command you want (before sourcing Oh My Zsh) to override this behavior.

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -1,13 +1,13 @@
-# Use apt or aptitude if installed, fallback is apt-get
+# Use aptitude or apt if installed, fallback is apt-get
 # You can just set apt_pref='apt-get' to override it.
 
 if [[ -z $apt_pref || -z $apt_upgr ]]; then
-    if [[ -e $commands[apt] ]]; then
-        apt_pref='apt'
-        apt_upgr='upgrade'
-    elif [[ -e $commands[aptitude] ]]; then
+    if [[ -e $commands[aptitude] ]]; then
         apt_pref='aptitude'
         apt_upgr='safe-upgrade'
+    elif [[ -e $commands[apt] ]]; then
+        apt_pref='apt'
+        apt_upgr='upgrade'
     else
         apt_pref='apt-get'
         apt_upgr='upgrade'


### PR DESCRIPTION
`apt` is installed by default at Debian (maybe Ubuntu too),
while `aptitude` does not seem to be installed by default.
For that, it may be better for most users to prefer `aptitude` if installed.