### PR TITLE
[Security] Update dotenv plugin to prompt before executing env

### DIFF
--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -1,13 +1,12 @@
 source_env() {
   if [[ -f $ZSH_DOTENV_FILE ]]; then
-  	
-    # confirmation before sourcing .env file
-    echo -n "dotenv: source .env file in the directory [Y/n]?: "
-    read confirmation
-    if [[ ($confirmation == "n") || ($confirmation == "N") ]]; then
+    # confirm before sourcing .env file
+    local confirmation
+    echo -n "dotenv: source '$ZSH_DOTENV_FILE' file in the directory? (Y/n) "
+    if read -k 1 confirmation && [[ $confirmation = [nN] ]]; then
       return
     fi
-    
+
     # test .env syntax
     zsh -fn $ZSH_DOTENV_FILE || echo "dotenv: error when sourcing '$ZSH_DOTENV_FILE' file" >&2
 

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -1,5 +1,13 @@
 source_env() {
   if [[ -f $ZSH_DOTENV_FILE ]]; then
+  	
+    # confirmation before sourcing .env file
+    echo -n "zsh: source .env file in the directory [Y/n]?: "
+    read confirmation
+    if [[ ($confirmation == "n") || ($confirmation == "N") ]]; then
+      return
+    fi
+    
     # test .env syntax
     zsh -fn $ZSH_DOTENV_FILE || echo "dotenv: error when sourcing '$ZSH_DOTENV_FILE' file" >&2
 

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -2,7 +2,7 @@ source_env() {
   if [[ -f $ZSH_DOTENV_FILE ]]; then
   	
     # confirmation before sourcing .env file
-    echo -n "zsh: source .env file in the directory [Y/n]?: "
+    echo -n "dotenv: source .env file in the directory [Y/n]?: "
     read confirmation
     if [[ ($confirmation == "n") || ($confirmation == "N") ]]; then
       return


### PR DESCRIPTION
Hi all,

I have encountered an issue on the usage of .dotenv plugin.  Sourcing arbitrary .env files can lead a direct remote code execution on user machines. source doesn't soley read environment variables, it executes the code.

If I download a malicious repo, with a .env file. Then it would be executed with informing me about the execution of the source file.
```bash
$> cat .env             
touch /tmp/hacked
head -n 1 /etc/passwd
```
```bash
$> cd downloaded-dir
root:x:0:0:root:/root:/bin/bash
```

Fix: we can prompt the user before the execution.
```
$> cd x   
zsh: source .env file in the directory [Y/n]?: n
```