### PR TITLE
[debian plugin] Add new alu and aar alias

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -58,6 +58,10 @@ if [[ $use_sudo -eq 1 ]]; then
 
     # apt-get only
     alias ads="sudo apt-get dselect-upgrade"
+    alias aar="sudo apt-get autoremove"
+    
+    # apt only
+    alias alu="sudo apt update && apt list -u && sudo apt upgrade"
 
     # Install all .deb files in the current directory.
     # Warning: you will need to put the glob in single quotes if you use:


### PR DESCRIPTION
Add an update option which also lists the available updates before updating (apt list -u).
The new alias would be alias alu='sudo apt update && sudo apt list -u && sudo apt upgrade'. This is necessary to see the exact version change of a package.

Also adds the aar='sudo apt autoremove' alias.