### PR TITLE
Fix fzf plugin for nixos

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -7,6 +7,9 @@ function setup_using_base_dir() {
 
     test -d "${FZF_BASE}" && fzf_base="${FZF_BASE}"
 
+    # Set this to the nix path on a nix system
+    test -f /etc/nixos/configuration.nix && fzf_base=`fzf-share`
+
     if [[ -z "${fzf_base}" ]]; then
         fzfdirs=(
           "${HOME}/.fzf"
@@ -31,8 +34,8 @@ function setup_using_base_dir() {
     fi
 
     if [[ -d "${fzf_base}" ]]; then
-        # Fix fzf shell directory for Archlinux package
-        if [[ ! -d "${fzf_base}/shell" ]] && [[ -f /etc/arch-release ]]; then
+        # Fix fzf shell directory for Archlinux and nixos package
+        if [[ ! -d "${fzf_base}/shell" ]] && [[ -f /etc/arch-release || -f /etc/nixos/configuration.nix ]]; then
           fzf_shell="${fzf_base}"
         else
           fzf_shell="${fzf_base}/shell"


### PR DESCRIPTION
On nixos systems, there is a `fzf-share` command available to find the fzf shell folder which directly contains the completion scripts. This pr updates the fzf plugin to use that.
Also the shell folder does not have a subdirectory `/shell` where the plugin would normally look for the scripts. This is the same as on arch based systems. This pr fixes this.

As my bash script skills are not the best, it may be a good idea to test the changes of this pr on an arch system first, to avoid breaking something unintentionally.