### PR TITLE
Requested alias #8216.

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -64,6 +64,7 @@ alias gcam='git commit -a -m'
 alias gcsm='git commit -s -m'
 alias gcb='git checkout -b'
 alias gcf='git config --list'
+function gccd() { git clone $1; cd "$(basename $_ .git)" }
 alias gcl='git clone --recurse-submodules'
 alias gclean='git clean -id'
 alias gpristine='git reset --hard && git clean -dfx'


### PR DESCRIPTION
This function can `cd` after `clone` with and without the `.git` extension at the end
Can't be one with an alias, as it needs to take a parameter for both the `clone`, and then the following `cd`

Sourced from this [StackExchange question/answer](https://unix.stackexchange.com/questions/9123/is-there-a-one-liner-that-allows-me-to-create-a-directory-and-move-into-it-at-th)

Fixes #8216 