### PR TITLE
Add option to automatically upgrade custom plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ By default, you will be prompted to check for upgrades every few weeks. If you w
 DISABLE_UPDATE_PROMPT=true
 ```
 
+To automatically update custom plugins and themes in `$ZSH_CUSTOM` (disabled by default), set the following in your `~/.zshrc`:
+
+```shell
+AUTOUPDATE_CUSTOM_PLUGINS=true
+```
+
 To disable automatic upgrades, set the following in your `~/.zshrc`:
 
 ```shell

--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -7,7 +7,7 @@ function uninstall_oh_my_zsh() {
 }
 
 function upgrade_oh_my_zsh() {
-  env ZSH=$ZSH sh $ZSH/tools/upgrade.sh
+  env ZSH=$ZSH ZSH_CUSTOM=$ZSH_CUSTOM AUTOUPDATE_CUSTOM_PLUGINS=$AUTOUPDATE_CUSTOM_PLUGINS sh $ZSH/tools/upgrade.sh
 }
 
 function take() {

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -26,6 +26,10 @@ ZSH_THEME="robbyrussell"
 # Uncomment the following line to disable bi-weekly auto-update checks.
 # DISABLE_AUTO_UPDATE="true"
 
+# Uncomment the following line to enable automatic updates of custom plugins and
+# themes in $ZSH_CUSTOM/
+# AUTOUPDATE_CUSTOM_PLUGINS="true"
+
 # Uncomment the following line to change how often to auto-update (in days).
 # export UPDATE_ZSH_DAYS=13
 

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -11,7 +11,7 @@ function _update_zsh_update() {
 }
 
 function _upgrade_zsh() {
-  env ZSH=$ZSH sh $ZSH/tools/upgrade.sh
+  env ZSH=$ZSH ZSH_CUSTOM=$ZSH_CUSTOM AUTOUPDATE_CUSTOM_PLUGINS=$AUTOUPDATE_CUSTOM_PLUGINS sh $ZSH/tools/upgrade.sh
   # update the zsh file
   _update_zsh_update
 }

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -37,3 +37,31 @@ then
 else
   printf "${RED}%s${NORMAL}\n" 'There was an error updating. Try again later?'
 fi
+
+if [ "$AUTOUPDATE_CUSTOM_PLUGINS" = "true" ]; then
+  printf "${GREEN}%s${NORMAL}\n" "Updating custom plugins"
+  cd "$ZSH_CUSTOM/plugins"
+  for dir in ./*; do
+      if [[ -d $dir && -d $dir/.git ]]; then
+          if git -C $dir pull --rebase --stat origin master
+          then
+              printf "${BLUE}%s${NORMAL}\n" "Hooray! Oh My Zsh custom plugin $dir has been updated and/or is at the current version."
+          else
+              printf "${RED}%s${NORMAL}\n" "There was an error updating custom plugin $dir. Try again later?"
+          fi
+      fi
+  done
+
+  printf "${GREEN}%s${NORMAL}\n" "Updating custom themes"
+  cd "$ZSH_CUSTOM/themes"
+  for dir in ./*; do
+      if [[ -d $dir && -d $dir/.git ]]; then
+        if git -C $dir pull --rebase --stat origin master
+        then
+            printf "${BLUE}%s${NORMAL}\n" "Hooray! Oh My Zsh custom theme $dir has been updated and/or is at the current version."
+        else
+            printf "${RED}%s${NORMAL}\n" "There was an error updating custom theme $dir. Try again later?"
+        fi
+      fi
+  done
+fi


### PR DESCRIPTION
Closes #5599

### Objective
It is a common use case to have custom plugins or themes managed in git repositories similar to OMZ itself. Popular examples are https://github.com/zsh-users/zsh-autosuggestions or https://github.com/zsh-users/zsh-syntax-highlighting for plugins and https://github.com/denysdovhan/spaceship-prompt for themes. 

It would be nice if these custom plugins and themes would smoothly integrate into OMZ's update process. The scope of this PR is to add this functionality.

### Comments
- I don't want to steal anybody's work, most of the effort was done by @benwaffle in the corresponding issue. 
- I think it is a good choice to add the possibility for automatic updates but disable it by default. Users should take a conscious decision (and be aware of it's implications) when choosing to enable automatic updates of custom plugins and themes.
- These are my first steps with OMZ happy to receive feedback and comments.

### Discussion
I am not entirely sure, if a feature like this has it's place in OMZ.