### PR TITLE
Fix/emacs from terminal

### DIFF
--- a/plugins/emacs/README.md
+++ b/plugins/emacs/README.md
@@ -15,6 +15,9 @@ To use it, add emacs to the plugins array in your zshrc file:
 plugins=(... emacs)
 ```
 
+For non-X users, set the variable `ZSH_EMACS_NOX` to `true`. This will ensure
+that Emacs is started with the `-nw` flag (no windows).
+
 ## Aliases
 
 The plugin uses a custom launcher (which we'll call here `$EMACS_LAUNCHER`) that is just a wrapper around [`emacsclient`](https://www.emacswiki.org/emacs/EmacsClient).

--- a/plugins/emacs/emacs.plugin.zsh
+++ b/plugins/emacs/emacs.plugin.zsh
@@ -16,7 +16,13 @@ if "$ZSH/tools/require_tool.sh" emacsclient 24 2>/dev/null ; then
     # set EDITOR if not already defined.
     export EDITOR="${EDITOR:-${EMACS_PLUGIN_LAUNCHER}}"
 
-    alias emacs="$EMACS_PLUGIN_LAUNCHER --no-wait"
+    # if ZSH_EMACS_NOX is true (no X windows), use the -nw flag by default
+    if [[ -z "$ZSH_EMACS_NOX" ]]; then
+        alias emacs="$EMACS_PLUGIN_LAUNCHER --no-wait"
+    else
+        # open terminal emacsclient
+        alias emacs="$EMACS_PLUGIN_LAUNCHER -nw"
+    fi
     alias e=emacs
     # open terminal emacsclient
     alias te="$EMACS_PLUGIN_LAUNCHER -nw"


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- This PR adds emacs plugin support for non-X users. This allows one to start emacs always with the `-nw` flag.
The change is backwards compatible. Onlyl if the variable `ZSH_EMACS_NOX` is defined and set to `true`, the new option will be enforced.