### PR TITLE
Update Taskwarrior plugin: autocompletitions don't work due to a mistake of compdef command

### DIFF
--- a/plugins/taskwarrior/taskwarrior.plugin.zsh
+++ b/plugins/taskwarrior/taskwarrior.plugin.zsh
@@ -4,4 +4,4 @@ zstyle ':completion:*:*:task:*:descriptions' format '%U%B%d%b%u'
 zstyle ':completion:*:*:task:*' group-name ''
 
 alias t=task
-compdef _task t=task
+compdef _task t, task


### PR DESCRIPTION
Compdef executions don't work without this change.

Any of this not work to solve the issue #3796:

* Try deleting the zcompdump files: rm ~/.zcompdump* and restart the terminal.
* Try running compaudit | xargs chmod g-w,o-w
* Start zsh, then run autoload -T _task, and then try task [TAB].
* Try switching your locale temporarily: run LC_ALL=C and then try again to autocomplete.

Fix #3796