### PR TITLE
Add conda env to avit prompt

### DIFF
--- a/themes/avit.zsh-theme
+++ b/themes/avit.zsh-theme
@@ -1,7 +1,7 @@
 # AVIT ZSH Theme
 
 PROMPT='
-$(_user_host)${_current_dir} $(git_prompt_info) $(_ruby_version)
+$(_user_host)${_current_dir}$(_conda_env)$(git_prompt_info) $(_ruby_version)
 %{$fg[$CARETCOLOR]%}▶%{$resetcolor%} '
 
 PROMPT2='%{$fg[$CARETCOLOR]%}◀%{$reset_color%} '
@@ -11,6 +11,20 @@ RPROMPT='$(_vi_status)%{$(echotc UP 1)%}$(_git_time_since_commit) $(git_prompt_s
 local _current_dir="%{$fg_bold[blue]%}%3~%{$reset_color%} "
 local _return_status="%{$fg_bold[red]%}%(?..⍉)%{$reset_color%}"
 local _hist_no="%{$fg[grey]%}%h%{$reset_color%}"
+
+# Anaconda: current working conda env
+# Code based on this commit: https://github.com/robbyrussell/oh-my-zsh/pull/7067/files
+# To replace the conda modification of PS1 do `conda config --set changeps1 False`
+# or add 'changeps1: False' to your .condarc file.
+function _conda_env() {
+  local conda_env="$CONDA_DEFAULT_ENV"
+  if [[ -n $conda_env ]]; then
+    local conda_changeps1="`conda config --show changeps1`" 
+    if [[ $conda_changeps1 == "changeps1: False" && $conda_env != "base" ]]; then
+      echo "%{$fg[yellow]%}($CONDA_DEFAULT_ENV)%{$reset_color%} "
+    fi
+  fi
+}
 
 function _current_dir() {
   local _max_pwd_length="65"
@@ -50,7 +64,9 @@ function _ruby_version() {
 # use a neutral color, otherwise colors will vary according to time.
 function _git_time_since_commit() {
 # Only proceed if there is actually a commit.
-  if last_commit=$(git log --pretty=format:'%at' -1 2> /dev/null); then
+  if git log -1 > /dev/null 2>&1; then
+    # Get the last commit.
+    last_commit=$(git log --pretty=format:'%at' -1 2> /dev/null)
     now=$(date +%s)
     seconds_since_last_commit=$((now-last_commit))
 
@@ -63,7 +79,7 @@ function _git_time_since_commit() {
     sub_hours=$((hours % 24))
     sub_minutes=$((minutes % 60))
 
-    if [ $hours -ge 24 ]; then
+    if [ $hours -gt 24 ]; then
       commit_age="${days}d"
     elif [ $minutes -gt 60 ]; then
       commit_age="${sub_hours}h${sub_minutes}m"
@@ -102,7 +118,7 @@ ZSH_THEME_GIT_TIME_SHORT_COMMIT_MEDIUM="%{$fg[yellow]%}"
 ZSH_THEME_GIT_TIME_SINCE_COMMIT_LONG="%{$fg[red]%}"
 ZSH_THEME_GIT_TIME_SINCE_COMMIT_NEUTRAL="%{$fg[white]%}"
 
-# LS colors, made with https://geoff.greer.fm/lscolors/
+# LS colors, made with http://geoff.greer.fm/lscolors/
 export LSCOLORS="exfxcxdxbxegedabagacad"
 export LS_COLORS='di=34;40:ln=35;40:so=32;40:pi=33;40:ex=31;40:bd=34;46:cd=34;43:su=0;41:sg=0;46:tw=0;42:ow=0;43:'
 export GREP_COLOR='1;33'


### PR DESCRIPTION
This adds the conda environment in the avit theme's prompt, inline with the current directory and git info.

Code based on this PR for the agnoster prompt: https://github.com/robbyrussell/oh-my-zsh/pull/7067.