### PR TITLE
gitfast: add mergetool completion

### DIFF
--- a/plugins/gitfast/_git
+++ b/plugins/gitfast/_git
@@ -144,6 +144,7 @@ __git_zsh_cmd_common ()
 	init:'create an empty Git repository or reinitialize an existing one'
 	log:'show commit logs'
 	merge:'join two or more development histories together'
+	mergetool:'run merge conflict resolution tools to resolve merge conflicts'
 	mv:'move or rename a file, a directory, or a symlink'
 	pull:'fetch from and merge with another repository or a local branch'
 	push:'update remote refs along with associated objects'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- `mergetool` has been added to the `git` completion in the `gitfast` plugin.

## Other comments:

I switched to `gitfast` because I started using `git switch`. `mergetool` was the one completion I really missed and started typing wrong because `git m<tab>` would complete to `git merge `. (Note the trailing space.)