### PR TITLE
colorize: add $ZSH_COLORIZE_CHROMA_FORMATTER config env var

### DIFF
--- a/plugins/colorize/README.md
+++ b/plugins/colorize/README.md
@@ -38,6 +38,14 @@ Pygments offers multiple styles. By default, the `default` style is used, but yo
 ZSH_COLORIZE_STYLE="colorful"
 ```
 
+### Chroma Formatter Settings
+
+Chroma supports terminal output in 8 color, 256 color, and true-color. If you need to change the default terminal output style from the standard 8 color output, set the `ZSH_COLORIZE_CHROMA_FORMATTER` environment variable:
+
+```
+ZSH_COLORIZE_CHROMA_FORMATTER=terminal256
+```
+
 ## Usage
 
 * `ccat <file> [files]`: colorize the contents of the file (or files, if more than one are provided).

--- a/plugins/colorize/colorize.plugin.zsh
+++ b/plugins/colorize/colorize.plugin.zsh
@@ -46,7 +46,11 @@ colorize_cat() {
         if [[ "$ZSH_COLORIZE_TOOL" == "pygmentize" ]]; then
             pygmentize -O style="$ZSH_COLORIZE_STYLE" -g
         else
-            chroma --style="$ZSH_COLORIZE_STYLE"
+            if [ -z "$ZSH_COLORIZE_CHROMA_FORMATTER" ]; then
+                chroma --style="$ZSH_COLORIZE_STYLE"
+            else
+                chroma --style="$ZSH_COLORIZE_STYLE" --formatter="$ZSH_COLORIZE_CHROMA_FORMATTER"
+            fi
         fi
         return $?
     fi
@@ -62,7 +66,11 @@ colorize_cat() {
                 pygmentize -O style="$ZSH_COLORIZE_STYLE" -g "$FNAME"
             fi
         else
-            chroma --style="$ZSH_COLORIZE_STYLE" "$FNAME"
+            if [ -z "$ZSH_COLORIZE_CHROMA_FORMATTER" ]; then
+                chroma --style="$ZSH_COLORIZE_STYLE" "$FNAME"
+            else
+                chroma --style="$ZSH_COLORIZE_STYLE" --formatter="$ZSH_COLORIZE_CHROMA_FORMATTER" "$FNAME"
+            fi
         fi
     done
 }

--- a/plugins/colorize/colorize.plugin.zsh
+++ b/plugins/colorize/colorize.plugin.zsh
@@ -46,11 +46,7 @@ colorize_cat() {
         if [[ "$ZSH_COLORIZE_TOOL" == "pygmentize" ]]; then
             pygmentize -O style="$ZSH_COLORIZE_STYLE" -g
         else
-            if [ -z "$ZSH_COLORIZE_CHROMA_FORMATTER" ]; then
-                chroma --style="$ZSH_COLORIZE_STYLE"
-            else
-                chroma --style="$ZSH_COLORIZE_STYLE" --formatter="$ZSH_COLORIZE_CHROMA_FORMATTER"
-            fi
+            chroma --style="$ZSH_COLORIZE_STYLE" --formatter="${ZSH_COLORIZE_CHROMA_FORMATTER:-terminal}"
         fi
         return $?
     fi

--- a/plugins/colorize/colorize.plugin.zsh
+++ b/plugins/colorize/colorize.plugin.zsh
@@ -62,11 +62,7 @@ colorize_cat() {
                 pygmentize -O style="$ZSH_COLORIZE_STYLE" -g "$FNAME"
             fi
         else
-            if [ -z "$ZSH_COLORIZE_CHROMA_FORMATTER" ]; then
-                chroma --style="$ZSH_COLORIZE_STYLE" "$FNAME"
-            else
-                chroma --style="$ZSH_COLORIZE_STYLE" --formatter="$ZSH_COLORIZE_CHROMA_FORMATTER" "$FNAME"
-            fi
+            chroma --style="$ZSH_COLORIZE_STYLE" --formatter="${ZSH_COLORIZE_CHROMA_FORMATTER:-terminal}" "$FNAME"
         fi
     done
 }


### PR DESCRIPTION
In order to get colorize to work with my setup I needed to change the formatter chroma was using to `terminal256`. This updates colorize to look for a new $ZSH_COLORIZE_CHROMA_FORMATTER env var to set this value.

## Changes:

- Check for the existence of `$ZSH_COLORIZE_CHROMA_FORMATTER` and if present add a `--format` flag to the `chroma` call

## Other comments:

Super simple low risk change.