### PR TITLE
Add aliases for kubectl top command

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -105,3 +105,7 @@ plugins=(... kubectl)
 | kdelss  | `kubectl delete statefulset`        | Delete the statefulset                                                                           |
 | ksss    | `kubectl scale statefulset`         | Scale a statefulset                                                                              |
 | krsss   | `kubectl rollout status statefulset`| Check the rollout status of a deployment                                                         |
+|         |                                     | **Display Resource (CPU/Memory/Storage) usage**                                                           |
+| ktno    | `kubectl top node`                  | Display Resource (CPU/Memory/Storage) usage of nodes                                             |
+| ktpo    | `kubectl top pod`                   | Display Resource (CPU/Memory/Storage) usage of pods                                              |
+

--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -108,4 +108,6 @@ plugins=(... kubectl)
 |         |                                     | **Display Resource (CPU/Memory/Storage) usage**                                                           |
 | ktno    | `kubectl top node`                  | Display Resource (CPU/Memory/Storage) usage of nodes                                             |
 | ktpo    | `kubectl top pod`                   | Display Resource (CPU/Memory/Storage) usage of pods                                              |
-
+|         |                                     | **Events**                                                                                       |
+| kge     | `kubectl get events`                | Display events                                                                                   |
+| kgew    | `kubectl get events -w`             | Display events, and wait for new ones                                                            |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -136,3 +136,12 @@ alias kdelpvc='kubectl delete pvc'
 # Resource Usage
 alias ktpo='kubectl top pod'
 alias ktno='kubectl top node'
+
+# Events
+_kge_go_template='go-template={{range .items}}{{.involvedObject.name}}{{"\t"}}{{.involvedObject.kind}}{{"\t"}}{{.message}}{{"\t"}}{{.reason}}{{"\t"}}{{.type}}{{"\t"}}{{.firstTimestamp}}{{"\n"}}{{end}}'
+kge() {
+    kubectl get events --sort-by='.metadata.creationTimestamp' -o "${_kge_go_template}" $@
+}
+kgew() {
+    kubectl get events -w -o "${_kge_go_template}" $@
+}

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -133,3 +133,6 @@ alias kepvc='kubectl edit pvc'
 alias kdpvc='kubectl describe pvc'
 alias kdelpvc='kubectl delete pvc'
 
+# Resource Usage
+alias ktpo='kubectl top pod'
+alias ktno='kubectl top node'


### PR DESCRIPTION
I've added some aliases I've been using for quickly monitoring pod / node statistics. Essentially this is an expansion on #6790.

This PR will add the following aliases
```sh
ktno='kubectl top node'
ktpo='kubectl top pod'
```