### PR TITLE
Support konsole-256color TERM in title function

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -17,7 +17,7 @@ function title {
   : ${2=$1}
 
   case "$TERM" in
-    cygwin|xterm*|putty*|rxvt*|ansi)
+    cygwin|xterm*|putty*|rxvt*|konsole*|ansi)
       print -Pn "\e]2;$2:q\a" # set window name
       print -Pn "\e]1;$1:q\a" # set tab name
       ;;


### PR DESCRIPTION
Currently, if TERM is set to `konsole-256color`, the `title` function doesn't do anything. I've tested locally and adding this in does fix the issue - `konsole` uses the same escape codes as `xterm` and the others.

Konsole defaults to `TERM=xterm-256color` because of issues like this, but using that creates other issues. Mainly, console applications like [kakoune](https://github.com/mawww/kakoune) assume incorrect terminal facts, and create inaccurate colors.

Since this is fairly small, and shouldn't have any adverse side affects, I hope it's a reasonable change. I'm not sure how widespread the use of `konsole-256term` is since konsole itself doesn't default to it, but I don't believe it would actively hurt anything but maintainability to include it.

Let me know if there's anything else I can do.