### PR TITLE
Add MSYS2 support to system clipboard integration

### DIFF
--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -24,7 +24,7 @@ function clipcopy() {
     else
       cat $file | pbcopy
     fi
-  elif [[ $OSTYPE == cygwin* ]]; then
+  elif [[ $OSTYPE == (cygwin*|msys)* ]]; then
     if [[ -z $file ]]; then
       cat > /dev/clipboard
     else
@@ -71,7 +71,7 @@ function clippaste() {
   emulate -L zsh
   if [[ $OSTYPE == darwin* ]]; then
     pbpaste
-  elif [[ $OSTYPE == cygwin* ]]; then
+  elif [[ $OSTYPE == (cygwin*|msys)* ]]; then
     cat /dev/clipboard
   else
     if (( $+commands[xclip] )); then

--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -24,7 +24,7 @@ function clipcopy() {
     else
       cat $file | pbcopy
     fi
-  elif [[ $OSTYPE == (cygwin*|msys)* ]]; then
+  elif [[ $OSTYPE == (cygwin|msys)* ]]; then
     if [[ -z $file ]]; then
       cat > /dev/clipboard
     else
@@ -71,7 +71,7 @@ function clippaste() {
   emulate -L zsh
   if [[ $OSTYPE == darwin* ]]; then
     pbpaste
-  elif [[ $OSTYPE == (cygwin*|msys)* ]]; then
+  elif [[ $OSTYPE == (cygwin|msys)* ]]; then
     cat /dev/clipboard
   else
     if (( $+commands[xclip] )); then


### PR DESCRIPTION
This pull request enables the clipboard features on the Cygwin-based [MSYS2](https://www.msys2.org/). MSYS2 has the same `/dev/clipboard` device as Cygwin but MSYS2 reports `msys` in `$OSTYPE`.