### PR TITLE
Fix setting title via terminfo (e.g. on vt320)

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -32,7 +32,8 @@ function title {
         # Try to use terminfo to set the title
         # If the feature is available set title
         if [[ -n "$terminfo[fsl]" ]] && [[ -n "$terminfo[tsl]" ]]; then
-	  echoti tsl
+	  echoti tsl 0
+	  echoti dl1
 	  print -Pn "$1"
 	  echoti fsl
 	fi

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -34,7 +34,7 @@ function title {
         if [[ -n "$terminfo[fsl]" ]] && [[ -n "$terminfo[tsl]" ]]; then
 	  echoti tsl 0
 	  echoti dl1
-	  print -Pn "$1"
+	  print -Pn "$2"
 	  echoti fsl
 	fi
       fi


### PR DESCRIPTION
The `title` function in `lib/termsupport.zsh` tries to use terminfo sequences to set the title if not using one of various known terminal emulators, but it's broken: it only issues a `tsl` with no argument (it takes one argument, and the status line also has to be cleared). On my VT320, this causes garbage to pile up in the status line. This patch fixes it.