### PR TITLE
safe-paste: refresh plugin (update for zsh 5.1 and vi keymaps)

### DIFF
--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -57,6 +57,7 @@ function _paste_insert() {
 }
 
 function _bracketed_paste_zle_init() {
+  _bracketed_paste_content=''
   # Tell terminal to send escape codes around pastes
   if [ $TERM =~ '^(rxvt-unicode|xterm(-256color)?|screen(-256color)?)$' ]; then
     printf '\e[?2004h'

--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -73,10 +73,12 @@ _bracketed_paste_end() {
   unset _bracketed_paste_content _bracketed_paste_restore_keymap
 }
 
+# Append a pasted character to the content which is later inserted as a whole
 _bracketed_paste_enqueue() {
   _bracketed_paste_content+=$KEYS
 }
 
+# Run at zle-line-init
 _bracketed_paste_zle_init() {
   _bracketed_paste_content=''
   # Tell terminal to send escape codes around pastes
@@ -85,6 +87,7 @@ _bracketed_paste_zle_init() {
   fi
 }
 
+# Run at zle-line-finish
 _bracketed_paste_zle_finish() {
   # Turn off bracketed paste when we leave ZLE, so pasting in other programs
   # doesn't get the ^[[200~ codes around the pasted text

--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -1,7 +1,10 @@
 # Code from Mikael Magnusson: https://www.zsh.org/mla/users/2011/msg00367.html
 #
-# Requires xterm, urxvt, iTerm2 or any other terminal that supports bracketed
-# paste mode as documented: https://www.xfree86.org/current/ctlseqs.html
+# Requires xterm, urxvt, iTerm2 or any other terminal that supports
+# Bracketed Paste Mode as documented:
+# https://www.xfree86.org/current/ctlseqs.html#Bracketed%20Paste%20Mode
+#
+# Additional technical details: https://cirw.in/blog/bracketed-paste
 
 # create a new keymap to use while pasting
 bindkey -N paste
@@ -26,8 +29,8 @@ function _start_paste() {
   bindkey -A paste main
 }
 
-# go back to our normal keymap, and insert all the pasted text in the
-# command line. this has the nice effect of making the whole paste be
+# Go back to our normal keymap, and insert all the pasted text in the
+# command line. This has the nice effect of making the whole paste be
 # a single undo/redo event.
 function _end_paste() {
 #use bindkey -v here with vi mode probably. maybe you want to track

--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -26,6 +26,8 @@ fi
 # Bracketed Paste Mode as documented:
 # https://www.xfree86.org/current/ctlseqs.html#Bracketed%20Paste%20Mode
 #
+# For tmux, use:   bind ] paste-buffer -p
+#
 # Additional technical details: https://cirw.in/blog/bracketed-paste
 
 # Create a new keymap to use while pasting

--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -5,8 +5,8 @@
 
 # create a new keymap to use while pasting
 bindkey -N paste
-# make everything in this keymap call our custom widget
-bindkey -R -M paste "^@"-"\M-^?" paste-insert
+# Make everything in this new keymap enqueue characters for pasting
+bindkey -RM paste '\x00-\xFF' paste-insert
 # these are the codes sent around the pasted text in bracketed
 # paste mode.
 # do the first one with both -M viins and -M vicmd in vi mode

--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -6,16 +6,15 @@
 #
 # Additional technical details: https://cirw.in/blog/bracketed-paste
 
-# create a new keymap to use while pasting
+# Create a new keymap to use while pasting
 bindkey -N paste
 # Make everything in this new keymap enqueue characters for pasting
 bindkey -RM paste '\x00-\xFF' paste-insert
-# these are the codes sent around the pasted text in bracketed
-# paste mode.
+# These are the codes sent around the pasted text in bracketed paste mode
 # do the first one with both -M viins and -M vicmd in vi mode
 bindkey '^[[200~' _start_paste
 bindkey -M paste '^[[201~' _end_paste
-# insert newlines rather than carriage returns when pasting newlines
+# Insert newlines rather than carriage returns when pasting newlines
 bindkey -M paste -s '^M' '^J'
 
 zle -N _start_paste
@@ -24,7 +23,7 @@ zle -N zle-line-init _zle_line_init
 zle -N zle-line-finish _zle_line_finish
 zle -N paste-insert _paste_insert
 
-# switch the active keymap to paste mode
+# Switch the active keymap to paste mode
 function _start_paste() {
   bindkey -A paste main
 }
@@ -52,8 +51,8 @@ function _zle_line_init() {
 }
 
 function _zle_line_finish() {
-  # Tell it to stop when we leave zle, so pasting in other programs
-  # doesn't get the ^[[200~ codes around the pasted text.
+  # Turn off bracketed paste when we leave ZLE, so pasting in other programs
+  # doesn't get the ^[[200~ codes around the pasted text
   if [ $TERM =~ '^(rxvt-unicode|xterm(-256color)?|screen(-256color)?)$' ]; then
     printf '\e[?2004l'
   fi

--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -42,13 +42,17 @@ function _paste_insert() {
 }
 
 function _zle_line_init() {
-  # Tell terminal to send escape codes around pastes.
-  [[ $TERM == rxvt-unicode || $TERM == xterm || $TERM = xterm-256color || $TERM = screen || $TERM = screen-256color ]] && printf '\e[?2004h'
+  # Tell terminal to send escape codes around pastes
+  if [ $TERM =~ '^(rxvt-unicode|xterm(-256color)?|screen(-256color)?)$' ]; then
+    printf '\e[?2004h'
+  fi
 }
 
 function _zle_line_finish() {
   # Tell it to stop when we leave zle, so pasting in other programs
   # doesn't get the ^[[200~ codes around the pasted text.
-  [[ $TERM == rxvt-unicode || $TERM == xterm || $TERM = xterm-256color || $TERM = screen || $TERM = screen-256color ]] && printf '\e[?2004l'
+  if [ $TERM =~ '^(rxvt-unicode|xterm(-256color)?|screen(-256color)?)$' ]; then
+    printf '\e[?2004l'
+  fi
 }
 

--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -1,3 +1,25 @@
+# A good summary of the zsh 5.1 Bracketed Paste Mode changes is at:
+# https://archive.zhimingwang.org/blog/2015-09-21-zsh-51-and-bracketed-paste.html
+
+# zsh 5.1 (September 2015) introduced built-in support for Bracketed Paste Mode
+# https://github.com/zsh-users/zsh/blob/68405f31a043bdd5bf338eb06688ed3e1f740937/README#L38-L45
+#
+# zsh 5.1 breaks url-quote-magic and other widgets replacing self-insert
+# zsh-users' bracketed-paste-magic resolves these issues:
+# https://github.com/zsh-users/zsh/blob/f702e17b14d75aa21bff014168fa9048124db286/Functions/Zle/bracketed-paste-magic#L9-L12
+
+# Load bracketed-paste-magic if zsh version is >= 5.1
+if [[ ${ZSH_VERSION:0:3} -ge 5.1 ]]; then
+  set zle_bracketed_paste  # Explicitly restore this zsh default
+  autoload -Uz bracketed-paste-magic
+  zle -N bracketed-paste bracketed-paste-magic
+  return  ### The rest of this file is NOT executed on zsh version >= 5.1 ###
+fi
+
+######################################################################
+#    The rest of this file is ONLY executed if zsh version < 5.1
+######################################################################
+
 # Code from Mikael Magnusson: https://www.zsh.org/mla/users/2011/msg00367.html
 #
 # Requires xterm, urxvt, iTerm2 or any other terminal that supports


### PR DESCRIPTION
### Functionality

* Prefer built-in bracketed paste goodness if zsh version >= 5.1
* Save/restore active keymap before/after paste (resolves #7883)
* Attempt to not clobber `zle_line_{init,finish}`
  * Partially addresses [Plugins breaks if `zle -N zle-line-init` is called #70](https://github.com/zsh-users/zsh-history-substring-search/issues/70)
* Clear paste content queue before first use

### Style

* [Style guide](https://github.com/robbyrussell/oh-my-zsh/wiki/Coding-style-guide)
  * Wrap lines at 80 columns
  * Remove `function` before function definitions
* Make paste keymap range more readable
* Simplify `$TERM` tests
* Ensure all functions have comments
* Prefix all globals with `bracketed`
* Improve punctuation in comments

Fixes #5237
Fixes #7883
Fixes #8749
Fixes #8886