### PR TITLE
Updated gg and gga aliases in git plugin not to lock console when executed.

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -94,8 +94,8 @@ alias gfo='git fetch origin'
 
 alias gfg='git ls-files | grep'
 
-alias gg='git gui citool'
-alias gga='git gui citool --amend'
+alias gg="(git gui citool&) &>/dev/null"
+alias gga="(git gui citool --amend&) &>/dev/null"
 
 function ggf() {
   [[ "$#" != 1 ]] && local b="$(git_current_branch)"


### PR DESCRIPTION
Updated `gg` and `gga` aliases in [plugins/git/git.plugin.zsh](https://github.com/robbyrussell/oh-my-zsh/pull/7867/files#diff-4ad2773a26526d0e361e66139c283099) not to lock console when executed.