### PR TITLE
kubectl add alias to decode secret data

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -86,6 +86,7 @@ alias kdecs='
 _kdecs() {
   if [ $(jq --version) != "jq-1.6" ]; then
       echo "kdecs requires jq-1.6 to use the base64d format";
+      unset -f _kdecs
       return 1
   fi
   kubectl get secret "$@" -o json | jq ".data | map_values(. | @base64d )";

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -82,18 +82,18 @@ alias kgsec='kubectl get secret'
 alias kgseca='kubectl get secret --all-namespaces'
 alias kdsec='kubectl describe secret'
 alias kdelsec='kubectl delete secret'
-alias kdecs='
-_kdecs() {
+alias kdecsec='
+_kdecsec() {
   if [ $(jq --version) != "jq-1.6" ]; then
-      echo "kdecs requires jq-1.6 to use the base64d format";
-      unset -f _kdecs
+      echo "kdecsec requires jq-1.6 to use the base64d format";
+      unset -f _kdecsec
       return 1
   fi
   kubectl get secret "$@" -o json | jq ".data | map_values(. | @base64d )";
-  unset -f _kdecs
+  unset -f _kdecsec
   return 0
 };
-_kdecs'
+_kdecsec'
 
 # Deployment management.
 alias kgd='kubectl get deployment'

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -55,7 +55,17 @@ alias kgswide='kgs -o wide'
 alias kes='kubectl edit svc'
 alias kds='kubectl describe svc'
 alias kdels='kubectl delete svc'
-alias kdecs='_check_jq(){ if [ $(jq --version) != "jq-1.6" ]; then echo "kdecs requires jq-1.6 to use the base64d format"; fi; unset -f _check_jq}; _check_jq; _kdecs(){kubectl get secret "$@" -o json | jq ".data | map_values(. | @base64d )"; unset -f _kdecs}; _kdecs'
+alias kdecs='
+_kdecs() {
+  if [ $(jq --version) != "jq-1.6" ]; then
+      echo "kdecs requires jq-1.6 to use the base64d format";
+      return 1
+  fi
+  kubectl get secret "$@" -o json | jq ".data | map_values(. | @base64d )";
+  unset -f _kdecs
+  return 0
+};
+_kdecs'
 
 # Ingress management
 alias kgi='kubectl get ingress'

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -55,6 +55,7 @@ alias kgswide='kgs -o wide'
 alias kes='kubectl edit svc'
 alias kds='kubectl describe svc'
 alias kdels='kubectl delete svc'
+alias kdecs='_check_jq(){ if [ $(jq --version) != "jq-1.6" ]; then echo "kdecs requires jq-1.6 to use the base64d format"; fi; unset -f _check_jq}; _check_jq; _kdecs(){kubectl get secret "$@" -o json | jq ".data | map_values(. | @base64d )"; unset -f _kdecs}; _kdecs'
 
 # Ingress management
 alias kgi='kubectl get ingress'

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -55,17 +55,6 @@ alias kgswide='kgs -o wide'
 alias kes='kubectl edit svc'
 alias kds='kubectl describe svc'
 alias kdels='kubectl delete svc'
-alias kdecs='
-_kdecs() {
-  if [ $(jq --version) != "jq-1.6" ]; then
-      echo "kdecs requires jq-1.6 to use the base64d format";
-      return 1
-  fi
-  kubectl get secret "$@" -o json | jq ".data | map_values(. | @base64d )";
-  unset -f _kdecs
-  return 0
-};
-_kdecs'
 
 # Ingress management
 alias kgi='kubectl get ingress'
@@ -93,6 +82,17 @@ alias kgsec='kubectl get secret'
 alias kgseca='kubectl get secret --all-namespaces'
 alias kdsec='kubectl describe secret'
 alias kdelsec='kubectl delete secret'
+alias kdecs='
+_kdecs() {
+  if [ $(jq --version) != "jq-1.6" ]; then
+      echo "kdecs requires jq-1.6 to use the base64d format";
+      return 1
+  fi
+  kubectl get secret "$@" -o json | jq ".data | map_values(. | @base64d )";
+  unset -f _kdecs
+  return 0
+};
+_kdecs'
 
 # Deployment management.
 alias kgd='kubectl get deployment'

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -83,17 +83,9 @@ alias kgseca='kubectl get secret --all-namespaces'
 alias kdsec='kubectl describe secret'
 alias kdelsec='kubectl delete secret'
 alias kdecsec='
-_kdecsec() {
-  if [ $(jq --version) != "jq-1.6" ]; then
-      echo "kdecsec requires jq-1.6 to use the base64d format";
-      unset -f _kdecsec
-      return 1
-  fi
-  kubectl get secret "$@" -o json | jq ".data | map_values(. | @base64d )";
-  unset -f _kdecsec
-  return 0
-};
-_kdecsec'
+kdecsec_go_template='{{range $k,$v := .data}}{{"### "}}{{$k}}{{"\n"}}{{$v|base64decode}}{{"\n\n"}}{{end}}'
+alias kdecsec="kubectl get secret -o go-template='$kdecsec_go_template'"
+unset kdecsec_go_template
 
 # Deployment management.
 alias kgd='kubectl get deployment'

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -82,10 +82,7 @@ alias kgsec='kubectl get secret'
 alias kgseca='kubectl get secret --all-namespaces'
 alias kdsec='kubectl describe secret'
 alias kdelsec='kubectl delete secret'
-alias kdecsec='
-kdecsec_go_template='{{range $k,$v := .data}}{{"### "}}{{$k}}{{"\n"}}{{$v|base64decode}}{{"\n\n"}}{{end}}'
-alias kdecsec="kubectl get secret -o go-template='$kdecsec_go_template'"
-unset kdecsec_go_template
+alias kdecsec='kubectl get secret -o go-template='\''{{range $k,$v := .data}}{{"### "}}{{$k}}{{"\n"}}{{$v|base64decode}}{{"\n\n"}}{{end}}'\'''
 
 # Deployment management.
 alias kgd='kubectl get deployment'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
  Mine with inspiration from https://github.com/mveritym/kubedecode
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
 - Add `kdecsec` alias to `kubectl` plugin to base64 decode kubernetes secrets

  ```
  $ kubectl create secret generic my-secret --from-literal=key1=supersecret --from-literal=key2=topsecret
  $ kdecsec my-secret
  {
    "key1": "supersecret",
    "key2": "topsecret"
  }
  ```
## Other comments:

[Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) have their data encoded in base64. More often than not, when wanting to know what's in a given secret, we want the data.

The `kdecsec` alias is pretty much the same thing as [kubedecode](https://github.com/mveritym/kubedecode), which solves the same problem. Making it part of the `kubectl` plugin is just super convenient. :grin:   