### PR TITLE
direnv: check if direnv is installed

### DIFF
--- a/plugins/direnv/direnv.plugin.zsh
+++ b/plugins/direnv/direnv.plugin.zsh
@@ -1,15 +1,16 @@
-if type "direnv" > /dev/null; then
-  _direnv_hook() {
-    trap -- '' SIGINT;
-    eval "$(direnv export zsh)";
-    trap - SIGINT;
-  }
-  typeset -ag precmd_functions;
-  if [[ -z ${precmd_functions[(r)_direnv_hook]} ]]; then
-    precmd_functions=( _direnv_hook ${precmd_functions[@]} )
-  fi
-  typeset -ag chpwd_functions;
-  if [[ -z ${chpwd_functions[(r)_direnv_hook]} ]]; then
-    chpwd_functions=( _direnv_hook ${chpwd_functions[@]} )
-  fi
+# Don't continue if direnv is not found
+command -v direnv &>/dev/null || return
+
+_direnv_hook() {
+  trap -- '' SIGINT;
+  eval "$(direnv export zsh)";
+  trap - SIGINT;
+}
+typeset -ag precmd_functions;
+if [[ -z ${precmd_functions[(r)_direnv_hook]} ]]; then
+  precmd_functions=( _direnv_hook ${precmd_functions[@]} )
+fi
+typeset -ag chpwd_functions;
+if [[ -z ${chpwd_functions[(r)_direnv_hook]} ]]; then
+  chpwd_functions=( _direnv_hook ${chpwd_functions[@]} )
 fi

--- a/plugins/direnv/direnv.plugin.zsh
+++ b/plugins/direnv/direnv.plugin.zsh
@@ -1,13 +1,15 @@
-_direnv_hook() {
-  trap -- '' SIGINT;
-  eval "$(direnv export zsh)";
-  trap - SIGINT;
-}
-typeset -ag precmd_functions;
-if [[ -z ${precmd_functions[(r)_direnv_hook]} ]]; then
-  precmd_functions=( _direnv_hook ${precmd_functions[@]} )
-fi
-typeset -ag chpwd_functions;
-if [[ -z ${chpwd_functions[(r)_direnv_hook]} ]]; then
-  chpwd_functions=( _direnv_hook ${chpwd_functions[@]} )
+if type "direnv" > /dev/null; then
+  _direnv_hook() {
+    trap -- '' SIGINT;
+    eval "$(direnv export zsh)";
+    trap - SIGINT;
+  }
+  typeset -ag precmd_functions;
+  if [[ -z ${precmd_functions[(r)_direnv_hook]} ]]; then
+    precmd_functions=( _direnv_hook ${precmd_functions[@]} )
+  fi
+  typeset -ag chpwd_functions;
+  if [[ -z ${chpwd_functions[(r)_direnv_hook]} ]]; then
+    chpwd_functions=( _direnv_hook ${chpwd_functions[@]} )
+  fi
 fi


### PR DESCRIPTION
Instead of printing that the direnv hook failed for every command
prompt, this fix changes the plugin to only load the hook if the
'direnv' command is available on the system.

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Extend the direnv plugin with a simple `if` statement to check if the `direnv` command is installed on the system.

## Other comments:

- Testing performed: touch testing on two systems (w/ and w/o direnv)
