### PR TITLE
Add bilibili.com search to web-search plugin

### DIFF
--- a/plugins/web-search/README.md
+++ b/plugins/web-search/README.md
@@ -34,6 +34,7 @@ Available search contexts are:
 | `yandex`              | `https://yandex.ru/yandsearch?text=`     |
 | `github`              | `https://github.com/search?q=`           |
 | `baidu`               | `https://www.baidu.com/s?wd=`            |
+| `bilibili`            | `https://search.bilibili.com/all?keyword=`|
 | `ecosia`              | `https://www.ecosia.org/search?q=`       |
 | `goodreads`           | `https://www.goodreads.com/search?q=`    |
 | `qwant`               | `https://www.qwant.com/?q=`              |

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -13,6 +13,7 @@ function web_search() {
     startpage   "https://www.startpage.com/do/search?q="
     yandex      "https://yandex.ru/yandsearch?text="
     github      "https://github.com/search?q="
+    bilibili    "https://search.bilibili.com/all?keyword="
     baidu       "https://www.baidu.com/s?wd="
     ecosia      "https://www.ecosia.org/search?q="
     goodreads   "https://www.goodreads.com/search?q="
@@ -51,6 +52,7 @@ alias sp='web_search startpage'
 alias yandex='web_search yandex'
 alias github='web_search github'
 alias baidu='web_search baidu'
+alias bilibili='web_search bilibili'
 alias ecosia='web_search ecosia'
 alias goodreads='web_search goodreads'
 alias qwant='web_search qwant'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- just add [bilibili.com](https://www.bilibili.com) search to web-search plugin `README.md` and `web-search.plugin.zsh`. 

## Other comments:
For thousands of Chinese young people, bilibili is our youtube. I would appreciate it if I can search directly from the terminal by this amazing plugin ;)