### PR TITLE
Add alias for tmuxinator and tmuxinator stop

### DIFF
--- a/plugins/tmuxinator/tmuxinator.plugin.zsh
+++ b/plugins/tmuxinator/tmuxinator.plugin.zsh
@@ -1,5 +1,7 @@
 # aliases
+alias tx='tmuxinator'
 alias txs='tmuxinator start'
+alias txx='tmuxinator stop'
 alias txo='tmuxinator open'
 alias txn='tmuxinator new'
 alias txl='tmuxinator list'


### PR DESCRIPTION
This PR adds an alias for `tmuxinator` as `tx` as well as an alias for calling `tmuxinator stop` as `txx`.

I've been using this plugin for a while now and feel like this is missing from it.