### PR TITLE
Print Git Remote status when details are not required

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -49,6 +49,8 @@ function git_remote_status() {
 
         if [[ -n $ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED ]]; then
             git_remote_status="$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX$remote$git_remote_status_detailed$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX"
+        else
+            git_remote_status="$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX$remote$git_remote_status$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX"
         fi
 
         echo $git_remote_status


### PR DESCRIPTION
Earlier the git_remote_status function would return nothing if "ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED" was not set to true in theme and other theme properties were not present.
This patch changes that behavious by returning the remote branch if details are not needed.

Signed-off-by: Sahil Soni <SscSPs@gmail.com>