### PR TITLE
Add kgcrd and kgapi aliases to kubectl plugin

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -147,3 +147,8 @@ alias kepvc='kubectl edit pvc'
 alias kdpvc='kubectl describe pvc'
 alias kdelpvc='kubectl delete pvc'
 
+# Custom Resources
+alias kgcrd='kubectl get customresourcedefinitions.apiextensions.k8s.io'
+
+# API Services
+alias kgapi='kubectl get apiservices.apiregistration.k8s.io'


### PR DESCRIPTION
Add kubectl aliases to:

- get custom resource definitions using `kgcrd`
- get k8s api services using `kgapi`
