### PR TITLE
Added FZF base path for freebsd

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -12,6 +12,7 @@ function setup_using_base_dir() {
           "${HOME}/.fzf"
           "/usr/local/opt/fzf"
           "/usr/share/fzf"
+          "/usr/local/share/examples/fzf"
         )
         for dir in ${fzfdirs}; do
             if [[ -d "${dir}" ]]; then


### PR DESCRIPTION
Added the fzf base path for freebsd to fzf.plugin.zsh.

@maxbrunet 
@mcornella