### PR TITLE
perform CoW copy if possible

### DIFF
--- a/lib/cp.zsh
+++ b/lib/cp.zsh
@@ -1,0 +1,23 @@
+# Modern filesystems, e.g. BTRFS, APFS, implement copy-on-write (CoW) feature,
+# which could perform instant (lightweight) copy.
+
+__TEMP_1=`mktemp`
+__TEMP_2=`mktemp`
+
+if [[ "$OSTYPE" == darwin* ]]; then
+    # APFS supports CoW, and macOS since 10.12 implements it via clonefile().
+    # However, in rare cases, it will fail on cross-filesystem or non-CoW filesystem.
+    # We try clonefile() first, then fall back to normal copyfile().
+    if /bin/cp -c ${__TEMP_1} ${__TEMP_2} &>/dev/null; then
+        cp () { /bin/cp -c "$@" 2>/dev/null || /bin/cp "$@" ; }
+    fi
+elif [[ "$OSTYPE" == linux-gnu ]]; then
+    # --reflink=auto will fall back to a standard copy if fails on lightweight copy,
+    # so it could always consider safe.
+    if /bin/cp --reflink=auto ${__TEMP_1} ${__TEMP_2} &>/dev/null; then
+        alias cp='/bin/cp --reflink=auto'
+    fi
+fi
+
+rm -f ${__TEMP_1} ${__TEMP_1} &>/dev/null
+unset __TEMP_1 __TEMP_2


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Modern filesystems, e.g. BTRFS, APFS, implement copy-on-write (CoW) feature, which could perform instant (lightweight) copy. We try performing CoW copy if possible.

fix https://github.com/ohmyzsh/ohmyzsh/issues/8791