### PR TITLE
feat(macports): add commands to get list of updated ports

### DIFF
--- a/plugins/macports/README.md
+++ b/plugins/macports/README.md
@@ -9,12 +9,38 @@ To use it, add `macports` to the plugins array in your zshrc file:
 plugins=(... macports)
 ```
 
+## Commands
+
+### port-livecheck-maintainer
+
+```
+Usage:
+  port-livecheck-maintainer
+  port-livecheck-maintainer (maintainer)+
+  port-livecheck-maintainer -h|--help
+
+Check
+
+Options:
+  maintainer  maintainer id
+  -h          print this help message and exit
+```
+
+Checks whether updates are available for ports whose maintainer is the current
+user, or any of a specified list of maintainer expressions.  The current user
+maintainer id is retrieved as follows:
+
+* The value of the `MACPORTS_MAINTAINER` variable, if set and not null.
+* The value of the `USER` variable.
+
 ## Aliases
 
 | Alias | Command                            | Description                                                  |
 |-------|------------------------------------|--------------------------------------------------------------|
 | pc    | `sudo port clean --all installed`  | Clean up intermediate installation files for installed ports |
 | pi    | `sudo port install`                | Install package given as argument                            |
+| pli   | `port livecheck installed`         | Check for updates for installed ports                        |
+| plm   | `port-livecheck-maintainer`        | Check for updates of ports mainained by the specified users  |
 | psu   | `sudo port selfupdate`             | Update ports tree with MacPorts repository                   |
 | puni  | `sudo port uninstall inactive`     | Uninstall inactive ports                                     |
 | puo   | `sudo port upgrade outdated`       | Upgrade ports with newer versions available                  |

--- a/plugins/macports/README.md
+++ b/plugins/macports/README.md
@@ -9,11 +9,24 @@ To use it, add `macports` to the plugins array in your zshrc file:
 plugins=(... macports)
 ```
 
+## Aliases
+
+| Alias | Command                            | Description                                                  |
+|-------|------------------------------------|--------------------------------------------------------------|
+| pc    | `sudo port clean --all installed`  | Clean up intermediate installation files for installed ports |
+| pi    | `sudo port install`                | Install package given as argument                            |
+| pli   | `port livecheck installed`         | Check for updates for installed ports                        |
+| plm   | `port-livecheck-maintainer`        | Check for updates of ports mainained by the specified users  |
+| psu   | `sudo port selfupdate`             | Update ports tree with MacPorts repository                   |
+| puni  | `sudo port uninstall inactive`     | Uninstall inactive ports                                     |
+| puo   | `sudo port upgrade outdated`       | Upgrade ports with newer versions available                  |
+| pup   | `psu && puo`                       | Update ports tree, then upgrade ports to newest versions     |
+
 ## Commands
 
 ### port-livecheck-maintainer
 
-```
+```text
 Usage:
   port-livecheck-maintainer
   port-livecheck-maintainer (maintainer)+
@@ -32,16 +45,3 @@ maintainer id is retrieved as follows:
 
 * The value of the `MACPORTS_MAINTAINER` variable, if set and not null.
 * The value of the `USER` variable.
-
-## Aliases
-
-| Alias | Command                            | Description                                                  |
-|-------|------------------------------------|--------------------------------------------------------------|
-| pc    | `sudo port clean --all installed`  | Clean up intermediate installation files for installed ports |
-| pi    | `sudo port install`                | Install package given as argument                            |
-| pli   | `port livecheck installed`         | Check for updates for installed ports                        |
-| plm   | `port-livecheck-maintainer`        | Check for updates of ports mainained by the specified users  |
-| psu   | `sudo port selfupdate`             | Update ports tree with MacPorts repository                   |
-| puni  | `sudo port uninstall inactive`     | Uninstall inactive ports                                     |
-| puo   | `sudo port upgrade outdated`       | Upgrade ports with newer versions available                  |
-| pup   | `psu && puo`                       | Update ports tree, then upgrade ports to newest versions     |

