### PR TITLE
Add 'hgci' alias to the mercurial plugin

### DIFF
--- a/plugins/mercurial/mercurial.plugin.zsh
+++ b/plugins/mercurial/mercurial.plugin.zsh
@@ -2,6 +2,7 @@
 alias hga='hg add'
 alias hgc='hg commit'
 alias hgca='hg commit --amend'
+alias hgci='hg commit --interactive'
 alias hgb='hg branch'
 alias hgba='hg branches'
 alias hgbk='hg bookmarks'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add one alias `hgci` representing `hg commit --interactive`

@ptrv @oshybystyi 