### PR TITLE
Use official dotnet zsh plugin

### DIFF
--- a/plugins/dotnet/README.md
+++ b/plugins/dotnet/README.md
@@ -1,6 +1,6 @@
 # .NET Core CLI plugin
 
-This plugin provides completion for [.NET Core CLI](https://dotnet.microsoft.com/).
+This plugin provides completion and useful aliases for [.NET Core CLI](https://dotnet.microsoft.com/).
 
 To use it, add `dotnet` to the plugins array in your zshrc file.
 
@@ -21,4 +21,3 @@ plugins=(... dotnet)
 | da    | dotnet add       | Add a package or reference to a .NET project.                     |
 | dp    | dotnet pack      | Create a NuGet package.                                           |
 | dng   | dotnet nuget     | Provides additional NuGet commands.                               |
-

--- a/plugins/dotnet/README.md
+++ b/plugins/dotnet/README.md
@@ -1,23 +1,9 @@
 # .NET Core CLI plugin
 
-This plugin provides completion and useful aliases for [.NET Core CLI](https://dotnet.microsoft.com/).
+This plugin provides completion for [.NET Core CLI](https://dotnet.microsoft.com/).
 
 To use it, add `dotnet` to the plugins array in your zshrc file.
 
 ```
 plugins=(... dotnet)
 ```
-
-## Aliases
-
-| Alias | Command          | Description                                                       |
-|-------|------------------|-------------------------------------------------------------------|
-| dn    | dotnet new       | Create a new .NET project or file.                                |
-| dr    | dotnet run       | Build and run a .NET project output.                              |
-| dt    | dotnet test      | Run unit tests using the test runner specified in a .NET project. |
-| dw    | dotnet watch     | Watch for source file changes and restart the dotnet command.     |
-| dwr   | dotnet watch run | Watch for source file changes and restart the `run` command.      |
-| ds    | dotnet sln       | Modify Visual Studio solution files.                              |
-| da    | dotnet add       | Add a package or reference to a .NET project.                     |
-| dp    | dotnet pack      | Create a NuGet package.                                           |
-| dng   | dotnet nuget     | Provides additional NuGet commands.                               |

--- a/plugins/dotnet/README.md
+++ b/plugins/dotnet/README.md
@@ -7,3 +7,18 @@ To use it, add `dotnet` to the plugins array in your zshrc file.
 ```
 plugins=(... dotnet)
 ```
+
+## Aliases
+
+| Alias | Command          | Description                                                       |
+|-------|------------------|-------------------------------------------------------------------|
+| dn    | dotnet new       | Create a new .NET project or file.                                |
+| dr    | dotnet run       | Build and run a .NET project output.                              |
+| dt    | dotnet test      | Run unit tests using the test runner specified in a .NET project. |
+| dw    | dotnet watch     | Watch for source file changes and restart the dotnet command.     |
+| dwr   | dotnet watch run | Watch for source file changes and restart the `run` command.      |
+| ds    | dotnet sln       | Modify Visual Studio solution files.                              |
+| da    | dotnet add       | Add a package or reference to a .NET project.                     |
+| dp    | dotnet pack      | Create a NuGet package.                                           |
+| dng   | dotnet nuget     | Provides additional NuGet commands.                               |
+

--- a/plugins/dotnet/dotnet.plugin.zsh
+++ b/plugins/dotnet/dotnet.plugin.zsh
@@ -1,119 +1,19 @@
-# --------------------------------------------------------------------- #
-# Aliases and Completions for .NET Core (https://dotnet.microsoft.com/) #
-# Author: Shaun Tabone (https://github.com/xontab)                      #
-# --------------------------------------------------------------------- #
+# This scripts is copied from (MIT License):
+# https://github.com/dotnet/toolset/blob/master/scripts/register-completions.zsh
 
-# Helper function to cache and load completions
-local cache_base_path="${ZSH_CACHE_DIR}/dotnet_"
-_dotnet_cache_completion() {
-    local cache="${cache_base_path}$(echo $1)_completion"
-    if [[ ! -f $cache ]]; then
-        $2 $cache
-    fi
+_dotnet_zsh_complete() 
+{
+  local completions=("$(dotnet complete "$words")")
 
-    [[ -f $cache ]] && cat $cache
-}
-
-_dotnet_cache_completion_cleanup() {
-    local cache="${cache_base_path}$(echo $1)_completion"
-    rm -f $cache
-}
-
-# --------------------------------------------------------------------- #
-# dotnet new                                                            #
-# ALIAS: dn                                                             #
-# --------------------------------------------------------------------- #
-_dotnet_new_completion() {
-    if [ $commands[dotnet] ]; then
-        dotnet new -l | tail -n +21 | sed 's/  \+/:/g' | cut -d : -f 2 >$1
-    fi
-}
-
-_dotnet_new_completion_cached() {
-    _dotnet_cache_completion 'new' _dotnet_new_completion
-}
-
-_dotnet_cache_completion_cleanup 'new'
-
-alias dn='dotnet new'
-
-# --------------------------------------------------------------------- #
-# dotnet                                                                #
-# --------------------------------------------------------------------- #
-_dotnet() {
-    if [ $CURRENT -eq 2 ]; then
-        _arguments \
-            '--diagnostics[Enable diagnostic output.]' \
-            '--help[Show command line help.]' \
-            '--info[Display .NET Core information.]' \
-            '--list-runtimes[Display the installed runtimes.]' \
-            '--list-sdks[Display the installed SDKs.]' \
-            '--version[Display .NET Core SDK version in use.]'
-
-        _values \
-            'add[Add a package or reference to a .NET project.]' \
-            'build[Build a .NET project.]' \
-            'build-server[Interact with servers started by a build.]' \
-            'clean[Clean build outputs of a .NET project.]' \
-            'help[Show command line help.]' \
-            'list[List project references of a .NET project.]' \
-            'msbuild[Run Microsoft Build Engine (MSBuild) commands.]' \
-            'new[Create a new .NET project or file.]' \
-            'nuget[Provides additional NuGet commands.]' \
-            'pack[Create a NuGet package.]' \
-            'publish[Publish a .NET project for deployment.]' \
-            'remove[Remove a package or reference from a .NET project.]' \
-            'restore[Restore dependencies specified in a .NET project.]' \
-            'run[Build and run a .NET project output.]' \
-            'sln[Modify Visual Studio solution files.]' \
-            'store[Store the specified assemblies in the runtime package store.]' \
-            'test[Run unit tests using the test runner specified in a .NET project.]' \
-            'tool[Install or manage tools that extend the .NET experience.]' \
-            'vstest[Run Microsoft Test Engine (VSTest) commands.]' \
-            'dev-certs[Create and manage development certificates.]' \
-            'fsi[Start F# Interactive / execute F# scripts.]' \
-            'sql-cache[SQL Server cache command-line tools.]' \
-            'user-secrets[Manage development user secrets.]' \
-            'watch[Start a file watcher that runs a command when files change.]'
-        return
-    fi
-
-    if [ $CURRENT -eq 3 ]; then
-        case ${words[2]} in
-        "new")
-            compadd -X ".NET Installed Templates" $(_dotnet_new_completion_cached)
-            return
-            ;;
-        "sln")
-            _values \
-                'add[Add one or more projects to a solution file.]' \
-                'list[List all projects in a solution file.]' \
-                'remove[Remove one or more projects from a solution file.]'
-            return
-            ;;
-        "nuget")
-            _values \
-                'delete[Deletes a package from the server.]' \
-                'locals[Clears or lists local NuGet resources such as http requests cache, packages folder, plugin operations cache  or machine-wide global packages folder.]' \
-                'push[Pushes a package to the server and publishes it.]'
-            return
-            ;;
-        esac
-    fi
-
+  # If the completion list is empty, just continue with filename selection
+  if [ -z "$completions" ]
+  then
     _arguments '*::arguments: _normal'
+    return
+  fi
+
+  # This is not a variable assigment, don't remove spaces!
+  _values = "${(ps:\n:)completions}"
 }
 
-compdef _dotnet dotnet
-
-# --------------------------------------------------------------------- #
-# Other Aliases                                                         #
-# --------------------------------------------------------------------- #
-alias dr='dotnet run'
-alias dt='dotnet test'
-alias dw='dotnet watch'
-alias dwr='dotnet watch run'
-alias ds='dotnet sln'
-alias da='dotnet add'
-alias dp='dotnet pack'
-alias dng='dotnet nuget'
+compdef _dotnet_zsh_complete dotnet

--- a/plugins/dotnet/dotnet.plugin.zsh
+++ b/plugins/dotnet/dotnet.plugin.zsh
@@ -21,6 +21,7 @@ compdef _dotnet_zsh_complete dotnet
 # Aliases bellow are here for backwards compatibility
 # added by Shaun Tabone (https://github.com/xontab) 
 
+alias dn='dotnet new'
 alias dr='dotnet run'
 alias dt='dotnet test'
 alias dw='dotnet watch'
@@ -29,4 +30,3 @@ alias ds='dotnet sln'
 alias da='dotnet add'
 alias dp='dotnet pack'
 alias dng='dotnet nuget'
-

--- a/plugins/dotnet/dotnet.plugin.zsh
+++ b/plugins/dotnet/dotnet.plugin.zsh
@@ -17,3 +17,16 @@ _dotnet_zsh_complete()
 }
 
 compdef _dotnet_zsh_complete dotnet
+
+# Aliases bellow are here for backwards compatibility
+# added by Shaun Tabone (https://github.com/xontab) 
+
+alias dr='dotnet run'
+alias dt='dotnet test'
+alias dw='dotnet watch'
+alias dwr='dotnet watch run'
+alias ds='dotnet sln'
+alias da='dotnet add'
+alias dp='dotnet pack'
+alias dng='dotnet nuget'
+


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Replaced the custom dotnet plugin with the official one
  - Official autocomplete has several more features than the custom one, like autocompletion of nuget packages (try doing `dotnet add package MonoGame.~` and it will autocomplete possible nuget packages)

## Other comments:

Link to the official plugin (the code base is MIT License): https://github.com/dotnet/toolset/blob/master/scripts/register-completions.zsh