### PR TITLE
Add git functions for sorted listing of branches based on last commit date

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -270,3 +270,17 @@ function grename() {
     git push --set-upstream origin "$2"
   fi
 }
+
+# Git branch list local: list local branches, sort by last commit date
+function gbll {
+  git for-each-ref --sort=committerdate refs/heads/ --format="%(committerdate:short)|%(refname:short)|%(committername)" | while IFS='|' read date branch name; do
+    printf "%s %-40s %s\n" "$date" "$branch" "$name"
+  done
+}
+
+# Git branch list origin: list remote branches on origin, sort by last commit date
+function gblo {
+  git for-each-ref --sort=committerdate refs/remotes/origin --format="%(committerdate:short)|%(refname:short)|%(committername)" | while IFS='|' read date branch name; do
+    printf "%s %-40s %s\n" "$date" "${branch##origin/}" "$name"
+  done
+}


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Only changes to the git plugin. Two new functions that makes it easy to see what branches you've worked on last, and what branches collaborators worked on last

- `gbll`: List local branches, sort by commit date
- `gblo` List branches on origin, sort by commit date

## Other comments:

Sample

```
╰ gblo
2019-07-11 something_some                           John Doe
2019-07-18 address_metrics_feedback                 Jostein Gogstad
2019-07-23 something-else-entirely                  GitHub
``` 

Same output for `gbll` just based on local branches