### PR TITLE
Improvement to issue number  #7332

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -64,7 +64,7 @@ fi
 
 # Save the location of the current completion dump file.
 if [ -z "$ZSH_COMPDUMP" ]; then
-  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+  ZSH_COMPDUMP="${ZDOTDIR:-${ZSH}}/cache/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
 if [[ $ZSH_DISABLE_COMPFIX != true ]]; then

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -42,7 +42,8 @@ is_plugin() {
   local base_dir=$1
   local name=$2
   test -f $base_dir/plugins/$name/$name.plugin.zsh \
-    || test -f $base_dir/plugins/$name/_$name
+    || test -f $base_dir/plugins/$name/_$name \
+    || test -f $base_dir/$name/
 }
 # Add all defined plugins to fpath. This must be done
 # before running compinit.
@@ -51,6 +52,13 @@ for plugin ($plugins); do
     fpath=($ZSH_CUSTOM/plugins/$plugin $fpath)
   elif is_plugin $ZSH $plugin; then
     fpath=($ZSH/plugins/$plugin $fpath)
+    # Add elif branch for MacOS and Homebrew
+  elif [[ "$OSTYPE" = darwin* ]]; then
+      if is_plugin /usr/local/Cellar $plugin; then
+        fpath=( /usr/local/Cellar/$plugin $fpath)
+      fi
+  else
+    echo "Warning: plugin $plugin not found"
   fi
 done
 


### PR DESCRIPTION
Improvement to issue number  #7332
updated my oh-my-zsh.sh file - because of the same reason "it looks like this is because regardless of the set $ZSH directory the ZSH_COMPDUMP file is always set to point to the $HOME directory."

```
# Save the location of the current completion dump file.
if [ -z "$ZSH_COMPDUMP" ]; then
  ZSH_COMPDUMP="${ZDOTDIR:-${ZSH}}/cache/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
fi
```

Replacing ${HOME}} with ${ZSH}}/cache
I think this is a much more tidy way of doing things.