### PR TITLE
zsh_reload: respect ZSH_COMPDUMP

### DIFF
--- a/plugins/zsh_reload/zsh_reload.plugin.zsh
+++ b/plugins/zsh_reload/zsh_reload.plugin.zsh
@@ -1,9 +1,8 @@
 src() {
-	local cache="$ZSH_CACHE_DIR"
 	autoload -U compinit zrecompile
-	compinit -i -d "$cache/zcomp-$HOST"
+	compinit -i -d "${ZSH_COMPDUMP}"
 
-	for f in ${ZDOTDIR:-~}/.zshrc "$cache/zcomp-$HOST"; do
+	for f in ${ZDOTDIR:-~}/.zshrc "${ZSH_COMPDUMP}"; do
 		zrecompile -p $f && command rm -f $f.zwc.old
 	done
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

zsh_reload should respect `ZSH_COMPDUMP` instead of make its own.
