### PR TITLE
aws: fix aws_change_access_key function with awscli v2

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -31,12 +31,12 @@ function aws_change_access_key() {
 
   echo Insert the credentials when asked.
   asp "$1" || return 1
-  aws iam create-access-key
-  aws configure --profile "$1"
+  AWS_PAGER="" aws iam create-access-key
+  AWS_PAGER="" aws configure --profile "$1"
 
   echo You can now safely delete the old access key running \`aws iam delete-access-key --access-key-id ID\`
   echo Your current keys are:
-  aws iam list-access-keys
+  AWS_PAGER="" aws iam list-access-keys
 }
 
 function aws_profiles() {


### PR DESCRIPTION
After the upgrade to AWS CLI v2, if the default client side pager is set
the aws_change_access_key stopped working.

Fixes #8815

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

The default pager is set before any call to the aws cli:
```zsh
# before
aws iam create-access-key

# now
AWS_PAGER="" aws iam create-access-key
```

## Other comments:

This prevents the aws cli to paginate any request, regardless of the default pager of the user.
