### PR TITLE
Speed up command-not-found plugin

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -26,10 +26,8 @@ fi
 
 # OSX command-not-found support
 # https://github.com/Homebrew/homebrew-command-not-found
-if type brew &> /dev/null; then
-  if brew command command-not-found-init > /dev/null 2>&1; then
-    eval "$(brew command-not-found-init)";
-  fi
+if [[ -s '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh' ]]; then
+    source '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh'
 fi
 
 # NixOS command-not-found support


### PR DESCRIPTION
The command-not-found plugin is very slow. (Disabling it for me made my shell start-up time go from 0.75s to 0.15s.) After some searching I found a similar issue was reported and fixed in the prezto zsh framework: 

https://github.com/GuyHarwood/prezto/commit/46ef6091f63ddc052df1ec59cc3573ede0537103

https://github.com/sorin-ionescu/prezto/issues/1451

This PR includes this fix. The fix will source the specific files directly instead of calling the brew commands to get the code. 

The fix makes the plugin a little less robust since homebrew users could decide to install in a different location than suggested. But the speed difference is so big that I think it is worth it to use the method in this PR instead. 

The latter could be fixed by using `brew --repo homebrew/homebrew-command-not-found` to find the install location, but that would again make this plugin much slower again since calling brew is so slow. (Even if we call it now once instead of twice.)