### PR TITLE
Run pyenv init with --no-rehash

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -25,7 +25,7 @@ if [[ $FOUND_PYENV -ne 1 ]]; then
 fi
 
 if [[ $FOUND_PYENV -eq 1 ]]; then
-    eval "$(pyenv init - zsh)"
+    eval "$(pyenv init - --no-rehash zsh)"
     if (( $+commands[pyenv-virtualenv-init] )); then
         eval "$(pyenv virtualenv-init - zsh)"
     fi


### PR DESCRIPTION
Add --no-rehash to the pyenv init command, which was removed in [#4492].

The rehash was likely disabled because it can affect shell startup times.
It should only be necessary when installing or removing Python versions.

See [pyenv/pyenv#784] and [sorin-ionescu/prezto#1603] for more detail.

[#4492]: https://github.com/ohmyzsh/ohmyzsh/pull/4492
[pyenv/pyenv#784]: https://github.com/pyenv/pyenv/issues/784
[sorin-ionescu/prezto#1603]: https://github.com/sorin-ionescu/prezto/pull/1603

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
