### PR TITLE
CHANGE Prompt - SSH user@hostname vs LOCAL user

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -86,10 +86,13 @@ prompt_end() {
 ### Prompt components
 # Each component will draw itself, and hide itself if no information needs to be shown
 
-# Context: user@hostname (who am I and where am I)
+# Context: user@hostname (who am I and where am I) in a remote SSH session
+# LOCAL: user (who am I) Set DEFAULT_USER="$USER" in .zshrc
 prompt_context() {
-  if [[ "$USER" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
-    prompt_segment black default "%(!.%{%F{yellow}%}.)%n@%m"
+  if [[ "$USER" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then                                          
+    prompt_segment black default "%(!.%{%F{yellow}%}.)%n@%m"                                             
+  else
+    prompt_segment black default "%(!.%{%F{yellow}%}.)$USER"                                             
   fi
 }
 


### PR DESCRIPTION
For a remote connection with ssh the user@hostname is displayed and if we are local only the username. This way it is easy to see where you are.