### PR TITLE
Adding in support for kubernetes context prompt

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -9,6 +9,20 @@ To use it, add `kubectl` to the plugins array in your zshrc file:
 plugins=(... kubectl)
 ```
 
+## Theme
+
+The plugin creates an `kctx_prompt_info` function that you can use in your theme which displays your current kubernetes context using `kccc` alias.. It uses two variables to
+control how that is shown:
+
+- ZSH_THEME_KCTX_PREFIX: sets the prefix of your current context. Defaults to `<kctx:`.
+
+- ZSH_THEME_KCTX_SUFFIX: sets the suffix of your current context. Defaults to `>`.
+
+## Plugin options
+
+* Set `HIDE_KTCX_PROMPT=true` in your zshrc file if you want to prevent the plugin from modifying your RPROMPT. Some themes might overwrite the value of RPROMPT instead of
+  appending to it, so they'll need to be fixed to see the Kubernetes context prompt.
+
 ## Aliases
 
 | Alias   | Command                             | Description                                                                                      |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -10,6 +10,16 @@ if (( $+commands[kubectl] )); then
     unset __KUBECTL_COMPLETION_FILE
 fi
 
+# Kube Context prompt
+function kctx_prompt_info() {
+  [[ -z $(kccc) ]] && return
+  echo "${ZSH_THEME_KCTX_PREFIX:=<kctx:}$(kccc)${ZSH_THEME_KCTX_SUFFIX:=>}"
+}
+
+if [[ ! -v HIDE_KTCX_PROMPT ]]; then
+  RPROMPT='$(kctx_prompt_info)'"$RPROMPT"
+fi
+
 # This command is used a LOT both below and in daily life
 alias k=kubectl
 


### PR DESCRIPTION
Following in the stype of AWS, adding in a cli prompt for current kubernetes context, using `kccc` alias.