### PR TITLE
[FEATURE: CHTH] change theme by command line

### DIFF
--- a/chth.sh
+++ b/chth.sh
@@ -6,15 +6,31 @@
 DEFAULT="\033[00m"
 YELLOW="\033[1;33m"
 TEAL="\033[1;36m"
+RED="\033[1;31m"
+GREEN="\033[1;32m"
 
 #
 ## function chth for change theme
 ## change the current ZSH_THEME by the one readed on stdin
-## TODO: add error handling on theme selected || autocompletion for theme choice
+## src:
+## - https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/themes/themes.plugin.zsh
+##           plugin which ables you to change your theme on your current term
+## - man sed
 #
 chth() {
 	echo -e $YELLOW'Current Theme: '$TEAL $ZSH_THEME $DEFAULT
 	read -p $'\e[1;33mEnter new theme: \e[00m' choice
-	sed -i -e '/ZSH_THEME=\"./s/'$ZSH_THEME'/'$choice'/g' ~/.zshrc
+    if [[ -f "$ZSH_CUSTOM/$choice.zsh-theme" ]]; then
+        sed -i -e '/ZSH_THEME=\"./s/'$ZSH_THEME'/'$choice'/g' ~/.zshrc
+    elif [[ -f "$ZSH_CUSTOM/themes/$choice.zsh-theme" ]]; then
+        sed -i -e '/ZSH_THEME=\"./s/'$ZSH_THEME'/'$choice'/g' ~/.zshrc
+    elif [[ -f "$ZSH/themes/$choice.zsh-theme" ]]; then
+        sed -i -e '/ZSH_THEME=\"./s/'$ZSH_THEME'/'$choice'/g' ~/.zshrc
+    else
+        echo -e $RED'ERROR: the theme selected is not avaible. Please retry with a valid theme.'$DEFAULT
+        return 84
+    fi
+    echo -e $GREEN"Your theme was changed successfully!"$DEFAULT
+    return 0
 }
 chth

--- a/chth.sh
+++ b/chth.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/sh
+
+#
+## Define colors
+#
+DEFAULT="\033[00m"
+YELLOW="\033[1;33m"
+TEAL="\033[1;36m"
+
+#
+## function chth for change theme
+## change the current ZSH_THEME by the one readed on stdin
+## TODO: add error handling on theme selected || autocompletion for theme choice
+#
+chth() {
+	echo -e $YELLOW'Current Theme: '$TEAL $ZSH_THEME $DEFAULT
+	read -p $'\e[1;33mEnter new theme: \e[00m' choice
+	sed -i -e '/ZSH_THEME=\"./s/'$ZSH_THEME'/'$choice'/g' ~/.zshrc
+}
+chth

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -8,7 +8,7 @@ export ZSH=$HOME/.oh-my-zsh
 # load a random theme each time oh-my-zsh is loaded, in which case,
 # to know which specific one was loaded, run: echo $RANDOM_THEME
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
-ZSH_THEME="robbyrussell"
+export ZSH_THEME="robbyrussell"
 
 # Set list of themes to pick from when loading at random
 # Setting this variable when ZSH_THEME=random will cause zsh to load
@@ -97,3 +97,4 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+#alias chth="~/.oh-my-zsh/chth.sh; source ~/.zshrc"


### PR DESCRIPTION
The script added in this feature aims to allow the modification of the theme without editing the .zshrc itself.
I know it's not necessarily a useful addition, but I thought it might be interesting to be able to select our theme by using command line.
To be 100% user friendly, I would like to add error handling to avoid choosing a theme that cannot be found. For that I had thought of using the _find_ command and check the result but I would first like to know if it is possible to add autocompletion in order to propose names of themes found in "oh-my-zsh / themes" directory.
![chth_look](https://user-images.githubusercontent.com/46595004/78017424-8f78f880-734c-11ea-83c9-b3f61fd02856.png)
