### PR TITLE
git: add convenience aliases for `git apply` and `git am`

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -19,6 +19,7 @@ plugins=(... git)
 | gau                  | git add --update                                                                                                                 |
 | gav                  | git add --verbose                                                                                                                |
 | gap                  | git apply                                                                                                                        |
+| gapt                 | git apply --3way                                                                                                                 |
 | gb                   | git branch                                                                                                                       |
 | gba                  | git branch -a                                                                                                                    |
 | gbd                  | git branch -d                                                                                                                    |
@@ -171,6 +172,11 @@ plugins=(... git)
 | glum                 | git pull upstream master                                                                                                         |
 | gwch                 | git whatchanged -p --abbrev-commit --pretty=medium                                                                               |
 | gwip                 | git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"           |
+| gam                  | git am                                                                                                                           |
+| gamc                 | git am --continue                                                                                                                |
+| gams                 | git am --skip                                                                                                                    |
+| gama                 | git am --abort                                                                                                                   |
+| gamscp               | git am --show-current-patch                                                                                                      |
 
 ### Deprecated aliases
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -38,6 +38,7 @@ alias gapa='git add --patch'
 alias gau='git add --update'
 alias gav='git add --verbose'
 alias gap='git apply'
+alias gapt='git apply --3way'
 
 alias gb='git branch'
 alias gba='git branch -a'
@@ -256,6 +257,12 @@ alias glum='git pull upstream master'
 
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'
 alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"'
+
+alias gam='git am'
+alias gamc='git am --continue'
+alias gams='git am --skip'
+alias gama='git am --abort'
+alias gamscp='git am --show-current-patch'
 
 function grename() {
   if [[ -z "$1" || -z "$2" ]]; then


### PR DESCRIPTION
These are common operations when applying patches from mbox files on
mailing list based projects like U-Boot or the Linux
Kernel.