### PR TITLE
Add named profile documentation to aws plugin README

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -22,6 +22,30 @@ plugins=(... aws)
 * `aws_profiles`: lists the available profiles in the  `$AWS_CONFIG_FILE` (default: `~/.aws/config`).
   Used to provide completion for the `asp` function.
 
+**Note**: The credentials file (`~/.aws/credentials`) uses a different naming
+format than the CLI config file (`~/.aws/config`) for named profiles. Include
+the prefix word "profile" only when configuring a named profile in the config
+file. Do not use the word profile when creating an entry in the credentials
+file.
+
+**Example**
+
+`~/.aws/credentials`
+
+```
+[root]
+aws_access_key_id=<...>
+aws_secret_access_key=<...>
+```
+
+`~/.aws/config`
+
+```
+[profile root]
+region=us-east-1
+output=json
+```
+
 ## Plugin options
 
 * Set `SHOW_AWS_PROMPT=false` in your zshrc file if you want to prevent the plugin from modifying your RPROMPT.


### PR DESCRIPTION
## Problem
When running `asp <profile>` with a malformed `~/.aws/config` file, I received the following error:

```
$ asp master
Profile 'master' not found in '[redacted]/.aws/config'
Available profiles: no profiles found
```

## Solution
The syntax for [named profiles](https://docs.aws.amazon.com/cli/latest/userguide//cli-configure-profiles.html) differs between the credentials and config file. Namely, the config file requires *profile* be prepended to the section declaration.

I added some documentation to elucidate this issue.

## References
#8472