### PR TITLE
Add bindings for Ctrl+Backspace and Ctrl+Delete

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -52,6 +52,9 @@ bindkey ' ' magic-space                               # [Space] - do history exp
 bindkey '^[[1;5C' forward-word                        # [Ctrl-RightArrow] - move forward one word
 bindkey '^[[1;5D' backward-word                       # [Ctrl-LeftArrow] - move backward one word
 
+bindkey '^[[3;5~' kill-word                           # [Ctrl-Backspace] - delete word backward
+bindkey '^H' backward-kill-word                       # [Ctrl-Delete] - delete word forward
+
 if [[ "${terminfo[kcbt]}" != "" ]]; then
   bindkey "${terminfo[kcbt]}" reverse-menu-complete   # [Shift-Tab] - move through the completion menu backwards
 fi


### PR DESCRIPTION
Delete words with Ctrl+Backspace and Ctrl+Delete, like it's standard in GUI applications. Fixes #7609.