### PR TITLE
check for each term setting and setting separately

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -4,16 +4,18 @@
 
 # Make sure that the terminal is in application mode when zle is active, since
 # only then values from $terminfo are valid
-if (( ${+terminfo[smkx]} )) && (( ${+terminfo[rmkx]} )); then
-  function zle-line-init() {
-    echoti smkx
-  }
-  function zle-line-finish() {
-    echoti rmkx
-  }
-  zle -N zle-line-init
-  zle -N zle-line-finish
-fi
+function zle-line-init () {
+	if (( ${+terminfo[smkx]} )); then
+		echoti smkx
+	fi
+}
+function zle-line-finish () {
+	if (( ${+terminfo[rmkx]} )); then
+		echoti rmkx
+	fi
+}
+zle -N zle-line-init
+zle -N zle-line-finish
 
 bindkey -e                                            # Use emacs key bindings
 


### PR DESCRIPTION
# description
key-bindings checks for smkx and rmkx on the terminfo together.
This breaks on terminal from within Emacs.

# changes
check for smkx on terminfo and rmkx separately.
fixes #8682 