### PR TITLE
Add gblist alias to git plugin

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -48,6 +48,7 @@ alias gbD='git branch -D'
 alias gbl='git blame -b -w'
 alias gbnm='git branch --no-merged'
 alias gbr='git branch --remote'
+alias gblist="git for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD) %(if)%(HEAD)%(then)%(color:cyan)%(else)%(color:yellow)%(end)%(refname:short)%(color:reset)%(if)%(push)%(then) [%(push:remotename)]%(end) %(color:red)%(objectname:short)%(color:reset) %(contents:subject) %(color:magenta)%(authorname)%(color:reset) (%(color:green)%(committerdate:relative)%(color:reset))'"
 alias gbs='git bisect'
 alias gbsb='git bisect bad'
 alias gbsg='git bisect good'


### PR DESCRIPTION
The gblist alias lists all the git branches ordered by committed date with additional information about the branch.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- adds a new git alias `gblist`

## Other comments:

If you are like me and work on multiple branches simultaneously where the branch names follow a certain format that makes them hard to remember (ticket numbers), switching between them can be tedious. This alias is a life-saver for me so I figured it could be useful to others as well. 

The formatting might be a bit too much and I can edit it be leaner, also the 80 character line length rule is not followed in this file so I didn't do it either, but I can add line breaks if necessary. Here's what it looks like for on this branch with a few examples branches:
![Screenshot from 2020-06-03 08-08-16](https://user-images.githubusercontent.com/2808092/83601744-74f01500-a571-11ea-8aa7-8be2ae59cb57.png)

