### PR TITLE
mercurial plugin: add hga alias to README.md

### DIFF
--- a/plugins/mercurial/README.md
+++ b/plugins/mercurial/README.md
@@ -26,6 +26,7 @@ Update .zshrc:
 ### What's inside?
 #### Adds handy aliases:
 ###### general
+* `hga` - 'hg add`
 * `hgc` - `hg commit`
 * `hgb` - `hg branch`
 * `hgba` - `hg branches`


### PR DESCRIPTION
#4969 added `hga` alias to the mercurial plugin, readme should be updated as well