### PR TITLE
Add an additional 'git pull' alias

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -160,6 +160,7 @@ alias gk='\gitk --all --branches'
 alias gke='\gitk --all $(git log -g --pretty=%h)'
 
 alias gl='git pull'
+alias gpl='git pull'
 alias glg='git log --stat'
 alias glgp='git log --stat -p'
 alias glgg='git log --graph'


### PR DESCRIPTION
## Standards checklist:

- [√] The PR title is descriptive.
- [√] The PR doesn't replicate another PR which is already open.
- [√] I have read the contribution guide and followed all the instructions.
- [√] The code follows the code style guide detailed in the wiki.
- [√] The code is mine or it's from somewhere with an MIT-compatible license.
- [√] The code is efficient, to the best of my ability, and does not waste computer resources.
- [√] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add an additional 'git pull' alias as `gpl` keeping the `gl` for backwards compatibility. This seems more instinctive as an alias and more inline with the git alias abbreviations as opposed to the current git `gl` alias, while also saving time  having to look it up and t

- With `gp` alias referring to `git push` it seems better fitted that `gpl` refers `git pull`

- `gl` would be more inline with/suited to 'git log' with the rest of the `gl` aliases referring to `git log`

