### PR TITLE
osx: fix exit on quit command in spotify function

### DIFF
--- a/plugins/osx/spotify
+++ b/plugins/osx/spotify
@@ -307,7 +307,7 @@ while [ $# -gt 0 ]; do
 
         "quit"    ) cecho "Quitting Spotify.";
             osascript -e 'tell application "Spotify" to quit';
-            exit 0 ;;
+            break ;;
 
         "next"    ) cecho "Going to next track." ;
             osascript -e 'tell application "Spotify" to next track';


### PR DESCRIPTION
Running `spotify quit` will quit Spotify then exit the current session with `exit 0`. To fix this replace `exit 0` with `break`.