### PR TITLE
Added macOS plugin

### DIFF
--- a/plugins/macos/README.md
+++ b/plugins/macos/README.md
@@ -1,0 +1,22 @@
+# macOS plugin
+
+## Introduction
+
+The `macos plugin` adds useful command-line utilities for macOS.
+
+To use it, add `macos` to the plugins array of your zshrc file:
+
+```
+plugins=(... macos)
+```
+
+## Commands
+
+| Command                             | Description                                          |
+|:------------------------------------|:-----------------------------------------------------|
+| `clean-purgeable-disk-space <disk>` | Cleanes up purgeable disk space on the selected disk |
+
+## Maintainer
+
+### [Rob Vadai](https://github.com/robvadai)
+

--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -1,0 +1,11 @@
+# Functions
+function clean-purgeable-disk-space(){
+    if ! [ -z $1] ; then
+        echo "Cleaning purgeable files from disk : $1 ...."
+        diskutil secureErase freespace 0 $1
+    else
+        echo "Usage : clean-purgeable-disk-space <disk>"
+        echo "Example : clean-purgeable-disk-space /dev/disk1s1"
+        echo "Get available disks from the 'df -h /' command"
+    fi
+}


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added new `macos` plugin to wrap utilities solely usable (and of course helpful) on the macOS platform
- Currently only has one command, that is, to force the cleaning up of purgeable disk space on a selected macOS disk, because macOS does this in an unpredictable way therefore if one needs to free up system caches etc it is not deterministic when it will run

## Other comments:

- The disk clean up command needs to be run as an `administrator`: the plugin does not make a judgement on who is running it; for non-administrator users a password prompt will appear on the screen
...