--- a/plugins/macports/macports.plugin.zsh
+++ b/plugins/macports/macports.plugin.zsh
@@ -4,3 +4,58 @@ alias psu="sudo port selfupdate"
 alias puni="sudo port uninstall inactive"
 alias puo="sudo port upgrade outdated"
 alias pup="psu && puo"
+alias pli="port livecheck installed"
+alias plm="port-livecheck-maintainer"
+
+_omz_macports_check_port_or_fail()
+{
+  command -v port > /dev/null 2>&1 ||
+    {
+      return 1
+    }
+}
+
+_omz_macports_port_livecheck_maintainer_usage() {
+  cat << EOF >&2
+Usage:
+  port-livecheck-maintainer
+  port-livecheck-maintainer (maintainer)+
+  port-livecheck-maintainer -h|--help
+
+Check
+
+Options:
+  maintainer  maintainer id
+  -h          print this help message and exit
+EOF
+}
+
+port-livecheck-maintainer()
+{
+  (( _omz_macports_check_port_or_fail == 0)) ||
+    {
+      print -- "port: not found" >&2
+      return 1
+    }
+
+  local -a help_flag
+
+  zparseopts -D -E \
+             h=help_flag    -help=help_flag
+
+  (( ${#help_flag} )) &&
+    {
+      _omz_macports_port_livecheck_maintainer_usage
+      return 1
+    }
+
+  local default_maintainer=${MACPORTS_MAINTAINER:-${USER}}
+
+  if (( $# > 0 )); then
+    for i in $*; do
+      port livecheck maintainer:${i}
+    done
+  else
+    port livecheck maintainer:${default_maintainer}
+  fi
+}

--- a/plugins/macports/macports.plugin.zsh
+++ b/plugins/macports/macports.plugin.zsh
@@ -1,22 +1,23 @@
 alias pc="sudo port clean --all installed"
 alias pi="sudo port install"
+alias pli="port livecheck installed"
+alias plm="port-livecheck-maintainer"
 alias psu="sudo port selfupdate"
 alias puni="sudo port uninstall inactive"
 alias puo="sudo port upgrade outdated"
-alias pup="psu && puo"
-alias pli="port livecheck installed"
-alias plm="port-livecheck-maintainer"
+alias pup="sudo port selfupdate && sudo port upgrade outdated"
 
-_omz_macports_check_port_or_fail()
-{
-  command -v port > /dev/null 2>&1 ||
-    {
-      return 1
-    }
-}
+port-livecheck-maintainer() {
+  (( ${+commands[port]} == 0 )) || {
+    print -- "port: not found" >&2
+    return 1
+  }
 
-_omz_macports_port_livecheck_maintainer_usage() {
-  cat << EOF >&2
+  local -a help_flag
+  zparseopts -D -E h=help_flag -help=help_flag
+
+  (( ${#help_flag} )) && {
+    cat << EOF >&2
 Usage:
   port-livecheck-maintainer
   port-livecheck-maintainer (maintainer)+
@@ -28,34 +29,16 @@ Options:
   maintainer  maintainer id
   -h          print this help message and exit
 EOF
-}
+    return 1
+  }
 
-port-livecheck-maintainer()
-{
-  (( _omz_macports_check_port_or_fail == 0)) ||
-    {
-      print -- "port: not found" >&2
-      return 1
-    }
-
-  local -a help_flag
-
-  zparseopts -D -E \
-             h=help_flag    -help=help_flag
-
-  (( ${#help_flag} )) &&
-    {
-      _omz_macports_port_livecheck_maintainer_usage
-      return 1
-    }
-
-  local default_maintainer=${MACPORTS_MAINTAINER:-${USER}}
-
-  if (( $# > 0 )); then
-    for i in $*; do
-      port livecheck maintainer:${i}
-    done
-  else
-    port livecheck maintainer:${default_maintainer}
+  if (( $# == 0 )); then
+    local default=${MACPORTS_MAINTAINER:-${USER}}
+    port livecheck maintainer:${default}
+    return $?
   fi
+
+  for i in $@; do
+    port livecheck maintainer:${i}
+  done
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Commands are provided to search with the following criteria:

* `pli`: check for updates of installed ports
* `plm`: check for updates of ports maintained by the specified list ids.

## Other comments:

...
