### PR TITLE
feat(frontend-search): adding packagephobia

### DIFF
--- a/plugins/frontend-search/README.md
+++ b/plugins/frontend-search/README.md
@@ -52,6 +52,7 @@ Available search contexts are:
 | mdn           | `https://developer.mozilla.org/search?q=`                                   |
 | nodejs        | `https://www.google.com/search?as_sitesearch=nodejs.org/en/docs/&as_q=`     |
 | npmjs         | `https://www.npmjs.com/search?q=`                                           |
+| packagephobia | `https://packagephobia.now.sh/result?p=`                                    |
 | qunit         | `https://api.qunitjs.com/?s=`                                               |
 | reactjs       | `https://google.com/search?as_sitesearch=facebook.github.io/react&as_q=`    |
 | smacss        | `https://google.com/search?as_sitesearch=smacss.com&as_q=`                  |

--- a/plugins/frontend-search/_frontend-search.sh
+++ b/plugins/frontend-search/_frontend-search.sh
@@ -38,6 +38,7 @@ function _frontend() {
     'mdn: Search in MDN website'
     'nodejs: Search in NodeJS website'
     'npmjs: Search in NPMJS website'
+    'packagephobia: Search in Packagephobia website'
     'qunit: Search in Qunit website'
     'reactjs: Search in React website'
     'smacss: Search in SMACSS website'
@@ -122,6 +123,9 @@ function _frontend() {
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
         bundlephobia)
+          _describe -t points "Warp points" frontend_points && ret=0
+          ;;
+        packagephobia)
           _describe -t points "Warp points" frontend_points && ret=0
           ;;
         flowtype)

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -19,6 +19,7 @@ alias lodash='frontend lodash'
 alias mdn='frontend mdn'
 alias nodejs='frontend nodejs'
 alias npmjs='frontend npmjs'
+alias packagephobia='frontend packagephobia'
 alias qunit='frontend qunit'
 alias reactjs='frontend reactjs'
 alias smacss='frontend smacss'
@@ -65,6 +66,7 @@ function frontend() {
     mdn            'https://developer.mozilla.org/search?q='
     nodejs         $(_frontend_fallback 'nodejs.org/en/docs/')
     npmjs          'https://www.npmjs.com/search?q='
+    packagephobia  'https://packagephobia.now.sh/result?p='
     qunit          'https://api.qunitjs.com/?s='
     reactjs        $(_frontend_fallback 'reactjs.org/')
     smacss         $(_frontend_fallback 'smacss.com')
@@ -82,7 +84,7 @@ function frontend() {
       print -P "%Uterm%u and what follows is what will be searched for in the %Ucontext%u website,"
       print -P "and %Ucontext%u is one of the following:"
       print -P ""
-      print -P "  angular, angularjs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow,"
+      print -P "  angular, angularjs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow, packagephobia"
       print -P "  dartlang, emberjs, fontello, flowtype, github, html5please, jestjs, jquery, lodash,"
       print -P "  mdn, npmjs, nodejs, qunit, reactjs, smacss, stackoverflow, unheap, vuejs, bundlephobia"
       print -P ""
@@ -98,7 +100,7 @@ function frontend() {
     echo ""
     echo "Valid contexts are:"
     echo ""
-    echo "  angular, angularjs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow,"
+    echo "  angular, angularjs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow, packagephobia"
     echo "  dartlang, emberjs, fontello, github, html5please, jest, jquery, lodash,"
     echo "  mdn, npmjs, nodejs, qunit, reactjs, smacss, stackoverflow, unheap, vuejs, bundlephobia"
     echo ""


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adding `packagephobia` integration into `frontend-search` plugin.

More details in https://packagephobia.now.sh/


## Other comments:

Example of search:

https://packagephobia.now.sh/result?p=perf-marks@1.8.0

cc/ @mcornella 