### PR TITLE
Update nvm.plugin.zsh

### DIFF
--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -9,7 +9,7 @@ if ! type "nvm" &> /dev/null; then
         # This loads nvm
         [ -s "${nvm_sh_dir}/nvm.sh" ] && . "${nvm_sh_dir}/nvm.sh"
         # This loads nvm bash_completion
-        [ -s "${nvm_sh_dir}/etc/bash_completion" ] && . "${nvm_sh_dir}/etc/bash_completion"
+        [ -s "${nvm_sh_dir}/etc/bash_completion.d/nvm" ] && . "${nvm_sh_dir}/etc/bash_completion.d/nvm"
     else
         # This loads nvm
         [[ -f "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -1,8 +1,17 @@
 # Set NVM_DIR if it isn't already defined
 [[ -z "$NVM_DIR" ]] && export NVM_DIR="$HOME/.nvm"
 
-# Try to load nvm only if command not already available
 if ! type "nvm" &> /dev/null; then
-    # Load nvm if it exists
-    [[ -f "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
+    # Load if it exists
+    if [ ! -f "/usr/local/opt/nvm" ]; then
+        # brew install nvm
+        nvm_sh_dir="/usr/local/opt/nvm"
+        # This loads nvm
+        [ -s "${nvm_sh_dir}/nvm.sh" ] && . "${nvm_sh_dir}/nvm.sh"
+        # This loads nvm bash_completion
+        [ -s "${nvm_sh_dir}/etc/bash_completion" ] && . "${nvm_sh_dir}/etc/bash_completion"
+    else
+        # This loads nvm
+        [[ -f "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
+    fi
 fi


### PR DESCRIPTION
- not load brew install path
- brew install path is `/usr/local/opt/nvm`
-----------
- OS: macOS
- Homebrew: 2.1.15-50-g6014011
- nvm: stable 0.35.0

```bash
$ brew info nvm

## ...

You should create NVM's working directory if it doesn't exist:

  mkdir ~/.nvm

Add the following to ~/.zshrc or your desired shell
configuration file:

  export NVM_DIR="$HOME/.nvm"
  [ -s "/usr/local/opt/nvm/nvm.sh" ] && . "/usr/local/opt/nvm/nvm.sh"  # This loads nvm
  [ -s "/usr/local/opt/nvm/etc/bash_completion" ] && . "/usr/local/opt/nvm/etc/bash_completion"  # This loads nvm bash_completion
```

Fix #8307 