### PR TITLE
Mercurial: add aliases for hg log

### DIFF
--- a/plugins/mercurial/README.md
+++ b/plugins/mercurial/README.md
@@ -33,6 +33,8 @@ Update .zshrc:
 * `hgco` - `hg checkout`
 * `hgd`  - `hg diff`
 * `hged` - `hg diffmerge`
+* `hglg` - `hg log --stat -v`
+* `hglgp` - `hg log --stat  -p -v`
 
 ###### pull and update
 * `hgi` - `hg incoming`

--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -7,6 +7,8 @@ alias hgbk='hg bookmarks'
 alias hgco='hg checkout'
 alias hgd='hg diff'
 alias hged='hg diffmerge'
+alias hglg='hg log --stat -v'
+alias hglgp='hg log --stat  -p -v'
 # pull and update
 alias hgi='hg incoming'
 alias hgl='hg pull -u'


### PR DESCRIPTION
Add aliases for mercurial hg log following by the same git convention
```
# git
glgg='git log --graph'
glgp='git log --stat -p'
# hg
hglg='hg log --stat -v'
hglgp='hg log --stat  -p -v'
```