### PR TITLE
feat(helm): cache completion file in the background

### DIFF
--- a/plugins/helm/helm.plugin.zsh
+++ b/plugins/helm/helm.plugin.zsh
@@ -1,7 +1,13 @@
 # Autocompletion for helm.
 #
-# Copy from kubectl : https://github.com/pstadler
+if (( $+commands[helm] )); then
+    __HELM_COMPLETION_FILE="${ZSH_CACHE_DIR}/helm_completion"
 
-if [ $commands[helm] ]; then
-  source <(helm completion zsh)
+    if [[ ! -f $__HELM_COMPLETION_FILE ]]; then
+        helm completion zsh >! $__HELM_COMPLETION_FILE
+    fi
+
+    [[ -f $__HELM_COMPLETION_FILE ]] && source $__HELM_COMPLETION_FILE
+
+    unset __HELM_COMPLETION_FILE
 fi

--- a/plugins/helm/helm.plugin.zsh
+++ b/plugins/helm/helm.plugin.zsh
@@ -1,13 +1,22 @@
-# Autocompletion for helm.
-#
-if (( $+commands[helm] )); then
-    __HELM_COMPLETION_FILE="${ZSH_CACHE_DIR}/helm_completion"
-
-    if [[ ! -f $__HELM_COMPLETION_FILE ]]; then
-        helm completion zsh >! $__HELM_COMPLETION_FILE
-    fi
-
-    [[ -f $__HELM_COMPLETION_FILE ]] && source $__HELM_COMPLETION_FILE
-
-    unset __HELM_COMPLETION_FILE
+if (( ! $+commands[helm] )); then
+  return
 fi
+
+# TODO: 2021-12-28: delete this block
+# Remove old generated file
+command rm -f "${ZSH_CACHE_DIR}/helm_completion"
+
+# TODO: 2021-12-28: remove this bit of code as it exists in oh-my-zsh.sh
+# Add completions folder in $ZSH_CACHE_DIR
+command mkdir -p "$ZSH_CACHE_DIR/completions"
+(( ${fpath[(Ie)"$ZSH_CACHE_DIR/completions"]} )) || fpath=("$ZSH_CACHE_DIR/completions" $fpath)
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `helm`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_helm" ]]; then
+  declare -A _comps
+  autoload -Uz _helm
+  _comps[helm]=_helm
+fi
+
+helm completion zsh >| "$ZSH_CACHE_DIR/completions/_helm" &|


### PR DESCRIPTION
This PR updates the way of using `helm completion  zsh` command by creating a file that will be used as a cache to speed things up.