### PR TITLE
Add custom themes to the random theme picker

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -98,9 +98,20 @@ unset config_file
 # Load the theme
 if [[ "$ZSH_THEME" == "random" ]]; then
   if [[ "${(t)ZSH_THEME_RANDOM_CANDIDATES}" = "array" ]] && [[ "${#ZSH_THEME_RANDOM_CANDIDATES[@]}" -gt 0 ]]; then
-    themes=($ZSH/themes/${^ZSH_THEME_RANDOM_CANDIDATES}.zsh-theme)
+    themes=()
+    for candidate in "${ZSH_THEME_RANDOM_CANDIDATES[@]}"; do
+      theme_file=($ZSH_CUSTOM/themes/${candidate}.zsh-theme)
+      if [ -f $theme_file ]; then
+        themes+=($theme_file)
+      else
+        theme_file=($ZSH/themes/${candidate}.zsh-theme)
+        if [ -f $theme_file ]; then
+          themes+=($theme_file)
+        fi
+       fi
+    done
   else
-    themes=($ZSH/themes/*zsh-theme)
+    themes=($ZSH_CUSTOM/themes/*zsh-theme $ZSH/themes/*zsh-theme)
   fi
   N=${#themes[@]}
   ((N=(RANDOM%N)+1))

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -12,7 +12,9 @@ ZSH_THEME="robbyrussell"
 
 # Set list of themes to pick from when loading at random
 # Setting this variable when ZSH_THEME=random will cause zsh to load
-# a theme from this variable instead of looking in ~/.oh-my-zsh/themes/
+# a theme from this variable instead of looking in $ZSH/themes/ and
+# $ZSH_CUSTOM/themes/. The random theme file is searched in both default and
+# custom themes folders.
 # If set to an empty array, this variable will have no effect.
 # ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
 


### PR DESCRIPTION
Fixes #7696.
The random theme picker searches both $ZSH/themes and $ZSH_CUSTOM/themes
folders.

Signed-off-by: Mihai Serban <mihai.serban@gmail.com>