### PR TITLE
Add git-town

### DIFF
--- a/plugins/git-town/README.md
+++ b/plugins/git-town/README.md
@@ -16,6 +16,8 @@ https://github.com/Originate/git-town#commands
 | Alias   | Command                    | Description                            |
 |---------|----------------------------|----------------------------------------|
 | `gt`    | `git town`                 | Git-Town command                       |
+| `gtab`  | `git town abort`           | Aborts the last run git-town command   |
+| `gtc`   | `git town continue`        | Restarts last after resolved conflict  |
 | `gth`   | `git town hack`            | New feature branch off main branch     |
 | `gtsy`  | `git town sync`            | Updates current branch w/ all changes  |
 | `gtnpr` | `git town new-pull-request`| Create a new pull request              |

--- a/plugins/git-town/README.md
+++ b/plugins/git-town/README.md
@@ -1,0 +1,22 @@
+# Git-Town plugin
+
+This plugin adds completion and aliases for the `git-town` command. More information
+at https://www.git-town.com.
+
+Enable git-town plugin in your zshrc file:
+```
+plugins=(... git-town)
+```
+
+## Aliases
+
+More information about `git-town` commands:
+https://github.com/Originate/git-town#commands
+
+| Alias   | Command                    | Description                            |
+|---------|----------------------------|----------------------------------------|
+| `gt`    | `git town`                 | Git-Town command                       |
+| `gth`   | `git town hack`            | New feature branch off main branch     |
+| `gtsy`  | `git town sync`            | Updates current branch w/ all changes  |
+| `gtnpr` | `git town new-pull-request`| Create a new pull request              |
+| `gtsh`  | `git town ship`            | Delivers feature branch and removes it |

--- a/plugins/git-town/git-town.plugin.zsh
+++ b/plugins/git-town/git-town.plugin.zsh
@@ -1,0 +1,19 @@
+#!zsh
+#
+# Installation
+# ------------
+#
+# WIP
+
+#Alias
+| `gt`    | `git town`                 | Git-Town command                       |
+| `gth`   | `git town hack`            | New feature branch off main branch     |
+| `gtsy`  | `git town sync`            | Updates current branch w/ all changes  |
+| `gtnpr` | `git town new-pull-request`| Create a new pull request              |
+| `gtsh`  | `git town ship`            | Delivers feature branch and removes it |
+
+alias gt='git town'
+alias gth='git town hack'
+alias gtsy='git town sync'
+alias gtnpr='git town new-pull-request'
+alias gtsh='git town ship'

--- a/plugins/git-town/git-town.plugin.zsh
+++ b/plugins/git-town/git-town.plugin.zsh
@@ -7,12 +7,16 @@
 
 #Alias
 | `gt`    | `git town`                 | Git-Town command                       |
+| `gtab`  | `git town abort`           | Aborts the last run git-town command   |
+| `gtc`   | `git town continue`        | Restarts last after resolved conflict  |
 | `gth`   | `git town hack`            | New feature branch off main branch     |
 | `gtsy`  | `git town sync`            | Updates current branch w/ all changes  |
 | `gtnpr` | `git town new-pull-request`| Create a new pull request              |
 | `gtsh`  | `git town ship`            | Delivers feature branch and removes it |
 
 alias gt='git town'
+alias gta='git town abort'
+alias gtc='git town continue'
 alias gth='git town hack'
 alias gtsy='git town sync'
 alias gtnpr='git town new-pull-request'


### PR DESCRIPTION
Starting out with some of the more popular commands.

```
Git Town makes software development teams who use Git even more productive and happy.

It adds Git commands that support GitHub Flow, Git Flow, the Nvie model, GitLab Flow, and other workflows more directly,
and it allows you to perform many common Git operations faster and easier.

Usage:
  git-town [command]

Available Commands:
  abort                       Aborts the last run git-town command
  alias                       Adds or removes default global aliases
  append                      Creates a new feature branch as a child of the current branch
  config                      Displays your Git Town configuration
  continue                    Restarts the last run git-town command after having resolved conflicts
  discard                     Discards the saved state of the previous git-town command
  hack                        Creates a new feature branch off the main development branch
  help                        Help about any command
  install-fish-autocompletion Installs the autocompletion definition for Fish shell
  kill                        Removes an obsolete feature branch
  main-branch                 Displays or sets your main development branch
  new-branch-push-flag        Displays or sets your new branch push flag
  new-pull-request            Creates a new pull request
  offline                     Displays or sets offline mode
  perennial-branches          Displays your perennial branches
  prepend                     Creates a new feature branch as the parent of the current branch
  prune-branches              Deletes local branches whose tracking branch no longer exists
  pull-branch-strategy        Displays or sets your pull branch strategy
  rename-branch               Renames a branch both locally and remotely
  repo                        Opens the repository homepage
  set-parent-branch           Prompts to set the parent branch for the current branch
  ship                        Deliver a completed feature branch
  skip                        Restarts the last run git-town command by skipping the current branch
  sync                        Updates the current branch with all relevant changes
  undo                        Undoes the last run git-town command
  version                     Displays the version

Flags:
      --debug   Developer tool to print git commands run under the hood
  -h, --help    help for git-town

Use "git-town [command] --help" for more information about a command.
```