### PR TITLE
fix aws completer path on nixos

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -93,8 +93,8 @@ else
     elif [[ -e /usr/share/zsh/vendor-completions/_awscli ]]; then
       _aws_zsh_completer_path=/usr/share/zsh/vendor-completions/_awscli
     # NixOS
-    elif [[ -e "$(dirname "$(dirname $(realpath "$(command -v aws)"))")/share/zsh/site-functions/aws_zsh_completer.sh" ]]; then
-      _aws_zsh_completer_path="$(dirname "$(dirname $(realpath "$(command -v aws)"))")/share/zsh/site-functions/aws_zsh_completer.sh"
+    elif [[ -e "${commands[aws]:P:h:h}/share/zsh/site-functions/aws_zsh_completer.sh" ]]; then
+      _aws_zsh_completer_path="${commands[aws]:P:h:h}/share/zsh/site-functions/aws_zsh_completer.sh"
     # RPM
     else
       _aws_zsh_completer_path=/usr/share/zsh/site-functions/aws_zsh_completer.sh

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -92,6 +92,9 @@ else
     # Ubuntu
     elif [[ -e /usr/share/zsh/vendor-completions/_awscli ]]; then
       _aws_zsh_completer_path=/usr/share/zsh/vendor-completions/_awscli
+    # NixOS
+    elif [[ -e "$(dirname "$(dirname $(realpath "$(command -v aws)"))")/share/zsh/site-functions/aws_zsh_completer.sh" ]]; then
+      _aws_zsh_completer_path="$(dirname "$(dirname $(realpath "$(command -v aws)"))")/share/zsh/site-functions/aws_zsh_completer.sh"
     # RPM
     else
       _aws_zsh_completer_path=/usr/share/zsh/site-functions/aws_zsh_completer.sh


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add a new aws completer path which works on nixos

## Other comments:

...
