### PR TITLE
Added hostopt to keychain execution.

### DIFF
--- a/plugins/keychain/keychain.plugin.zsh
+++ b/plugins/keychain/keychain.plugin.zsh
@@ -15,7 +15,7 @@ function _start_agent() {
 	zstyle -a :omz:plugins:keychain options options
 
 	# start keychain...
-	keychain ${^options:-} --agents ${agents:-gpg} ${^identities}
+	keychain ${^options:-} --agents ${agents:-gpg} ${^identities} --host $SHORT_HOST
 
 	# Get the filenames to store/lookup the environment from
 	_keychain_env_sh="$HOME/.keychain/$SHORT_HOST-sh"


### PR DESCRIPTION
Fixes issue #8380 .

What ```keychain``` creates will now match up with what the plugin sources. 