### PR TITLE
Allow disabling virtualenv prompt in agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -204,7 +204,7 @@ prompt_dir() {
 # Virtualenv: current working virtualenv
 prompt_virtualenv() {
   local virtualenv_path="$VIRTUAL_ENV"
-  if [[ -n $virtualenv_path && -z $VIRTUAL_ENV_DISABLE_PROMPT ]]; then
+  if [[ -n $virtualenv_path && -n $VIRTUAL_ENV_DISABLE_PROMPT ]]; then
     prompt_segment blue black "(`basename $virtualenv_path`)"
   fi
 }

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -204,7 +204,7 @@ prompt_dir() {
 # Virtualenv: current working virtualenv
 prompt_virtualenv() {
   local virtualenv_path="$VIRTUAL_ENV"
-  if [[ -n $virtualenv_path && -n $VIRTUAL_ENV_DISABLE_PROMPT ]]; then
+  if [[ -n $virtualenv_path && -z $VIRTUAL_ENV_DISABLE_PROMPT ]]; then
     prompt_segment blue black "(`basename $virtualenv_path`)"
   fi
 }

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -204,7 +204,7 @@ prompt_dir() {
 # Virtualenv: current working virtualenv
 prompt_virtualenv() {
   local virtualenv_path="$VIRTUAL_ENV"
-  if [[ -n $virtualenv_path && -n $VIRTUAL_ENV_DISABLE_PROMPT ]]; then
+  if [[ -n $virtualenv_path && -n $VIRTUAL_ENV_DISABLE_PROMPT && ${VIRTUAL_ENV_DISABLE_PROMPT} != "YES_DISABLE_OMZ_PROMPT_TOO" ]]; then
     prompt_segment blue black "(`basename $virtualenv_path`)"
   fi
 }


### PR DESCRIPTION
Bug fix for schrodingers VIRTUAL_ENV_DISABLE_PROMPT (7985)

This PR fixes the logic bug here: https://github.com/robbyrussell/oh-my-zsh/issues/7985

This is version two of the fix.  v1: https://github.com/robbyrussell/oh-my-zsh/pull/8050

We need to support three use cases:

 1. Disable python prompt, disable OMZ prompt
 2. Disable python prompt, enable OMZ prompt
 3. Enable python prompt, disable OMZ prompt

This can be achieved by:

 1. Setting `$VIRTUAL_ENV_DISABLE_PROMPT` to `"YES_DISABLE_OMZ_PROMPT_TOO"`
 1. Setting `$VIRTUAL_ENV_DISABLE_PROMPT` to anything else
 1. Unsetting `$VIRTUAL_ENV_DISABLE_PROMPT`