### PR TITLE
Add calling VS Code Insiders

### DIFF
--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -1,6 +1,6 @@
-# VS code
+# VS Code
 
-This plugin makes interaction between the command line and the code editor easier.
+This plugin makes interaction between the command line and the VS Code editor easier.
 
 To start using it, add the `vscode` plugin to your `plugins` array in `~/.zshrc`:
 
@@ -8,9 +8,11 @@ To start using it, add the `vscode` plugin to your `plugins` array in `~/.zshrc`
 plugins=(... vscode)
 ```
 
-If you are using [Visual Studio Code Insiders](https://code.visualstudio.com/insiders/),
-add the following line in the oh-my-zsh settings section (between the `ZSH_THEME` and
-the `plugins=()` line). This will make the plugin use the Insiders version instead.
+## VS Code Insiders
+
+🍏 **If you are only using [VS Code Insiders](https://code.visualstudio.com/insiders/), the plugin will automatically bind to your Insiders installation.**
+
+But, if you have both Stable and Insiders versions and want to configure the plugin to just use the Insiders version, add the following line in the oh-my-zsh settings section (between the `ZSH_THEME` and the `plugins=()` line). This will make the plugin use the Insiders version instead.
 
 ```zsh
 ZSH_THEME=...

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -1,9 +1,17 @@
 # VScode zsh plugin
-# author: https://github.com/MarsiBarsi
+# Authors:
+#   https://github.com/MarsiBarsi (original author)
+#   https://github.com/babakks
 
-# Use main Visual Studio Code version by default
-: ${VSCODE:=code}
+# Use the stable VS Code release, unless the Insiders version is the only
+# available installation
+if ! which code > /dev/null && which code-insiders > /dev/null; then
+  : ${VSCODE:=code-insiders}
+else
+  : ${VSCODE:=code}
+fi
 
+# Define aliases
 alias vsc="$VSCODE ."
 alias vsca="$VSCODE --add"
 alias vscd="$VSCODE --diff"


### PR DESCRIPTION
The current [VS Code](https://github.com/microsoft/vscode) plugin (at `plugins/vscode`) only invokes the *Stable* release installation, unless the user make changes to `.zshrc` (which are already explained in the README.md of the plugin).

However, some enthusiastic users, including myself, just install the *Insiders* release to follow up on the upcoming features of VS Code. For those users to be able to use this great plugin out of the box, I've modified the script to use `code-insidiers` (instead of `code`), **if the Insiders release was the only available installation** on the host machine.