### PR TITLE
Jira Plugin: Use last part of branch (basename).

### DIFF
--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -63,8 +63,9 @@ function jira() {
   else
     # Anything that doesn't match a special action is considered an issue name
     # but `branch` is a special case that will parse the current git branch
+    # and returns its basename 
     if [[ "$action" == "branch" ]]; then
-      local issue_arg=$(git rev-parse --abbrev-ref HEAD)
+      local issue_arg=$(basename $(git rev-parse --abbrev-ref HEAD))
       local issue="${jira_prefix}${issue_arg}"
     else
       local issue_arg=$action


### PR DESCRIPTION
We divide our branches in fixes and features:
-  feature/IOT-4461
-  feature/IOT-4490
-  fix/IOT-4643

To open  jira with the right path only the basename is needed.

The change is transparent to existing behaviour, because if you add anything except jira issue number it cannot be opened anyway.
