### PR TITLE
Add aliases for 'git commit -S -s [-m]'

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -85,6 +85,8 @@ alias gcp='git cherry-pick'
 alias gcpa='git cherry-pick --abort'
 alias gcpc='git cherry-pick --continue'
 alias gcs='git commit -S'
+alias gcss='git commit -S -s'
+alias gcssm='git commit -S -s -m'
 
 alias gd='git diff'
 alias gdca='git diff --cached'


### PR DESCRIPTION
I thought it would be useful to add these aliases. 

There are already aliases for `git commit -S` and `git commit -s` but there is none for both simultaneously =)

@ncanceill could you please take a look?