### PR TITLE
Jira: Add command to search branch name as is

### DIFF
--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -17,14 +17,15 @@ This plugin supplies one command, `jira`, through which all its features are exp
 ```
 jira            # performs the default action
 
-jira new        # opens a new issue
-jira dashboard  # opens your JIRA dashboard
+jira new          # opens a new issue
+jira dashboard    # opens your JIRA dashboard
 jira reported [username]  # queries for issues reported by a user
 jira assigned [username]  # queries for issues assigned to a user
-jira myissues   # queries for you own issues
-jira branch     # opens an existing issue matching the current branch name
-jira ABC-123    # opens an existing issue
-jira ABC-123 m  # opens an existing issue for adding a comment
+jira myissues     # queries for you own issues
+jira branch       # opens an existing issue matching the current branch name, prepended with prefix
+jira branch-as-is # opens an existing issue matching the current branch name, exactly as is
+jira ABC-123      # opens an existing issue
+jira ABC-123 m    # opens an existing issue for adding a comment
 ```
 
 #### Debugging usage  ####

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -66,6 +66,9 @@ function jira() {
     if [[ "$action" == "branch" ]]; then
       local issue_arg=$(git rev-parse --abbrev-ref HEAD)
       local issue="${jira_prefix}${issue_arg}"
+    if [[ "$action" == "branch-as-is" ]]; then
+      local issue_arg=$(git rev-parse --abbrev-ref HEAD)
+      local issue="${issue_arg}"
     else
       local issue_arg=$action
       local issue="${jira_prefix}${issue_arg}"


### PR DESCRIPTION
Add branch-as-is command to take branch name without applying prefix. My team puts our prefix in branch names as a convention but I still want a prefix set for looking up other tickets. 

By adding a new command I also won't conflict with other PRs wanting to change the beviour of the branch command, such as [jhonny007's](https://github.com/robbyrussell/oh-my-zsh/pull/8161). 