### PR TITLE
Add option to change shell quietly

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -20,7 +20,7 @@
 #   BRANCH  - branch to check out immediately after install (default: master)
 #
 # Other options:
-#   CHSH    - 'no' means the installer will not change the default shell (default: yes)
+#   CHSH    - 'no' means the installer will not change the default shell (default: ask)
 #   RUNZSH  - 'no' means the installer will not run zsh after the install (default: yes)
 #
 # You can also pass some arguments to the install script to set some these options:
@@ -38,7 +38,7 @@ REMOTE=${REMOTE:-https://github.com/${REPO}.git}
 BRANCH=${BRANCH:-master}
 
 # Other options
-CHSH=${CHSH:-yes}
+CHSH=${CHSH:-ask}
 RUNZSH=${RUNZSH:-yes}
 
 
@@ -154,16 +154,18 @@ setup_shell() {
 		return
 	fi
 
-	echo "${BLUE}Time to change your default shell to zsh:${RESET}"
+	if [ $CHSH = ask ]; then
+		echo "${BLUE}Time to change your default shell to zsh:${RESET}"
 
-	# Prompt for user choice on changing the default login shell
-	printf "${YELLOW}Do you want to change your default shell to zsh? [Y/n]${RESET} "
-	read opt
-	case $opt in
-		y*|Y*|"") echo "Changing the shell..." ;;
-		n*|N*) echo "Shell change skipped."; return ;;
-		*) echo "Invalid choice. Shell change skipped."; return ;;
-	esac
+		# Prompt for user choice on changing the default login shell
+		printf "${YELLOW}Do you want to change your default shell to zsh? [Y/n]${RESET} "
+		read opt
+		case $opt in
+			y*|Y*|"") echo "Changing the shell..." ;;
+			n*|N*) echo "Shell change skipped."; return ;;
+			*) echo "Invalid choice. Shell change skipped."; return ;;
+		esac
+	fi
 
 	# Test for the right location of the "shells" file
 	if [ -f /etc/shells ]; then


### PR DESCRIPTION
Provide an option to skip the `change default shell?` prompt. It would be done with the addition of `ask` value of `CHSH`:

`no` - the default shell will not be changed
`ask` (default, current behavior) - the installer will prompt for a yes/no choice
`yes` (or anything else) - the installer will change the default shell without asking

This would be useful when you are running the installer from inside another script and don't want to have any prompts (like quiet run).