### PR TITLE
ZSH_CACHE_DIR should respect XDG_CACHE_HOME first

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -1,7 +1,7 @@
 # Set ZSH_CACHE_DIR to the path where cache files should be created
 # or else we will use the default cache/
 if [[ -z "$ZSH_CACHE_DIR" ]]; then
-  ZSH_CACHE_DIR="$ZSH/cache"
+  ZSH_CACHE_DIR=${XDG_CACHE_HOME:-"$ZSH/cache"}
 fi
 
 # Migrate .zsh-update file to $ZSH_CACHE_DIR


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

In some distro, i.e. archlinux, oh-my-zsh is packaged system-wide, which causes the whole `ZSH` readonly. Since `XDG_CACHE_HOME` has been defined in _XDG Base Directory Specification_, we should respect it first.