### PR TITLE
kubectl plugin; added alias to get pods from all namespaces

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -27,6 +27,7 @@ plugins=(... kubectl)
 | kdelf   | `kubectl delete -f`                 | Delete a pod using the type and name specified in -f argument                                    |
 |         |                                     | **Pod management**                                                                               |
 | kgp     | `kubectl get pods`                  | List all pods in ps output format                                                                |
+| kgpa    | `kubectl get pods --all-namespaces` | List all pods of all namespaces in ps output format                                              |
 | kgpw    | `kgp --watch`                       | After listing/getting the requested object, watch for changes                                    |
 | kgpwide | `kgp -o wide`                       | Output in plain-text format with any additional information. For pods, the node name is included |
 | kep     | `kubectl edit pods`                 | Edit pods from the default editor                                                                |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -34,6 +34,7 @@ alias kdelf='kubectl delete -f'
 
 # Pod management.
 alias kgp='kubectl get pods'
+alias kgpa='kubectl get pods --all-namespaces'
 alias kgpw='kgp --watch'
 alias kgpwide='kgp -o wide'
 alias kep='kubectl edit pods'


### PR DESCRIPTION
adding an alias for "kubectl get pods --all-namespaces" since this is a rather commonly used kubectl command