### PR TITLE
update path for snapd /snap/bin/* which is used by Linux systems

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -29,6 +29,8 @@ alias stn=create_project
         "/usr/local/bin/sublime_text"
         "/usr/bin/subl"
         "/usr/bin/subl3"
+        "/snap/bin/subl"
+        "/snap/bin/sublime-text.subl"
       )
     fi
   elif [[ "$OSTYPE" = darwin* ]]; then


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds path to sublime binary installed when using `snap`:
  - /snap/bin/subl
  - /snap/bin/sublime-text.subl

## Other comments:

Fixes #8686
