### PR TITLE
Some fixes for plugins when running the shell with non-default options

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -17,7 +17,7 @@ function parse_git_dirty() {
     if [[ $POST_1_7_2_GIT -gt 0 ]]; then
       FLAGS+='--ignore-submodules=dirty'
     fi
-    if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" == "true" ]]; then
+    if [[ "${DISABLE_UNTRACKED_FILES_DIRTY:-false}" == "true" ]]; then
       FLAGS+='--untracked-files=no'
     fi
     STATUS=$(command git status ${FLAGS} 2> /dev/null | tail -n1)

--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -19,6 +19,7 @@ export DIRHISTORY_SIZE=30
 # Returns the element if the array was not empty,
 # otherwise returns empty string.
 function pop_past() {
+  setopt localoptions no_ksh_arrays
   eval "$1='$dirhistory_past[$#dirhistory_past]'"
   if [[ $#dirhistory_past -gt 0 ]]; then
     dirhistory_past[$#dirhistory_past]=()
@@ -26,6 +27,7 @@ function pop_past() {
 }
 
 function pop_future() {
+  setopt localoptions no_ksh_arrays
   eval "$1='$dirhistory_future[$#dirhistory_future]'"
   if [[ $#dirhistory_future -gt 0 ]]; then
     dirhistory_future[$#dirhistory_future]=()
@@ -35,6 +37,7 @@ function pop_future() {
 # Push a new element onto the end of dirhistory_past. If the size of the array 
 # is >= DIRHISTORY_SIZE, the array is shifted
 function push_past() {
+  setopt localoptions no_ksh_arrays
   if [[ $#dirhistory_past -ge $DIRHISTORY_SIZE ]]; then
     shift dirhistory_past
   fi
@@ -44,6 +47,7 @@ function push_past() {
 }
 
 function push_future() {
+  setopt localoptions no_ksh_arrays
   if [[ $#dirhistory_future -ge $DIRHISTORY_SIZE ]]; then
     shift dirhistory_future
   fi

--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -20,7 +20,7 @@ export DIRHISTORY_SIZE=30
 # otherwise returns empty string.
 function pop_past() {
   setopt localoptions no_ksh_arrays
-  eval "$1='$dirhistory_past[$#dirhistory_past]'"
+  typeset -g "$1=${dirhistory_past[-1]}"
   if [[ $#dirhistory_past -gt 0 ]]; then
     dirhistory_past[$#dirhistory_past]=()
   fi
@@ -28,7 +28,7 @@ function pop_past() {
 
 function pop_future() {
   setopt localoptions no_ksh_arrays
-  eval "$1='$dirhistory_future[$#dirhistory_future]'"
+  typeset -g "$1=${dirhistory_future[-1]}"
   if [[ $#dirhistory_future -gt 0 ]]; then
     dirhistory_future[$#dirhistory_future]=()
   fi


### PR DESCRIPTION
Fixes:

  * `z`: Crashes when shell is run with `no_unset` because it tests whether variables are defined using `[ -n "${varname}" ]`
  * `lib/git`: Crashes on detecting working tree state because it expects default expansion (empty string) for some variables without using `${varname:-}`
  * `dirhistory`: Crashes in weird ways when `ksh_arrays` is set