### PR TITLE
httpie: add alias for https

### DIFF
--- a/plugins/httpie/README.md
+++ b/plugins/httpie/README.md
@@ -11,4 +11,10 @@ plugins=(... httpie)
 
 It uses completion from [zsh-completions](https://github.com/zsh-users/zsh-completions).
 
+## Aliases
+
+| Alias        | Command                                                          |
+| ------------ | ---------------------------------------------------------------- |
+| `https`      | `http --default-scheme=https`                                    |
+
 **Maintainer:** [lululau](https://github.com/lululau)

--- a/plugins/httpie/httpie.plugin.zsh
+++ b/plugins/httpie/httpie.plugin.zsh
@@ -1,0 +1,7 @@
+#
+# Aliases
+# (sorted alphabetically)
+#
+
+alias https='http --default-scheme=https'
+


### PR DESCRIPTION
Added an alias creating https, which uses httpie with https.
https://httpie.org/doc#custom-default-scheme