### PR TITLE
jsontools: correct usage for is_json

### DIFF
--- a/plugins/jsontools/README.md
+++ b/plugins/jsontools/README.md
@@ -29,7 +29,7 @@ curl https://coderwall.com/bobwilliams.json | pp_json
 - **is_json**:
 
 ```sh
-# pretty print the contents of an existing json file
+# Validate if file's content conforms to a valid JSON schema
 less data.json | is_json
 ```
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR, which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Update README - is_json usage for validation

## Other comments:

- Issue #8858: Usage for is_json wrongly mentioned pretty print
