### PR TITLE
archlinux: Fix pacfiles nolonger works for pacman

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -119,7 +119,7 @@
 | pacupg       | sudo pacman -Syu                        | Sync with repositories before upgrading packages             |
 | upgrade      | sudo pacman -Syu                        | Sync with repositories before upgrading packages             |
 | pacfileupg   | sudo pacman -Fy                         | Download fresh package databases from the server             |
-| pacfiles     | pacman -Fs                              | Search package file names for matching strings               |
+| pacfiles     | pacman -F                               | Search package file names for matching strings               |
 | pacls        | pacman -Ql                              | List files in a package                                      |
 | pacown       | pacman -Qo                              | Show which package owns a file                               |
 

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -149,7 +149,7 @@ alias pacmir='sudo pacman -Syy'
 alias paclsorphans='sudo pacman -Qdt'
 alias pacrmorphans='sudo pacman -Rs $(pacman -Qtdq)'
 alias pacfileupg='sudo pacman -Fy'
-alias pacfiles='pacman -Fs'
+alias pacfiles='pacman -F'
 alias pacls='pacman -Ql'
 alias pacown='pacman -Qo'
 


### PR DESCRIPTION
Since `pacman -F` nolonger accepts & requires `-s` flag to search in pacman 5.2.0 
This commit remove the `-s` flag in `pacfiles` alias.