### PR TITLE
changed apple icon to awesomefont compatible

### DIFF
--- a/themes/apple.zsh-theme
+++ b/themes/apple.zsh-theme
@@ -1,5 +1,5 @@
 function toon {
-  echo -n ""
+  echo -n ""
 }
 
 get_git_dirty() {


### PR DESCRIPTION
The old apple icon didn't appear once I installed a https://github.com/ryanoasis/nerd-fonts/blob/master/patched-fonts/UbuntuMono. Once I copied in the character taken from https://fontawesome.com/icons/apple , it appears properly.