### PR TITLE
dotenv plugin: agree once improvement

### DIFF
--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -4,9 +4,7 @@ Automatically load your project ENV variables from `.env` file when you `cd` int
 
 Storing configuration in the environment is one of the tenets of a [twelve-factor app](https://www.12factor.net). Anything that is likely to change between deployment environments, such as resource handles for databases or credentials for external services, should be extracted from the code into environment variables.
 
-## Installation
-
-Just add the plugin to your `.zshrc`:
+To use it, add `dotenv` to the plugins array in your zshrc file:
 
 ```sh
 plugins=(... dotenv)
@@ -17,22 +15,26 @@ plugins=(... dotenv)
 Create `.env` file inside your project root directory and put your ENV variables there.
 
 For example:
+
 ```sh
 export AWS_S3_TOKEN=d84a83539134f28f412c652b09f9f98eff96c9a
 export SECRET_KEY=7c6c72d959416d5aa368a409362ec6e2ac90d7f
 export MONGO_URI=mongodb://127.0.0.1:27017
 export PORT=3001
 ```
+
 `export` is optional. This format works as well:
+
 ```sh
 AWS_S3_TOKEN=d84a83539134f28f412c652b09f9f98eff96c9a
 SECRET_KEY=7c6c72d959416d5aa368a409362ec6e2ac90d7f
 MONGO_URI=mongodb://127.0.0.1:27017
 PORT=3001
 ```
+
 You can even mix both formats, although it's probably a bad idea.
 
-## Plugin options
+## Settings
 
 ### ZSH_DOTENV_FILE
 
@@ -40,7 +42,7 @@ You can also modify the name of the file to be loaded with the variable `ZSH_DOT
 If the variable isn't set, the plugin will default to use `.env`.
 For example, this will make the plugin look for files named `.dotenv` and load them:
 
-```
+```zsh
 # in ~/.zshrc, before Oh My Zsh is sourced:
 ZSH_DOTENV_FILE=.dotenv
 ```
@@ -48,6 +50,27 @@ ZSH_DOTENV_FILE=.dotenv
 ### ZSH_DOTENV_PROMPT
 
 Set `ZSH_DOTENV_PROMPT=false` in your zshrc file if you don't want the confirmation message.
+You can also choose the `Always` option when prompted to always allow sourcing the .env file
+in that directory. See the next section for more details.
+
+### ZSH_DOTENV_ALLOWED_LIST
+
+The default behavior of the plugin is to always ask whether to source a dotenv file. There's
+a **Y**es, **N**o, and **A**lways option. If you choose Always, the directory of the .env file
+will be added to an allowed list. If a directory is found in this list, the plugin won't ask
+for confirmation and will instead source the .env file directly.
+
+This allowed list is saved by default in `$ZSH_CACHE_DIR/dotenv-allowed.list`. If you want
+to change that location, change the `$ZSH_DOTENV_ALLOWED_LIST` variable, like so:
+
+```zsh
+# in ~/.zshrc, before Oh My Zsh is sourced:
+ZSH_DOTENV_ALLOWED_LIST=/path/to/dotenv/allowed/list
+```
+
+This file is just a list of directories allowed, separated by a newline character. If you want
+to disallow a directory, just edit this file and remove the line for the directory you want to
+disallow.
 
 ## Version Control
 
@@ -58,5 +81,6 @@ Set `ZSH_DOTENV_PROMPT=false` in your zshrc file if you don't want the confirmat
 This plugin only sources the `.env` file. Nothing less, nothing more. It doesn't do any checks. It's designed to be the fastest and simplest option. You're responsible for the `.env` file content. You can put some code (or weird symbols) there, but do it on your own risk. `dotenv` is the basic tool, yet it does the job.
 
 If you need more advanced and feature-rich ENV management, check out these awesome projects:
+
 * [direnv](https://github.com/direnv/direnv)
 * [zsh-autoenv](https://github.com/Tarrasch/zsh-autoenv)

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -1,3 +1,14 @@
+## Settings
+
+# Filename of the dotenv file to look for
+: ${ZSH_DOTENV_FILE:=.env}
+
+# Path to the file containing allowed paths
+: ${ZSH_DOTENV_ALLOWED_LIST:="${ZSH_CACHE_DIR}/dotenv-allowed.list"}
+
+
+## Functions
+
 source_env() {
   if [[ -f $ZSH_DOTENV_FILE ]]; then
     if [[ "$ZSH_DOTENV_PROMPT" != false ]]; then
@@ -24,25 +35,12 @@ source_env() {
     # test .env syntax
     zsh -fn $ZSH_DOTENV_FILE || echo "dotenv: error when sourcing '$ZSH_DOTENV_FILE' file" >&2
 
-    if [[ -o a ]]; then
-      source $ZSH_DOTENV_FILE
-    else
-      set -a
-      source $ZSH_DOTENV_FILE
-      set +a
-    fi
+    setopt localoptions allexport
+    source $ZSH_DOTENV_FILE
   fi
 }
 
 autoload -U add-zsh-hook
 add-zsh-hook chpwd source_env
-
-if [[ -z $ZSH_DOTENV_FILE ]]; then
-  ZSH_DOTENV_FILE=.env
-fi
-
-if [[ -z $ZSH_DOTENV_AGREE_LIST_FILE ]]; then
-  ZSH_DOTENV_AGREE_LIST_FILE="${ZSH}/dotenv-agree.list"
-fi
 
 source_env

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -1,26 +1,23 @@
 source_env() {
   if [[ -f $ZSH_DOTENV_FILE ]]; then
-    if [ "$ZSH_DOTENV_PROMPT" != "false" ]; then
-      # agree list
-      touch "${ZSH_DOTENV_AGREE_LIST_FILE}"
-      local dotenv_absolutepath="${ZSH_DOTENV_FILE:A}"
-      local agree_list="${(@f)"$(<${ZSH_DOTENV_AGREE_LIST_FILE})"}"
-      [[ ${agree_list[(ie)$]} -le ${#agree_list} ]]; local alreadyagreed=$?
+    if [[ "$ZSH_DOTENV_PROMPT" != false ]]; then
+      local confirmation dirpath="$PWD"
 
-      if ! [ "$alreadyagreed" = "1" ]; then
-        # confirm before sourcing file
-        local confirmation
+      # make sure there is an allowed file
+      touch "$ZSH_DOTENV_ALLOWED_LIST"
+
+      # check if current directory's .env file is allowed or ask for confirmation
+      if ! grep -q "$dirpath" "$ZSH_DOTENV_ALLOWED_LIST" &>/dev/null; then
         # print same-line prompt and output newline character if necessary
-        echo -n "dotenv: source '$ZSH_DOTENV_FILE' file in the directory? ([Y]es/[a]lways/[n]n) "
+        echo -n "dotenv: found '$ZSH_DOTENV_FILE' file. Source it? ([Y]es/[n]o/[a]lways) "
         read -k 1 confirmation; [[ "$confirmation" != $'\n' ]] && echo
-        # only bail out if confirmation character is n
-        if [[ "$confirmation" = [nN] ]]; then
-          return
-        fi
 
-        if [[ "$confirmation" = [aA] ]]; then
-          echo "${dotenv_absolutepath}" >> "${ZSH_DOTENV_AGREE_LIST_FILE}"
-        fi
+        # check input
+        case "$confirmation" in
+          [nN]) return ;;
+          [aA]) echo "$dirpath" >> "$ZSH_DOTENV_ALLOWED_LIST" ;;
+          *) ;; # interpret anything else as a yes
+        esac
       fi
     fi
 

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -12,7 +12,7 @@
 source_env() {
   if [[ -f $ZSH_DOTENV_FILE ]]; then
     if [[ "$ZSH_DOTENV_PROMPT" != false ]]; then
-      local confirmation dirpath="$PWD"
+      local confirmation dirpath="${PWD:A}"
 
       # make sure there is an allowed file
       touch "$ZSH_DOTENV_ALLOWED_LIST"

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -3,7 +3,7 @@ source_env() {
     if [ "$ZSH_DOTENV_PROMPT" != "false" ]; then
       # agree list
       touch "${ZSH_DOTENV_AGREE_LIST_FILE}"
-      local dotenv_absolutepath="$(readlink -f $ZSH_DOTENV_FILE)"
+      local dotenv_absolutepath="${ZSH_DOTENV_FILE:A}"
       local agree_list="${(@f)"$(<${ZSH_DOTENV_AGREE_LIST_FILE})"}"
       [[ ${agree_list[(ie)$]} -le ${#agree_list} ]]; local alreadyagreed=$?
 
@@ -49,4 +49,3 @@ if [[ -z $ZSH_DOTENV_AGREE_LIST_FILE ]]; then
 fi
 
 source_env
-

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -4,7 +4,7 @@
 : ${ZSH_DOTENV_FILE:=.env}
 
 # Path to the file containing allowed paths
-: ${ZSH_DOTENV_ALLOWED_LIST:="${ZSH_CACHE_DIR}/dotenv-allowed.list"}
+: ${ZSH_DOTENV_ALLOWED_LIST:="${ZSH_CACHE_DIR:-$ZSH/cache}/dotenv-allowed.list"}
 
 
 ## Functions

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -18,9 +18,9 @@ source_env() {
           return
         fi
 
-	      if [[ "$confirmation" = [aA] ]]; then
-	        echo "${dotenv_absolutepath}" >> "${ZSH_DOTENV_AGREE_LIST_FILE}"
-	      fi
+        if [[ "$confirmation" = [aA] ]]; then
+          echo "${dotenv_absolutepath}" >> "${ZSH_DOTENV_AGREE_LIST_FILE}"
+        fi
       fi
     fi
 
@@ -41,11 +41,11 @@ autoload -U add-zsh-hook
 add-zsh-hook chpwd source_env
 
 if [[ -z $ZSH_DOTENV_FILE ]]; then
-    ZSH_DOTENV_FILE=.env
+  ZSH_DOTENV_FILE=.env
 fi
 
 if [[ -z $ZSH_DOTENV_AGREE_LIST_FILE ]]; then
-    ZSH_DOTENV_AGREE_LIST_FILE="${ZSH}/dotenv-agree.list"
+  ZSH_DOTENV_AGREE_LIST_FILE="${ZSH}/dotenv-agree.list"
 fi
 
 source_env


### PR DESCRIPTION
Hi! I must admit that I got really annoyed when dotenv plugin started asking me over and over whether I want to load .env files. On the other hand I understand that this is crucial to my security and I am really thankful to the one who introduced that prompt feature. To make it more convenient I made a small improvement that allows you to accept .env at given path once. I think it is a good compromise between convenience and security.

With oss love,
Jędrzej

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- New feature for **dotenv** plugin: you can ask plugin to accept given .env file once
  - When prompted if you want to load .env file, you can now type 'a' which will add absolute path to a list of accepted .env files
  - Once path is added to the list, the plugin will not ask again if you want to load this particular .env
  - The list is kept in a file `$ZSH/dotenv-agree.list`.
  - Path to the list file is configurable via `$ZSH_DOTENV_AGREE_LIST_FILE` variable
