### PR TITLE
Add random theme and consolidate logic from init and themes plugin

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -97,25 +97,12 @@ done
 unset config_file
 
 # Load the theme
-if [[ "$ZSH_THEME" == "random" ]]; then
-  if [[ "${(t)ZSH_THEME_RANDOM_CANDIDATES}" = "array" ]] && [[ "${#ZSH_THEME_RANDOM_CANDIDATES[@]}" -gt 0 ]]; then
-    themes=($ZSH/themes/${^ZSH_THEME_RANDOM_CANDIDATES}.zsh-theme)
+if [ ! "$ZSH_THEME" = ""  ]; then
+  if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then
+    source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
+  elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
+    source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
   else
-    themes=($ZSH/themes/*zsh-theme)
-  fi
-  N=${#themes[@]}
-  ((N=(RANDOM%N)+1))
-  RANDOM_THEME=${themes[$N]}
-  source "$RANDOM_THEME"
-  echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
-else
-  if [ ! "$ZSH_THEME" = ""  ]; then
-    if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then
-      source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
-    elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
-      source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
-    else
-      source "$ZSH/themes/$ZSH_THEME.zsh-theme"
-    fi
+    source "$ZSH/themes/$ZSH_THEME.zsh-theme"
   fi
 fi

--- a/plugins/themes/_theme
+++ b/plugins/themes/_theme
@@ -1,3 +1,0 @@
-#compdef theme
-
-_arguments "1: :($(lstheme | tr "\n" " "))"

--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -1,19 +1,17 @@
 function theme
 {
-    if [ -z "$1" ] || [ "$1" = "random" ]; then
-	themes=($ZSH/themes/*zsh-theme)
-	N=${#themes[@]}
-	((N=(RANDOM%N)+1))
-	RANDOM_THEME=${themes[$N]}
-	source "$RANDOM_THEME"
-	echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+    if [ -z "$1" ]; then
+        1="random"
+    fi
+
+    if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]
+    then
+        source "$ZSH_CUSTOM/$1.zsh-theme"
+    elif [ -f "$ZSH_CUSTOM/themes/$1.zsh-theme" ]
+    then
+        source "$ZSH_CUSTOM/themes/$1.zsh-theme"
     else
-	if [ -f "$ZSH_CUSTOM/themes/$1.zsh-theme" ]
-	then
-	    source "$ZSH_CUSTOM/themes/$1.zsh-theme"
-	else
-	    source "$ZSH/themes/$1.zsh-theme"
-	fi
+        source "$ZSH/themes/$1.zsh-theme"
     fi
 }
 

--- a/plugins/themes/themes.plugin.zsh
+++ b/plugins/themes/themes.plugin.zsh
@@ -1,24 +1,27 @@
-function theme
-{
-    if [ -z "$1" ]; then
-        1="random"
-    fi
+function theme {
+    : ${1:=random} # Use random theme if none provided
 
-    if [ -f "$ZSH_CUSTOM/$1.zsh-theme" ]
-    then
+    if [[ -f "$ZSH_CUSTOM/$1.zsh-theme" ]]; then
         source "$ZSH_CUSTOM/$1.zsh-theme"
-    elif [ -f "$ZSH_CUSTOM/themes/$1.zsh-theme" ]
-    then
+    elif [[ -f "$ZSH_CUSTOM/themes/$1.zsh-theme" ]]; then
         source "$ZSH_CUSTOM/themes/$1.zsh-theme"
-    else
+    elif [[ -f "$ZSH/themes/$1.zsh-theme" ]]; then
         source "$ZSH/themes/$1.zsh-theme"
+    else
+        echo "$0: Theme '$1' not found"
+        return 1
     fi
 }
 
-function lstheme
-{
+function _theme {
+    _arguments "1: :($(lstheme))"
+}
+
+compdef _theme theme
+
+function lstheme {
     # Resources:
     # http://zsh.sourceforge.net/Doc/Release/Expansion.html#Modifiers
     # http://zsh.sourceforge.net/Doc/Release/Expansion.html#Glob-Qualifiers
-    print -l {$ZSH,$ZSH_CUSTOM}/themes/*.zsh-theme(N:t:r)
+    print "$ZSH_CUSTOM"/*.zsh-theme(N:t:r) {"$ZSH_CUSTOM","$ZSH"}/themes/*.zsh-theme(N:t:r)
 }

--- a/themes/random.zsh-theme
+++ b/themes/random.zsh-theme
@@ -1,0 +1,10 @@
+if [[ "${(t)ZSH_THEME_RANDOM_CANDIDATES}" = "array" ]] && [[ "${#ZSH_THEME_RANDOM_CANDIDATES[@]}" -gt 0 ]]; then
+  themes=($ZSH/themes/${^ZSH_THEME_RANDOM_CANDIDATES}.zsh-theme)
+else
+  themes=($ZSH/themes/*zsh-theme)
+fi
+N=${#themes[@]}
+((N=(RANDOM%N)+1))
+RANDOM_THEME=${themes[$N]}
+source "$RANDOM_THEME"
+echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."

--- a/themes/random.zsh-theme
+++ b/themes/random.zsh-theme
@@ -5,19 +5,23 @@ if [[ "${(t)ZSH_THEME_RANDOM_CANDIDATES}" = array && ${#ZSH_THEME_RANDOM_CANDIDA
   # Use ZSH_THEME_RANDOM_CANDIDATES if properly defined
   themes=($ZSH_THEME_RANDOM_CANDIDATES)
 else
-  # Look for themes in $ZSH_CUSTOM and $ZSH and add only the theme name (:t)
+  # Look for themes in $ZSH_CUSTOM and $ZSH and add only the theme name
   themes=(
     "$ZSH_CUSTOM"/*.zsh-theme(N:t:r)
     "$ZSH_CUSTOM"/themes/*.zsh-theme(N:t:r)
     "$ZSH"/themes/*.zsh-theme(N:t:r)
   )
+  # Remove blacklisted themes from the list
+  for theme in ${ZSH_THEME_RANDOM_BLACKLIST[@]}; do
+    themes=("${(@)themes:#$theme}")
+  done
 fi
 
 # Choose a theme out of the pool of candidates
 N=${#themes[@]}
 (( N = (RANDOM%N) + 1 ))
 RANDOM_THEME="${themes[$N]}"
-unset N themes
+unset N themes theme
 
 # Source theme
 if [[ -f "$ZSH_CUSTOM/$RANDOM_THEME.zsh-theme" ]]; then

--- a/themes/random.zsh-theme
+++ b/themes/random.zsh-theme
@@ -1,10 +1,34 @@
-if [[ "${(t)ZSH_THEME_RANDOM_CANDIDATES}" = "array" ]] && [[ "${#ZSH_THEME_RANDOM_CANDIDATES[@]}" -gt 0 ]]; then
-  themes=($ZSH/themes/${^ZSH_THEME_RANDOM_CANDIDATES}.zsh-theme)
+# Make themes a unique array
+typeset -Ua themes
+
+if [[ "${(t)ZSH_THEME_RANDOM_CANDIDATES}" = array && ${#ZSH_THEME_RANDOM_CANDIDATES[@]} -gt 0 ]]; then
+  # Use ZSH_THEME_RANDOM_CANDIDATES if properly defined
+  themes=($ZSH_THEME_RANDOM_CANDIDATES)
 else
-  themes=($ZSH/themes/*zsh-theme)
+  # Look for themes in $ZSH_CUSTOM and $ZSH and add only the theme name (:t)
+  themes=(
+    "$ZSH_CUSTOM"/*.zsh-theme(N:t:r)
+    "$ZSH_CUSTOM"/themes/*.zsh-theme(N:t:r)
+    "$ZSH"/themes/*.zsh-theme(N:t:r)
+  )
 fi
+
+# Choose a theme out of the pool of candidates
 N=${#themes[@]}
-((N=(RANDOM%N)+1))
-RANDOM_THEME=${themes[$N]}
-source "$RANDOM_THEME"
-echo "[oh-my-zsh] Random theme '$RANDOM_THEME' loaded..."
+(( N = (RANDOM%N) + 1 ))
+RANDOM_THEME="${themes[$N]}"
+unset N themes
+
+# Source theme
+if [[ -f "$ZSH_CUSTOM/$RANDOM_THEME.zsh-theme" ]]; then
+  source "$ZSH_CUSTOM/$RANDOM_THEME.zsh-theme"
+elif [[ -f "$ZSH_CUSTOM/themes/$RANDOM_THEME.zsh-theme" ]]; then
+  source "$ZSH_CUSTOM/themes/$RANDOM_THEME.zsh-theme"
+elif [[ -f "$ZSH/themes/$RANDOM_THEME.zsh-theme" ]]; then
+  source "$ZSH/themes/$RANDOM_THEME.zsh-theme"
+else
+  echo "[oh-my-zsh] Random theme '${RANDOM_THEME}' not found"
+  return 1
+fi
+
+echo "[oh-my-zsh] Random theme '${RANDOM_THEME}' loaded"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Put the random theme logic in a theme of the name random, taking it out of the init script and the theme plugin (closes #2962, closes #3337).
- Change the logic such that themes in `$ZSH_CUSTOM` are also taken into account (fixes #7696, closes #7697).
- Add array variable to blacklist themes from the random pool (`$ZSH_THEME_RANDOM_BLACKLIST`) (fixes #3704, closes #3703).
- In the themes plugin, the `theme` function errors when it can't find the theme provided.
- In the themes plugin, the `lstheme` function uses wildcard expansion and looks in the `$ZSH_CUSTOM` folder as well. Also, the themes are printed in one line with spaces in between, instead of in a column separated by newlines.
- In the themes plugin, the completion function has been placed inside the `.plugin.zsh` file.

## Other comments:

Closes #4605.
Closes #3036 (the blacklist setting solves this, plus now most default themes check for their dependencies and gracefully fail).

## Tested

- For the `random` theme:
  + `ZSH_THEME_RANDOM_CANDIDATES` works as expected.
  + `ZSH_THEME_RANDOM_BLACKLIST` works as expected (only applied when `ZSH_THEME_RANDOM_CANDIDATES` isn't set up, *should probably document this in the wiki).
  + When a theme isn't found (such as when it was specified in `ZSH_THEME_RANDOM_CANDIDATES`, but didn't exist), the current behavior is to fail with an error:
    ```
    $ ZSH_THEME=random zsh
    [oh-my-zsh] Random theme 'nonexistent' not found
    ```
    **Should nonexistent themes be purged from the list of candidates?**
- For the `themes` plugin:
  + The completion for the `theme` function has been tested and it works.
  + The `lstheme` function finds themes both in the default folder and the `$ZSH_CUSTOM/*` and `$ZSH_CUSTOM/themes/*.zsh-theme`.

## Not working

- Theme names that contain paths, such as the powerlevel10k that tells users to put it in `$ZSH_CUSTOM` under a `powerlevel10k` folder, such that the theme name becomes `powerlevel10k/powerlevel10k`:
  + The `random` theme doesn't look in subfolders, but if `powerlevel10k/powerlevel10k` is specified in the candidates variable it will be correctly picked up.
  + The `themes` plugin's completion doesn't look in subfolders either, but the `theme` function will correctly source the theme if specified in the first argument (`theme "powerlevel10k/powerlevel10k"` works).