### PR TITLE
Change direnv not assume /usr/local/bin

### DIFF
--- a/plugins/direnv/direnv.plugin.zsh
+++ b/plugins/direnv/direnv.plugin.zsh
@@ -1,6 +1,6 @@
 _direnv_hook() {
   trap -- '' SIGINT;
-  eval "$("/usr/local/bin/direnv" export zsh)";
+  eval "$(direnv export zsh)";
   trap - SIGINT;
 }
 typeset -ag precmd_functions;


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Change direnv plugin to not assume location of direnv, which is not portable across platforms (e.g. Ubuntu)

## Other comments:
