### PR TITLE
feat: Enhance sdk plugin to Add SDKMAN! install and source to the install path.

### DIFF
--- a/plugins/sdk/README.md
+++ b/plugins/sdk/README.md
@@ -1,8 +1,8 @@
 # sdk
 
-Plugin for SDKMAN, a tool for managing parallel versions of multiple Software Development Kits on most Unix based systems.
-Provides autocompletion for all known commands.
+Plugin for _SDKMAN!_, a tool for managing parallel versions of multiple Software Development Kits on most Unix based systems.
+Provides autocompletion for all known commands. Also, automatically installs and sources _SDKMAN!_ in your shell.
 
 ## Requirements
 
- * [SDKMAN](http://sdkman.io/)
+ * [SDKMAN](http://sdkman.io/) Automatically installs, if not present.

--- a/plugins/sdk/sdk.plugin.zsh
+++ b/plugins/sdk/sdk.plugin.zsh
@@ -29,6 +29,14 @@
 #    version    :  where optional, defaults to latest stable if not provided
 #                  eg: $ sdk install groovy
 
+SDKMAN_DIR=${SDKMAN_DIR:-$HOME/.sdkman}
+
+# If SDKMAN is missing, install it.
+! test -s ${SDKMAN_DIR}/bin/sdkman-init.sh && curl -fsSL https://get.sdkman.io | bash
+
+# Source SDKMAN to make it availble in the shell
+. ${SDKMAN_DIR}/bin/sdkman-init.sh
+
 local _sdk_commands=(
     install     i
     uninstall   rm
@@ -80,3 +88,4 @@ _sdk () {
 }
 
 compdef _sdk sdk
+


### PR DESCRIPTION
@rahulsom 

Adding the functionality of my current sdkman plugin here. https://github.com/hermitmaster/sdkman

Installs sdkman to `$SDKMAN_DIR` if not present, and sources it.