### PR TITLE
Added "doas" plugin to support a "sudo" alternative

### DIFF
--- a/plugins/doas/README.md
+++ b/plugins/doas/README.md
@@ -1,0 +1,57 @@
+# doas
+
+Easily prefix your current or previous commands with `doas` by pressing <kbd>esc</kbd> twice
+
+## Enabling the plugin
+
+1.  Open your `.zshrc` file and add `doas` in the plugins section:
+
+    ```zsh
+    plugins=(
+        # all your enabled plugins
+        doas
+    )
+    ```
+
+2.  Restart your shell or restart your Terminal session:
+
+    ```console
+    $ exec zsh
+    $
+    ```
+
+## Usage examples
+
+### Current typed commands
+
+Say you have typed a long command and forgot to add `doas` in front:
+
+```console
+$ pacman -S base
+```
+
+By pressing the <kbd>esc</kbd> key twice, you will have the same command with `doas` prefixed without typing:
+
+```console
+$ doas pacman -S base
+```
+
+### Previous executed commands
+
+Say you want to delete a system file and denied:
+
+```console
+$ rm some-system-file.txt
+-su: some-system-file.txt: Permission denied
+$
+```
+
+By pressing the <kbd>esc</kbd> key twice, you will have the same command with `doas` prefixed without typing:
+
+```console
+$ rm some-system-file.txt
+-su: some-system-file.txt: Permission denied
+$ doas rm some-system-file.txt
+Password:
+$
+```

--- a/plugins/doas/doas.plugin.zsh
+++ b/plugins/doas/doas.plugin.zsh
@@ -1,0 +1,28 @@
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+# doas will be inserted before the command
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+# * Dongweiming <ciici123@gmail.com> (original sudo plugin)
+# * NeoTheFox <soniczerops@gmail.com> (doas edit)
+#
+# ------------------------------------------------------------------------------
+
+doas-command-line() {
+    [[ -z $BUFFER ]] && zle up-history
+    if [[ $BUFFER == doas\ * ]]; then
+        LBUFFER="${LBUFFER#doas }"
+    else
+        LBUFFER="doas $LBUFFER"
+    fi
+}
+zle -N doas-command-line
+# Defined shortcut keys: [Esc] [Esc]
+bindkey -M emacs '\e\e' doas-command-line
+bindkey -M vicmd '\e\e' doas-command-line
+bindkey -M viins '\e\e' doas-command-line


### PR DESCRIPTION
## Changes:

- Added "doas" plugin that is just a carbon copy of "sudo" plugin.

## Other comments:

This will help OpenBSD users and Linux users that use doas instead of sudo for privilege escalation. You can also use doas on OSX. There isn't really any new code here or major changes.
