### PR TITLE
core: remove inc_append_history option

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -36,5 +36,4 @@ setopt hist_expire_dups_first # delete duplicates first when HISTFILE size excee
 setopt hist_ignore_dups       # ignore duplicated commands history list
 setopt hist_ignore_space      # ignore commands that start with space
 setopt hist_verify            # show command with history expansion to user before running it
-setopt inc_append_history     # add commands to HISTFILE in order of execution
 setopt share_history          # share command history data


### PR DESCRIPTION
The doc says it is useless to have both:

>This option both imports new commands from the history file, and also causes your typed commands to be appended to the history file (the latter is like specifying INC_APPEND_HISTORY, which should be turned off if this option is in effect)

http://zsh.sourceforge.net/Doc/Release/Options.html