### PR TITLE
[dotnet] Add dotnet watch and dotnet watch run aliases

### DIFF
--- a/plugins/dotnet/README.md
+++ b/plugins/dotnet/README.md
@@ -10,12 +10,14 @@ plugins=(... dotnet)
 
 ## Aliases
 
-| Alias | Command      | Description                                                       |
-|-------|--------------|-------------------------------------------------------------------|
-| dn    | dotnet new   | Create a new .NET project or file.                                |
-| dr    | dotnet run   | Build and run a .NET project output.                              |
-| dt    | dotnet test  | Run unit tests using the test runner specified in a .NET project. |
-| ds    | dotnet sln   | Modify Visual Studio solution files.                              |
-| da    | dotnet add   | Add a package or reference to a .NET project.                     |
-| dp    | dotnet pack  | Create a NuGet package.                                           |
-| dng   | dotnet nuget | Provides additional NuGet commands.                               |
+| Alias | Command          | Description                                                       |
+|-------|------------------|-------------------------------------------------------------------|
+| dn    | dotnet new       | Create a new .NET project or file.                                |
+| dr    | dotnet run       | Build and run a .NET project output.                              |
+| dt    | dotnet test      | Run unit tests using the test runner specified in a .NET project. |
+| dw    | dotnet watch     | Watch for source file changes and restart the dotnet command.     |
+| dwr   | dotnet watch run | Watch for source file changes and restart the `run` command.      |
+| ds    | dotnet sln       | Modify Visual Studio solution files.                              |
+| da    | dotnet add       | Add a package or reference to a .NET project.                     |
+| dp    | dotnet pack      | Create a NuGet package.                                           |
+| dng   | dotnet nuget     | Provides additional NuGet commands.                               |

--- a/plugins/dotnet/dotnet.plugin.zsh
+++ b/plugins/dotnet/dotnet.plugin.zsh
@@ -111,6 +111,8 @@ compdef _dotnet dotnet
 # --------------------------------------------------------------------- #
 alias dr='dotnet run'
 alias dt='dotnet test'
+alias dw='dotnet watch'
+alias dwr='dotnet watch run'
 alias ds='dotnet sln'
 alias da='dotnet add'
 alias dp='dotnet pack'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds a sensible default alias for `dotnet watch` and `dotnet watch run`

## Other comments:

I know this could easily go in my own .zshrc, but I think this is sensible to add to the dotnet plugin as a whole.
