### PR TITLE
zsh_reload: Respect `$ZDOTDIR` when searching for `.zshrc`

### DIFF
--- a/plugins/zsh_reload/zsh_reload.plugin.zsh
+++ b/plugins/zsh_reload/zsh_reload.plugin.zsh
@@ -3,7 +3,7 @@ src() {
 	autoload -U compinit zrecompile
 	compinit -i -d "$cache/zcomp-$HOST"
 
-	for f in ~/.zshrc "$cache/zcomp-$HOST"; do
+	for f in ${ZDOTDIR:-~}/.zshrc "$cache/zcomp-$HOST"; do
 		zrecompile -p $f && command rm -f $f.zwc.old
 	done
 


### PR DESCRIPTION
Title says it all. Related to #7052, had originally planned on proposing this after that one is merged, but maybe this one doesn't need as much scrutiny.