### PR TITLE
rsync: update -z to -zz

### DIFF
--- a/plugins/rsync/rsync.plugin.zsh
+++ b/plugins/rsync/rsync.plugin.zsh
@@ -1,4 +1,4 @@
-alias rsync-copy="rsync -avz --progress -h"
-alias rsync-move="rsync -avz --progress -h --remove-source-files"
-alias rsync-update="rsync -avzu --progress -h"
-alias rsync-synchronize="rsync -avzu --delete --progress -h"
+alias rsync-copy="rsync -avzz --progress -h"
+alias rsync-move="rsync -avzz --progress -h --remove-source-files"
+alias rsync-update="rsync -avzzu --progress -h"
+alias rsync-synchronize="rsync -avzzu --delete --progress -h"


### PR DESCRIPTION
```
This rsync lacks old-style --compress due to its external zlib.  Try -zz.
Continuing without compression.
```

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
