### PR TITLE
gnu-utils: append make to cmds

### DIFF
--- a/plugins/gnu-utils/gnu-utils.plugin.zsh
+++ b/plugins/gnu-utils/gnu-utils.plugin.zsh
@@ -36,7 +36,7 @@ __gnu_utils() {
   gcmds+=('gfind' 'gxargs' 'glocate')
 
   # Not part of either coreutils or findutils, installed separately.
-  gcmds+=('gsed' 'gtar' 'gtime')
+  gcmds+=('gsed' 'gtar' 'gtime' 'gmake')
 
   for gcmd in "${gcmds[@]}"; do
     # Do nothing if the command isn't found


### PR DESCRIPTION
GNU "make" is installed as "gmake" by homebrew.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

append make to cmds in gnu-utils plugin.