### PR TITLE
Add bitwarden useful aliases

### DIFF
--- a/plugins/bitwarden/README.md
+++ b/plugins/bitwarden/README.md
@@ -1,0 +1,32 @@
+# Bitwarden plugin
+
+This plugin provides basic bitwarden aliases to manage your bitwarden session
+
+-------
+
+
+This adds two aliases:
+
+### `bwpass`
+
+`bwpass` uses an open session to fetch a password, can be combined with `pbcopy` on mac or `xclip` on linux to copy a password:
+
+```
+$ bwpass google.com | pbcopy
+```
+
+It will request the master password if an open session couldn't be used.
+
+### `bwunlock`
+
+Unlock and saves the session in the current shell
+
+
+```
+$ bwunlock
+? Master password: [input is hidden]
+```
+
+
+Crafted by Carlos Palhares ([@xjunior](https://github.com/xjunior))
+

--- a/plugins/bitwarden/bitwarden.plugin.zsh
+++ b/plugins/bitwarden/bitwarden.plugin.zsh
@@ -1,2 +1,2 @@
 alias bwunlock='export BW_SESSION=`bw unlock --raw`'
-alias bwpass='bw --quiet sync || bwunlock && bw get password'
+alias bwpass='bw --quiet --nointeraction sync || bwunlock && bw get password'

--- a/plugins/bitwarden/bitwarden.plugin.zsh
+++ b/plugins/bitwarden/bitwarden.plugin.zsh
@@ -1,0 +1,5 @@
+# Add your own custom plugins in the custom/plugins directory. Plugins placed
+# here will override ones with the same name in the main plugins directory.
+
+alias bwunlock='export BW_SESSION=`bw unlock --raw`'
+alias bwpass='bw --quiet get password test || bwunlock && bw get password'

--- a/plugins/bitwarden/bitwarden.plugin.zsh
+++ b/plugins/bitwarden/bitwarden.plugin.zsh
@@ -1,5 +1,2 @@
-# Add your own custom plugins in the custom/plugins directory. Plugins placed
-# here will override ones with the same name in the main plugins directory.
-
 alias bwunlock='export BW_SESSION=`bw unlock --raw`'
-alias bwpass='bw --quiet get password test || bwunlock && bw get password'
+alias bwpass='bw --quiet sync || bwunlock && bw get password'


### PR DESCRIPTION
Adds two bitwarden aliases:

* `bwunlock` to unlock the vault and keep the session open in the current shell
* `bwpass` to get a password (useful for scripts) and keep or reuse the shell's session