### PR TITLE
gradle: force `--console plain` for tasks cache generation

### DIFF
--- a/plugins/gradle/_gradle
+++ b/plugins/gradle/_gradle
@@ -116,9 +116,9 @@ __gradle-generate-tasks-cache() {
     # Reuse Gradle Daemon if IDLE but don't start a new one.
     local gradle_tasks_output
     if [[ ! -z "$($gradle_cmd --status 2>/dev/null | grep IDLE)" ]]; then
-        gradle_tasks_output="$($gradle_cmd --daemon --build-file $gradle_build_file -q tasks --all 2>/dev/null)"
+        gradle_tasks_output="$($gradle_cmd --daemon --build-file $gradle_build_file --console plain -q tasks --all 2>/dev/null)"
     else
-        gradle_tasks_output="$($gradle_cmd --no-daemon --build-file $gradle_build_file -q tasks --all 2>/dev/null)"
+        gradle_tasks_output="$($gradle_cmd --no-daemon --build-file $gradle_build_file --console plain -q tasks --all 2>/dev/null)"
     fi
     local gradle_all_tasks="" root_tasks="" subproject_tasks="" output_line
     local -a match


### PR DESCRIPTION
Fixes #8730

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds `--console plain` to `gradle tasks` invocation to turn off colored output
