### PR TITLE
note of precedence from vim-mode over magic-enter

### DIFF
--- a/plugins/magic-enter/README.md
+++ b/plugins/magic-enter/README.md
@@ -14,4 +14,10 @@ MAGIC_ENTER_OTHER_COMMAND='ls -lh .'
 plugins=(... magic-enter)
 ```
 
+Note that if you also use `vim-mode`, you should declare `magic-enter` *after* `vim-mode` to avoid precedence.
+
+```zsh
+plugins=(... vim-mode ... magic-enter ...)
+```
+
 **Maintainer:** [@dufferzafar](https://github.com/dufferzafar)


### PR DESCRIPTION
If magic-enter is declared before vim-mode, pressing [enter] don't make any magic :-(

## Standards checklist:

- [v] The PR title is descriptive.
- [v] The PR doesn't replicate another PR which is already open.
- [v] I have read the contribution guide and followed all the instructions.
- [v] The code follows the code style guide detailed in the wiki.
- [v] The code is mine or it's from somewhere with an MIT-compatible license.
- [v] The code is efficient, to the best of my ability, and does not waste computer resources.
- [v] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- add a notice in the documentation

## Other comments:

Little words can help to save lot of time and frustrations, sometimes :-)
