### PR TITLE
Add markdown Readme to z

### DIFF
--- a/plugins/z/README.md
+++ b/plugins/z/README.md
@@ -1,0 +1,23 @@
+# z - jump around
+
+This plugin defines the [z command](https://github.com/rupa/z) that tracks your most visited directories and allows you to access them with very few keystrokes.
+
+### Example
+Assume that you have previously visited directory `~/.oh-my-zsh/plugins`. From any folder in your command line, you can quickly access it by using a regex match to this folder:
+
+```bash
+/usr/bin$ z plug  # Even 'z p' might suffice
+~/.oh-my-zsh/plugins$
+```
+
+### Setup
+To enable z, add `z` to your `plugins` array in your zshrc file:
+
+```zsh
+plugins=(... z)
+```
+
+### Further reading
+
+For advanced usage and details of z, see [README](./README) (in man page format, copied from [rupa/z](https://github.com/rupa/z)).
+


### PR DESCRIPTION
## Standards checklist
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes
- Add markdown readme for the z plugin
- The new readme enables quick understanding of z and its installation in zsh

## Other comments
- I did not replace the original README file that contains the complete description from https://github.com/rupa/z. I'm only linking to it from the new readme. This way, we can continue to easily pull updates from https://github.com/rupa/z to the original README.
- I [verified](https://github.com/cbachhuber/ohmyzsh/tree/update-z-readme/plugins/z) that GitHub gives higher priority to rendering `README.md` over `README`.