### PR TITLE
Add missing dependency - cmp (GNU Diffutils)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To learn more, visit [ohmyz.sh](https://ohmyz.sh), follow [@ohmyzsh](https://twi
 * [Zsh](https://www.zsh.org) should be installed (v4.3.9 or more recent). If not pre-installed (run `zsh --version` to confirm), check the following instructions here: [Installing ZSH](https://github.com/ohmyzsh/ohmyzsh/wiki/Installing-ZSH)
 * `curl` or `wget` should be installed
 * `git` should be installed (recommended v1.7.2 or higher)
+* `cmp` should be installed, it is a part of [GNU Diffutils](https://www.gnu.org/software/diffutils/)
 
 ### Basic Installation
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.

- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add missing dependency - cmp which is a part of [GNU Diffutils](https://www.gnu.org/software/diffutils/). cmp is used here: [oh-my-zsh.sh:71](https://github.com/ohmyzsh/ohmyzsh/blob/93cc3964e2d265ab0571298d69d2eed0a65d13f2/oh-my-zsh.sh#L71)
