### PR TITLE
Typo: do not print large message when unattended option is opted

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -43,6 +43,7 @@ BRANCH=${BRANCH:-master}
 CHSH=${CHSH:-yes}
 RUNZSH=${RUNZSH:-yes}
 KEEP_ZSHRC=${KEEP_ZSHRC:-no}
+STARTUP_MESSAGE=${STARTUP_MESSAGE:-yes}
 
 
 command_exists() {
@@ -233,7 +234,7 @@ main() {
 	# Parse arguments
 	while [ $# -gt 0 ]; do
 		case $1 in
-			--unattended) RUNZSH=no; CHSH=no ;;
+			--unattended) STARTUP_MESSAGE=no; RUNZSH=no; CHSH=no ;;
 			--skip-chsh) CHSH=no ;;
 			--keep-zshrc) KEEP_ZSHRC=yes ;;
 		esac
@@ -258,25 +259,27 @@ main() {
 	setup_ohmyzsh
 	setup_zshrc
 	setup_shell
+	
+	if [ $STARTUP_MESSAGE = yes ]; then
+		printf "$GREEN"
+		cat <<-'EOF'
+					__                                     __
+			____  / /_     ____ ___  __  __   ____  _____/ /_
+			/ __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \
+			/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / /
+			\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/
+									/____/                       ....is now installed!
 
-	printf "$GREEN"
-	cat <<-'EOF'
-		         __                                     __
-		  ____  / /_     ____ ___  __  __   ____  _____/ /_
-		 / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \
-		/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / /
-		\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/
-		                        /____/                       ....is now installed!
 
+			Please look over the ~/.zshrc file to select plugins, themes, and options.
 
-		Please look over the ~/.zshrc file to select plugins, themes, and options.
+			p.s. Follow us on https://twitter.com/ohmyzsh
 
-		p.s. Follow us on https://twitter.com/ohmyzsh
+			p.p.s. Get stickers, shirts, and coffee mugs at https://shop.planetargon.com/collections/oh-my-zsh
 
-		p.p.s. Get stickers, shirts, and coffee mugs at https://shop.planetargon.com/collections/oh-my-zsh
-
-	EOF
-	printf "$RESET"
+		EOF
+		printf "$RESET"
+	fi
 
 	if [ $RUNZSH = no ]; then
 		echo "${YELLOW}Run zsh to try it out.${RESET}"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- When unattended is opted, we do not display a large message at the end of the installation script.

## Other comments:

...
