### PR TITLE
Add support for Symfony Client

### DIFF
--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -1,7 +1,13 @@
 # Symfony2 basic command completion
 
 _symfony_console () {
-  echo "php $(find . -maxdepth 2 -mindepth 1 -name 'console' -type f | head -n 1)"
+  if [ -x symfony ]; then
+    echo "./symfony console"
+  else if command -v symfony >/dev/null 2>&1; then
+    echo "$(command -v symfony) console"
+  else
+    echo "php $(find . -maxdepth 2 -mindepth 1 -name 'console' -type f | head -n 1)"
+  fi
 }
 
 _symfony2_get_command_list () {


### PR DESCRIPTION
Symfony has a new [Symfony Client](https://github.com/symfony/cli), which is a binary called `symfony`.
You can use `symfony console` the same way as the old way with `php bin/console` with an incredible difference: It loads a local `php.ini`. [docs](https://symfony.com/doc/current/setup/symfony_server.html#overriding-php-config-options-per-project)

I don't know anything about compdef and never contributed to a zsh plugin. So this is just a typed idea.

I think there could be something like the following, but it doesn't work as expected:
```bash
compdef _symfony2 'symfony console'
```
Could you please implement this?