### PR TITLE
parameter not set error when using set -u option in interactive shell

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -14,7 +14,7 @@ function parse_git_dirty() {
   local -a FLAGS
   FLAGS=('--porcelain' '--ignore-submodules=dirty')
   if [[ "$(command git config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
-    if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" == "true" ]]; then
+    if [[ "${DISABLE_UNTRACKED_FILES_DIRTY:-}" == "true" ]]; then
       FLAGS+='--untracked-files=no'
     fi
     STATUS=$(command git status ${FLAGS} 2> /dev/null | tail -n1)
@@ -69,7 +69,6 @@ function git_current_branch() {
   fi
   echo ${ref#refs/heads/}
 }
-
 
 # Gets the number of commits ahead from remote
 function git_commits_ahead() {

--- a/plugins/z/z.sh
+++ b/plugins/z/z.sh
@@ -36,7 +36,7 @@ _z() {
     [ -h "$datafile" ] && datafile=$(readlink "$datafile")
 
     # bail if we don't own ~/.z and $_Z_OWNER not set
-    [ -z "$_Z_OWNER" -a -f "$datafile" -a ! -O "$datafile" ] && return
+    [ -z "${_Z_OWNER:-}" -a -f "$datafile" -a ! -O "$datafile" ] && return
 
     _z_dirs () {
         local line
@@ -56,7 +56,7 @@ _z() {
 
         # don't track excluded directory trees
         local exclude
-        for exclude in "${_Z_EXCLUDE_DIRS[@]}"; do
+        for exclude in "${_Z_EXCLUDE_DIRS[@]:-}"; do
             case "$*" in "$exclude*") return;; esac
         done
 
@@ -89,7 +89,7 @@ _z() {
         if [ $? -ne 0 -a -f "$datafile" ]; then
             env rm -f "$tempfile"
         else
-            [ "$_Z_OWNER" ] && chown $_Z_OWNER:"$(id -ng $_Z_OWNER)" "$tempfile"
+            [ "${_Z_OWNER:-}" ] && chown $_Z_OWNER:"$(id -ng $_Z_OWNER)" "$tempfile"
             env mv -f "$tempfile" "$datafile" || env rm -f "$tempfile"
         fi
 


### PR DESCRIPTION
Sometimes in an interactive shell I find myself using `set -u` or `set -e` options but `oh-my-zsh`  components are found exiting because of unbound variables (z plugin and oh-my-zsh git prompt):

```
archf@wm:~/d/oh-my-zsh master>
_z:5: _Z_OWNER: parameter not set                                                                                                                      
parse_git_dirty:8: DISABLE_UNTRACKED_FILES_DIRTY: parameter not set
```