### PR TITLE
Bugfix for copybuffer.plugin:

### DIFF
--- a/plugins/copybuffer/copybuffer.plugin.zsh
+++ b/plugins/copybuffer/copybuffer.plugin.zsh
@@ -3,7 +3,7 @@
 
 copybuffer () {
   if which clipcopy &>/dev/null; then
-    echo $BUFFER | clipcopy
+    printf '%s' "$BUFFER" | clipcopy
   else
     echo "clipcopy function not found. Please make sure you have Oh My Zsh installed correctly."
   fi


### PR DESCRIPTION
Now the buffer is copyed without alterations
 - no extra line returns are copyed anymore
 - escape sequences like \n are not interpreted as escape sequences anymore

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

plugins/copybuffer/copybuffer.plugin.zsh

## Other comments:

Regarding - [x] The code is efficient, to the best of my ability, and does not waste computer resources:
I have tryed <<< redirection to avoid piping but unfortunately the <<< redirection adds an undesired line return
