### PR TITLE
core: refresh zcompdump cache file in init script

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -61,6 +61,18 @@ if [ -z "$ZSH_COMPDUMP" ]; then
   ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
+# Construct zcompdump OMZ metadata
+zcompdump_metadata="\
+#omz revision: $(cd -q "$ZSH"; git rev-parse HEAD 2>/dev/null)
+#omz fpath: $fpath\
+"
+
+# Delete the zcompdump file if OMZ zcompdump metadata changed
+if ! cmp -s <(command grep '^#omz' "$ZSH_COMPDUMP" 2>/dev/null) <<< "$zcompdump_metadata"; then
+  command rm -f "$ZSH_COMPDUMP"
+  zcompdump_refresh=1
+fi
+
 if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
   source $ZSH/lib/compfix.zsh
   # If completion insecurities exist, warn the user
@@ -71,6 +83,13 @@ else
   # If the user wants it, load from all found directories
   compinit -u -C -d "${ZSH_COMPDUMP}"
 fi
+
+# Append zcompdump metadata if missing
+if (( $zcompdump_refresh )); then
+  echo "\n$zcompdump_metadata" >>! "$ZSH_COMPDUMP"
+fi
+
+unset zcompdump_metadata zcompdump_refresh
 
 
 # Load all of the config files in ~/oh-my-zsh that end in .zsh


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

The current algorithm is very simple:
- Get the OMZ revision and fpath
- Append it to the zcompdump cache file when creating it
- On subsequent loads, check if it revision and fpath are the same as last time

## Other comments:

Fixes #7642 

Documentation: update [FAQ](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ#i-have-enabled-a-completion-plugin-but-the-completion-doesnt-work) when this PR is merged.