### PR TITLE
man: Removed everything but the command itself before prepending man

### DIFF
--- a/plugins/man/man.plugin.zsh
+++ b/plugins/man/man.plugin.zsh
@@ -14,7 +14,8 @@
 
 man-command-line() {
     [[ -z $BUFFER ]] && zle up-history
-    [[ $BUFFER != man\ * ]] && LBUFFER="man $LBUFFER"
+    local command="$(cut -d' ' -f1 <<<"$LBUFFER")"
+    [[ $BUFFER != man\ * ]] && LBUFFER="man $command"
 }
 zle -N man-command-line
 # Defined shortcut keys: [Esc]man

--- a/plugins/man/man.plugin.zsh
+++ b/plugins/man/man.plugin.zsh
@@ -13,9 +13,12 @@
 # ------------------------------------------------------------------------------
 
 man-command-line() {
-    [[ -z $BUFFER ]] && zle up-history
-    local command="$(cut -d' ' -f1 <<<"$LBUFFER")"
-    [[ $BUFFER != man\ * ]] && LBUFFER="man $command"
+    # if there is no command typed, use the last command
+    [[ -z "$BUFFER" ]] && zle up-history
+
+    # prepend man to only the first part of the typed command
+    # http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion-Flags
+    [[ "$BUFFER" != man\ * ]] && BUFFER="man ${${(Az)BUFFER}[1]}"
 }
 zle -N man-command-line
 # Defined shortcut keys: [Esc]man


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Changed man plugin, so it removes all the arguments form the previous command and prepends man to the command itself without arguments

