### PR TITLE
Fix Symfony Console Selection Priority

### DIFF
--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -1,7 +1,7 @@
 # Symfony2 basic command completion
 
 _symfony_console () {
-  echo "php $(find . -maxdepth 2 -mindepth 1 -name 'console' -type f | head -n 1)"
+  echo "php $(find . -maxdepth 2 -mindepth 1 -name 'console' -type f | tail -n 1)"
 }
 
 _symfony2_get_command_list () {


### PR DESCRIPTION
This change selects the last (instead of the first) `console` executable found. This has the effect of selecting `bin/console` instead of `app/console` when both exist. The `app/console` executable has been deprecated and displays a warning when it's called. Without this change, using any of the plugin's aliases will also cause the warning to display.