### PR TITLE
Add alias for 'git add --interactive' for git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -34,6 +34,7 @@ alias g='git'
 
 alias ga='git add'
 alias gaa='git add --all'
+alias gai='git add --interactive'
 alias gapa='git add --patch'
 alias gau='git add --update'
 alias gav='git add --verbose'


### PR DESCRIPTION
I sometimes use the big brother of `git add --patch` which is more powerful. Wonder if you are interested in adding this alias. Difference between `--patch` and `--interactive` can be found [here][article].

[article]: https://nuclearsquid.com/writings/git-add/