### PR TITLE
Extract hardcoded $HOME to a configurable variable

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -58,7 +58,8 @@ fi
 
 # Save the location of the current completion dump file.
 if [ -z "$ZSH_COMPDUMP" ]; then
-  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+  ZSH_COMPDUMP_DEFAULT_DIR="${ZSH_COMPDUMP_DEFAULT_DIR:-${HOME}}"
+  ZSH_COMPDUMP="${ZDOTDIR:-${ZSH_COMPDUMP_DEFAULT_DIR}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
 if [[ $ZSH_DISABLE_COMPFIX != true ]]; then


### PR DESCRIPTION
Fixes #7332

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

The new variable `ZSH_COMPDUMP_DEFAULT_DIR` can now be configured alone, having
$HOME as the default, keeping the same behaviour as until now.
For instance, one could set `ZSH_COMPDUMP_DEFAULT_DIR=${ZSH_CACHE_DIR}` to have
the .zcompdump files in the cache directory of her preference.

## Other comments:

Read further: https://github.com/ohmyzsh/ohmyzsh/issues/7332#issuecomment-593308026