### PR TITLE
kubectl: add alias to list pods by namespace

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -33,7 +33,8 @@ plugins=(... kubectl)
 | kep     | `kubectl edit pods`                 | Edit pods from the default editor                                                                |
 | kdp     | `kubectl describe pods`             | Describe all pods                                                                                |
 | kdelp   | `kubectl delete pods`               | Delete all pods matching passed arguments                                                        |
-| kgpl    | `kgp -l`                            | Get pod by label. Example: `kgpl "app=myapp" -n myns`                                            |
+| kgpl    | `kgp -l`                            | Get pods by label. Example: `kgpl "app=myapp" -n myns`                                           |
+| kgpn    | `kgp -n`                            | Get pods by namespace. Example: `kgpn kube-system`                                               |
 |         |                                     | **Service management**                                                                           |
 | kgs     | `kubectl get svc`                   | List all services in ps output format                                                            |
 | kgsw    | `kgs --watch`                       | After listing all services, watch for changes                                                    |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -47,6 +47,9 @@ alias kdelp='kubectl delete pods'
 # get pod by label: kgpl "app=myapp" -n myns
 alias kgpl='kgp -l'
 
+# get pod by namespace: kgpn kube-system"
+alias kgpn='kgp -n'
+
 # Service management.
 alias kgs='kubectl get svc'
 alias kgsa='kubectl get svc --all-namespaces'


### PR DESCRIPTION
This PR adds new alias to list all pods within a namespace passed as parameter:

```
kgpn <namespace>
```

Examples:
```
kgpn kube-system
kpgn production -l tier=frontend
```