### PR TITLE
Add alias wpreset to reset the database

### DIFF
--- a/plugins/wp-cli/wp-cli.plugin.zsh
+++ b/plugins/wp-cli/wp-cli.plugin.zsh
@@ -27,6 +27,7 @@ alias wpcrs='wp cron schedule'
 alias wpcrt='wp cron test'
 
 # Db
+alias wpreset='wp db reset'
 
 # Eval
 


### PR DESCRIPTION
`wp db reset` removes all tables from the database, opening the website URL in the browser will aks for installation details. It's a convenient way to "start from scratch", if you use the site for tests and development.

Without parameter `--yes` the user will be prompted to confirm the command.