### PR TITLE
dotenv: add ZSH_DOTENV_PROMPT config

### DIFF
--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -32,6 +32,8 @@ PORT=3001
 ```
 You can even mix both formats, although it's probably a bad idea.
 
+## Plugin options
+
 ### ZSH_DOTENV_FILE
 
 You can also modify the name of the file to be loaded with the variable `ZSH_DOTENV_FILE`.
@@ -42,6 +44,10 @@ For example, this will make the plugin look for files named `.dotenv` and load t
 # in ~/.zshrc, before Oh My Zsh is sourced:
 ZSH_DOTENV_FILE=.dotenv
 ```
+
+### ZSH_DOTENV_PROMPT
+
+Set `ZSH_DOTENV_PROMPT=false` in your zshrc file if you don't want the confirmation message.
 
 ## Version Control
 

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -1,10 +1,13 @@
 source_env() {
   if [[ -f $ZSH_DOTENV_FILE ]]; then
-    # confirm before sourcing .env file
-    local confirmation
-    echo -n "dotenv: source '$ZSH_DOTENV_FILE' file in the directory? (Y/n) "
-    if read -k 1 confirmation && [[ $confirmation = [nN] ]]; then
-      return
+
+    if [ "$ZSH_DOTENV_PROMPT" != "false" ]; then
+      # confirm before sourcing file
+      local confirmation
+      echo -n "dotenv: source '$ZSH_DOTENV_FILE' file in the directory? (Y/n) "
+      if read -k 1 confirmation && [[ $confirmation = [nN] ]]; then
+        return
+      fi
     fi
 
     # test .env syntax


### PR DESCRIPTION
Hello,

Now we have a confirmation prompt in dotenv plugins. See https://github.com/ohmyzsh/ohmyzsh/pull/8606 PR.

I find security issue really important, but in my case I don't want to answer the question every time.

## New

I add `ZSH_DOTENV_PROMPT` var, you can set this variable to false in your zshrc if you don't want the confirmation message.

- [x] add variable
- [x] update doc