### PR TITLE
add alias gpot

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -112,6 +112,7 @@ plugins=(... git)
 | gpf                  | git push --force-with-lease                                                                                                   |
 | gpf!                 | git push --force                                                                                                              |
 | gpoat                | git push origin --all && git push origin --tags                                                                               |
+| gpot                 | git push origin && git push origin --tags                                                                                     | 
 | gpu                  | git push upstream                                                                                                             |
 | gpv                  | git push -v                                                                                                                   |
 | gr                   | git remote                                                                                                                    |
@@ -123,7 +124,7 @@ plugins=(... git)
 | grbi                 | git rebase -i                                                                                                                 |
 | grbm                 | git rebase master                                                                                                             |
 | grbs                 | git rebase --skip                                                                                                             |
-| grev                 | git revert                                                                                                                   |
+| grev                 | git revert                                                                                                                    |
 | grh                  | git reset                                                                                                                     |
 | grhh                 | git reset --hard                                                                                                              |
 | groh                 | git reset origin/$(git_current_branch) --hard                                                                                 |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -187,6 +187,7 @@ alias gpd='git push --dry-run'
 alias gpf='git push --force-with-lease'
 alias gpf!='git push --force'
 alias gpoat='git push origin --all && git push origin --tags'
+alias gpot='git push origin && git push origin --tags'
 alias gpu='git push upstream'
 alias gpv='git push -v'
 


### PR DESCRIPTION
Adds the `gpot` alias to *only* push tags to origin.

Other existing `gpoat` alias has the side effect of also pushing *all branches* to remote origin, which is not always desired, for example, when you have many develop branches still being worked on.

Side edit, just aligned the table line of one entry that was misaligned.