### PR TITLE
Add Kube Context to the default prompt of Agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -242,11 +242,27 @@ prompt_aws() {
   esac
 }
 
+prompt_kubecontext() {
+  [[ -z "$(which kubectl)" ]] && return
+  local kube_prompt="k8s: "
+  local current_context="$(kubectl config current-context)"
+  local current_namespace="$(kubectl config get-contexts --no-headers | grep '*' | awk '{print $5}')"
+  [[ -z "${current_context}" ]] && return
+  kube_prompt+="${current_context}"
+  [[ "${current_namespace}" ]] && [[ "${current_namespace}" != "default" ]]&& kube_prompt+="/${current_namespace}"
+
+  case "$kube_prompt" in
+    *prod*|*production*) prompt_segment red black "${kube_prompt}" ;;
+    *) prompt_segment cyan $CURRENT_FG "${kube_prompt}" ;;
+  esac
+}
+
 ## Main prompt
 build_prompt() {
   RETVAL=$?
   prompt_status
   prompt_virtualenv
+  prompt_kubecontext
   prompt_aws
   prompt_context
   prompt_dir


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds a kube context line to the Agnoster theme
- If the user doesn't have a current context set or does not have kubectl installed the prompt is a noop
