### PR TITLE
Mention FAQ in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ ZSH_THEME_RANDOM_CANDIDATES=(
 
 ### FAQ
 
-If you have some more questions or issues, you might find a solution in our [FAQ](https://github.com/robbyrussell/oh-my-zsh/wiki/FAQ).
+If you have some more questions or issues, you might find a solution in our [FAQ](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ).
 
 ## Advanced Topics
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ ZSH_THEME_RANDOM_CANDIDATES=(
 )
 ```
 
+### FAQ
+
+If you have some more questions or issues, you might find a solution in our [FAQ](https://github.com/robbyrussell/oh-my-zsh/wiki/FAQ).
+
 ## Advanced Topics
 
 If you're the type that likes to get their hands dirty, these sections might resonate.


### PR DESCRIPTION
I couldn't make docker-compose completions to work. I wondered if I misconfigured something in ZSH. Turned out, I wasn't the only one with that problem: #4365
I thought that if this is a thing that happens with plugins, it should be mentioned in the README part dealing with enabling plugins, as it would be nice if it had all the info you need to get going.