### PR TITLE
asdf: fix completions if ASDF_DIR is already exported

### DIFF
--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -3,7 +3,7 @@ ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
 ASDF_COMPLETIONS="$ASDF_DIR/completions"
 
 # If not found, check for Homebrew package
-if ([[ ! -f "$ASDF_DIR/asdf.sh" ]] || [[ ! -f "$ASDF_COMPLETIONS/asdf.bash" ]]) && (( $+commands[brew] )); then
+if [[ ! -f "$ASDF_DIR/asdf.sh" || ! -f "$ASDF_COMPLETIONS/asdf.bash" ]] && (( $+commands[brew] )); then
    ASDF_DIR="$(brew --prefix asdf)"
    ASDF_COMPLETIONS="$ASDF_DIR/etc/bash_completion.d"
 fi

--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -3,7 +3,7 @@ ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
 ASDF_COMPLETIONS="$ASDF_DIR/completions"
 
 # If not found, check for Homebrew package
-if [[ ! -f "$ASDF_DIR/asdf.sh" ]] && (( $+commands[brew] )); then
+if ([[ ! -f "$ASDF_DIR/asdf.sh" ]] || [[ ! -f "$ASDF_COMPLETIONS/asdf.bash" ]]) && (( $+commands[brew] )); then
    ASDF_DIR="$(brew --prefix asdf)"
    ASDF_COMPLETIONS="$ASDF_DIR/etc/bash_completion.d"
 fi


### PR DESCRIPTION
Asdf completions are broken if the plugin is loaded after the `$ASDF_DIR/asdf.sh` application is loaded (asdf.sh exports ASDF_DIR) or if the ASDF_DIR variable is exported at all (manually for example) before the plugin is loaded.