### PR TITLE
screen plugin: (optional) hiding host and/or path

### DIFF
--- a/plugins/screen/screen.plugin.zsh
+++ b/plugins/screen/screen.plugin.zsh
@@ -1,15 +1,28 @@
 # if using GNU screen, let the zsh tell screen what the title and hardstatus
 # of the tab window should be.
+
+#put 'SCREENTAB_USE_HOST="no"' in .zshrc to hide the hostname in the title
+#put 'SCREENTAB_USE_PATH="no"' in .zshrc to hide the current path in the title
+
 if [[ "$TERM" == screen* ]]; then
+  #Find the path and host.
+  #The path should always be found because it's used in TAB_HARDSTATUS_PREFIX
   if [[ $_GET_PATH == '' ]]; then
     _GET_PATH='echo $PWD | sed "s/^\/Users\//~/;s/^\/home\//~/;s/^~$USER/~/"'
   fi
-  if [[ $_GET_HOST == '' ]]; then
+  if [[ $_GET_HOST == '' && ! $SCREENTAB_USE_HOST == "no" ]]; then
     _GET_HOST='echo $HOST | sed "s/\..*//"'
   fi
 
-  # use the current user as the prefix of the current tab title 
-  TAB_TITLE_PREFIX='"`'$_GET_HOST'`:`'$_GET_PATH' | sed "s:..*/::"`$PROMPT_CHAR"'
+  # use the hostname and current path as the prefix of the current tab title
+  TAB_TITLE_PREFIX='"'
+  if [[ ! $SCREENTAB_USE_HOST == "no" ]]; then
+    TAB_TITLE_PREFIX=$TAB_TITLE_PREFIX'$('$_GET_HOST'):'
+  fi
+  if [[ ! $SCREENTAB_USE_PATH == "no" ]]; then
+    TAB_TITLE_PREFIX=$TAB_TITLE_PREFIX'$('$_GET_PATH' | sed "s:..*/::"):'
+  fi
+  TAB_TITLE_PREFIX=$TAB_TITLE_PREFIX'$PROMPT_CHAR"'
   # when at the shell prompt, show a truncated version of the current path (with
   # standard ~ replacement) as the rest of the title.
   TAB_TITLE_PROMPT='$SHELL:t'
@@ -19,7 +32,7 @@ if [[ "$TERM" == screen* ]]; then
 
   # use the current path (with standard ~ replacement) in square brackets as the
   # prefix of the tab window hardstatus.
-  TAB_HARDSTATUS_PREFIX='"[`'$_GET_PATH'`] "'
+  TAB_HARDSTATUS_PREFIX='"[$('$_GET_PATH')] "'
   # when at the shell prompt, use the shell name (truncated to remove the path to
   # the shell) as the rest of the title
   TAB_HARDSTATUS_PROMPT='$SHELL:t'
@@ -28,27 +41,27 @@ if [[ "$TERM" == screen* ]]; then
   TAB_HARDSTATUS_EXEC='$cmd'
 
   # tell GNU screen what the tab window title ($1) and the hardstatus($2) should be
-  function screen_set()
-  {
+  screen_set() {
     # set the tab window title (%t) for screen
     print -nR $'\033k'$1$'\033'\\\
 
     # set hardstatus of tab window (%h) for screen
     print -nR $'\033]0;'$2$'\a'
+    return 0
   }
   # called by zsh before executing a command
-  function preexec()
-  {
+  preexec() {
     local -a cmd; cmd=(${(z)1}) # the command string
-    eval "tab_title=$TAB_TITLE_PREFIX:$TAB_TITLE_EXEC"
+    eval "tab_title=$TAB_TITLE_PREFIX$TAB_TITLE_EXEC"
     eval "tab_hardstatus=$TAB_HARDSTATUS_PREFIX:$TAB_HARDSTATUS_EXEC"
     screen_set $tab_title $tab_hardstatus
+    return 0
   }
   # called by zsh before showing the prompt
-  function precmd()
-  {
-    eval "tab_title=$TAB_TITLE_PREFIX:$TAB_TITLE_PROMPT"
+  precmd() {
+    eval "tab_title=$TAB_TITLE_PREFIX$TAB_TITLE_PROMPT"
     eval "tab_hardstatus=$TAB_HARDSTATUS_PREFIX:$TAB_HARDSTATUS_PROMPT"
     screen_set $tab_title $tab_hardstatus
+    return 0
   }
 fi


### PR DESCRIPTION


## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
- By setting `SCREENTAB_USE_HOST="no"` and/or `SCREENTAB_USE_PATH="no"` in `.zshrc` the hostname and/or current path will be hidden in the tab titles
- Update the incorrect comment about showing the current user

## Other comments:

- By default the behavior of the plugin stays exactly the same
- Although i followed the code style guide for MY changes, i only partially fixed the code style of the original file (where it could be done without changing the code too much).
This is done to keep the code reasonably similar, fixing the code style completely should be done in a different PR.