### PR TITLE
Updates Amuse theme prompt to include python virtualenv

### DIFF
--- a/themes/amuse.zsh-theme
+++ b/themes/amuse.zsh-theme
@@ -10,8 +10,11 @@ ZSH_THEME_GIT_PROMPT_CLEAN=""
 ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg_bold[red]%}‹"
 ZSH_THEME_RUBY_PROMPT_SUFFIX="›%{$reset_color%}"
 
+ZSH_THEME_VIRTUALENV_PREFIX="$fg_bold[green]%}("
+ZSH_THEME_VIRTUALENV_SUFFIX=")%{$reset_color%} "
+
 PROMPT='
-%{$fg_bold[green]%}%~%{$reset_color%}$(git_prompt_info) ⌚ %{$fg_bold[red]%}%*%{$reset_color%}
+$(virtualenv_prompt_info)%{$fg_bold[green]%}%~%{$reset_color%}$(git_prompt_info) ⌚ %{$fg_bold[red]%}%*%{$reset_color%}
 $ '
 
 RPROMPT='$(ruby_prompt_info)'


### PR DESCRIPTION
Fixes #7766 

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added the ZSH_THEME_VIRTUALENV_[PREFIX & SUFFIX] to control the brackets 
- Added the virtualenv_prompt_info call to fetch which virtual environment is active. 

## Other comments:

...
