### PR TITLE
Remove calls to deprecated tools, abs and aur

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -39,9 +39,6 @@
 | trrem   | trizen -Rns                        | Remove packages, including its settings and unneeded dependencies   |
 | trrep   | trizen -Si                         | Display information about a package in the repositories             |
 | trreps  | trizen -Ss                         | Search for packages in the repositories                             |
-| trupd   | trizen -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases             |
-| trupd   | trizen -Sy && sudo abs             | Update and refresh the local package and ABS databases              |
-| trupd   | trizen -Sy && sudo aur             | Update and refresh the local package and AUR databases              |
 | trupd   | trizen -Sy                         | Update and refresh the local package database                       |
 | trupg   | trizen -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
 | trsu    | trizen -Syua --no-confirm          | Same as `trupg`, but without confirmation                           |
@@ -64,9 +61,6 @@
 | yarem   | yaourt -Rns                        | Remove packages, including its settings and unneeded dependencies   |
 | yarep   | yaourt -Si                         | Display information about a package in the repositories             |
 | yareps  | yaourt -Ss                         | Search for packages in the repositories                             |
-| yaupd   | yaourt -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases             |
-| yaupd   | yaourt -Sy && sudo abs             | Update and refresh the local package and ABS databases              |
-| yaupd   | yaourt -Sy && sudo aur             | Update and refresh the local package and AUR databases              |
 | yaupd   | yaourt -Sy                         | Update and refresh the local package database                       |
 | yaupg   | yaourt -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
 | yasu    | yaourt -Syua --no-confirm          | Same as `yaupg`, but without confirmation                           |
@@ -88,9 +82,6 @@
 | parem   | pacaur -Rns                        | Remove packages, including its settings and unneeded dependencies   |
 | parep   | pacaur -Si                         | Display information about a package in the repositories             |
 | pareps  | pacaur -Ss                         | Search for packages in the repositories                             |
-| paupd   | pacaur -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases             |
-| paupd   | pacaur -Sy && sudo abs             | Update and refresh the local package and ABS databases              |
-| paupd   | pacaur -Sy && sudo aur             | Update and refresh the local package and AUR databases              |
 | paupd   | pacaur -Sy                         | Update and refresh the local package database                       |
 | paupg   | pacaur -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
 | pasu    | pacaur -Syua --no-confirm          | Same as `paupg`, but without confirmation                           |
@@ -112,9 +103,6 @@
 | pacrep       | pacman -Si                              | Display information about a package in the repositories      |
 | pacreps      | pacman -Ss                              | Search for packages in the repositories                      |
 | pacrmorphans | sudo pacman -Rs $(pacman -Qtdq)         | Delete all orphaned packages                                 |
-| pacupd       | sudo pacman -Sy && sudo abs && sudo aur | Update and refresh the local package, ABS and AUR databases  |
-| pacupd       | sudo pacman -Sy && sudo abs             | Update and refresh the local package and ABS databases       |
-| pacupd       | sudo pacman -Sy && sudo aur             | Update and refresh the local package and AUR databases       |
 | pacupd       | sudo pacman -Sy                         | Update and refresh the local package database                |
 | pacupg       | sudo pacman -Syu                        | Sync with repositories before upgrading packages             |
 | upgrade      | sudo pacman -Syu                        | Sync with repositories before upgrading packages             |

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -14,17 +14,7 @@ if (( $+commands[trizen] )); then
   alias trorph='trizen -Qtd'
   alias trinsd='trizen -S --asdeps'
   alias trmir='trizen -Syy'
-
-
-  if (( $+commands[abs] && $+commands[aur] )); then
-    alias trupd='trizen -Sy && sudo abs && sudo aur'
-  elif (( $+commands[abs] )); then
-    alias trupd='trizen -Sy && sudo abs'
-  elif (( $+commands[aur] )); then
-    alias trupd='trizen -Sy && sudo aur'
-  else
-    alias trupd='trizen -Sy'
-  fi
+  alias trupd='trizen -Sy'
 fi
 
 if (( $+commands[yaourt] )); then
@@ -43,17 +33,7 @@ if (( $+commands[yaourt] )); then
   alias yaorph='yaourt -Qtd'
   alias yainsd='yaourt -S --asdeps'
   alias yamir='yaourt -Syy'
-
-
-  if (( $+commands[abs] && $+commands[aur] )); then
-    alias yaupd='yaourt -Sy && sudo abs && sudo aur'
-  elif (( $+commands[abs] )); then
-    alias yaupd='yaourt -Sy && sudo abs'
-  elif (( $+commands[aur] )); then
-    alias yaupd='yaourt -Sy && sudo aur'
-  else
-    alias yaupd='yaourt -Sy'
-  fi
+  alias yaupd='yaourt -Sy'
 fi
 
 if (( $+commands[yay] )); then
@@ -72,17 +52,7 @@ if (( $+commands[yay] )); then
   alias yaorph='yay -Qtd'
   alias yainsd='yay -S --asdeps'
   alias yamir='yay -Syy'
-
-
-  if (( $+commands[abs] && $+commands[aur] )); then
-    alias yaupd='yay -Sy && sudo abs && sudo aur'
-  elif (( $+commands[abs] )); then
-    alias yaupd='yay -Sy && sudo abs'
-  elif (( $+commands[aur] )); then
-    alias yaupd='yay -Sy && sudo aur'
-  else
-    alias yaupd='yay -Sy'
-  fi
+  alias yaupd='yay -Sy'
 fi
 
 if (( $+commands[pacaur] )); then
@@ -100,16 +70,7 @@ if (( $+commands[pacaur] )); then
   alias paorph='pacaur -Qtd'
   alias painsd='pacaur -S --asdeps'
   alias pamir='pacaur -Syy'
-
-  if (( $+commands[abs] && $+commands[aur] )); then
-    alias paupd='pacaur -Sy && sudo abs && sudo aur'
-  elif (( $+commands[abs] )); then
-    alias paupd='pacaur -Sy && sudo abs'
-  elif (( $+commands[aur] )); then
-    alias paupd='pacaur -Sy && sudo aur'
-  else
-    alias paupd='pacaur -Sy'
-  fi
+  alias paupd='pacaur -Sy'
 fi
 
 if (( $+commands[trizen] )); then
@@ -152,17 +113,7 @@ alias pacfileupg='sudo pacman -Fy'
 alias pacfiles='pacman -Fs'
 alias pacls='pacman -Ql'
 alias pacown='pacman -Qo'
-
-
-if (( $+commands[abs] && $+commands[aur] )); then
-  alias pacupd='sudo pacman -Sy && sudo abs && sudo aur'
-elif (( $+commands[abs] )); then
-  alias pacupd='sudo pacman -Sy && sudo abs'
-elif (( $+commands[aur] )); then
-  alias pacupd='sudo pacman -Sy && sudo aur'
-else
-  alias pacupd='sudo pacman -Sy'
-fi
+alias pacupd='sudo pacman -Sy'
 
 function paclist() {
   # Source: https://bbs.archlinux.org/viewtopic.php?id=93683


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Remove calls to deprecated tools, abs and aur

## Other comments:
#8591  
https://www.archlinux.org/news/deprecation-of-abs/
