### PR TITLE
Adding #debugging section to the documentation for those who might get an error.

### DIFF
--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -8,6 +8,15 @@ To start using it, add the `vscode` plugin to your `plugins` array in `~/.zshrc`
 plugins=(... vscode)
 ```
 
+## Requirements
+
+To use VS Code in the terminal **in macOS**, first you need to install the `code` command in the PATH,
+otherwise you might receive this message: `zsh: command not found: code`.
+
+[As the docs say](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line), open
+the Command Palette via (F1 or ⇧⌘P) and type shell command to find the Shell Command:
+> Install 'code' command in PATH
+
 ## VS Code Insiders
 
 🍏 **If you are only using [VS Code Insiders](https://code.visualstudio.com/insiders/), the plugin will automatically bind to your Insiders installation.**
@@ -53,9 +62,3 @@ source $ZSH/oh-my-zsh.sh
 | vscv         | code --verbose            | Print verbose output (implies --wait).                                                                                |
 | vscl `level` | code --log `level`        | Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'. |
 | vscde        | code --disable-extensions | Disable all installed extensions.                                                                                     |
-
-## Debugging
-If you recieved this message `zsh: command not found: code` you need to install the command path first in vscode. 
-Open the Command Palette via (⇧⌘P) and type shell command to find the Shell Command:
-> Install 'code' command in PATH** command
-Thanks to this [StackOverflow Post](https://stackoverflow.com/questions/29955500/code-not-working-in-command-line-for-visual-studio-code-on-osx-mac).

--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -53,3 +53,9 @@ source $ZSH/oh-my-zsh.sh
 | vscv         | code --verbose            | Print verbose output (implies --wait).                                                                                |
 | vscl `level` | code --log `level`        | Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'. |
 | vscde        | code --disable-extensions | Disable all installed extensions.                                                                                     |
+
+## Debugging
+If you recieved this message `zsh: command not found: code` you need to install the command path first in vscode. 
+Open the Command Palette via (⇧⌘P) and type shell command to find the Shell Command:
+> Install 'code' command in PATH** command
+Thanks to this [StackOverflow Post](https://stackoverflow.com/questions/29955500/code-not-working-in-command-line-for-visual-studio-code-on-osx-mac).


### PR DESCRIPTION
Found a quick solution but I figured it'd be useful in the plugin installation information. This adds a section to the bottom of the documentation for "debugging" and a solution I found. 

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
