### PR TITLE
sudo: add support for shell redirection

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -9,19 +9,33 @@
 # -------
 #
 # * Dongweiming <ciici123@gmail.com>
+# * Tim D <tim.deh@pm.me>
 #
 # ------------------------------------------------------------------------------
+setopt extendedglob
+
+sudo-off() {
+    if [[ $BUFFER == sudoedit\ * ]]; then
+        LBUFFER="${LBUFFER#sudoedit }"
+        LBUFFER="${EDITOR:t} $LBUFFER"
+    elif [[  $BUFFER == sudo\ ${SHELL:t}\ -c\ * ]]; then
+        BUFFER="${BUFFER##sudo ${SHELL:t} -c ##[\'\"]#}"
+        BUFFER="${BUFFER%[\"\']}"
+        BUFFER="${BUFFER//\\\"/\"}"
+    else
+        LBUFFER="${LBUFFER#sudo }"
+   fi
+}
 
 sudo-command-line() {
     [[ -z $BUFFER ]] && zle up-history
-    if [[ $BUFFER == sudo\ * ]]; then
-        LBUFFER="${LBUFFER#sudo }"
-    elif [[ $BUFFER == $EDITOR\ * ]]; then
-        LBUFFER="${LBUFFER#$EDITOR }"
+    if [[ $BUFFER == sudo(edit)#\ * ]]; then
+        sudo-off
+    elif [[ $BUFFER == ${EDITOR:t}\ * ]] || [[ $(alias ${BUFFER%% *}) =~ "EDITOR" ]]; then
+        LBUFFER="${LBUFFER#${BUFFER%% *} }"
         LBUFFER="sudoedit $LBUFFER"
-    elif [[ $BUFFER == sudoedit\ * ]]; then
-        LBUFFER="${LBUFFER#sudoedit }"
-        LBUFFER="$EDITOR $LBUFFER"
+    elif [[ ${BUFFER//(\"[^\"]#\"|\'[^\']#\')/} =~ '[<>|]'  ]]; then
+        BUFFER="sudo zsh -c \"${BUFFER//\"/\\\"}\""
     else
         LBUFFER="sudo $LBUFFER"
     fi


### PR DESCRIPTION
The sudo plugin is now much more powerful and can handle situations of
shell redirection. In the past these commands would often fail leaving
the user to wrap the command in `zsh -c "command"` manually. This is now
detected and handled automatically.

* detect shell indirection ie `[<|>]`, and wrap with `$SHELL -c "command"`
* 'off' logic is more complex; refactor into its own function
* 'sudoedit' now also works with shell aliases set to $EDITOR
* ensure quoting is handled properly when toggling on and off