### PR TITLE
feat(npm): add alias for `npm i -f`

### DIFF
--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -14,6 +14,7 @@ plugins=(... npm)
 | `npmg`  | `npm i -g`                   | Install dependencies globally                                   |
 | `npmS`  | `npm i -S`                   | Install and save to dependencies in your package.json           |
 | `npmD`  | `npm i -D`                   | Install and save to dev-dependencies in your package.json       |
+| `npmF`  | `npm i -f`                   | Force install from remote registries ignoring local cache       |
 | `npmE`  | `PATH="$(npm bin)":"$PATH"`  | Run command from node_modules folder based on current directory |
 | `npmO`  | `npm outdated`               | Check which npm modules are outdated                            |
 | `npmV`  | `npm -v`                     | Check package versions                                          |

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -25,12 +25,12 @@ alias npmS="npm i -S "
 # npmd is used by https://github.com/dominictarr/npmd
 alias npmD="npm i -D "
 
+# Force npm to fetch remote resources even if a local copy exists on disk.
+alias npmF='npm i -f'
+
 # Execute command from node_modules folder based on current directory
 # i.e npmE gulp
 alias npmE='PATH="$(npm bin)":"$PATH"'
-
-# Force npm to fetch remote resources even if a local copy exists on disk.
-alias npmF='npm i -f'
 
 # Check which npm modules are outdated
 alias npmO="npm outdated"

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -29,6 +29,9 @@ alias npmD="npm i -D "
 # i.e npmE gulp
 alias npmE='PATH="$(npm bin)":"$PATH"'
 
+# Force npm to fetch remote resources even if a local copy exists on disk.
+alias npmF='npm i -f'
+
 # Check which npm modules are outdated
 alias npmO="npm outdated"
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add alias for `npm i -f`

## Other comments:

It's an useful alias that forces npm to fetch remote resources even if a local copy exists on disk.
