### PR TITLE
Added git_files_changed function

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -278,3 +278,34 @@ function git_repo_name() {
     echo ${repo_path:t}
   fi
 }
+
+# Outputs 3 stats for git repo
+# 1) number of files changed,
+# 2) the total number of lines added
+# 3) total number of lines removed
+# 
+# Example 
+#  3f:69+:6-
+function git_files_changed() {
+    local -i files=0
+    local -i insertions=0
+    local -i deletions=0
+    local raw=$(command git diff --numstat 2>/dev/null) || return 0
+    if [[ -n $raw ]]; then
+      echo $raw | while IFS= read -r line; do
+        local -i d=$line[(w)2]
+        local -i i=$line[(w)1]
+        insertions+=i
+        deletions+=d
+        files+=1
+      done
+      local output="$ZSH_THEME_GIT_FILES_CHANGED_PREFIX${files}f$ZSH_THEME_GIT_FILES_CHANGED_SUFFIX"
+      if (( $insertions > 0 )); then
+          output="$output:$ZSH_THEME_GIT_LINES_ADDED_PREFIX${insertions}+$ZSH_THEME_GIT_LINES_ADDED_SUFFIX"
+      fi
+      if (( $deletions > 0 )); then
+          output="$output:$ZSH_THEME_GIT_LINES_REMOVED_PREFIX${deletions}-$ZSH_THEME_GIT_LINES_REMOVED_SUFFIX"
+      fi
+      echo $output
+    fi
+}


### PR DESCRIPTION
This patch adds the git library function for building a
short string that represents the output of git diff --numstat.
This gives theme designers the ability to add the
Number of files changed, number of lines added and number of
lines removed in their prompt for a git repository, while the user's
current working directory is in the git repo.

The new function supports prefix and suffix for each of the
options, files changed, lines added and lines removed.

To colorize the output, you can do something like this in your
theme file

ZSH_THEME_GIT_FILES_CHANGED_PREFIX="%{$fg[yellow]%}"
ZSH_THEME_GIT_FILES_CHANGED_SUFFIX="%{$reset_color%}"
ZSH_THEME_GIT_LINES_ADDED_PREFIX="%{$fg[green]%}"
ZSH_THEME_GIT_LINES_ADDED_SUFFIX="%{$reset_color%}"
ZSH_THEME_GIT_LINES_REMOVED_PREFIX="%{$fg[red]%}"
ZSH_THEME_GIT_LINES_REMOVED_SUFFIX="%{$fg[blue]%}"

For example, if there are
3 files changed, 10 lines added and no lines removed you will get
3f:10+

1 files changed, 20 lines added and 6 lines removed:
1f:20+:6-

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
