### PR TITLE
Fix systemd prompt appearance

### DIFF
--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -78,7 +78,7 @@ function systemd_prompt_info {
   local unit
   for unit in $@; do
     echo -n "$ZSH_THEME_SYSTEMD_PROMPT_PREFIX"
-    [[ -n "$ZSH_THEME_SYSTEMD_PROMPT_CAPS" ]] && echo "${(U)unit}:" || echo "$unit:"
+    [[ -n "$ZSH_THEME_SYSTEMD_PROMPT_CAPS" ]] && echo -n "${(U)unit}:" || echo -n "$unit:"
     if systemctl is-active $unit &>/dev/null; then
         echo -n "$ZSH_THEME_SYSTEMD_PROMPT_ACTIVE" 
     else


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fixes a bug where the prompt string has an unnecessary newline which caused issues in the prompt creation

## Other comments:

...
