### PR TITLE
Add support for AWS CLI v2 autocompletion

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -76,22 +76,27 @@ function _awscli-homebrew-installed() {
   fi
 }
 
-# get aws_zsh_completer.sh location from $PATH
-_aws_zsh_completer_path="$commands[aws_zsh_completer.sh]"
+# AWS CLI v2 comes with its own autocompletion. Check if that is there, otherwise fall back
+if [[ -x /usr/local/bin/aws_completer ]]; then
+  complete -C aws_completer aws
+else
+  # get aws_zsh_completer.sh location from $PATH
+  _aws_zsh_completer_path="$commands[aws_zsh_completer.sh]"
 
-# otherwise check common locations
-if [[ -z $_aws_zsh_completer_path ]]; then
-  # Homebrew
-  if _awscli-homebrew-installed; then
-    _aws_zsh_completer_path=$_brew_prefix/libexec/bin/aws_zsh_completer.sh
-  # Ubuntu
-  elif [[ -e /usr/share/zsh/vendor-completions/_awscli ]]; then
-    _aws_zsh_completer_path=/usr/share/zsh/vendor-completions/_awscli
-  # RPM
-  else
-    _aws_zsh_completer_path=/usr/share/zsh/site-functions/aws_zsh_completer.sh
+  # otherwise check common locations
+  if [[ -z $_aws_zsh_completer_path ]]; then
+    # Homebrew
+    if _awscli-homebrew-installed; then
+      _aws_zsh_completer_path=$_brew_prefix/libexec/bin/aws_zsh_completer.sh
+    # Ubuntu
+    elif [[ -e /usr/share/zsh/vendor-completions/_awscli ]]; then
+      _aws_zsh_completer_path=/usr/share/zsh/vendor-completions/_awscli
+    # RPM
+    else
+      _aws_zsh_completer_path=/usr/share/zsh/site-functions/aws_zsh_completer.sh
+    fi
   fi
-fi
 
-[[ -r $_aws_zsh_completer_path ]] && source $_aws_zsh_completer_path
-unset _aws_zsh_completer_path _brew_prefix
+  [[ -r $_aws_zsh_completer_path ]] && source $_aws_zsh_completer_path
+  unset _aws_zsh_completer_path _brew_prefix
+fi

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -62,24 +62,25 @@ fi
 
 # Load awscli completions
 
-function _awscli-homebrew-installed() {
-  # check if Homebrew is installed
-  (( $+commands[brew] )) || return 1
-
-  # speculatively check default brew prefix
-  if [ -h /usr/local/opt/awscli ]; then
-    _brew_prefix=/usr/local/opt/awscli
-  else
-    # ok, it is not in the default prefix
-    # this call to brew is expensive (about 400 ms), so at least let's make it only once
-    _brew_prefix=$(brew --prefix awscli)
-  fi
-}
-
 # AWS CLI v2 comes with its own autocompletion. Check if that is there, otherwise fall back
 if [[ -x /usr/local/bin/aws_completer ]]; then
+  autoload -Uz bashcompinit && bashcompinit
   complete -C aws_completer aws
 else
+  function _awscli-homebrew-installed() {
+    # check if Homebrew is installed
+    (( $+commands[brew] )) || return 1
+
+    # speculatively check default brew prefix
+    if [ -h /usr/local/opt/awscli ]; then
+      _brew_prefix=/usr/local/opt/awscli
+    else
+      # ok, it is not in the default prefix
+      # this call to brew is expensive (about 400 ms), so at least let's make it only once
+      _brew_prefix=$(brew --prefix awscli)
+    fi
+  }
+
   # get aws_zsh_completer.sh location from $PATH
   _aws_zsh_completer_path="$commands[aws_zsh_completer.sh]"
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Check if the autocompletion installed by AWS CLI v2 is present, and if so use that. Otherwise fall back to the original autocompletion code.

## Other comments:

Version 2 of the AWS CLI was released on [February 10](https://aws.amazon.com/blogs/developer/aws-cli-v2-is-now-generally-available/) and comes with its own autocompletion built-in. Per [the README for the v2 branch](https://github.com/aws/aws-cli/blob/v2/README.rst#command-completion), this can be enabled with a wrapper in zsh, or with the `complete` command that ohmyzsh already supports. 

I realise I have a hardcoded path in the check, but both the [Linux](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html) and [macOS](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-mac.html) installation instructions highlight that this is where a symlink to the actual binary will be.