### PR TITLE
Sort completed refs by most recent committerdate

### DIFF
--- a/plugins/gitfast/_git
+++ b/plugins/gitfast/_git
@@ -73,7 +73,13 @@ __gitcomp_direct ()
 
 	local IFS=$'\n'
 	compset -P '*[=:]'
-	compadd -Q -- ${=1} && _ret=0
+
+
+	# https://www.zsh.org/mla/users//2014/msg01270.html
+	local expl
+	_description -V retainsorting expl 'Group that retains the already existing sorting'
+
+	compadd "$expl[@]" -Q -- ${=1} && _ret=0
 }
 
 __gitcomp_nl ()

--- a/plugins/gitfast/git-completion.bash
+++ b/plugins/gitfast/git-completion.bash
@@ -693,14 +693,17 @@ __git_refs ()
 				"refs/remotes/$match*" "refs/remotes/$match*/**")
 			;;
 		esac
-		__git_dir="$dir" __git for-each-ref --format="$fer_pfx%($format)$sfx" \
+		__git_dir="$dir" __git for-each-ref \
+			--sort=-committerdate \
+			--format="$fer_pfx%($format)$sfx" \
 			"${refs[@]}"
 		if [ -n "$track" ]; then
 			# employ the heuristic used by git checkout
 			# Try to find a remote branch that matches the completion word
 			# but only output if the branch name is unique
-			__git for-each-ref --format="$fer_pfx%(refname:strip=3)$sfx" \
-				--sort="refname:strip=3" \
+			__git for-each-ref \
+				--format="$fer_pfx%(refname:strip=3)$sfx" \
+				--sort=-committerdate \
 				"refs/remotes/*/$match*" "refs/remotes/*/$match*/**" | \
 			uniq -u
 		fi
@@ -721,7 +724,9 @@ __git_refs ()
 			case "HEAD" in
 			$match*)	echo "${pfx}HEAD$sfx" ;;
 			esac
-			__git for-each-ref --format="$fer_pfx%(refname:strip=3)$sfx" \
+			__git for-each-ref \
+				--sort=-committerdate \
+				--format="$fer_pfx%(refname:strip=3)$sfx" \
 				"refs/remotes/$remote/$match*" \
 				"refs/remotes/$remote/$match*/**"
 		else


### PR DESCRIPTION
Resolves https://github.com/ohmyzsh/ohmyzsh/issues/8767.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Sort refs for completion by most recent committer date.


## Other comments:

This behaviour is currently not configurable, mainly due to my limited knowledge around writing zsh completion scripts.

I noticed that with the current design, the `__git_refs` function calls `git for-each-ref` three times. This is suboptimal because it means that I had to make the same change three times.
Also, the refs returned by each of those three invocations are concatenated and only sorted by committerdate internally but not overall.

I can't fix this myself but maybe someone can refactor this function to only call `git for-each-ref` once and just assign the arguments correctly based on the parameters to the function.