### PR TITLE
themes/agnoster: add prompt segment for current conda env

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -209,6 +209,14 @@ prompt_virtualenv() {
   fi
 }
 
+# Conda: current working environment
+prompt_conda() {
+  local conda_env="$CONDA_DEFAULT_ENV"
+  if [[ -n $conda_env && -z $CONDA_PROMPT_MODIFIER ]]; then
+    prompt_segment blue black "conda:$conda_env"
+  fi
+}
+
 # Status:
 # - was there an error
 # - am I root
@@ -241,6 +249,7 @@ build_prompt() {
   RETVAL=$?
   prompt_status
   prompt_virtualenv
+  prompt_conda
   prompt_aws
   prompt_context
   prompt_dir


### PR DESCRIPTION
**This PR is DOES duplicates #7067, but:**
1. #7067 seems to be inactive for almost 2 years. No one commented on it nor merged it.
2. It has some major flaws. It is NOT efficient and it DOES waste computer resources. I did put a comment there with suggested changes but I'm not sure the original author will bother to fix them.

For the reasons above I'm suggesting my own version to this much-needed feature. 

## Standards checklist:

- [] The PR doesn't replicate another PR which is already open.
- [x] The PR title is descriptive.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added the currently activated conda env to the prompt

## Other comments:
The prompt is prepended with "conda:" to make it clear that it is a conda env, and not regular `venv`.
I know it is a bit unconventional, but I think it adds clarity, and thos "()" weren't useful anyway.
BUT - If you feel this change is too much - I'd be happy to revert the promp to the old `(envname)` format.

![image](https://user-images.githubusercontent.com/831127/76024926-9a4e9200-5f34-11ea-8a64-e7e46b36abfe.png)

...
