### PR TITLE
agnoster: fix bzr prompt with breezy installed

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -140,24 +140,24 @@ prompt_git() {
 }
 
 prompt_bzr() {
-    (( $+commands[bzr] )) || return
-    if (bzr status >/dev/null 2>&1); then
-        status_mod=`bzr status | head -n1 | grep "modified" | wc -m`
-        status_all=`bzr status | head -n1 | wc -m`
-        revision=`bzr log | head -n2 | tail -n1 | sed 's/^revno: //'`
-        if [[ $status_mod -gt 0 ]] ; then
-            prompt_segment yellow black
-            echo -n "bzr@"$revision "✚ "
-        else
-            if [[ $status_all -gt 0 ]] ; then
-                prompt_segment yellow black
-                echo -n "bzr@"$revision
-            else
-                prompt_segment green black
-                echo -n "bzr@"$revision
-            fi
-        fi
+  (( $+commands[bzr] )) || return
+  if (bzr status >/dev/null 2>&1); then
+    status_mod=`bzr status | head -n1 | grep "modified" | wc -m`
+    status_all=`bzr status | head -n1 | wc -m`
+    revision=`bzr log | head -n2 | tail -n1 | sed 's/^revno: //'`
+    if [[ $status_mod -gt 0 ]] ; then
+      prompt_segment yellow black
+      echo -n "bzr@"$revision "✚ "
+    else
+      if [[ $status_all -gt 0 ]] ; then
+        prompt_segment yellow black
+        echo -n "bzr@"$revision
+      else
+        prompt_segment green black
+        echo -n "bzr@"$revision
+      fi
     fi
+  fi
 }
 
 prompt_hg() {

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -141,20 +141,26 @@ prompt_git() {
 
 prompt_bzr() {
   (( $+commands[bzr] )) || return
-  if (bzr status >/dev/null 2>&1); then
-    status_mod=`bzr status | head -n1 | grep "modified" | wc -m`
-    status_all=`bzr status | head -n1 | wc -m`
-    revision=`bzr log | head -n2 | tail -n1 | sed 's/^revno: //'`
+
+  # Test if bzr repository in directory hierarchy
+  local dir="$PWD"
+  while [[ ! -d "$dir/.bzr" ]]; do
+    [[ "$dir" = "/" ]] && return
+    dir="${dir:h}"
+  done
+
+  local bzr_status status_mod status_all revision
+  if bzr_status=$(bzr status 2>&1); then
+    status_mod=$(echo -n "$bzr_status" | head -n1 | grep "modified" | wc -m)
+    status_all=$(echo -n "$bzr_status" | head -n1 | wc -m)
+    revision=$(bzr log -r-1 --log-format line | cut -d: -f1)
     if [[ $status_mod -gt 0 ]] ; then
-      prompt_segment yellow black
-      echo -n "bzr@"$revision "✚ "
+      prompt_segment yellow black "bzr@$revision ✚"
     else
       if [[ $status_all -gt 0 ]] ; then
-        prompt_segment yellow black
-        echo -n "bzr@"$revision
+        prompt_segment yellow black "bzr@$revision"
       else
-        prompt_segment green black
-        echo -n "bzr@"$revision
+        prompt_segment green black "bzr@$revision"
       fi
     fi
   fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Check if there is a `.bzr` folder in the current directory in parent directories, before attempting to call `bzr`.
- Optimize `bzr` calls: from 3 `bzr status` calls to 1.
- Use a more direct `bzr log` command to get the revision.
- Clean up `prompt_segments` calls.

## Other comments:

Fixes #8237.
