### PR TITLE
Edit for better consistency in template

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -33,7 +33,7 @@ ZSH_THEME="robbyrussell"
 # export UPDATE_ZSH_DAYS=13
 
 # Uncomment the following line if pasting URLs and other text is messed up.
-# DISABLE_MAGIC_FUNCTIONS=true
+# DISABLE_MAGIC_FUNCTIONS="true"
 
 # Uncomment the following line to disable colors in ls.
 # DISABLE_LS_COLORS="true"


### PR DESCRIPTION
Other places in the template use `="true"` style, while solely this line uses `=true`.

Not much of a big deal, since both styles accomplish what we want.
But I felt consistency is better looking than non-consistency.