### PR TITLE
Check changes on plugins to remove .zcompdump file - closes #7642

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -61,6 +61,17 @@ if [ -z "$ZSH_COMPDUMP" ]; then
   ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
+if [ -z "$OMZ_PLUGINS"]; then
+  OMZ_PLUGINS="${ZDOTDIR:-${HOME}}/.omz-plugins"
+fi
+
+[[ -s ${OMZ_PLUGINS} ]] || echo none > $OMZ_PLUGINS
+
+if [[ "$(cat $OMZ_PLUGINS)" != "$plugins" ]]; then
+  echo $plugins > $OMZ_PLUGINS
+  rm $HOME/.zcompdump $ZSH_COMPDUMP
+fi
+
 if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
   source $ZSH/lib/compfix.zsh
   # If completion insecurities exist, warn the user


### PR DESCRIPTION
Closes #7642

The  propose is to create a file to control previous enabled plugins, and if detected plugin enabled change on environment $plugins, it removes .zcompdump and $ZSH_COMPDUMP files.