### PR TITLE
fishy.zsh-theme: Fixed duplicate return codes

### DIFF
--- a/themes/fishy.zsh-theme
+++ b/themes/fishy.zsh-theme
@@ -14,7 +14,7 @@ PROMPT='%n@%m %{$fg[$user_color]%}$(_fishy_collapsed_wd)%{$reset_color%}%(!.#.>)
 PROMPT2='%{$fg[red]%}\ %{$reset_color%}'
 
 local return_status="%{$fg_bold[red]%}%(?..%?)%{$reset_color%}"
-RPROMPT="${RPROMPT}"'${return_status}$(git_prompt_info)$(git_prompt_status)%{$reset_color%}'
+RPROMPT='${return_status}$(git_prompt_info)$(git_prompt_status)%{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" "
 ZSH_THEME_GIT_PROMPT_SUFFIX=""


### PR DESCRIPTION
$RPROMPT was referencing itself upon variable assignment. This caused
the return code to be printed n+1 times after sourcing .zshrc n times.
Removed the self-reference so return code is only printed once.