### PR TITLE
terraform: add fmt -recursive flag autocompletion

### DIFF
--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -77,7 +77,8 @@ __fmt() {
         '-list=[(true) List files whose formatting differs (always false if using STDIN)]' \
         '-write=[(true) Write result to source file instead of STDOUT (always false if using STDIN or -check)]' \
         '-diff=[(false) Display diffs of formatting changes]' \
-        '-check=[(false) Check if the input is formatted. Exit status will be 0 if all input is properly formatted and non-zero otherwise.]'
+        '-check=[(false) Check if the input is formatted. Exit status will be 0 if all input is properly formatted and non-zero otherwise.]' \
+        '-recursive=[(false) Also process files in subdirectories. By default, only the given directory (or current directory) is processed.]'
 }
 
 __get() {


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add `terraform fmt -recursive` flag autocompletion 

## Other comments:

The flag description is taken verbatim from the `terraform fmt -help` command:

```
$ terraform fmt --help
Usage: terraform fmt [options] [DIR]

[…]

Options:

[…]

  -recursive     Also process files in subdirectories. By default, only the
                 given directory (or current directory) is processed.
```