### PR TITLE
Add vi-mode support for interactive-cd

### DIFF
--- a/plugins/zsh-interactive-cd/zsh-interactive-cd.plugin.zsh
+++ b/plugins/zsh-interactive-cd/zsh-interactive-cd.plugin.zsh
@@ -144,4 +144,5 @@ zic-completion() {
 }
 
 zle -N zic-completion
-bindkey '^I' zic-completion
+bindkey -M emacs '^I' zic-completion
+bindkey -M viins '^I' zic-completion


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add vi-mode support for interactive-cd

## Other comments:

Used [sudo.plugin.zsh](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/sudo/sudo.plugin.zsh) as a reference.  
However, decided to skip on `vicmd` since it's probably not the intentional use, nor intuitive for the user.