### PR TITLE
Fix a bug in upgrade.sh where it fails to reset terminal color

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -52,7 +52,7 @@ if [ -n "$remote" ]; then
   git remote set-url "$remote" "https://github.com/ohmyzsh/ohmyzsh.git"
 fi
 
-printf "${BLUE}%s${NORMAL}\n" "Updating Oh My Zsh"
+printf "${BLUE}%s${RESET}\n" "Updating Oh My Zsh"
 if git pull --rebase --stat origin master
 then
   printf '%s         %s__      %s           %s        %s       %s     %s__   %s\n' $RB_RED $RB_ORANGE $RB_YELLOW $RB_GREEN $RB_BLUE $RB_INDIGO $RB_VIOLET $RB_RESET


### PR DESCRIPTION
The bug was introduced in https://github.com/ohmyzsh/ohmyzsh/commit/27f4e079329dabf8e7008b98c8bddf443116eb54#diff-6d2fa595805de6f141a64f905f4db641. This commit has renamed `NORMAL` to `RESET` everywhere except one place.