### PR TITLE
Handle the DISABLE_UNTRACKED_FILES_DIRTY and DISABLE_AUTO_TITLE variables not being set

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -14,7 +14,7 @@ function parse_git_dirty() {
   local -a FLAGS
   FLAGS=('--porcelain')
   if [[ "$(command git config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
-    if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" == "true" ]]; then
+    if [[ "${DISABLE_UNTRACKED_FILES_DIRTY:-}" == "true" ]]; then
       FLAGS+='--untracked-files=no'
     fi
     case "$GIT_STATUS_IGNORE_SUBMODULES" in

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -50,13 +50,13 @@ fi
 
 # Runs before showing the prompt
 function omz_termsupport_precmd {
-  [[ "$DISABLE_AUTO_TITLE" == true ]] && return
+  [[ "${DISABLE_AUTO_TITLE:-}" == true ]] && return
   title $ZSH_THEME_TERM_TAB_TITLE_IDLE $ZSH_THEME_TERM_TITLE_IDLE
 }
 
 # Runs before executing the command
 function omz_termsupport_preexec {
-  [[ "$DISABLE_AUTO_TITLE" == true ]] && return
+  [[ "${DISABLE_AUTO_TITLE:-}" == true ]] && return
 
   emulate -L zsh
   setopt extended_glob


### PR DESCRIPTION
Handle the DISABLE_UNTRACKED_FILES_DIRTY and DISABLE_AUTO_TITLE variables not being set

If the user has set -u option to report attempts to use undeclared / unassigned variable, accessing the variables needs to be conditional.

Fixes #8942

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

