### PR TITLE
Remove invalid battery

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -116,12 +116,12 @@ elif [[ "$OSTYPE" = freebsd*  ]] ; then
 elif [[ "$OSTYPE" = linux*  ]] ; then
 
   function battery_is_charging() {
-    ! [[ $(acpi 2>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]]
+    ! [[ $(acpi 2>/dev/null | grep -v "rate information unavailable" | grep -c '^Battery.*Discharging') -gt 0 ]]
   }
 
   function battery_pct() {
     if (( $+commands[acpi] )) ; then
-      echo "$(acpi 2>/dev/null | cut -f2 -d ',' | tr -cd '[:digit:]')"
+      echo "$(acpi 2>/dev/null | grep -v "rate information unavailable" | cut -f2 -d ',' | tr -cd '[:digit:]')"
     fi
   }
 
@@ -134,14 +134,14 @@ elif [[ "$OSTYPE" = linux*  ]] ; then
   }
 
   function battery_time_remaining() {
-    if [[ $(acpi 2>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
-      echo $(acpi 2>/dev/null | cut -f3 -d ',')
+    if [[ $(acpi 2>/dev/null | grep -v "rate information unavailable" | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
+      echo $(acpi 2>/dev/null | grep -v "rate information unavailable" | cut -f3 -d ',')
     fi
   }
 
   function battery_pct_prompt() {
     b=$(battery_pct_remaining) 
-    if [[ $(acpi 2>/dev/null | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
+    if [[ $(acpi 2>/dev/null | grep -v "rate information unavailable" | grep -c '^Battery.*Discharging') -gt 0 ]] ; then
       if [ $b -gt 50 ] ; then
         color='green'
       elif [ $b -gt 20 ] ; then


### PR DESCRIPTION
From my reading, ACPI can sometime detect invalid device. in this case, we could end up with the process detecting multiple battery but there is only one:

```
$ acpi
Battery 0: Discharging, 0%, rate information unavailable
Battery 1: Full, 100%
Battery 2: Discharging, 0%, rate information unavailable
```

Here battery 0 and 2 are wrong. 

I add a filter on "rate information unavailable" in the battery plugin to remove those. 

Now I do not know if a valid battery could end up with the "rate information unavailable" I think not ( except defective battery?) so I hope this is ok for everybody.
