### PR TITLE
pipenv: fix error when Pipfile is not a file

### DIFF
--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -7,7 +7,7 @@ compdef _pipenv pipenv
 # Automatic pipenv shell activation/deactivation
 _togglePipenvShell() {
   # deactivate shell if Pipfile doesn't exist and not in a subdir
-  if [[ ! -a "$PWD/Pipfile" ]]; then
+  if [[ ! -f "$PWD/Pipfile" ]]; then
     if [[ "$PIPENV_ACTIVE" == 1 ]]; then
       if [[ "$PWD" != "$pipfile_dir"* ]]; then
         exit
@@ -17,7 +17,7 @@ _togglePipenvShell() {
 
   # activate the shell if Pipfile exists
   if [[ "$PIPENV_ACTIVE" != 1 ]]; then
-    if [[ -a "$PWD/Pipfile" ]]; then
+    if [[ -f "$PWD/Pipfile" ]]; then
       export pipfile_dir="$PWD"
       pipenv shell
     fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- `Pipfile` check from `-a` to `-f`.

## Other comments:

This fixes a bug when `Pipfile` is a directory which cuases `pipenv` to
crash.

To reproduce it:

* Create a directory `Pipfile`.
* Enter the directory.

You are going to see an output similar to this:

```
Traceback (most recent call last):
  File "/Users/rmax/.pyenv/versions/3.8.2/bin/pipenv", line 10, in <module>
    sys.exit(cli())
  ...
  File "/Users/rmax/.pyenv/versions/3.8.2/lib/python3.8/site-packages/pipenv/project.py", line 677, in touch_pipfile
    with open("Pipfile", "a"):
IsADirectoryError: [Errno 21] Is a directory: 'Pipfile'
```

The current code does a `-a` check which is true for any file type,
including directories. A better way is to use `-f` to ensure `Pipfile`
is a regular file.