### PR TITLE
fix(vi-mode): control cursor, restore and use visual mode and speed up mode changes

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -1,3 +1,14 @@
+# Control whether to force a redraw on each mode change.
+#
+# Resetting the prompt on every mode change can cause lag when switching modes.
+# This is especially true if the prompt does things like checking git status.
+#
+# Set to "true" to force the prompt to reset on each mode change.
+# Set to "false" to force the prompt *not* to reset on each mode change.
+#
+# (The default is not to reset, unless we're showing the mode in RPS1).
+typeset -g VI_MODE_RESET_PROMPT_ON_MODE_CHANGE
+
 VI_KEYMAP=main
 
 function _vi-mode-set-cursor-shape-for-keymap() {
@@ -21,8 +32,10 @@ function zle-keymap-select() {
   # update keymap variable for the prompt
   VI_KEYMAP=$KEYMAP
 
-  zle reset-prompt
-  zle -R
+  if [ "${VI_MODE_RESET_PROMPT_ON_MODE_CHANGE:-}" = true ]; then
+    zle reset-prompt
+    zle -R
+  fi
   _vi-mode-set-cursor-shape-for-keymap "${VI_KEYMAP}"
 }
 zle -N zle-keymap-select
@@ -94,6 +107,13 @@ if [[ "$MODE_INDICATOR" == "" ]]; then
 fi
 
 function vi_mode_prompt_info() {
+  # If we're using the prompt to display mode info, and we haven't explicitly
+  # disabled "reset prompt on mode change", then set it here.
+  #
+  # We do that here instead of the `if` statement below because the user may
+  # set RPS1/RPROMPT to something else in their custom config.
+  : "${VI_MODE_RESET_PROMPT_ON_MODE_CHANGE:=true}"
+
   echo "${${VI_KEYMAP/vicmd/$MODE_INDICATOR}/(main|viins)/}"
 }
 

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -8,8 +8,7 @@
 #
 # (The default is not to reset, unless we're showing the mode in RPS1).
 typeset -g VI_MODE_RESET_PROMPT_ON_MODE_CHANGE
-
-VI_KEYMAP=main
+typeset -g VI_KEYMAP=main
 
 function _vi-mode-set-cursor-shape-for-keymap() {
   # https://vt100.net/docs/vt510-rm/DECSCUSR
@@ -30,7 +29,7 @@ function _vi-mode-set-cursor-shape-for-keymap() {
 # Updates editor information when the keymap changes.
 function zle-keymap-select() {
   # update keymap variable for the prompt
-  VI_KEYMAP=$KEYMAP
+  typeset -g VI_KEYMAP=$KEYMAP
 
   if [ "${VI_MODE_RESET_PROMPT_ON_MODE_CHANGE:-}" = true ]; then
     zle reset-prompt
@@ -43,7 +42,7 @@ zle -N zle-keymap-select
 # These "echoti" statements were originally set in lib/key-bindings.zsh
 # Not sure the best way to extend without overriding.
 function zle-line-init() {
-  VI_KEYMAP=main
+  typeset -g VI_KEYMAP=main
   (( ! ${+terminfo[smkx]} )) || echoti smkx
   _vi-mode-set-cursor-shape-for-keymap "${VI_KEYMAP}"
 }

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -45,6 +45,33 @@ bindkey '^s' history-incremental-search-forward
 bindkey '^a' beginning-of-line
 bindkey '^e' end-of-line
 
+if [[ "${terminfo[kpp]}" != "" ]]; then
+  bindkey "${terminfo[kpp]}" up-line-or-history       # [PageUp] - Up a line of history
+fi
+if [[ "${terminfo[knp]}" != "" ]]; then
+  bindkey "${terminfo[knp]}" down-line-or-history     # [PageDown] - Down a line of history
+fi
+
+# start typing + [Up-Arrow] - fuzzy find history forward
+if [[ "${terminfo[kcuu1]}" != "" ]]; then
+  autoload -U up-line-or-beginning-search
+  zle -N up-line-or-beginning-search
+  bindkey "${terminfo[kcuu1]}" up-line-or-beginning-search
+fi
+# start typing + [Down-Arrow] - fuzzy find history backward
+if [[ "${terminfo[kcud1]}" != "" ]]; then
+  autoload -U down-line-or-beginning-search
+  zle -N down-line-or-beginning-search
+  bindkey "${terminfo[kcud1]}" down-line-or-beginning-search
+fi
+
+if [[ "${terminfo[khome]}" != "" ]]; then
+  bindkey "${terminfo[khome]}" beginning-of-line      # [Home] - Go to beginning of line
+fi
+if [[ "${terminfo[kend]}" != "" ]]; then
+  bindkey "${terminfo[kend]}"  end-of-line            # [End] - Go to end of line
+fi
+
 # if mode indicator wasn't setup by theme, define default
 if [[ "$MODE_INDICATOR" == "" ]]; then
   MODE_INDICATOR="%{$fg_bold[red]%}<%{$fg[red]%}<<%{$reset_color%}"

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -1,5 +1,21 @@
 VI_KEYMAP=main
 
+function _vi-mode-set-cursor-shape-for-keymap() {
+  # https://vt100.net/docs/vt510-rm/DECSCUSR
+  local _shape=0
+  case "${1:-${VI_KEYMAP:-main}}" in
+    main)    _shape=6 ;; # vi insert: line
+    viins)   _shape=6 ;; # vi insert: line
+    isearch) _shape=6 ;; # inc search: line
+    command) _shape=6 ;; # read a command name
+    vicmd)   _shape=2 ;; # vi cmd: block
+    visual)  _shape=2 ;; # vi visual mode: block
+    viopp)   _shape=0 ;; # vi operation pending: blinking block
+    *)       _shape=0 ;;
+  esac
+  printf $'\e[%d q' "${_shape}"
+}
+
 # Updates editor information when the keymap changes.
 function zle-keymap-select() {
   # update keymap variable for the prompt
@@ -7,6 +23,7 @@ function zle-keymap-select() {
 
   zle reset-prompt
   zle -R
+  _vi-mode-set-cursor-shape-for-keymap "${VI_KEYMAP}"
 }
 zle -N zle-keymap-select
 
@@ -15,11 +32,13 @@ zle -N zle-keymap-select
 function zle-line-init() {
   VI_KEYMAP=main
   (( ! ${+terminfo[smkx]} )) || echoti smkx
+  _vi-mode-set-cursor-shape-for-keymap "${VI_KEYMAP}"
 }
 zle -N zle-line-init
 
 function zle-line-finish() {
   (( ! ${+terminfo[rmkx]} )) || echoti rmkx
+  _vi-mode-set-cursor-shape-for-keymap default
 }
 zle -N zle-line-finish
 

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -23,11 +23,6 @@ bindkey -v
 bindkey -M vicmd '^J' vi-accept-line
 bindkey -M vicmd '^M' vi-accept-line
 
-# allow v to edit the command line (standard behaviour)
-autoload -Uz edit-command-line
-zle -N edit-command-line
-bindkey -M vicmd 'v' edit-command-line
-
 # allow ctrl-p, ctrl-n for navigate history (standard behaviour)
 bindkey '^P' up-history
 bindkey '^N' down-history

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -1,3 +1,5 @@
+VI_KEYMAP=main
+
 # Updates editor information when the keymap changes.
 function zle-keymap-select() {
   # update keymap variable for the prompt
@@ -6,22 +8,22 @@ function zle-keymap-select() {
   zle reset-prompt
   zle -R
 }
-
 zle -N zle-keymap-select
 
-function vi-accept-line() {
+# These "echoti" statements were originally set in lib/key-bindings.zsh
+# Not sure the best way to extend without overriding.
+function zle-line-init() {
   VI_KEYMAP=main
-  zle accept-line
+  (( ! ${+terminfo[smkx]} )) || echoti smkx
 }
+zle -N zle-line-init
 
-zle -N vi-accept-line
-
+function zle-line-finish() {
+  (( ! ${+terminfo[rmkx]} )) || echoti rmkx
+}
+zle -N zle-line-finish
 
 bindkey -v
-
-# use custom accept-line widget to update $VI_KEYMAP
-bindkey -M vicmd '^J' vi-accept-line
-bindkey -M vicmd '^M' vi-accept-line
 
 # allow ctrl-p, ctrl-n for navigate history (standard behaviour)
 bindkey '^P' up-history

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -101,6 +101,19 @@ if [[ "${terminfo[kend]}" != "" ]]; then
   bindkey "${terminfo[kend]}"  end-of-line            # [End] - Go to end of line
 fi
 
+if [[ "${terminfo[kcbt]}" != "" ]]; then
+  bindkey "${terminfo[kcbt]}" reverse-menu-complete   # [Shift-Tab] - move through the completion menu backwards
+fi
+
+bindkey '^?' backward-delete-char                     # [Backspace] - delete backward
+if [[ "${terminfo[kdch1]}" != "" ]]; then
+  bindkey "${terminfo[kdch1]}" delete-char            # [Delete] - delete forward
+else
+  bindkey "^[[3~" delete-char
+  bindkey "^[3;5~" delete-char
+  bindkey "\e[3~" delete-char
+fi
+
 () {
   local wrap_clipboard_widgets
   function wrap_clipboard_widgets() {

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -139,7 +139,7 @@ fi
 
 # if mode indicator wasn't setup by theme, define default
 if [[ "$MODE_INDICATOR" == "" ]]; then
-  MODE_INDICATOR="%{$fg_bold[red]%}<%{$fg[red]%}<<%{$reset_color%}"
+  MODE_INDICATOR='%B%F{red}<%b<<%f'
 fi
 
 function vi_mode_prompt_info() {


### PR DESCRIPTION
This fixes all issues I'm aware of for vi-mode. Tested on zsh-5.7.1 on macOS, and I've been using it extensively for a quite a while.

In summary:
  * Fix: Fixes consistency issues with tracking mode changes
  * Fix: Restores zsh's very good built-in visual mode, rather than launching a full editor…
  * Fix: Restores up-arrow etc. keybindings.
  * Enhancement: Speeds up mode changes by avoiding unnecessary prompt "full resets" which can trigger `git` work. (See also—not dependent, but helps— _[#7804 - Safety fix and speed-ups for lib/git.zsh prompt functions](https://github.com/robbyrussell/oh-my-zsh/pull/7804)_)
  * Feature: Draws the cursor style based on the current mode.
  * Feature: Copying and pasting in vi-mode uses `clipcopy`/`clippaste`, to integrate with your clipboard. (See also—not dependent, but helps— _[#8000 - Enhanced clipboard detection and management](https://github.com/robbyrussell/oh-my-zsh/pull/8000)_)

Some related PRs, which I think this mostly covers:
  * Closes #6332 (completely covered here)
  * Closes #5980 (invalid)
  * Closes #5857 (has conflicts; interesting idea though)
  * Closes #7978 (the core issue is covered here, but has some other small changes)