### PR TITLE
[virtualenvwrapper plugin]: Adding $HOME/.local/bin/virtualenvwrapper.sh

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -5,7 +5,8 @@ function {
              /usr/share/virtualenvwrapper/virtualenvwrapper{_lazy,}.sh \
              /usr/local/bin/virtualenvwrapper{_lazy,}.sh \
              /etc/bash_completion.d/virtualenvwrapper \
-             /usr/share/bash-completion/completions/virtualenvwrapper
+             /usr/share/bash-completion/completions/virtualenvwrapper \
+             $HOME/.local/bin/virtualenvwrapper.sh
     do
         if [[ -f $f ]]; then
             source $f


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- On Debian 10 virtualenvwrapper script is installed in directory $HOME/.local/bin/virtualenvwrapper.sh, after installing oh-my-zsh and enabling virtualenvwrapper plugin I've got the following error:

"[oh-my-zsh] virtualenvwrapper plugin: Cannot find virtualenvwrapper.sh.
 Please install with `pip install virtualenvwrapper`
[oh-my-zsh] virtualenvwrapper plugin: shell function 'workon' not defined.
 Please check" 

I added the path  $HOME/.local/bin/virtualenvwrapper.sh on virtualenvwrapper.plugin.zsh  because it was not included in #8521 