### PR TITLE
git: add `gla` alias for top git graph recipe on StackOverflow

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -89,6 +89,7 @@ plugins=(... git)
 | gk                   | gitk --all --branches                                                                                                            |
 | gke                  | gitk --all $(git log -g --pretty=%h)                                                                                             |
 | gl                   | git pull                                                                                                                         |
+| gla                  | git log --graph --abbrev-commit --decorate --format=format:'%C(bold blue)%h%C(reset) - %C(bold green)(%ar)%C(reset) %C(white)%s%C(reset) %C(dim white)- %an%C(reset)%C(bold yellow)%d%C(reset)' --all |
 | glg                  | git log --stat                                                                                                                   |
 | glgp                 | git log --stat -p                                                                                                                |
 | glgg                 | git log --graph                                                                                                                  |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -186,6 +186,7 @@ alias gk='\gitk --all --branches'
 alias gke='\gitk --all $(git log -g --pretty=%h)'
 
 alias gl='git pull'
+alias gla="git log --graph --abbrev-commit --decorate --format=format:'%C(bold blue)%h%C(reset) - %C(bold green)(%ar)%C(reset) %C(white)%s%C(reset) %C(dim white)- %an%C(reset)%C(bold yellow)%d%C(reset)' --all"
 alias glg='git log --stat'
 alias glgp='git log --stat -p'
 alias glgg='git log --graph'


### PR DESCRIPTION
https://stackoverflow.com/questions/1057564/pretty-git-branch-graphs

Compared to current `git log --graph` aliases (`glola` is the closest)
this one easy to remember - `gla`(nce) or `git log --all`, more
readable - puts dates first and moves ref names to the end of the line
making comments aligned.

![image](https://user-images.githubusercontent.com/8781107/103169439-a5203d80-484c-11eb-96b9-0f6e9046d80d.png)
