### PR TITLE
extract: add lz4 support

### DIFF
--- a/plugins/extract/README.md
+++ b/plugins/extract/README.md
@@ -26,6 +26,7 @@ plugins=(... extract)
 | `ipsw`            | iOS firmware file                    |
 | `jar`             | Java Archive                         |
 | `lrz`             | LRZ archive                          |
+| `lz4`             | LZ4 archive                          |
 | `lzma`            | LZMA archive                         |
 | `rar`             | WinRAR archive                       |
 | `rpm`             | RPM package                          |
@@ -35,6 +36,7 @@ plugins=(... extract)
 | `tar.gz`          | Tarball with gzip compression        |
 | `tar.lrz`         | Tarball with lrzip compression       |
 | `tar.lz`          | Tarball with lzip compression        |
+| `tar.lz4`         | Tarball with lz4 compression         |
 | `tar.xz`          | Tarball with lzma2 compression       |
 | `tar.zma`         | Tarball with lzma compression        |
 | `tar.zst`         | Tarball with zstd compression        |

--- a/plugins/extract/_extract
+++ b/plugins/extract/_extract
@@ -3,5 +3,5 @@
 
 _arguments \
   '(-r --remove)'{-r,--remove}'[Remove archive.]' \
-  "*::archive file:_files -g '(#i)*.(7z|Z|apk|aar|bz2|deb|gz|ipsw|jar|lrz|lzma|rar|rpm|sublime-package|tar|tar.bz2|tar.gz|tar.lrz|tar.lz|tar.xz|tar.zma|tar.zst|tbz|tbz2|tgz|tlz|txz|tzst|war|whl|xpi|xz|zip|zst)(-.)'" \
+  "*::archive file:_files -g '(#i)*.(7z|Z|apk|aar|bz2|deb|gz|ipsw|jar|lrz|lz4|lzma|rar|rpm|sublime-package|tar|tar.bz2|tar.gz|tar.lrz|tar.lz|tar.lz4|tar.xz|tar.zma|tar.zst|tbz|tbz2|tgz|tlz|txz|tzst|war|whl|xpi|xz|zip|zst)(-.)'" \
     && return 0

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -46,11 +46,13 @@ extract() {
 				|| zstdcat "$1" | tar xvf - ;;
 			(*.tar) tar xvf "$1" ;;
 			(*.tar.lz) (( $+commands[lzip] )) && tar xvf "$1" ;;
+			(*.tar.lz4) lz4 -c -d "$1" | tar xvf - ;;
 			(*.tar.lrz) (( $+commands[lrzuntar] )) && lrzuntar "$1" ;;
 			(*.gz) (( $+commands[pigz] )) && pigz -dk "$1" || gunzip -k "$1" ;;
 			(*.bz2) bunzip2 "$1" ;;
 			(*.xz) unxz "$1" ;;
 			(*.lrz) (( $+commands[lrunzip] )) && lrunzip "$1" ;;
+			(*.lz4) lz4 -d "$1" ;;
 			(*.lzma) unlzma "$1" ;;
 			(*.z) uncompress "$1" ;;
 			(*.zip|*.war|*.jar|*.sublime-package|*.ipsw|*.xpi|*.apk|*.aar|*.whl) unzip "$1" -d $extract_dir ;;


### PR DESCRIPTION
Support decompression of `.tar.lz4` and `.lz4` files, with `lz4` command.