### PR TITLE
Use oh-my-zsh path variables in zshrc.zsh-template

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -12,7 +12,7 @@ ZSH_THEME="robbyrussell"
 
 # Set list of themes to pick from when loading at random
 # Setting this variable when ZSH_THEME=random will cause zsh to load
-# a theme from this variable instead of looking in ~/.oh-my-zsh/themes/
+# a theme from this variable instead of looking in $ZSH/themes/
 # If set to an empty array, this variable will have no effect.
 # ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
 
@@ -64,8 +64,8 @@ ZSH_THEME="robbyrussell"
 # ZSH_CUSTOM=/path/to/new-custom-folder
 
 # Which plugins would you like to load?
-# Standard plugins can be found in ~/.oh-my-zsh/plugins/*
-# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
+# Standard plugins can be found in $ZSH/plugins/
+# Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(git)


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open. - https://github.com/ohmyzsh/ohmyzsh/pulls?q=is%3Apr+is%3Aopen+zshrc.zsh-template lists only one other PR
- [x] I have read the contribution guide and followed all the instructions.
~The code follows the code style guide detailed in the wiki.~
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
~The code is efficient, to the best of my ability, and does not waste computer resources.~
~The code is stable and I have tested it myself, to the best of my abilities.~

## Changes:

Replace ` ~/.oh-my-zsh` with $ZSH and ` ~/.oh-my-zsh/custom` with $ZSH_CUSTOM