### PR TITLE
chore: caution against `COMPLETION_WAITING_DOTS` in template

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -45,8 +45,8 @@ ZSH_THEME="robbyrussell"
 # ENABLE_CORRECTION="true"
 
 # Uncomment the following line to display red dots whilst waiting for completion.
-# Caution: This setting can cause issues for multiline prompts.
-# See https://github.com/robbyrussell/oh-my-zsh/issues/5765
+# Caution: this setting can cause issues with multiline prompts (zsh 5.7.1 and newer seem to work)
+# See https://github.com/ohmyzsh/ohmyzsh/issues/5765
 # COMPLETION_WAITING_DOTS="true"
 
 # Uncomment the following line if you want to disable marking untracked files

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -45,6 +45,8 @@ ZSH_THEME="robbyrussell"
 # ENABLE_CORRECTION="true"
 
 # Uncomment the following line to display red dots whilst waiting for completion.
+# Caution: This setting can cause issues for multiline prompts.
+# See https://github.com/robbyrussell/oh-my-zsh/issues/5765
 # COMPLETION_WAITING_DOTS="true"
 
 # Uncomment the following line if you want to disable marking untracked files


### PR DESCRIPTION
Enabling this setting causes issues for multiline prompts when tab
completion is triggered. Add a caution in template warning against the
same.
See https://github.com/robbyrussell/oh-my-zsh/issues/5765