### PR TITLE
kubectl add aliases for get and describe

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -26,6 +26,8 @@ plugins=(... kubectl)
 |         |                                     | **General aliases**                                                                              |
 | kdel    | `kubectl delete`                    | Delete resources by filenames, stdin, resources and names, or by resources and label selector    |
 | kdelf   | `kubectl delete -f`                 | Delete a pod using the type and name specified in -f argument                                    |
+| kg      | `kubectl get`                       | Get resources by filenames, stdin, resources and names, or by resources and label selector       |
+| kd      | `kubectl describe`                  | Describe resources by filenames, stdin, resources and names, or by resources and label selector  |
 |         |                                     | **Pod management**                                                                               |
 | kgp     | `kubectl get pods`                  | List all pods in ps output format                                                                |
 | kgpw    | `kgp --watch`                       | After listing/getting the requested object, watch for changes                                    |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -34,6 +34,8 @@ alias kcgc='kubectl config get-contexts'
 # General aliases
 alias kdel='kubectl delete'
 alias kdelf='kubectl delete -f'
+alias kg='kubectl get'
+alias kd='kubectl describe'
 
 # Pod management.
 alias kgp='kubectl get pods'


### PR DESCRIPTION

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

 * Add the alias `kd` for `kubectl describe`
 * Add the alias `kg` for `kubectl get`

## Other comments:

There seems to be no maintainer for this plugin. I am savvy enough with kubernetes to judge PRs for this plugin. Who should i contact?

...
