### PR TITLE
builtin cd overrides user aliases and functions

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -103,7 +103,7 @@ EOF
 function _omz::pr::clean {
     (
         set -e
-        cd -q "$ZSH"
+        builtin cd -q "$ZSH"
 
         _omz::log info "removing all Oh My Zsh Pull Request branches..."
         command git branch --list 'ohmyzsh/pull-*' | while read branch; do
@@ -126,7 +126,7 @@ function _omz::pr::test {
 
     # Save current git HEAD
     local branch
-    branch=$(cd -q "$ZSH"; git symbolic-ref --short HEAD) || {
+    branch=$(builtin cd -q "$ZSH"; git symbolic-ref --short HEAD) || {
         _omz::log error "error when getting the current git branch. Aborting..."
         return 1
     }
@@ -136,7 +136,7 @@ function _omz::pr::test {
     # If any of these operations fail, undo the changes made
     (
         set -e
-        cd -q "$ZSH"
+        builtin cd -q "$ZSH"
 
         # Get the ohmyzsh git remote
         command git remote -v | while read remote url _; do
@@ -185,7 +185,7 @@ function _omz::pr::test {
 
     (
         set -e
-        cd -q "$ZSH"
+        builtin cd -q "$ZSH"
 
         command git checkout "$branch" -- || {
             _omz::log error "could not go back to the previous branch ('$branch')."

--- a/lib/diagnostics.zsh
+++ b/lib/diagnostics.zsh
@@ -192,19 +192,19 @@ function _omz_diag_dump_one_big_text() {
   command ls -ld ~/.oh*
   builtin echo
   builtin echo oh-my-zsh git state:
-  (cd $ZSH && builtin echo "HEAD: $(git rev-parse HEAD)" && git remote -v && git status | command grep "[^[:space:]]")
+  (builtin cd $ZSH && builtin echo "HEAD: $(git rev-parse HEAD)" && git remote -v && git status | command grep "[^[:space:]]")
   if [[ $verbose -ge 1 ]]; then
-    (cd $ZSH && git reflog --date=default | command grep pull)
+    (builtin cd $ZSH && git reflog --date=default | command grep pull)
   fi
   builtin echo
   if [[ -e $ZSH_CUSTOM ]]; then
     local custom_dir=$ZSH_CUSTOM
     if [[ -h $custom_dir ]]; then
-      custom_dir=$(cd $custom_dir && pwd -P)
+      custom_dir=$(builtin cd $custom_dir && pwd -P)
     fi
     builtin echo "oh-my-zsh custom dir:"
     builtin echo "   $ZSH_CUSTOM ($custom_dir)"
-    (cd ${custom_dir:h} && command find ${custom_dir:t} -name .git -prune -o -print)
+    (builtin cd ${custom_dir:h} && command find ${custom_dir:t} -name .git -prune -o -print)
     builtin echo
   fi
 

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -63,7 +63,7 @@ fi
 
 # Construct zcompdump OMZ metadata
 zcompdump_metadata="\
-#omz revision: $(cd -q "$ZSH"; git rev-parse HEAD 2>/dev/null)
+#omz revision: $(builtin cd -q "$ZSH"; git rev-parse HEAD 2>/dev/null)
 #omz fpath: $fpath\
 "
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

builtin cd to override user alias and functions in system OMZ functions. Important when capturing output and writing to zcompdump

~/oh-my-zsh/oh-my-zsh.sh: 66 #omz revision: $(builtin cd -q "$ZSH"; git rev-parse HEAD 2>/dev/null)## Other comments:

## Other comments:

tested
