### PR TITLE
fzf: setup FZF_DEFAULT_COMMAND based on installed tools

### DIFF
--- a/plugins/fzf/README.md
+++ b/plugins/fzf/README.md
@@ -2,25 +2,32 @@
 
 This plugin enables [junegunn's fzf](https://github.com/junegunn/fzf) fuzzy auto-completion and key bindings
 
+To use it, add `fzf` to the plugins array in your zshrc file:
+```zsh
+plugins=(... fzf)
+```
+
+## Settings
+
+Add these before the `plugins=()` line in your zshrc file:
+
 ```zsh
 # Set fzf installation directory path
-export FZF_BASE=/path/to/fzf/install/dir
+# export FZF_BASE=/path/to/fzf/install/dir
+
+# Uncomment to set the FZF_DEFAULT_COMMAND
+# export FZF_DEFAULT_COMMAND='<your fzf default commmand>'
 
 # Uncomment the following line to disable fuzzy completion
-# export DISABLE_FZF_AUTO_COMPLETION="true"
+# DISABLE_FZF_AUTO_COMPLETION="true"
 
 # Uncomment the following line to disable key bindings (CTRL-T, CTRL-R, ALT-C)
-# export DISABLE_FZF_KEY_BINDINGS="true"
-
-plugins=(
-  ...
-  fzf
-)
+# DISABLE_FZF_KEY_BINDINGS="true"
 ```
 
-The plugin will also set the `FZF_DEFAULT_COMMAND` environment variable based on which finder you have available.
-You can override this on your `.zshrc`:
-```zsh
-export FZF_DEFAULT_COMMAND='<your fzf default commmand>'
-unlet FZF_DEFAULT_COMMAND  # use default FZF command
-```
+| Setting                     | Example value              | Description                                                 |
+|-----------------------------|----------------------------|-------------------------------------------------------------|
+| FZF_BASE                    | `/path/to/fzf/install/dir` | Set fzf installation directory path (**export**)            |
+| FZF_DEFAULT_COMMAND         | `fd --type f`              | Set default command to use when input is tty (**export**)   |
+| DISABLE_FZF_AUTO_COMPLETION | `true`                     | Set whether to load fzf auto-completion                     |
+| DISABLE_FZF_KEY_BINDINGS    | `true`                     | Set whether to disable key bindings (CTRL-T, CTRL-R, ALT-C) |

--- a/plugins/fzf/README.md
+++ b/plugins/fzf/README.md
@@ -17,3 +17,10 @@ plugins=(
   fzf
 )
 ```
+
+The plugin will also set the `FZF_DEFAULT_COMMAND` environment variable based on which finder you have available.
+You can override this on your `.zshrc`:
+```zsh
+export FZF_DEFAULT_COMMAND='<your fzf default commmand>'
+unlet FZF_DEFAULT_COMMAND  # use default FZF command
+```

--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -99,10 +99,12 @@ setup_using_debian_package || setup_using_base_dir || indicate_error
 
 unset -f setup_using_debian_package setup_using_base_dir indicate_error
 
-if (( $+commands[rg] )); then
-    export FZF_DEFAULT_COMMAND='rg --files --hidden'
-elif (( $+commands[fd] )); then
-    export FZF_DEFAULT_COMMAND='fd --type f --hidden --exclude .git'
-elif (( $+commands[ag] )); then
-    export FZF_DEFAULT_COMMAND='ag -l --hidden -g ""'
+if [[ -z "$FZF_DEFAULT_COMMAND" ]]; then
+    if (( $+commands[rg] )); then
+        export FZF_DEFAULT_COMMAND='rg --files --hidden'
+    elif (( $+commands[fd] )); then
+        export FZF_DEFAULT_COMMAND='fd --type f --hidden --exclude .git'
+    elif (( $+commands[ag] )); then
+        export FZF_DEFAULT_COMMAND='ag -l --hidden -g ""'
+    fi
 fi

--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -98,3 +98,11 @@ function indicate_error() {
 setup_using_debian_package || setup_using_base_dir || indicate_error
 
 unset -f setup_using_debian_package setup_using_base_dir indicate_error
+
+if (( $+commands[rg] )); then
+    export FZF_DEFAULT_COMMAND='rg --files --hidden'
+elif (( $+commands[fd] )); then
+    export FZF_DEFAULT_COMMAND='fd --type f --hidden --exclude .git'
+elif (( $+commands[ag] )); then
+    export FZF_DEFAULT_COMMAND='ag -l --hidden -g ""'
+fi


### PR DESCRIPTION
Setting the FZF_DEFAULT_COMMAND allow fzf to use a faster searcher

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
- Set `$FZF_DEFAULT_COMMAND` on `fzf` plugin

## Other comments:
This PR is based on a personal necessity, since I was having to do this on my config, and I found an issue related to it (#8187), that was close because there was no PR
