### PR TITLE
Created new theme with streamlined variant of xiong-chiamiov-plus.

### DIFF
--- a/themes/xiong-chiamiov-plus-streamlined.zsh-theme
+++ b/themes/xiong-chiamiov-plus-streamlined.zsh-theme
@@ -1,0 +1,6 @@
+# user, host, full path, and time/date
+# on two lines for easier vgrepping
+# entry in a nice long thread on the Arch Linux forums: https://bbs.archlinux.org/viewtopic.php?pid=521888#p521888
+PROMPT=$'%{\e[0;34m%}%B┌─[%b%{\e[0m%}%{\e[1;32m%}%n%{\e[1;30m%}@%{\e[0m%}%{\e[0;36m%}%m%{\e[0;34m%}%B]%b%{\e[0m%} - %b%{\e[0;34m%}%B[%b%{\e[1;37m%}%1d%{\e[0;34m%}%B]%b%{\e[0m%} - %{\e[0;34m%}%B[%b%{\e[0;33m%}'%D{"%a %b %d, %H:%M"}%b$'%{\e[0;34m%}%B]%b%{\e[0m%}
+%{\e[0;34m%}%B└─%B[%{\e[1;35m%}$%{\e[0;34m%}%B] <$(git_prompt_info)>%{\e[0m%}%b '
+PS2=$' \e[0;34m%}%B>%{\e[0m%}%b '


### PR DESCRIPTION
Created new theme with streamlined variant of xiong-chiamiov-plus where the directory 
displayed is only the current working directory rather than the full path relative to the user home directory. This reduces the footprint of the first line in the prompt, accommodating smaller view-port sizes for terminals without having that top line break, which normally results in increasing bulkiness and reducing readability.  