### PR TITLE
vi-mode: fix behaviour on ctrl-c and define default keybindings

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -27,14 +27,14 @@ bindkey -v
 bindkey -M vicmd '^J' vi-accept-line
 bindkey -M vicmd '^M' vi-accept-line
 
-# allow v to edit the command line (standard behaviour)
+# allow ctrl-v to edit the command line (standard behaviour)
 autoload -Uz edit-command-line
 zle -N edit-command-line
-bindkey -M vicmd 'v' edit-command-line
+bindkey -M vicmd '^V' edit-command-line
 
-# allow ctrl-p, ctrl-n for navigate history (standard behaviour)
-bindkey '^P' up-history
-bindkey '^N' down-history
+# allow ctrl-p, ctrl-n for navigate history and fuzzy find history
+bindkey '^P' up-line-or-beginning-search
+bindkey '^N' down-line-or-beginning-search
 
 # allow ctrl-h, ctrl-w, ctrl-? for char and word deletion (standard behaviour)
 bindkey '^?' backward-delete-char
@@ -58,6 +58,11 @@ if [[ "${terminfo[kend]}" != "" ]]; then
 fi
 if [[ "${terminfo[kdch1]}" != "" ]]; then
   bindkey -M vicmd "${terminfo[kdch1]}" delete-char            # [Delete] - delete forward
+fi
+
+# allow reverse menu complete
+if [[ "${terminfo[kcbt]}" != "" ]]; then
+  bindkey "${terminfo[kcbt]}" reverse-menu-complete   # [Shift-Tab] - move through the completion menu backwards
 fi
 
 # if mode indicator wasn't setup by theme, define default

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -1,12 +1,14 @@
 # Updates editor information when the keymap changes.
-function zle-keymap-select() {
+function zle-line-init zle-keymap-select() {
   # update keymap variable for the prompt
   VI_KEYMAP=$KEYMAP
 
+  echoti smkx
   zle reset-prompt
   zle -R
 }
 
+zle -N zle-line-init
 zle -N zle-keymap-select
 
 function vi-accept-line() {
@@ -44,6 +46,17 @@ bindkey '^s' history-incremental-search-forward
 # allow ctrl-a and ctrl-e to move to beginning/end of line
 bindkey '^a' beginning-of-line
 bindkey '^e' end-of-line
+
+# allow delete, home and end keys to work in normal mode as a default behaviour
+if [[ "${terminfo[khome]}" != "" ]]; then
+  bindkey -M vicmd "${terminfo[khome]}" beginning-of-line      # [Home] - Go to beginning of line
+fi
+if [[ "${terminfo[kend]}" != "" ]]; then
+  bindkey -M vicmd "${terminfo[kend]}"  end-of-line            # [End] - Go to end of line
+fi
+if [[ "${terminfo[kdch1]}" != "" ]]; then
+  bindkey -M vicmd "${terminfo[kdch1]}" delete-char            # [Delete] - delete forward
+fi
 
 # if mode indicator wasn't setup by theme, define default
 if [[ "$MODE_INDICATOR" == "" ]]; then

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -3,7 +3,9 @@ function zle-line-init zle-keymap-select() {
   # update keymap variable for the prompt
   VI_KEYMAP=$KEYMAP
 
-  echoti smkx
+  if (( ${+terminfo[smkx]} )); then
+    echoti smkx
+  fi
   zle reset-prompt
   zle -R
 }


### PR DESCRIPTION
Sending a ctrl-c interrupts resets VI_KEYMAP and as a result, we get a
false vi mode since that variable is not set. A workaround is to redefine
both zle-keymap-select and zle-line-init to perform the same task.

Use some default key bindings for home, end, and delete keys. #7610