### PR TITLE
Automatic title: Replace fg with description from jobs

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -32,10 +32,10 @@ function title {
         # Try to use terminfo to set the title
         # If the feature is available set title
         if [[ -n "$terminfo[fsl]" ]] && [[ -n "$terminfo[tsl]" ]]; then
-	  echoti tsl
-	  print -Pn "$1"
-	  echoti fsl
-	fi
+          echoti tsl
+          print -Pn "$1"
+          echoti fsl
+        fi
       fi
       ;;
   esac
@@ -50,23 +50,16 @@ fi
 
 # Runs before showing the prompt
 function omz_termsupport_precmd {
-  emulate -L zsh
-
-  if [[ "$DISABLE_AUTO_TITLE" == true ]]; then
-    return
-  fi
-
+  [[ "$DISABLE_AUTO_TITLE" == true ]] && return
   title $ZSH_THEME_TERM_TAB_TITLE_IDLE $ZSH_THEME_TERM_TITLE_IDLE
 }
 
 # Runs before executing the command
 function omz_termsupport_preexec {
+  [[ "$DISABLE_AUTO_TITLE" == true ]] && return
+
   emulate -L zsh
   setopt extended_glob
-
-  if [[ "$DISABLE_AUTO_TITLE" == true ]]; then
-    return
-  fi
 
   # split command into array of arguments
   local -a cmdargs
@@ -99,10 +92,9 @@ function omz_termsupport_preexec {
     esac
 
     # override preexec function arguments with job command
-    local job_cmd="${jobtexts[$job_id]}"
-    if [[ -n "$job_cmd" ]]; then
-      1="$job_cmd"
-      2="$job_cmd"
+    if [[ -n "${jobtexts[$job_id]}" ]]; then
+      1="${jobtexts[$job_id]}"
+      2="${jobtexts[$job_id]}"
     fi
   fi
 

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -72,19 +72,22 @@ function omz_termsupport_preexec {
   local CMD=${1[(wr)^(*=*|sudo|ssh|mosh|rake|-*)]:gs/%/%%}
   local LINE="${2:gs/%/%%}"
 
+  # replace fg, possibly with argument, with description from jobs
   if [[ "$CMD" = fg ]]; then
-    # replace fg, possibly with argument, with description from jobs
     local JOB
     if [[ ${(z)1} = fg ]]; then # no arguments
-      JOB="$(jobs %%)"
+      JOB="$(jobs %% 2>/dev/null)"
     else # arguments
-      JOB="$(jobs ${${(z)1}[2]})"
+      JOB="$(jobs ${${(z)1}[2]} 2>/dev/null)"
     fi
-    JOB="${${(z)JOB}[4,$]}" # trim job number, +, pid, status
-    title ${JOB:gs/%/%%} ${JOB:gs/%/%%}
-  else
-    title '$CMD' '%100>...>$LINE%<<'
+    if [[ $? -eq 0 ]]; then
+      JOB="${${(z)JOB}[4,$]}" # trim job number, +, pid, status
+      title ${JOB:gs/%/%%} ${JOB:gs/%/%%}
+      return
+    fi
   fi
+
+  title '$CMD' '%100>...>$LINE%<<'
 }
 
 precmd_functions+=(omz_termsupport_precmd)

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -72,7 +72,19 @@ function omz_termsupport_preexec {
   local CMD=${1[(wr)^(*=*|sudo|ssh|mosh|rake|-*)]:gs/%/%%}
   local LINE="${2:gs/%/%%}"
 
-  title '$CMD' '%100>...>$LINE%<<'
+  if [[ "$CMD" = fg ]]; then
+    # replace fg, possibly with argument, with description from jobs
+    local JOB
+    if [[ ${(z)1} = fg ]]; then # no arguments
+      JOB="$(jobs %%)"
+    else # arguments
+      JOB="$(jobs ${${(z)1}[2]})"
+    fi
+    JOB="${${(z)JOB}[4,$]}" # trim job number, +, pid, status
+    title ${JOB:gs/%/%%} ${JOB:gs/%/%%}
+  else
+    title '$CMD' '%100>...>$LINE%<<'
+  fi
 }
 
 precmd_functions+=(omz_termsupport_precmd)


### PR DESCRIPTION
Fix #7981 by using actual job title instead of `fg` in window title.  Based on part on [this superuser.com discussion](https://superuser.com/questions/497715/keep-tmux-title-from-fg-to-original-jobname).

I'm new to zsh scripting, so please let me know if this could be written any cleaner/shorter.  I found it particularly odd that I needed to check for the no-argument case separately; otherwise, `${${(z)1}[2]}` would return `g` (the second character of `fg`).