### PR TITLE
Clean up the general aliases in the kubectl plugin

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -13,18 +13,21 @@ plugins=(... kubectl)
 
 | Alias   | Command                             | Description                                                                                      |
 |:--------|:------------------------------------|:-------------------------------------------------------------------------------------------------|
+|         |                                   | **General aliases**                                                                              |
 | k       | `kubectl`                           | The kubectl command                                                                              |
 | kca     | `kubectl --all-namespaces`          | The kubectl command targeting all namespaces                                                     |
 | kaf     | `kubectl apply -f`                  | Apply a YML file                                                                                 |
 | keti    | `kubectl exec -ti`                  | Drop into an interactive terminal on a container                                                 |
+| kg      | `kubectl get`                       | Issue a kubectl get on the specified resource                                                    |
+| kgans   | `kubectl get $@ --all-namespaces`   | Issue a kubectl get on the specified resource across all namespaces                               |
+| kd      | `kubectl describe`                  | Issue a kubectl describe no the specified resource                                                |
+| kdel    | `kubectl delete`                    | Delete resources by filenames, stdin, resources and names, or by resources and label selector    |
+| kdelf   | `kubectl delete -f`                 | Delete a resource via the specified YML file                                                      |
 |         |                                     | **Manage configuration quickly to switch contexts between local, dev and staging**               |
 | kcuc    | `kubectl config use-context`        | Set the current-context in a kubeconfig file                                                     |
 | kcsc    | `kubectl config set-context`        | Set a context entry in kubeconfig                                                                |
 | kcdc    | `kubectl config delete-context`     | Delete the specified context from the kubeconfig                                                 |
 | kccc    | `kubectl config current-context`    | Display the current-context                                                                      |
-|         |                                     | **General aliases**                                                                              |
-| kdel    | `kubectl delete`                    | Delete resources by filenames, stdin, resources and names, or by resources and label selector    |
-| kdelf   | `kubectl delete -f`                 | Delete a pod using the type and name specified in -f argument                                    |
 |         |                                     | **Pod management**                                                                               |
 | kgp     | `kubectl get pods`                  | List all pods in ps output format                                                                |
 | kgpw    | `kgp --watch`                       | After listing/getting the requested object, watch for changes                                    |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -22,6 +22,15 @@ alias kaf='kubectl apply -f'
 # Drop into an interactive terminal on a container
 alias keti='kubectl exec -ti'
 
+# Execute a kubectl get command on the provided resource
+alias kg='kubectl get'
+
+# Execute a kubectl get <resource> --all-namespaces  command on the provided resource
+alias kgans='f(){ kubectl get "$@" --all-namespaces;  unset -f f; }; f'
+
+# Execute a kubectl describe command on the provided resource
+alias kd='kubectl describe'
+
 # Manage configuration quickly to switch contexts between local, dev ad staging.
 alias kcuc='kubectl config use-context'
 alias kcsc='kubectl config set-context'


### PR DESCRIPTION
There's a ton of aliases being added for kubectl commands, which is
awesome, but if you're like me you only remember a handufl of them.
Really the top level aliases are usually the most valuable for me and
easier to remember.

This change adds a few missing `general` aliases, and groups the general
aliases together in the top of the doc.  This way even if "your
specific" alias is missing, all the primitives are in place to provide
the foundation and make kubectl much easier to work with.

Added aliases:
  * kg    - kubectl get
  * kgans - kubectl get $@ --all-namespaces (kga is already taken)
  * kd    - kubectl describe