### PR TITLE
[arcanist] Allow for easier copy pasting of URLS via functions and add arc diff --preview

### DIFF
--- a/plugins/arcanist/README.md
+++ b/plugins/arcanist/README.md
@@ -36,5 +36,5 @@ E.g., `ardu` accepts `https://arcanist-url.com/<REVISION>` as well as `<REVISION
 
 | Function                  | Command                                  |
 | ------------------------- | ---------------------------------------- |
-| ardu [URL or revision_id] | `arc diff --update` [URL or revision_id] |
-| arpa [URL or revision_id] | `arc patch` [URL or revision_id]         |
+| ardu [URL or revision_id] | `arc diff --update` [revision_id] |
+| arpa [URL or revision_id] | `arc patch` [revision_id]         |

--- a/plugins/arcanist/README.md
+++ b/plugins/arcanist/README.md
@@ -31,10 +31,11 @@ plugins=(... arcanist)
 
 ## Functions
 
-The following functions make copy pasting revision ids from the URL bar of your browser easier as they allow for copy pasting the whole URL.
-E.g., `ardu` accepts `https://arcanist-url.com/<REVISION>` as well as `<REVISION>`.
+The following functions make copy pasting revision ids from the URL bar of your browser
+easier, as they allow for copy pasting the whole URL. For example: `ardu` accepts
+both `https://arcanist-url.com/<REVISION>` as well as `<REVISION>`.
 
-| Function                  | Command                                  |
-| ------------------------- | ---------------------------------------- |
+| Function                  | Command                           |
+| ------------------------- | --------------------------------- |
 | ardu [URL or revision_id] | `arc diff --update` [revision_id] |
 | arpa [URL or revision_id] | `arc patch` [revision_id]         |

--- a/plugins/arcanist/README.md
+++ b/plugins/arcanist/README.md
@@ -11,13 +11,14 @@ plugins=(... arcanist)
 ## Aliases
 
 | Alias   | Command                            |
-|---------|------------------------------------|
+| ------- | ---------------------------------- |
 | ara     | `arc amend`                        |
 | arb     | `arc branch`                       |
 | arco    | `arc cover`                        |
 | arci    | `arc commit`                       |
 | ard     | `arc diff`                         |
 | ardc    | `arc diff --create`                |
+| ardp    | `arc diff --preview`               |
 | ardnu   | `arc diff --nounit`                |
 | ardnupc | `arc diff --nounit --plan-changes` |
 | ardpc   | `arc diff --plan-changes`          |
@@ -27,3 +28,13 @@ plugins=(... arcanist)
 | arli    | `arc lint`                         |
 | arls    | `arc list`                         |
 | arpa    | `arc patch`                        |
+
+## Functions
+
+The following functions make copy pasting revision ids from the URL bar of your browser easier as they allow for copy pasting the whole URL.
+E.g., `ardu` accepts `https://arcanist-url.com/<REVISION>` as well as `<REVISION>`.
+
+| Function                  | Command                                  |
+| ------------------------- | ---------------------------------------- |
+| ardu [URL or revision_id] | `arc diff --update` [URL or revision_id] |
+| arpa [URL or revision_id] | `arc patch` [URL or revision_id]         |

--- a/plugins/arcanist/arcanist.plugin.zsh
+++ b/plugins/arcanist/arcanist.plugin.zsh
@@ -26,12 +26,21 @@ alias arls='arc list'
 # (sorted alphabetically)
 #
 
+
+_extract_revision_id(){
+  # helper function to extract everything after the last slash.
+  # If there is no slash, returns the whole variable
+  local -a URL
+  URL=("${(s:/:)1}") # split by slash
+  echo "${URL[-1]}"
+}
+
 ardu() {
 # With this, both, `ardu https://arcanist-url.com/<REVISION>`, and `ardu <REVISION>` work.
-  arc diff --update "${${(s./.)1}[-1]}"
+  arc diff --update "$(_extract_revision_id $1)"
 }
 
 arpa() {
 # With this, both, `arpa https://arcanist-url/.com/<REVISION>`, and `arpa <REVISION>` work.
-  arc patch "${${(s./.)1}[-1]}"
+  arc patch "$(_extract_revision_id $1)"
 }

--- a/plugins/arcanist/arcanist.plugin.zsh
+++ b/plugins/arcanist/arcanist.plugin.zsh
@@ -26,20 +26,12 @@ alias arls='arc list'
 # (sorted alphabetically)
 #
 
-_extract_revision_id(){
-  # helper function to extract everything after the last slash.
-  # If there is no slash, returns the whole variable
-  local -a URL
-  URL=("${(s:/:)1}") # split by slash
-  echo "${URL[-1]}"
-}
-
 ardu() {
-# With this, both, `ardu https://arcanist-url.com/<REVISION>`, and `ardu <REVISION>` work.
-  arc diff --update "$(_extract_revision_id $1)"
+  # Both `ardu https://arcanist-url.com/<REVISION>`, and `ardu <REVISION>` work.
+  arc diff --update "${1:t}"
 }
 
 arpa() {
-# With this, both, `arpa https://arcanist-url/.com/<REVISION>`, and `arpa <REVISION>` work.
-  arc patch "$(_extract_revision_id $1)"
+  # Both `arpa https://arcanist-url.com/<REVISION>`, and `ardu <REVISION>` work.
+  arc patch "${1:t}"
 }

