### PR TITLE
Update template to prevent redefining ZSH_THEME.

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -8,7 +8,7 @@ export ZSH=$HOME/.oh-my-zsh
 # load a random theme each time oh-my-zsh is loaded, in which case,
 # to know which specific one was loaded, run: echo $RANDOM_THEME
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
-ZSH_THEME="robbyrussell"
+ZSH_THEME="${ZSH_THEME:-robbyrussell}"
 
 # Set list of themes to pick from when loading at random
 # Setting this variable when ZSH_THEME=random will cause zsh to load


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Use an existing ZSH_THEME if it exists. 

## Other comments:

Fixes #8782

```
╭─jsteel@blacktop ~/.oh-my-zsh ‹use_existing_theme› 
╰─$ date
Sun Mar 29 12:08:15 EDT 2020

╭─jsteel@blacktop ~/.oh-my-zsh ‹use_existing_theme› 
╰─$ unset ZSH_THEME                                                                    
╭─jsteel@blacktop ~/.oh-my-zsh ‹use_existing_theme› 
╰─$ exec zsh
➜  .oh-my-zsh git:(use_existing_theme) echo $ZSH_THEME
robbyrussell
➜  .oh-my-zsh git:(use_existing_theme) ZSH_THEME=bira exec zsh

╭─jsteel@blacktop ~/.oh-my-zsh ‹use_existing_theme› 
╰─$ git --no-pager show
commit e7ab9cedf51a5c7f0f5b8ff020984f7fd194f6e0 (HEAD -> use_existing_theme)
Author: John Steel <john@steelcomputers.com>
Date:   Sun Mar 29 11:47:07 2020 -0400

    Update template to prevent redefining ZSH_THEME.

diff --git a/templates/zshrc.zsh-template b/templates/zshrc.zsh-template
index d16713cc..2702f846 100644
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -8,7 +8,7 @@ export ZSH=$HOME/.oh-my-zsh
 # load a random theme each time oh-my-zsh is loaded, in which case,
 # to know which specific one was loaded, run: echo $RANDOM_THEME
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
-ZSH_THEME="robbyrussell"
+ZSH_THEME="${ZSH_THEME:-robbyrussell}"
 
 # Set list of themes to pick from when loading at random
 # Setting this variable when ZSH_THEME=random will cause zsh to load
╭─jsteel@blacktop ~/.oh-my-zsh ‹use_existing_theme› 
╰─$ 

╭─jsteel@blacktop ~/.oh-my-zsh ‹use_existing_theme› 
╰─$ git --no-pager log --all --decorate --oneline --graph --max-count=5 # git log a dog
* e7ab9ced (HEAD -> use_existing_theme, yugen/use_existing_theme) Update template to prevent redefining ZSH_THEME.
| * 4f48e28b (master) Update template to prevent redefining ZSH_THEME.
|/  
* d247f98d (origin/master, origin/HEAD) nebirhos: use short hostname in prompt
* 00f3fa2c keychain: define SHORT_HOST if not defined
* bcc3ee8c systemd: remove newline from systemd prompt (#8772)
```