### PR TITLE
Provide a shell prompt prefix and suffix for terraform plugin

### DIFF
--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -4,6 +4,6 @@ function tf_prompt_info() {
     # check if in terraform dir
     if [ -d .terraform ]; then
       workspace=$(terraform workspace show 2> /dev/null) || return
-      echo "[${workspace}]"
+      echo "${ZSH_THEME_TF_PROMPT_PREFIX}${workspace}${ZSH_THEME_TF_PROMPT_SUFFIX}"
     fi
 }

--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -1,9 +1,10 @@
 function tf_prompt_info() {
-    # dont show 'default' workspace in home dir
-    [[ "$PWD" == ~ ]] && return
-    # check if in terraform dir
-    if [ -d .terraform ]; then
-      workspace=$(terraform workspace show 2> /dev/null) || return
-      echo "${ZSH_THEME_TF_PROMPT_PREFIX}${workspace}${ZSH_THEME_TF_PROMPT_SUFFIX}"
-    fi
+  # dont show 'default' workspace in home dir
+  [[ "$PWD" != ~ ]] || return
+  # check if in terraform dir
+  [[ -d .terraform ]] || return
+
+  local workspace
+  workspace=$(terraform workspace show 2>/dev/null) || return
+  echo "${ZSH_THEME_TF_PROMPT_PREFIX-[}${workspace:gs/%/%%}${ZSH_THEME_TF_PROMPT_SUFFIX-]}"
 }


### PR DESCRIPTION
**Proposed Changes**:
- This changeset aims to add a prefix and suffix to the output generated by the terraform plugin's `tf_prompt_info()` function so that theming might be possible for the prompt. It is based on the styling of the [`git_info_prompt()`](https://github.com/ohmyzsh/ohmyzsh/blob/master/lib/git.zsh#L7).