--- a/plugins/arcanist/arcanist.plugin.zsh
+++ b/plugins/arcanist/arcanist.plugin.zsh
@@ -26,7 +26,6 @@ alias arls='arc list'
 # (sorted alphabetically)
 #
 
-
 _extract_revision_id(){
   # helper function to extract everything after the last slash.
   # If there is no slash, returns the whole variable

--- a/plugins/arcanist/arcanist.plugin.zsh
+++ b/plugins/arcanist/arcanist.plugin.zsh
@@ -13,7 +13,7 @@ alias ardc='arc diff --create'
 alias ardnu='arc diff --nounit'
 alias ardnupc='arc diff --nounit --plan-changes'
 alias ardpc='arc diff --plan-changes'
-alias ardcp='arc diff --preview' # creates a new diff in the phab interface
+alias ardp='arc diff --preview' # creates a new diff in the phab interface
 
 alias are='arc export'
 alias arh='arc help'

--- a/plugins/arcanist/arcanist.plugin.zsh
+++ b/plugins/arcanist/arcanist.plugin.zsh
@@ -13,7 +13,7 @@ alias ardc='arc diff --create'
 alias ardnu='arc diff --nounit'
 alias ardnupc='arc diff --nounit --plan-changes'
 alias ardpc='arc diff --plan-changes'
-alias ardcp= 'arc diff --preview' # creates a new diff in the phab interface
+alias ardcp='arc diff --preview' # creates a new diff in the phab interface
 
 alias are='arc export'
 alias arh='arc help'
@@ -28,11 +28,10 @@ alias arls='arc list'
 
 ardu() {
 # With this, both, `ardu https://arcanist-url.com/<REVISION>`, and `ardu <REVISION>` work.
-arc diff --update "$(echo "$1" | awk '{n=split($1,a,"/");print a[n]}')"
+  arc diff --update "${${(s./.)1}[-1]}"
 }
 
 arpa() {
 # With this, both, `arpa https://arcanist-url/.com/<REVISION>`, and `arpa <REVISION>` work.
-arc patch "$(echo "$1" | awk '{n=split($1,a,"/");print a[n]}')"
+  arc patch "${${(s./.)1}[-1]}"
 }
-

--- a/plugins/arcanist/arcanist.plugin.zsh
+++ b/plugins/arcanist/arcanist.plugin.zsh
@@ -13,10 +13,26 @@ alias ardc='arc diff --create'
 alias ardnu='arc diff --nounit'
 alias ardnupc='arc diff --nounit --plan-changes'
 alias ardpc='arc diff --plan-changes'
+alias ardcp= 'arc diff --preview' # creates a new diff in the phab interface
 
 alias are='arc export'
 alias arh='arc help'
 alias arl='arc land'
 alias arli='arc lint'
 alias arls='arc list'
-alias arpa='arc patch'
+
+#
+# Functions
+# (sorted alphabetically)
+#
+
+ardu() {
+# With this, both, `ardu https://arcanist-url.com<REVISION>`, and `ardu <REVISION>` work.
+arc diff --update "$(echo "$1" | awk '{n=split($1,a,"/");print a[n]}')"
+}
+
+arpa() {
+# With this, both, `arpa https://arcanist-url/.com/<REVISION>`, and `arpa <REVISION>` work.
+arc patch "$(echo "$1" | awk '{n=split($1,a,"/");print a[n]}')"
+}
+

--- a/plugins/arcanist/arcanist.plugin.zsh
+++ b/plugins/arcanist/arcanist.plugin.zsh
@@ -27,7 +27,7 @@ alias arls='arc list'
 #
 
 ardu() {
-# With this, both, `ardu https://arcanist-url.com<REVISION>`, and `ardu <REVISION>` work.
+# With this, both, `ardu https://arcanist-url.com/<REVISION>`, and `ardu <REVISION>` work.
 arc diff --update "$(echo "$1" | awk '{n=split($1,a,"/");print a[n]}')"
 }
 

--- a/plugins/arcanist/arcanist.plugin.zsh
+++ b/plugins/arcanist/arcanist.plugin.zsh
@@ -32,6 +32,6 @@ ardu() {
 }
 
 arpa() {
-  # Both `arpa https://arcanist-url.com/<REVISION>`, and `ardu <REVISION>` work.
+  # Both `arpa https://arcanist-url.com/<REVISION>`, and `arpa <REVISION>` work.
   arc patch "${1:t}"
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
 - adds the alias
  - ardcp= 'arc diff --preview'
 - adds the functions
  - ardu: With this, both, `ardu https://arcanist-url.com/<REVISION>`, and `ardu <REVISION>` work.
  - arpa: With this, both, `arpa https://arcanist-url/.com/<REVISION>`, and `arpa <REVISION>` work.

Both accept a parameter which can either be the revision id or the whole URL to the revision.

 - updates the README