### PR TITLE
sdk: add support for local versions and optimize sed calls

### DIFF
--- a/plugins/sdk/sdk.plugin.zsh
+++ b/plugins/sdk/sdk.plugin.zsh
@@ -50,13 +50,14 @@ _listInstalledVersions() {
   __sdkman_build_version_csv $1 | sed -e "s/,/ /g"
 }
 
+# Remove local (+) and installed (*) versions from the list
 _listInstallableVersions() {
-  __sdkman_list_versions $1 | grep "^ " | sed -e "s/\* /*/g" | \
-      sed -e "s/>//g" | xargs -n 1 echo | grep -v "^*"
+  __sdkman_list_versions $1 | grep "^ " | sed -e "s/\* /*/g" | sed -e "s/\+ /+/g" | \
+      sed -e "s/>//g" | xargs -n 1 echo | grep -v "^[*|+]"
 }
 
 _listAllVersion() {
-  __sdkman_list_versions $1 | grep "^ " | sed -e "s/\*/ /g" | sed -e "s/>//g"
+  __sdkman_list_versions $1 | grep "^ " | sed -e "s/\*/ /g" | sed -e "s/\+ / /g" | sed -e "s/>//g"
 }
 
 _sdk () {

--- a/plugins/sdk/sdk.plugin.zsh
+++ b/plugins/sdk/sdk.plugin.zsh
@@ -50,14 +50,14 @@ _listInstalledVersions() {
   __sdkman_build_version_csv $1 | sed -e "s/,/ /g"
 }
 
-# Remove local (+) and installed (*) versions from the list
 _listInstallableVersions() {
-  __sdkman_list_versions $1 | grep "^ " | sed -e "s/\* /*/g" | sed -e "s/\+ /+/g" | \
-      sed -e "s/>//g" | xargs -n 1 echo | grep -v "^[*|+]"
+  # Remove local (+) and installed (*) versions from the list
+  __sdkman_list_versions $1 | sed -e '/^[^ ]/d;s/[+*] [^ ]\+//g;s/>//g'
 }
 
 _listAllVersion() {
-  __sdkman_list_versions $1 | grep "^ " | sed -e "s/\*/ /g" | sed -e "s/\+ / /g" | sed -e "s/>//g"
+  # Remove (*), (+), and (>) characters from the list
+  __sdkman_list_versions $1 | sed -e '/^[^ ]/d;s/[*+>] //g'
 }
 
 _sdk () {


### PR DESCRIPTION
Added support for local versions (prefixed by '+'), so they are filtered out in __listInstallableVersions()_ and they are displayed correctly by __listAllVersion()_

@rahulsom 