### PR TITLE
pipenv: spawn a shell within virtualenv on a new session

### DIFF
--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -24,6 +24,7 @@ _togglePipenvShell() {
   fi
 }
 chpwd_functions+=(_togglePipenvShell)
+_togglePipenvShell
 
 # Aliases
 alias pch="pipenv check"


### PR DESCRIPTION
When opening a new terminal tab or window (new session) on a directory which has **Pipfile**, new shell within project-specific **virtualenv** is not activated automatically.

So, hereby I let the plugin **pipenv** spawn a new shell on a new terminal session as well.