### PR TITLE
Make prefix check on "jira branch" command case-insensitive

### DIFF
--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -26,6 +26,11 @@ jira branch     # opens an existing issue matching the current branch name
                 # The branch name may have prefixes ending in "/": "feature/MP-1234",
                 # and also suffixes starting with "_": "MP-1234_fix_dashboard"
                 # In both these cases, the issue opened will be "MP-1234"
+		# This is also checks if the prefix is in the name, and adds it if not, so:
+		# "MP-1234" opens the issue "MP-1234",
+		# "mp-1234" opens the issue "mp-1234",
+		# and "1234" opens the issue "MP-1234".
+		# NOTE: since jira is case insensitive, the first two examples open the same issue
 jira ABC-123    # opens an existing issue
 jira ABC-123 m  # opens an existing issue for adding a comment
 ```

--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -26,11 +26,11 @@ jira branch     # opens an existing issue matching the current branch name
                 # The branch name may have prefixes ending in "/": "feature/MP-1234",
                 # and also suffixes starting with "_": "MP-1234_fix_dashboard"
                 # In both these cases, the issue opened will be "MP-1234"
-		# This is also checks if the prefix is in the name, and adds it if not, so:
-		# "MP-1234" opens the issue "MP-1234",
-		# "mp-1234" opens the issue "mp-1234",
-		# and "1234" opens the issue "MP-1234".
-		# NOTE: since jira is case insensitive, the first two examples open the same issue
+                # This is also checks if the prefix is in the name, and adds it if not, so:
+                # "MP-1234" opens the issue "MP-1234",
+                # "mp-1234" opens the issue "mp-1234",
+                # and "1234" opens the issue "MP-1234".
+# NOTE: since jira is case insensitive, the first two examples open the same issue
 jira ABC-123    # opens an existing issue
 jira ABC-123 m  # opens an existing issue for adding a comment
 ```

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -72,7 +72,7 @@ function jira() {
       # Strip suffixes starting with _
       issue_arg=(${(s:_:)issue_arg})
       issue_arg=${issue_arg[1]}
-      if [[ "$issue_arg" = ${jira_prefix}* ]]; then
+      if [[ "$issue_arg:l" = ${jira_prefix:l}* ]]; then
         issue="${issue_arg}"
       else
         issue="${jira_prefix}${issue_arg}"

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -72,7 +72,7 @@ function jira() {
       # Strip suffixes starting with _
       issue_arg=(${(s:_:)issue_arg})
       issue_arg=${issue_arg[1]}
-      if [[ "$issue_arg:l" = ${jira_prefix:l}* ]]; then
+      if [[ "${issue_arg:l}" = ${jira_prefix:l}* ]]; then
         issue="${issue_arg}"
       else
         issue="${jira_prefix}${issue_arg}"


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Converts both `issue_arg` and `JIRA_PREFIX` to lower case before checking if the prefix is already present. 

## Helps to Fix
- Teammates randomly deciding whether they want capital letters in their branch name
