### PR TITLE
fix(colored-man-pages): Suppress `env` shell lookup

### DIFF
--- a/plugins/colored-man-pages/colored-man-pages.plugin.zsh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.zsh
@@ -17,7 +17,7 @@ EOF
 fi
 
 function colored() {
-	env \
+	command env \
 		LESS_TERMCAP_mb=$(printf "\e[1;31m") \
 		LESS_TERMCAP_md=$(printf "\e[1;31m") \
 		LESS_TERMCAP_me=$(printf "\e[0m") \


### PR DESCRIPTION
If `env` is aliased or there is a function with a name conflict, this may cause `man` to fail. Prepending `env` with `command` "bypasses" any aliases or functions. See the issue I ran into in this [StackOverflow answer](https://unix.stackexchange.com/a/562814/297140).