### PR TITLE
Remove dirty git check from Agnoster theme's prompt on large git repo

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -108,7 +108,11 @@ prompt_git() {
 
   if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
     repo_path=$(git rev-parse --git-dir 2>/dev/null)
-    dirty=$(parse_git_dirty)
+    if [[ "$(git config --get oh-my-zsh.hide-status 2>/dev/null)" = 1 ]]; then
+      dirty=1
+    else
+      dirty=$(parse_git_dirty)
+    fi
     ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git rev-parse --short HEAD 2> /dev/null)"
     if [[ -n $dirty ]]; then
       prompt_segment yellow black


### PR DESCRIPTION
Right now Agnoster uses `parse_git_dirty` to check if a git repo is dirty. On a large git repo, this command may takes several seconds to finish, thus slowing the prompt for quite some time.

This PR adds support for a new git config option that's called `oh-my-zsh.hide-dirty`. You can set it to `1` to hide dirty status on your git repo. The `git` command is `git config --add oh-my-zsh.hide-dirty 1`.