### PR TITLE
Remove current directory from sys.path in python invocations

### DIFF
--- a/plugins/django/django.plugin.zsh
+++ b/plugins/django/django.plugin.zsh
@@ -374,7 +374,8 @@ _managepy-commands() {
 _applist() {
   local line
   local -a apps
-  _call_program help-command "python -c \"import os.path as op, re, django.conf, sys;\\
+  _call_program help-command "python -c \"import sys; sys.path.remove("");\\
+                                          import os.path as op, re, django.conf;\\
                                           bn=op.basename(op.abspath(op.curdir));[sys\\
                                           .stdout.write(str(re.sub(r'^%s\.(.*?)$' %
                                           bn, r'\1', i)) + '\n') for i in django.conf.settings.\\

--- a/plugins/django/django.plugin.zsh
+++ b/plugins/django/django.plugin.zsh
@@ -374,7 +374,7 @@ _managepy-commands() {
 _applist() {
   local line
   local -a apps
-  _call_program help-command "python -c \"import sys; sys.path.remove("");\\
+  _call_program help-command "python -c \"import sys; del sys.path[0];\\
                                           import os.path as op, re, django.conf;\\
                                           bn=op.basename(op.abspath(op.curdir));[sys\\
                                           .stdout.write(str(re.sub(r'^%s\.(.*?)$' %

--- a/plugins/jsontools/jsontools.plugin.zsh
+++ b/plugins/jsontools/jsontools.plugin.zsh
@@ -11,9 +11,10 @@ if [[ $(whence node) != "" && ( "x$JSONTOOLS_METHOD" = "x"  || "x$JSONTOOLS_METH
 	alias urlencode_json='xargs -0 node -e "console.log(encodeURIComponent(process.argv[1]))"'
 	alias urldecode_json='xargs -0 node -e "console.log(decodeURIComponent(process.argv[1]))"'
 elif [[ $(whence python) != "" && ( "x$JSONTOOLS_METHOD" = "x" || "x$JSONTOOLS_METHOD" = "xpython" ) ]]; then
-	alias pp_json='python -mjson.tool'
+	alias pp_json='python3 -Im json.tool'
 	alias is_json='python -c "
-import json, sys;
+import sys; sys.path.remove("");
+import json;
 try: 
 	json.loads(sys.stdin.read())
 except ValueError, e: 
@@ -22,11 +23,13 @@ else:
 	print True
 sys.exit(0)"'
 	alias urlencode_json='python -c "
-import urllib, json, sys;
+import sys; sys.path.remove("");
+import urllib, json;
 print urllib.quote_plus(sys.stdin.read())
 sys.exit(0)"'
 	alias urldecode_json='python -c "
-import urllib, json, sys;
+import sys; sys.path.remove("");
+import urllib, json;
 print urllib.unquote_plus(sys.stdin.read())
 sys.exit(0)"'
 elif [[ $(whence ruby) != "" && ( "x$JSONTOOLS_METHOD" = "x" || "x$JSONTOOLS_METHOD" = "xruby" ) ]]; then

--- a/plugins/jsontools/jsontools.plugin.zsh
+++ b/plugins/jsontools/jsontools.plugin.zsh
@@ -11,9 +11,9 @@ if [[ $(whence node) != "" && ( "x$JSONTOOLS_METHOD" = "x"  || "x$JSONTOOLS_METH
 	alias urlencode_json='xargs -0 node -e "console.log(encodeURIComponent(process.argv[1]))"'
 	alias urldecode_json='xargs -0 node -e "console.log(decodeURIComponent(process.argv[1]))"'
 elif [[ $(whence python) != "" && ( "x$JSONTOOLS_METHOD" = "x" || "x$JSONTOOLS_METHOD" = "xpython" ) ]]; then
-	alias pp_json='python3 -Im json.tool'
+	alias pp_json='python -c "import sys; del sys.path[0]; import runpy; runpy._run_module_as_main(\"json.tool\")"'
 	alias is_json='python -c "
-import sys; sys.path.remove("");
+import sys; del sys.path[0];
 import json;
 try: 
 	json.loads(sys.stdin.read())
@@ -23,12 +23,12 @@ else:
 	print True
 sys.exit(0)"'
 	alias urlencode_json='python -c "
-import sys; sys.path.remove("");
+import sys; del sys.path[0];
 import urllib, json;
 print urllib.quote_plus(sys.stdin.read())
 sys.exit(0)"'
 	alias urldecode_json='python -c "
-import sys; sys.path.remove("");
+import sys; del sys.path[0];
 import urllib, json;
 print urllib.unquote_plus(sys.stdin.read())
 sys.exit(0)"'

--- a/plugins/salt/_salt
+++ b/plugins/salt/_salt
@@ -271,7 +271,7 @@ _salt_comp(){
     fi
 
     if _cache_invalid salt/salt_dir || ! _retrieve_cache salt/salt_dir; then
-        salt_dir="${$(python2 -c 'import salt; print(salt.__file__);')%__init__*}"
+        salt_dir="${$(python2 -c 'import sys; sys.path.remove(""); import salt; print(salt.__file__);')%__init__*}"
         _store_cache salt/salt_dir salt_dir
     fi
 }

--- a/plugins/salt/_salt
+++ b/plugins/salt/_salt
@@ -271,7 +271,7 @@ _salt_comp(){
     fi
 
     if _cache_invalid salt/salt_dir || ! _retrieve_cache salt/salt_dir; then
-        salt_dir="${$(python2 -c 'import sys; sys.path.remove(""); import salt; print(salt.__file__);')%__init__*}"
+        salt_dir="${$(python2 -c 'import sys; del sys.path[0]; import salt; print(salt.__file__);')%__init__*}"
         _store_cache salt/salt_dir salt_dir
     fi
 }

--- a/plugins/urltools/urltools.plugin.zsh
+++ b/plugins/urltools/urltools.plugin.zsh
@@ -12,11 +12,11 @@ if [[ $(whence node) != "" && ( "x$URLTOOLS_METHOD" = "x"  || "x$URLTOOLS_METHOD
     alias urlencode='node -e "console.log(encodeURIComponent(process.argv[1]))"'
     alias urldecode='node -e "console.log(decodeURIComponent(process.argv[1]))"'
 elif [[ $(whence python3) != "" && ( "x$URLTOOLS_METHOD" = "x" || "x$URLTOOLS_METHOD" = "xpython" ) ]]; then
-    alias urlencode='python3 -c "import sys; sys.path.remove(""); import urllib.parse as up; print(up.quote_plus(sys.argv[1]))"'
-    alias urldecode='python3 -c "import sys; sys.path.remove(""); import urllib.parse as up; print(up.unquote_plus(sys.argv[1]))"'
+    alias urlencode='python3 -c "import sys; del sys.path[0]; import urllib.parse as up; print(up.quote_plus(sys.argv[1]))"'
+    alias urldecode='python3 -c "import sys; del sys.path[0]; import urllib.parse as up; print(up.unquote_plus(sys.argv[1]))"'
 elif [[ $(whence python2) != "" && ( "x$URLTOOLS_METHOD" = "x" || "x$URLTOOLS_METHOD" = "xpython" ) ]]; then
-    alias urlencode='python2 -c "import sys; sys.path.remove(""); import urllib as ul; print ul.quote_plus(sys.argv[1])"'
-    alias urldecode='python2 -c "import sys; sys.path.remove(""); import urllib as ul; print ul.unquote_plus(sys.argv[1])"'
+    alias urlencode='python2 -c "import sys; del sys.path[0]; import urllib as ul; print ul.quote_plus(sys.argv[1])"'
+    alias urldecode='python2 -c "import sys; del sys.path[0]; import urllib as ul; print ul.unquote_plus(sys.argv[1])"'
 elif [[ $(whence xxd) != "" && ( "x$URLTOOLS_METHOD" = "x" || "x$URLTOOLS_METHOD" = "xshell" ) ]]; then
     function urlencode() {echo $@ | tr -d "\n" | xxd -plain | sed "s/\(..\)/%\1/g"}
     function urldecode() {printf $(echo -n $@ | sed 's/\\/\\\\/g;s/\(%\)\([0-9a-fA-F][0-9a-fA-F]\)/\\x\2/g')"\n"}

--- a/plugins/urltools/urltools.plugin.zsh
+++ b/plugins/urltools/urltools.plugin.zsh
@@ -12,11 +12,11 @@ if [[ $(whence node) != "" && ( "x$URLTOOLS_METHOD" = "x"  || "x$URLTOOLS_METHOD
     alias urlencode='node -e "console.log(encodeURIComponent(process.argv[1]))"'
     alias urldecode='node -e "console.log(decodeURIComponent(process.argv[1]))"'
 elif [[ $(whence python3) != "" && ( "x$URLTOOLS_METHOD" = "x" || "x$URLTOOLS_METHOD" = "xpython" ) ]]; then
-    alias urlencode='python3 -c "import sys, urllib.parse as up; print(up.quote_plus(sys.argv[1]))"'
-    alias urldecode='python3 -c "import sys, urllib.parse as up; print(up.unquote_plus(sys.argv[1]))"'
+    alias urlencode='python3 -c "import sys; sys.path.remove(""); import urllib.parse as up; print(up.quote_plus(sys.argv[1]))"'
+    alias urldecode='python3 -c "import sys; sys.path.remove(""); import urllib.parse as up; print(up.unquote_plus(sys.argv[1]))"'
 elif [[ $(whence python2) != "" && ( "x$URLTOOLS_METHOD" = "x" || "x$URLTOOLS_METHOD" = "xpython" ) ]]; then
-    alias urlencode='python2 -c "import sys, urllib as ul; print ul.quote_plus(sys.argv[1])"'
-    alias urldecode='python2 -c "import sys, urllib as ul; print ul.unquote_plus(sys.argv[1])"'
+    alias urlencode='python2 -c "import sys; sys.path.remove(""); import urllib as ul; print ul.quote_plus(sys.argv[1])"'
+    alias urldecode='python2 -c "import sys; sys.path.remove(""); import urllib as ul; print ul.unquote_plus(sys.argv[1])"'
 elif [[ $(whence xxd) != "" && ( "x$URLTOOLS_METHOD" = "x" || "x$URLTOOLS_METHOD" = "xshell" ) ]]; then
     function urlencode() {echo $@ | tr -d "\n" | xxd -plain | sed "s/\(..\)/%\1/g"}
     function urldecode() {printf $(echo -n $@ | sed 's/\\/\\\\/g;s/\(%\)\([0-9a-fA-F][0-9a-fA-F]\)/\\x\2/g')"\n"}


### PR DESCRIPTION
Fixes #8400.

Uses [this solution](https://bugs.python.org/issue33053#msg313966) for `python -c` invocations, and [the `-I` option](https://docs.python.org/3/using/cmdline.html#id2) (added in Python 3.4) for module loading.