### PR TITLE
agnoster: better respect hide-dirty git config by plainly coloring prompt and not running checks for changes

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -112,6 +112,8 @@ prompt_git() {
     ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git rev-parse --short HEAD 2> /dev/null)"
     if [[ -n $dirty ]]; then
       prompt_segment yellow black
+    elif [[ "$(git config --get oh-my-zsh.hide-dirty 2>/dev/null)" = 1 ]]; then
+      prompt_segment white black
     else
       prompt_segment green $CURRENT_FG
     fi

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -129,7 +129,11 @@ prompt_git() {
 
     zstyle ':vcs_info:*' enable git
     zstyle ':vcs_info:*' get-revision true
-    zstyle ':vcs_info:*' check-for-changes true
+    if [[ -z $dirty ]]; then
+      zstyle ':vcs_info:*' check-for-staged-changes true
+    else
+      zstyle ':vcs_info:*' check-for-changes true
+    fi
     zstyle ':vcs_info:*' stagedstr '✚'
     zstyle ':vcs_info:*' unstagedstr '●'
     zstyle ':vcs_info:*' formats ' %u%c'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- In the git prompt: do not re-check entire working tree for changes if `parse_get_dirty` indicates a clean working tree. This will avoid re-processing clean working trees, and ensure that we respect `oh-my-zsh.hide-dirty` to avoid slow loading on large repos.
- In the git prompt: color the prompt segment white if `oh-my-zsh.hide-dirty` is set. Previously the prompt would be colored green (indicating a clean tree) whenever this flag is set, even if the tree is dirty. This new color indicates the lack of status, rather than misleadingly indicating a clean tree.

## Other comments:

* Similar to #6926, but with clearer prompt color and improved fallback behavior for staged changes.
* Relatedly, #7813 may be closed since it appears to duplicate a check of the git config