### PR TITLE
virtualenv should not take up a whole line

### DIFF
--- a/themes/peepcode.zsh-theme
+++ b/themes/peepcode.zsh-theme
@@ -37,8 +37,7 @@ git_prompt() {
 
 local smiley="%(?,%{$fg[green]%}☺%{$reset_color%},%{$fg[red]%}☹%{$reset_color%})"
 
-PROMPT='
-%~
+PROMPT=' %~
 ${smiley}  %{$reset_color%}'
 
 RPROMPT='%{$fg[white]%} $(ruby_prompt_info)$(git_prompt)%{$reset_color%}'


### PR DESCRIPTION
Before (3 lines -- too many)
```
~/env/src/misc/orara
☺  workon orara                                                                                                                                                                                                          gitlab-ci b5ab9bd ✗
(orara) 
~/env/src/misc/orara
☺
```

After (2 lines -- more familiar)
```
 ~/env/src/misc/orara
☺  workon orara                                                                                                                                                                                                          gitlab-ci b5ab9bd ✗
(orara)  ~/env/src/misc/orara
☺       
```

## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
