### PR TITLE
theme/agnoster: Fixed light colors for git dirty prompt

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -111,7 +111,7 @@ prompt_git() {
     dirty=$(parse_git_dirty)
     ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git rev-parse --short HEAD 2> /dev/null)"
     if [[ -n $dirty ]]; then
-      prompt_segment yellow black
+      prompt_segment yellow $CURRENT_FG
     else
       prompt_segment green $CURRENT_FG
     fi


### PR DESCRIPTION
Fixes foreground color for git prompt when it contains changes and light mode is used:

![screen shot 2019-03-04 at 2 00 44 pm](https://user-images.githubusercontent.com/2707524/53765984-61de2900-3e86-11e9-8e47-27d30635265f.png)
