### PR TITLE
fishy: improve performance and compatibility

### DIFF
--- a/themes/fishy.zsh-theme
+++ b/themes/fishy.zsh-theme
@@ -1,12 +1,16 @@
 # ZSH Theme emulating the Fish shell's default prompt.
 
 _fishy_collapsed_wd() {
-  echo $(pwd | perl -pe '
-   BEGIN {
-      binmode STDIN,  ":encoding(UTF-8)";
-      binmode STDOUT, ":encoding(UTF-8)";
-   }; s|^$ENV{HOME}|~|g; s|/([^/.])[^/]*(?=/)|/$1|g; s|/\.([^/])[^/]*(?=/)|/.$1|g
-')
+  local -a dirs=("${(s:/:)${(D)PWD}}")
+  for (( i=1; i<$#dirs; i++ )); do
+    local dir=$dirs[$i]
+    if [[ $dir[1] == "." ]]; then
+      dirs[i]=$dir[1,2]
+    else
+      dirs[i]=$dir[1]
+    fi
+  done
+  echo ${(j:/:)dirs}
 }
 
 local user_color='green'; [ $UID -eq 0 ] && user_color='red'

--- a/themes/fishy.zsh-theme
+++ b/themes/fishy.zsh-theme
@@ -1,16 +1,16 @@
 # ZSH Theme emulating the Fish shell's default prompt.
 
 _fishy_collapsed_wd() {
-  local -a dirs=("${(s:/:)${(D)PWD}}")
+  local -a dirs=("${(s:/:)${(Q)${(D)PWD}}}")
   for (( i=1; i<$#dirs; i++ )); do
     local dir=$dirs[$i]
-    if [[ $dir[1] == "." ]]; then
-      dirs[i]=$dir[1,2]
-    else
-      dirs[i]=$dir[1]
-    fi
+    case $dir[1] in
+      '.' | '\') dirs[i]=$dir[1,2] ;;
+      '~') (( i != 1 )) && dirs[i]=$dir[1] ;;
+      *) dirs[i]=$dir[1] ;;
+    esac
   done
-  echo ${(j:/:)dirs}
+  echo -E ${(j:/:)dirs}
 }
 
 local user_color='green'; [ $UID -eq 0 ] && user_color='red'


### PR DESCRIPTION
This PR improve performance and compatibility of fishy theme

# Performance
Here is a simple benchmark script:

```zsh
_fishy_collapsed_wd_old() {
  echo $(pwd | perl -pe '
   BEGIN {
      binmode STDIN,  ":encoding(UTF-8)";
      binmode STDOUT, ":encoding(UTF-8)";
   }; s|^$ENV{HOME}|~|g; s|/([^/.])[^/]*(?=/)|/$1|g; s|/\.([^/])[^/]*(?=/)|/.$1|g
')
}

_fishy_collapsed_wd_new() {
  local -a dirs=("${(s:/:)${(Q)${(D)PWD}}}")
  for (( i=1; i<$#dirs; i++ )); do
    local dir=$dirs[$i]
    case $dir[1] in
      '.' | '\') dirs[i]=$dir[1,2] ;;
      '~') (( i != 1 )) && dirs[i]=$dir[1] ;;
      *) dirs[i]=$dir[1] ;;
    esac
  done
  echo -E ${(j:/:)dirs}
}

PWD=/usr/lib/python3.8/site-packages/pip/__pycache__/

zmodload zsh/datetime

bench() {
    local start=$EPOCHREALTIME
    for i in {1..$1}; do
        $2 >/dev/null
    done
    echo "$2: $((EPOCHREALTIME - start))s"
}

bench 100 _fishy_collapsed_wd_old
bench 100 _fishy_collapsed_wd_new
```

The result is a ~250x speed up:
```
_fishy_collapsed_wd_old: 1.7637884616851807s
_fishy_collapsed_wd_new: 0.0072393417358398438s
```

# Compatibility

Run with `zsh -i`
```zsh
tmp=/tmp

mkdir -p '/tmp/\n/bar'
cd ~tmp/'\n'/bar

echo -E "old: $(_fishy_collapsed_wd_old)"
echo -E "new: $(_fishy_collapsed_wd_new)"
```

Result:
```
old: /t/\/bar
new: ~tmp/\n/bar
```
