### PR TITLE
npm: hardcode completion function and delete cached one

### DIFF
--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -1,14 +1,16 @@
 (( $+commands[npm] )) && {
-    __NPM_COMPLETION_FILE="${ZSH_CACHE_DIR:-$ZSH/cache}/npm_completion"
+  rm -f "${ZSH_CACHE_DIR:-$ZSH/cache}/npm_completion"
 
-    if [[ ! -f $__NPM_COMPLETION_FILE ]]; then
-        npm completion >! $__NPM_COMPLETION_FILE 2>/dev/null
-        [[ $? -ne 0 ]] && rm -f $__NPM_COMPLETION_FILE
-    fi
-
-    [[ -f $__NPM_COMPLETION_FILE ]] && source $__NPM_COMPLETION_FILE
-
-    unset __NPM_COMPLETION_FILE
+  _npm_completion() {
+    local si=$IFS
+    compadd -- $(COMP_CWORD=$((CURRENT-1)) \
+                 COMP_LINE=$BUFFER \
+                 COMP_POINT=0 \
+                 npm completion -- "${words[@]}" \
+                 2>/dev/null)
+    IFS=$si
+  }
+  compdef _npm_completion npm
 }
 
 # Install dependencies globally


### PR DESCRIPTION
Fixes #8665

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Remove `npm_completion` cache file if it exists.
- Use native zsh version of the `_npm_completion` function, which bypasses the `bashcompinit` bug found in #8665.

## Other comments:

Needs to be checked whether old versions of npm will broke with this function.