### PR TITLE
place default compdump in ZSH_CACHE_DIR instead of ZDOTDIR

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -58,7 +58,7 @@ fi
 
 # Save the location of the current completion dump file.
 if [ -z "$ZSH_COMPDUMP" ]; then
-  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+  ZSH_COMPDUMP="${ZSH_CACHE_DIR}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
 if [[ $ZSH_DISABLE_COMPFIX != true ]]; then

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -58,7 +58,7 @@ fi
 
 # Save the location of the current completion dump file.
 if [ -z "$ZSH_COMPDUMP" ]; then
-  ZSH_COMPDUMP="${ZSH_CACHE_DIR}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+  ZSH_COMPDUMP="${ZSH_CACHE_DIR}/zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
 if [[ $ZSH_DISABLE_COMPFIX != true ]]; then


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

_compdump_ should be consided as a cache file.  Don't pollute user's home, and `ZDOTDIR` maybe not writable.