### PR TITLE
feat(ys): add setting to hide dirty info in hg repositories

### DIFF
--- a/themes/ys.zsh-theme
+++ b/themes/ys.zsh-theme
@@ -26,10 +26,12 @@ ys_hg_prompt_info() {
 	if [ -d '.hg' ]; then
 		echo -n "${YS_VCS_PROMPT_PREFIX1}hg${YS_VCS_PROMPT_PREFIX2}"
 		echo -n $(hg branch 2>/dev/null)
-		if [ -n "$(hg status 2>/dev/null)" ]; then
-			echo -n "$YS_VCS_PROMPT_DIRTY"
-		else
-			echo -n "$YS_VCS_PROMPT_CLEAN"
+		if [[ "$(hg config oh-my-zsh.hide-dirty 2>/dev/null)" != "1" ]]; then
+			if [ -n "$(hg status 2>/dev/null)" ]; then
+				echo -n "$YS_VCS_PROMPT_DIRTY"
+			else
+				echo -n "$YS_VCS_PROMPT_CLEAN"
+			fi
 		fi
 		echo -n "$YS_VCS_PROMPT_SUFFIX"
 	fi


### PR DESCRIPTION
On large mercurial projects, using `hg status` to show dirty prompt causes significant delay.

This commit checks a local hg config value of `oh-my-zsh.hide-dirty` to skip dirty check.

Users who wish to skip dirty check can add this to their `.hg/hgrc` file.

```
[oh-my-zsh]
hide-dirty = 1
```

This config value uses the same naming as ones found for git, in file [lib/git.zsh](https://github.com/robbyrussell/oh-my-zsh/blob/1546e12/lib/git.zsh).

@ysmood 