### PR TITLE
Fix completions error for the asdf plugin

### DIFF
--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -1,19 +1,12 @@
 # Find where asdf should be installed
 ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
-ASDF_COMPLETIONS="$ASDF_DIR/completions"
 
 # If not found, check for Homebrew package
 if [[ ! -f "$ASDF_DIR/asdf.sh" ]] && (( $+commands[brew] )); then
    ASDF_DIR="$(brew --prefix asdf)"
-   ASDF_COMPLETIONS="$ASDF_DIR/etc/bash_completion.d"
 fi
 
 # Load command
 if [[ -f "$ASDF_DIR/asdf.sh" ]]; then
     . "$ASDF_DIR/asdf.sh"
-
-    # Load completions
-    if [[ -f "$ASDF_COMPLETIONS/asdf.bash" ]]; then
-        . "$ASDF_COMPLETIONS/asdf.bash"
-    fi
 fi


### PR DESCRIPTION
Per this comment [1] on the ASDF project, it's not necessary to source the completions, as they are loaded already via asdf.sh which this plugin already sources.

[1] https://github.com/asdf-vm/asdf/issues/68#issuecomment-229237561

Currently the plugin causes the following error: `.asdf/completions/asdf.bash:68: command not found: complete`

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Remove unnecessary completions references that cause the error mentioned