### PR TITLE
vagrant: fix vagrant box autocomplete

### DIFF
--- a/plugins/vagrant/_vagrant
+++ b/plugins/vagrant/_vagrant
@@ -64,7 +64,7 @@ __task_list ()
 
 __box_list ()
 {
-    _wanted application expl 'command' compadd $(command vagrant box list | sed -e 's/ /\\ /g')
+    _wanted application expl 'command' compadd $(command vagrant box list | sed -e 's/ \(.*\)/ /g')
 }
 
 __vm_list ()

--- a/plugins/vagrant/_vagrant
+++ b/plugins/vagrant/_vagrant
@@ -64,7 +64,7 @@ __task_list ()
 
 __box_list ()
 {
-    _wanted application expl 'command' compadd $(command vagrant box list | sed -e 's/ \(.*\)/ /g')
+    _wanted application expl 'command' compadd $(command vagrant box list | sed -e 's/  *(.*)//g;s/ /\\ /g')
 }
 
 __vm_list ()


### PR DESCRIPTION
This fixes the `vagrant box` autocomplete

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Update regex to parse the correct list. 

## Other comments:

