### PR TITLE
Terraform plugin: formatted prompt and added several aliases

### DIFF
--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -4,6 +4,22 @@ function tf_prompt_info() {
     # check if in terraform dir
     if [ -d .terraform ]; then
       workspace=$(terraform workspace show 2> /dev/null) || return
-      echo "[${workspace}]"
+      echo "$fg_bold[blue]terraform:($fg[red]${workspace}$fg_bold[blue]) "
     fi
 }
+
+alias twl='terraform workspace list'
+alias twn='terraform workspace new'
+alias tws='terraform workspace select'
+alias twd='terraform workspace delete'
+
+alias tinit='terraform init'
+alias tval='terraform validate'
+alias tplan='terraform plan'
+alias tapp='terraform apply'
+alias tdest='terraform destroy'
+
+alias tfmt='terraform fmt'
+alias tfu='terraform force-unlock'
+alias tget='terraform get'
+alias tshow='terraform show'


### PR DESCRIPTION
I formatted the prompt to add "Terraform" in front of which Terraform environment is being used, because it was looking strange with both a git branch and Terraform workspace in a single prompt.  I also added several aliases to make common commands simpler.