### PR TITLE
colorized-man-pages: Added hooks for commands dman and debman

### DIFF
--- a/plugins/colored-man-pages/README.md
+++ b/plugins/colored-man-pages/README.md
@@ -8,6 +8,8 @@ To use it, add `colored-man-pages` to the plugins array in your zshrc file:
 plugins=(... colored-man-pages)
 ```
 
+It will also automatically add colors to man pages displayed by `dman` or `debman` from `debian-goodies` (https://packages.debian.org/stable/debian-goodies).
+
 You can also try to color other pages by prefixing the respective command with `colored`:
 
 ```zsh

--- a/plugins/colored-man-pages/README.md
+++ b/plugins/colored-man-pages/README.md
@@ -8,7 +8,8 @@ To use it, add `colored-man-pages` to the plugins array in your zshrc file:
 plugins=(... colored-man-pages)
 ```
 
-It will also automatically add colors to man pages displayed by `dman` or `debman` from `debian-goodies` (https://packages.debian.org/stable/debian-goodies).
+It will also automatically colorize man pages displayed by `dman` or `debman`,
+from [`debian-goodies`](https://packages.debian.org/stable/debian-goodies).
 
 You can also try to color other pages by prefixing the respective command with `colored`:
 

--- a/plugins/colored-man-pages/colored-man-pages.plugin.zsh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.zsh
@@ -31,18 +31,9 @@ function colored() {
 			"$@"
 }
 
-function man() {
-	colored man "$@"
-}
-
-# Colorize online man pages displayed by dman of debian-goodies
-# https://packages.debian.org/stable/debian-goodies
-function dman() {
-	colored dman "$@"
-}
-
-# Colorize man pages of deb packages displayed by debman of debian-goodies
-# https://packages.debian.org/stable/debian-goodies
-function debman() {
-	colored dman "$@"
+# Colorize man and dman/debman (from debian-goodies)
+function man \
+	dman \
+	debman {
+	colored $0 "$@"
 }

--- a/plugins/colored-man-pages/colored-man-pages.plugin.zsh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.zsh
@@ -34,3 +34,15 @@ function colored() {
 function man() {
 	colored man "$@"
 }
+
+# Colorize online man pages displayed by dman of debian-goodies
+# https://packages.debian.org/stable/debian-goodies
+function dman() {
+	colored dman "$@"
+}
+
+# Colorize man pages of deb packages displayed by debman of debian-goodies
+# https://packages.debian.org/stable/debian-goodies
+function debman() {
+	colored dman "$@"
+}


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds hooks for `dman` and `debman` similar to existing hook of `man` to colorize its output using `less`
- README of the plugin also states that `dman` and `debman` are hooked.

## Other comments:

`dman` and `debman` are tools from the package `debian-goodies` for
Debian systems (see https://packages.debian.org/stable/debian-goodies).
They can display man pages from manpages.debian.org or local debian
packages respectively.

I thought about adding a new plugin for these but then code would either
be duplicated or a dependency to this plugin would be there and as I
think non Debian users will not be disturbed by these additions this
solution should be fine. If you see it otherwise, please let me know.
