### PR TITLE
Fix showing aws prompt out of the box in af-magic

### DIFF
--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -21,9 +21,9 @@ eval my_orange='$FG[214]'
 # right prompt
 if type "virtualenv_prompt_info" > /dev/null
 then
-	RPROMPT='$FG[078]$(virtualenv_prompt_info)%{$reset_color%} $my_gray%n@%m%{$reset_color%}%'
+	RPROMPT="${RPROMPT}"'$FG[078]$(virtualenv_prompt_info)%{$reset_color%} $my_gray%n@%m%{$reset_color%}%'
 else
-	RPROMPT='$my_gray%n@%m%{$reset_color%}%'
+	RPROMPT="${RPROMPT}"'$my_gray%n@%m%{$reset_color%}%'
 fi
 
 # git settings


### PR DESCRIPTION
Fix issue related to #7615, #7747 and #6346
After the update, aws prompt (which should be visible out of the box) disappears when a user uses a theme af-magic, because of fact that plugins are loaded before themes.
This pull request fixes issue with not showing aws prompt in theme af-magic, by appending RPROMPT in theme af-magic instead overwriting.