### PR TITLE
Some small updates to the Jira plugin

### DIFF
--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -22,7 +22,7 @@ jira dashboard  # opens your JIRA dashboard
 jira reported [username]  # queries for issues reported by a user
 jira assigned [username]  # queries for issues assigned to a user
 jira myissues   # queries for you own issues
-jira branch     # opens an existing issue matching the current branch name
+jira branch     # opens an existing issue matching the current branch name (strips any prefix like "feature/" or "bugfix/")
 jira ABC-123    # opens an existing issue
 jira ABC-123 m  # opens an existing issue for adding a comment
 ```

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -65,7 +65,7 @@ function jira() {
     # but `branch` is a special case that will parse the current git branch
     if [[ "$action" == "branch" ]]; then
       local issue_arg=$(git rev-parse --abbrev-ref HEAD)
-      local issue="${jira_prefix}${issue_arg}"
+      local issue="${jira_prefix}${issue_arg##*/}"
     else
       local issue_arg=$action
       local issue="${jira_prefix}${issue_arg}"
@@ -77,11 +77,7 @@ function jira() {
     else
       echo "Opening issue #$issue"
     fi
-    if [[ "$JIRA_RAPID_BOARD" == "true" ]]; then
-      open_command "${jira_url}/issues/${issue}${url_fragment}"
-    else
-      open_command "${jira_url}/browse/${issue}${url_fragment}"
-    fi
+    open_command "${jira_url}/browse/${issue}${url_fragment}"
   fi
 }
 


### PR DESCRIPTION
- Updating `branch` command to be compatible with git-flow style branches by removing any prefix before attempting to go to the ticket number in Jira.
- Removing the switch on the `branch` command between `/browse/` and `/issues/` based off of the `JIRA_RAPID_BOARD` setting - as all issues are under `/browse/` now it seems.