### PR TITLE
Run pyenv plugin only when necessary

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -1,41 +1,46 @@
 # This plugin loads pyenv into the current shell and provides prompt info via
 # the 'pyenv_prompt_info' function. Also loads pyenv-virtualenv if available.
 
-FOUND_PYENV=$+commands[pyenv]
+# Try to load pyenv only if command not already available
+if ! type "pyenv" &> /dev/null; then
 
-if [[ $FOUND_PYENV -ne 1 ]]; then
-    pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv" "/usr/local/opt/pyenv")
-    for dir in $pyenvdirs; do
-        if [[ -d $dir/bin ]]; then
-            export PATH="$PATH:$dir/bin"
-            FOUND_PYENV=1
-            break
-        fi
-    done
-fi
+    FOUND_PYENV=$+commands[pyenv]
 
-if [[ $FOUND_PYENV -ne 1 ]]; then
-    if (( $+commands[brew] )) && dir=$(brew --prefix pyenv 2>/dev/null); then
-        if [[ -d $dir/bin ]]; then
-            export PATH="$PATH:$dir/bin"
-            FOUND_PYENV=1
+    if [[ $FOUND_PYENV -ne 1 ]]; then
+        pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv" "/usr/local/opt/pyenv")
+        for dir in $pyenvdirs; do
+            if [[ -d $dir/bin ]]; then
+                export PATH="$PATH:$dir/bin"
+                FOUND_PYENV=1
+                break
+            fi
+        done
+    fi
+
+    if [[ $FOUND_PYENV -ne 1 ]]; then
+        if (( $+commands[brew] )) && dir=$(brew --prefix pyenv 2>/dev/null); then
+            if [[ -d $dir/bin ]]; then
+                export PATH="$PATH:$dir/bin"
+                FOUND_PYENV=1
+            fi
         fi
     fi
-fi
 
-if [[ $FOUND_PYENV -eq 1 ]]; then
-    eval "$(pyenv init - zsh)"
-    if (( $+commands[pyenv-virtualenv-init] )); then
-        eval "$(pyenv virtualenv-init - zsh)"
+    if [[ $FOUND_PYENV -eq 1 ]]; then
+        eval "$(pyenv init - zsh)"
+        if (( $+commands[pyenv-virtualenv-init] )); then
+            eval "$(pyenv virtualenv-init - zsh)"
+        fi
+        function pyenv_prompt_info() {
+            echo "$(pyenv version-name)"
+        }
+    else
+        # fallback to system python
+        function pyenv_prompt_info() {
+            echo "system: $(python -V 2>&1 | cut -f 2 -d ' ')"
+        }
     fi
-    function pyenv_prompt_info() {
-        echo "$(pyenv version-name)"
-    }
-else
-    # fallback to system python
-    function pyenv_prompt_info() {
-        echo "system: $(python -V 2>&1 | cut -f 2 -d ' ')"
-    }
-fi
 
-unset FOUND_PYENV pyenvdirs dir
+    unset FOUND_PYENV pyenvdirs dir
+
+fi

--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -1,46 +1,42 @@
 # This plugin loads pyenv into the current shell and provides prompt info via
 # the 'pyenv_prompt_info' function. Also loads pyenv-virtualenv if available.
 
-# Try to load pyenv only if command not already available
-if ! type "pyenv" &> /dev/null; then
+# Load pyenv only if command not already available
+command -v pyenv &> /dev/null && FOUND_PYENV=1 || FOUND_PYENV=0
 
-    FOUND_PYENV=$+commands[pyenv]
-
-    if [[ $FOUND_PYENV -ne 1 ]]; then
-        pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv" "/usr/local/opt/pyenv")
-        for dir in $pyenvdirs; do
-            if [[ -d $dir/bin ]]; then
-                export PATH="$PATH:$dir/bin"
-                FOUND_PYENV=1
-                break
-            fi
-        done
-    fi
-
-    if [[ $FOUND_PYENV -ne 1 ]]; then
-        if (( $+commands[brew] )) && dir=$(brew --prefix pyenv 2>/dev/null); then
-            if [[ -d $dir/bin ]]; then
-                export PATH="$PATH:$dir/bin"
-                FOUND_PYENV=1
-            fi
+if [[ $FOUND_PYENV -ne 1 ]]; then
+    pyenvdirs=("$HOME/.pyenv" "/usr/local/pyenv" "/opt/pyenv" "/usr/local/opt/pyenv")
+    for dir in $pyenvdirs; do
+        if [[ -d $dir/bin ]]; then
+            export PATH="$PATH:$dir/bin"
+            FOUND_PYENV=1
+            break
         fi
-    fi
-
-    if [[ $FOUND_PYENV -eq 1 ]]; then
-        eval "$(pyenv init - zsh)"
-        if (( $+commands[pyenv-virtualenv-init] )); then
-            eval "$(pyenv virtualenv-init - zsh)"
-        fi
-        function pyenv_prompt_info() {
-            echo "$(pyenv version-name)"
-        }
-    else
-        # fallback to system python
-        function pyenv_prompt_info() {
-            echo "system: $(python -V 2>&1 | cut -f 2 -d ' ')"
-        }
-    fi
-
-    unset FOUND_PYENV pyenvdirs dir
-
+    done
 fi
+
+if [[ $FOUND_PYENV -ne 1 ]]; then
+    if (( $+commands[brew] )) && dir=$(brew --prefix pyenv 2>/dev/null); then
+        if [[ -d $dir/bin ]]; then
+            export PATH="$PATH:$dir/bin"
+            FOUND_PYENV=1
+        fi
+    fi
+fi
+
+if [[ $FOUND_PYENV -eq 1 ]]; then
+    eval "$(pyenv init - zsh)"
+    if (( $+commands[pyenv-virtualenv-init] )); then
+        eval "$(pyenv virtualenv-init - zsh)"
+    fi
+    function pyenv_prompt_info() {
+        echo "$(pyenv version-name)"
+    }
+else
+    # fallback to system python
+    function pyenv_prompt_info() {
+        echo "system: $(python -V 2>&1 | cut -f 2 -d ' ')"
+    }
+fi
+
+unset FOUND_PYENV pyenvdirs dir


### PR DESCRIPTION
Wrapped pyenv plugin in condition, so it will only run if `pyenv` command is not already loaded.
Some software (Poetry for example), may spawn shell multiple times.
In this scenario `.zshrc` will be read again, running all plugins and changing $PATH again.
Seems like other plugins are aware of that, nvm for example.
May be it's not the best solution and plugin should create some environment variable that it has been already used.