### PR TITLE
fix: Update tmux plugin to use modern terminfo.

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -35,7 +35,7 @@ The plugin also supports the following -
 | `ZSH_TMUX_AUTOQUIT`                 | Automatically closes terminal once tmux exits (default: `ZSH_TMUX_AUTOSTART`) |
 | `ZSH_TMUX_FIXTERM`                  | Sets `$TERM` to 256-color term or not based on current terminal support       |
 | `ZSH_TMUX_ITERM2`                   | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)          |
-| `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `screen`)                |
-| `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `screen-256color`            |
+| `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `tmux`)                |
+| `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `tmux-256color`            |
 | `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`)                      |
 | `ZSH_TMUX_UNICODE`                  | Set `tmux -u` option to support unicode                                       |

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -29,11 +29,11 @@ alias tkss='tmux kill-session -t'
 # The TERM to use for non-256 color terminals.
 # Tmux states this should be screen, but you may need to change it on
 # systems without the proper terminfo
-: ${ZSH_TMUX_FIXTERM_WITHOUT_256COLOR:=screen}
+: ${ZSH_TMUX_FIXTERM_WITHOUT_256COLOR:=tmux}
 # The TERM to use for 256 color terminals.
 # Tmux states this should be screen-256color, but you may need to change it on
 # systems without the proper terminfo
-: ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=screen-256color}
+: ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=tmux-256color}
 # Set the configuration path
 : ${ZSH_TMUX_CONFIG:=$HOME/.tmux.conf}
 # Set -u option to support unicode

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -22,16 +22,16 @@ alias tkss='tmux kill-session -t'
 : ${ZSH_TMUX_AUTOCONNECT:=true}
 # Automatically close the terminal when tmux exits
 : ${ZSH_TMUX_AUTOQUIT:=$ZSH_TMUX_AUTOSTART}
-# Set term to screen or screen-256color based on current terminal support
+# Set term to tmux or tmux-256color based on current terminal support
 : ${ZSH_TMUX_FIXTERM:=true}
 # Set '-CC' option for iTerm2 tmux integration
 : ${ZSH_TMUX_ITERM2:=false}
 # The TERM to use for non-256 color terminals.
-# Tmux states this should be screen, but you may need to change it on
+# Tmux states this should be tmux, but you may need to change it on
 # systems without the proper terminfo
 : ${ZSH_TMUX_FIXTERM_WITHOUT_256COLOR:=tmux}
 # The TERM to use for 256 color terminals.
-# Tmux states this should be screen-256color, but you may need to change it on
+# Tmux states this should be tmux-256color, but you may need to change it on
 # systems without the proper terminfo
 : ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=tmux-256color}
 # Set the configuration path


### PR DESCRIPTION
The standard terminfo for modern tmux is `tmux` or `tmux-256color`. Updating to reflect the change.