### PR TITLE
xdg_config_home and --no-use

### DIFF
--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -1,8 +1,14 @@
 # Set NVM_DIR if it isn't already defined
-[[ -z "$NVM_DIR" ]] && export NVM_DIR="$HOME/.nvm"
+if [[ -z "$NVM_DIR" ]]; then
+	if [[ -z "$XDG_CONFIG_HOME" ]]; then
+		export NVM_DIR="$HOME/.nvm"
+	else
+		export NVM_DIR="$XDG_CONFIG_HOME/nvm"
+	fi
+fi
 
 # Try to load nvm only if command not already available
 if ! type "nvm" &> /dev/null; then
     # Load nvm if it exists
-    [[ -f "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
+    [[ -f "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh" --no-use
 fi


### PR DESCRIPTION
honor xdg_config_home if present and make use of the `--no-use` flag to lazy load it for nvm versions that support it