### PR TITLE
plugins/do_sudo: alias expansion handling for sudo

### DIFF
--- a/plugins/do_sudo/README.md
+++ b/plugins/do_sudo/README.md
@@ -1,0 +1,6 @@
+# `do_sudo` plugin
+
+This plugin provides a sudo wrapper that handles alias expansion and avoids
+being broken by `nocorrect` `noglob` from other aliases.
+
+Modified from the script by [Wayne Davison](https://www.zsh.org/mla/users/2008/msg01229.html).

--- a/plugins/do_sudo/do_sudo.plugin.zsh
+++ b/plugins/do_sudo/do_sudo.plugin.zsh
@@ -10,6 +10,7 @@ function _do_sudo() {
     local -a args
     local -a cmd_alias_arr
     local cmd_alias
+    local return_value
     while (($#)); do
         case "$1" in
         command|exec|-) shift; break ;;
@@ -43,8 +44,10 @@ function _do_sudo() {
         else
             PATH="/sbin:/usr/sbin:/usr/local/sbin:$PATH" command sudo "${args[@]}" $==*
         fi
+        return_value=$?
         unset __do_sudo_glob
         unset __do_sudo_expanded
+        return $return_value
     fi
 }
 

--- a/plugins/do_sudo/do_sudo.plugin.zsh
+++ b/plugins/do_sudo/do_sudo.plugin.zsh
@@ -17,14 +17,10 @@ function _do_sudo() {
         noglob) __do_sudo_glob=0; shift ;;
         *)
             cmd_alias="$(command -v 2>/dev/null -- "$1")"
-            if [[ "$?" -eq 0 ]]; then
-                if [[ "$cmd_alias" == 'alias'* ]] && [[ -z "$__do_sudo_expanded["$1"]" ]]; then
-                    __do_sudo_expanded["$1"]=1
-                    IFS=' ' read -A cmd_alias_arr <<< "$(sed -e "s/[^=]*=//" -e "s/^'//" -e "s/'$//" <<< "$cmd_alias")"
-                    args+=( "${cmd_alias_arr[@]}" )
-                else
-                    args+=( "$(sed "s/[^=]*=//" <<< "$(hash -v 2>/dev/null -- "$1")")" )
-                fi
+            if [[ "$?" -eq 0 ]] && [[ "$cmd_alias" == 'alias'* ]] && [[ -z "$__do_sudo_expanded["$1"]" ]]; then
+                __do_sudo_expanded["$1"]=1
+                IFS=' ' read -A cmd_alias_arr <<< "$(sed -e "s/[^=]*=//" -e "s/^'//" -e "s/'$//" <<< "$cmd_alias")"
+                args+=( "${cmd_alias_arr[@]}" )
                 shift
                 break
             else

--- a/plugins/do_sudo/do_sudo.plugin.zsh
+++ b/plugins/do_sudo/do_sudo.plugin.zsh
@@ -25,7 +25,11 @@ function _do_sudo() {
                 shift
                 break
             else
-                args+=( $1 )
+                if ((__do_sudo_glob)); then
+                    args+=( $~==1 )
+                else
+                    args+=( $==1 )
+                fi
                 shift
             fi
             ;;

--- a/plugins/do_sudo/do_sudo.plugin.zsh
+++ b/plugins/do_sudo/do_sudo.plugin.zsh
@@ -15,6 +15,7 @@ function _do_sudo() {
         command|exec|-) shift; break ;;
         nocorrect) shift ;;
         noglob) __do_sudo_glob=0; shift ;;
+        [1-9]) args+=( $1 ); shift ;;
         *)
             cmd_alias="$(command -v 2>/dev/null -- "$1")"
             if [[ "$?" -eq 0 ]] && [[ "$cmd_alias" == 'alias'* ]] && [[ -z "$__do_sudo_expanded["$1"]" ]]; then

--- a/plugins/do_sudo/do_sudo.plugin.zsh
+++ b/plugins/do_sudo/do_sudo.plugin.zsh
@@ -1,0 +1,27 @@
+if [[ "$ENABLE_CORRECTION" == "true" ]]; then
+    alias sudo='nocorrect noglob _do_sudo '
+else
+    alias sudo='noglob _do_sudo '
+fi
+
+function _do_sudo() {
+    integer glob=1
+    local -a run
+    run=( command sudo )
+    while (($#)); do
+        case "$1" in
+        command|exec|-) shift; break ;;
+        nocorrect) shift ;;
+        noglob) glob=0; shift ;;
+        *) break ;;
+        esac
+    done
+    if ((glob)); then
+        PATH="/sbin:/usr/sbin:/usr/local/sbin:$PATH" $run $~==*
+    else
+        PATH="/sbin:/usr/sbin:/usr/local/sbin:$PATH" $run $==*
+    fi
+}
+
+command -v _sudo >/dev/null 2>&1
+[[ $? -eq 0 ]] && compdef _sudo '_do_sudo'


### PR DESCRIPTION
Usually we may add `alias sudo='sudo '` to `.zshrc` so that shell can expand the following alias for us. This shouldn't be on by default cos of security reasons but it's indeed quite handy. One problem about it tho is that if the following alias is preceded by e.g. `nocorrect` `noglob` sudo will complain that the command cannot be found.

There was a workaround for this from [Zsh mailing list](https://www.zsh.org/mla/users/2008/msg01229.html) and I reckon it can be quite helpful to have it in oh-my-zsh. I removed the hard-coded `-u` support and `/bin/zsh` fallback so that the alias can work more similarly as `sudo` in the first commit.

The second commit is what I'm actually not that sure about. I tried to cover some fringe cases but ended up with something that tends to be overly complex. Compared with the original one, it can handle all sudo options and recursively expand aliases until it find a real command. For example:
```zsh
$ alias vim='nvim'
$ sudo -u michael -g dunder-mifflin vim  # not supported by the original one

$ alias xvim='nvim'
$ alias yvim='noglob xvim'
$ alias vim='yvim'
$ sudo vim *  # noglob is effective

$ alias vim=vim1
$ alias vim1=vim2
$ alias vim2=vim
$ sudo vim --version  # prevent infinite loop
```
It gets most of my use cases covered but not sure whether it can be simplified a little?