### PR TITLE
example fix for cursor up/down consistency issue

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -31,13 +31,15 @@ fi
 if [[ "${terminfo[kcuu1]}" != "" ]]; then
   autoload -U up-line-or-beginning-search
   zle -N up-line-or-beginning-search
-  bindkey "${terminfo[kcuu1]}" up-line-or-beginning-search
+  #bindkey "${terminfo[kcuu1]}" up-line-or-beginning-search
+  bindkey "^[[A" up-line-or-beginning-search
 fi
 # start typing + [Down-Arrow] - fuzzy find history backward
 if [[ "${terminfo[kcud1]}" != "" ]]; then
   autoload -U down-line-or-beginning-search
   zle -N down-line-or-beginning-search
-  bindkey "${terminfo[kcud1]}" down-line-or-beginning-search
+  #bindkey "${terminfo[kcud1]}" down-line-or-beginning-search
+  bindkey "^[[B" up-line-or-beginning-search
 fi
 
 if [[ "${terminfo[khome]}" != "" ]]; then


### PR DESCRIPTION
not a real PR but just an example of the fix.

See https://github.com/robbyrussell/oh-my-zsh/issues/6261

Someone more familiar with the terminal could maybe explain

* why this works
* if there is some symbolic terminfo constant that should be used instead
* if it would be good to make this the default
* if not the default, would it be good to add an option like `OH_MY_ZSH_CURSOR_UPDOWN_CONSISTENT_BEHAVIOR=true`