### PR TITLE
feat(dirhistory): add ALT+UP/DOWN key bindings for iTerm2

### DIFF
--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -2,7 +2,7 @@
 #   Navigate directory history using ALT-LEFT and ALT-RIGHT. ALT-LEFT moves back to directories 
 #   that the user has changed to in the past, and ALT-RIGHT undoes ALT-LEFT.
 # 
-#   Navigate directory hierarchy using ALT-UP and ALT-DOWN. (mac keybindings not yet implemented)
+#   Navigate directory hierarchy using ALT-UP and ALT-DOWN.
 #   ALT-UP moves to higher hierarchy (cd ..)
 #   ALT-DOWN moves into the first directory found in alphabetical order
 #
@@ -125,7 +125,7 @@ zle -N dirhistory_zle_dirhistory_back
 bindkey "\e[3D" dirhistory_zle_dirhistory_back
 bindkey "\e[1;3D" dirhistory_zle_dirhistory_back
 # Mac teminal (alt+left/right)
-if [[ "$TERM_PROGRAM" == "Apple_Terminal" ]]; then
+if [[ "$TERM_PROGRAM" == "Apple_Terminal" || "$TERM_PROGRAM" == "iTerm.app" ]]; then
   bindkey "^[b" dirhistory_zle_dirhistory_back
 fi
 # Putty:
@@ -136,7 +136,7 @@ bindkey "\eO3D" dirhistory_zle_dirhistory_back
 zle -N dirhistory_zle_dirhistory_future
 bindkey "\e[3C" dirhistory_zle_dirhistory_future
 bindkey "\e[1;3C" dirhistory_zle_dirhistory_future
-if [[ "$TERM_PROGRAM" == "Apple_Terminal" ]]; then
+if [[ "$TERM_PROGRAM" == "Apple_Terminal" || "$TERM_PROGRAM" == "iTerm.app" ]]; then
   bindkey "^[f" dirhistory_zle_dirhistory_future
 fi
 bindkey "\e\e[C" dirhistory_zle_dirhistory_future
@@ -175,8 +175,9 @@ zle -N dirhistory_zle_dirhistory_up
 # xterm in normal mode
 bindkey "\e[3A" dirhistory_zle_dirhistory_up
 bindkey "\e[1;3A" dirhistory_zle_dirhistory_up
-# Mac teminal (alt+up)
-    #bindkey "^[?" dirhistory_zle_dirhistory_up #dont know it
+if [[ "$TERM_PROGRAM" == "Apple_Terminal" || "$TERM_PROGRAM" == "iTerm.app" ]]; then
+  bindkey "^[[A" dirhistory_zle_dirhistory_up
+fi
 # Putty:
 bindkey "\e\e[A" dirhistory_zle_dirhistory_up
 # GNU screen:
@@ -185,7 +186,8 @@ bindkey "\eO3A" dirhistory_zle_dirhistory_up
 zle -N dirhistory_zle_dirhistory_down
 bindkey "\e[3B" dirhistory_zle_dirhistory_down
 bindkey "\e[1;3B" dirhistory_zle_dirhistory_down
-# Mac teminal (alt+down)
-    #bindkey "^[?" dirhistory_zle_dirhistory_down #dont know it
+if [[ "$TERM_PROGRAM" == "Apple_Terminal" || "$TERM_PROGRAM" == "iTerm.app" ]]; then
+  bindkey "^[[B" dirhistory_zle_dirhistory_down
+fi
 bindkey "\e\e[B" dirhistory_zle_dirhistory_down
 bindkey "\eO3B" dirhistory_zle_dirhistory_down


### PR DESCRIPTION
* Add the missing key bindings for ALT+UP and ALT+DOWN (note: they work in iTerm2 but not in Terminal.app)
* Add support for iTerm2