### PR TITLE
Add gpt as git alias for git push --tags

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -113,6 +113,7 @@ plugins=(... git)
 | gpf!                 | git push --force                                                                                                              |
 | gpoat                | git push origin --all && git push origin --tags                                                                               |
 | gpu                  | git push upstream                                                                                                             |
+| gpt                  | git push --tags                                                                                                               |
 | gpv                  | git push -v                                                                                                                   |
 | gr                   | git remote                                                                                                                    |
 | gra                  | git remote add                                                                                                                |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -188,6 +188,7 @@ alias gpf='git push --force-with-lease'
 alias gpf!='git push --force'
 alias gpoat='git push origin --all && git push origin --tags'
 alias gpu='git push upstream'
+alias gpt='git push --tags'
 alias gpv='git push -v'
 
 alias gr='git remote'


### PR DESCRIPTION
Hey,
It simply adds another alias in git plugin to push tags.