### PR TITLE
Adding complex git merge alias

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -193,6 +193,7 @@ alias gmt='git mergetool --no-prompt'
 alias gmtvim='git mergetool --no-prompt --tool=vimdiff'
 alias gmum='git merge upstream/master'
 alias gma='git merge --abort'
+alias gmlm='LATEST_BRANCH=$(git rev-parse --abbrev-ref HEAD) ; gcm ; ggpull ; gco $LATEST_BRANCH ; unset LATEST_BRANCH ; gm master --no-edit'
 
 alias gp='git push'
 alias gpd='git push --dry-run'


### PR DESCRIPTION
A short to Git Merge Lastest Master = gmlm
This alias will help to merge the latest remote master into your working branch with a single command.
It stores the branch name in a variable, checkout master, pull the latest master, checkout your original branch and merges master into it.

I have been using it in my local for more than a year (sorry I didn't make the time before), is helping me a lot, I hope it helps others.