### PR TITLE
Update rails plugin commands

### DIFF
--- a/plugins/rails/README.md
+++ b/plugins/rails/README.md
@@ -8,6 +8,9 @@ To use it, add `rails` to the plugins array in your zshrc file:
 plugins=(... rails)
 ```
 
+To use rails instead of rake, put rails after `bundler` plugin. 
+This should be default action for e.g. `rr` for rails >= 5.0 and is deprecated in rails 6.0.x
+
 ## List of Aliases
 
 ### Rails aliases
@@ -26,7 +29,7 @@ plugins=(... rails)
 | `rsd` | `rails server --debugger`  | Launch a web server with debugger                  |
 | `rsp` | `rails server --port`      | Launch a web server and specify the listening port |
 
-### Rake aliases
+### Rake or Rails aliases (depending on rails version)
 
 | Alias   | Command                         | Description                                            |
 |---------|---------------------------------|--------------------------------------------------------|
@@ -73,10 +76,3 @@ separately. For example: `REP rake db:migrate` will migrate the production db.
 | Alias   | Command                            |
 |---------|------------------------------------|
 | `sstat` | `thin --stats "/thin/stats" start` |
-| `sg`    | `ruby script/generate`             |
-| `sd`    | `ruby script/destroy`              |
-| `sp`    | `ruby script/plugin`               |
-| `sr`    | `ruby script/runner`               |
-| `ssp`   | `ruby script/spec`                 |
-| `sc`    | `ruby script/console`              |
-| `sd`    | `ruby script/server --debugger`    |

--- a/plugins/rails/_rails
+++ b/plugins/rails/_rails
@@ -11,8 +11,6 @@ _1st_arguments=(
     'application:Generate the Rails application code'
     'destroy:Undo code generated with "generate"'
 
-    'benchmarker:See how fast a piece of code runs'
-    'profiler:Get profile information from a piece of code'
     'plugin:Install a plugin'
 
     'plugin new:Generates skeleton for developing a Rails plugin'
@@ -21,24 +19,30 @@ _1st_arguments=(
 
 _rails_generate_arguments() {
     generate_arguments=(
-        assets
+        application_record
+        channel
         controller
-        decorator
         generator
         helper
         integration_test
+        job
+        mailbox
         mailer
         migration
         model
-        observer
-        performance_test
-        plugin
         resource
         scaffold
         scaffold_controller
         session_migration
-        stylesheets
+        responders_controller
+        system_test
         task
+        assets
+        stylesheets
+        observer
+        decorator
+        performance_test
+        plugin
     )
 }
 

--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -1,3 +1,4 @@
+
 function _rails_command () {
   if [ -e "bin/stubs/rails" ]; then
     bin/stubs/rails $@
@@ -12,8 +13,13 @@ function _rails_command () {
   fi
 }
 
-function _rake_command () {
-  if [ -e "bin/stubs/rake" ]; then
+alias rails='_rails_command'
+compdef _rails_command=rails
+
+function _rails_task_runner_command () {
+  if [[ $(_rails_command -v 2>&1) =~ 'Rails [5-9]' ]]; then
+    rails $@
+  elif [ -e "bin/stubs/rake" ]; then
     bin/stubs/rake $@
   elif [ -e "bin/rake" ]; then
     bin/rake $@
@@ -24,11 +30,8 @@ function _rake_command () {
   fi
 }
 
-alias rails='_rails_command'
-compdef _rails_command=rails
-
-alias rake='_rake_command'
-compdef _rake_command=rake
+alias rake='_rails_task_runner_command'
+compdef _rails_task_runner_command=rake
 
 alias devlog='tail -f log/development.log'
 alias prodlog='tail -f log/production.log'
@@ -51,7 +54,7 @@ alias rs='rails server'
 alias rsd='rails server --debugger'
 alias rsp='rails server --port'
 
-# Rake aliases
+# Rake aliases for rails < 5 (rails for more recent verions)
 alias rdm='rake db:migrate'
 alias rdms='rake db:migrate:status'
 alias rdr='rake db:rollback'
@@ -59,9 +62,9 @@ alias rdc='rake db:create'
 alias rds='rake db:seed'
 alias rdd='rake db:drop'
 alias rdrs='rake db:reset'
-alias rdtc='rake db:test:clone'
+alias rdtc='rake db:test:clone' # not exists
 alias rdtp='rake db:test:prepare'
-alias rdmtc='rake db:migrate db:test:clone'
+alias rdmtc='rake db:migrate db:test:clone' # not exists
 alias rdsl='rake db:schema:load'
 alias rlc='rake log:clear'
 alias rn='rake notes'
@@ -73,13 +76,6 @@ alias rsts='rake stats'
 
 # legacy stuff
 alias sstat='thin --stats "/thin/stats" start'
-alias sg='ruby script/generate'
-alias sd='ruby script/destroy'
-alias sp='ruby script/plugin'
-alias sr='ruby script/runner'
-alias ssp='ruby script/spec'
-alias sc='ruby script/console'
-alias sd='ruby script/server --debugger'
 
 function remote_console() {
   /usr/bin/env ssh $1 "( cd $2 && ruby script/console production )"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
* I want to reduce warnings using rails instead of rake aliases
```
DEPRECATION WARNING: Using `bin/rake routes` is deprecated and will be removed in Rails 6.1. Use `bin/rails routes` instead.
 (called from load at /Users/piotrwasiak/.rbenv/versions/2.7.1/bin/rake:23)
```
* I updated information about parameters and readme
* removed very legacy script commands

## Other comments:

Auto-completion does not work for me. I got this (--help is useless in current command)

<img width="852" alt="obraz" src="https://user-images.githubusercontent.com/11080848/83299095-d9b81200-a1f5-11ea-9d99-a8924cdf8641.png">

