### PR TITLE
Executing gradle literally, even if an alias exists (gradle plugin)

### DIFF
--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -7,7 +7,7 @@ gradle-or-gradlew() {
 		echo "executing gradlew instead of gradle";
 		./gradlew "$@";
 	else
-		gradle "$@";
+		command gradle "$@";
 	fi
 }
 


### PR DESCRIPTION
- Similarly to the mvn plugin
- Without this fix, the shell crashes in some cases
- fixes #8046