### PR TITLE
Add kubectl all-namespaces aliases for k8s objects

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -37,6 +37,7 @@ alias kdelf='kubectl delete -f'
 
 # Pod management.
 alias kgp='kubectl get pods'
+alias kgpa='kubectl get pods --all-namespaces'
 alias kgpw='kgp --watch'
 alias kgpwide='kgp -o wide'
 alias kep='kubectl edit pods'
@@ -48,6 +49,7 @@ alias kgpl='kgp -l'
 
 # Service management.
 alias kgs='kubectl get svc'
+alias kgsa='kubectl get svc --all-namespaces'
 alias kgsw='kgs --watch'
 alias kgswide='kgs -o wide'
 alias kes='kubectl edit svc'
@@ -56,6 +58,7 @@ alias kdels='kubectl delete svc'
 
 # Ingress management
 alias kgi='kubectl get ingress'
+alias kgia='kubectl get ingress --all-namespaces'
 alias kei='kubectl edit ingress'
 alias kdi='kubectl describe ingress'
 alias kdeli='kubectl delete ingress'
@@ -69,17 +72,20 @@ alias kcn='kubectl config set-context $(kubectl config current-context) --namesp
 
 # ConfigMap management
 alias kgcm='kubectl get configmaps'
+alias kgcma='kubectl get configmaps --all-namespaces'
 alias kecm='kubectl edit configmap'
 alias kdcm='kubectl describe configmap'
 alias kdelcm='kubectl delete configmap'
 
 # Secret management
 alias kgsec='kubectl get secret'
+alias kgseca='kubectl get secret --all-namespaces'
 alias kdsec='kubectl describe secret'
 alias kdelsec='kubectl delete secret'
 
 # Deployment management.
 alias kgd='kubectl get deployment'
+alias kgda='kubectl get deployment --all-namespaces'
 alias kgdw='kgd --watch'
 alias kgdwide='kgd -o wide'
 alias ked='kubectl edit deployment'
@@ -98,6 +104,7 @@ alias kru='kubectl rollout undo'
 
 # Statefulset management.
 alias kgss='kubectl get statefulset'
+alias kgssa='kubectl get statefulset --all-namespaces'
 alias kgssw='kgss --watch'
 alias kgsswide='kgss -o wide'
 alias kess='kubectl edit statefulset'
@@ -128,6 +135,7 @@ alias kdelno='kubectl delete node'
 
 # PVC management.
 alias kgpvc='kubectl get pvc'
+alias kgpvca='kubectl get pvc --all-namespaces'
 alias kgpvcw='kgpvc --watch'
 alias kepvc='kubectl edit pvc'
 alias kdpvc='kubectl describe pvc'


### PR DESCRIPTION
Add more get resources aliases with `--all-namespaces` option to kubectl. 