### PR TITLE
Fix an issue with escape characters

### DIFF
--- a/plugins/copybuffer/copybuffer.plugin.zsh
+++ b/plugins/copybuffer/copybuffer.plugin.zsh
@@ -1,9 +1,9 @@
 # copy the active line from the command line buffer 
-# onto the system clipboard (requires clipcopy plugin)
+# onto the system clipboard
 
 copybuffer () {
   if which clipcopy &>/dev/null; then
-    echo $BUFFER | clipcopy
+    printf "%s" $BUFFER | clipcopy
   else
     echo "clipcopy function not found. Please make sure you have Oh My Zsh installed correctly."
   fi

--- a/plugins/copybuffer/copybuffer.plugin.zsh
+++ b/plugins/copybuffer/copybuffer.plugin.zsh
@@ -3,7 +3,7 @@
 
 copybuffer () {
   if which clipcopy &>/dev/null; then
-    printf "%s" $BUFFER | clipcopy
+    printf "%s" "$BUFFER" | clipcopy
   else
     echo "clipcopy function not found. Please make sure you have Oh My Zsh installed correctly."
   fi


### PR DESCRIPTION
This PR fixes an issue of `copybuffer` about escape characters. And also fix the comment, since `clipcopy` is not a plugin anymore.

Issue description:

Typing `abc$'\0'def` on the command line, press Ctrl+O to copy the current line. We may get `abc$''def`(on macOS) or `abc$'`(on Ubuntu) in the clipboard.