### PR TITLE
edit colorize plugin: add `-f terminal` option

### DIFF
--- a/plugins/colorize/colorize.plugin.zsh
+++ b/plugins/colorize/colorize.plugin.zsh
@@ -9,7 +9,7 @@ colorize_via_pygmentize() {
 
     # pygmentize stdin if no arguments passed
     if [ $# -eq 0 ]; then
-        pygmentize -g
+        pygmentize -f terminal -g
         return $?
     fi
 
@@ -20,9 +20,9 @@ colorize_via_pygmentize() {
     do
         lexer=$(pygmentize -N "$FNAME")
         if [[ $lexer != text ]]; then
-            pygmentize -l "$lexer" "$FNAME"
+            pygmentize -f terminal -l "$lexer" "$FNAME"
         else
-            pygmentize -g "$FNAME"
+            pygmentize -f terminal -g "$FNAME"
         fi
     done
 }


### PR DESCRIPTION
The option (`pygmentize -f terminal <...>`) lets pygments use terminal color
scheme. Otherwise, it would use its default colors, which might be
unbalanced with that of terminal (e.g. not harmonious with background color of terminal).