### PR TITLE
feat(amuse): add virtualenv support

### DIFF
--- a/themes/amuse.zsh-theme
+++ b/themes/amuse.zsh-theme
@@ -11,8 +11,14 @@ ZSH_THEME_RUBY_PROMPT_PREFIX="%{$fg_bold[red]%}‹"
 ZSH_THEME_RUBY_PROMPT_SUFFIX="›%{$reset_color%}"
 
 PROMPT='
-%{$fg_bold[green]%}%~%{$reset_color%}$(git_prompt_info) ⌚ %{$fg_bold[red]%}%*%{$reset_color%}
+%{$fg_bold[green]%}%~%{$reset_color%}$(git_prompt_info)$(virtualenv_prompt_info) ⌚ %{$fg_bold[red]%}%*%{$reset_color%}
 $ '
 
 RPROMPT='$(ruby_prompt_info)'
+
+VIRTUAL_ENV_DISABLE_PROMPT=0
+ZSH_THEME_VIRTUAL_ENV_PROMPT_PREFIX=" %{$fg[green]%}🐍"
+ZSH_THEME_VIRTUAL_ENV_PROMPT_SUFFIX="%{$reset_color%}"
+ZSH_THEME_VIRTUALENV_PREFIX=$ZSH_THEME_VIRTUAL_ENV_PROMPT_PREFIX
+ZSH_THEME_VIRTUALENV_SUFFIX=$ZSH_THEME_VIRTUAL_ENV_PROMPT_SUFFIX
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- The prompt shows currently active python virtualenv (in green)
- A python unicode icon next to the env name
- Requires virtualenv plugin
- Demo:
![image](https://user-images.githubusercontent.com/34161949/83625092-092d9c80-a5b1-11ea-82ab-754252a86cef.png)

## Other comments:

Fixes #7766. There is another PR #8814  for the same purpose but I believe my design is better since it fits in better with the overall theme of amuse. Implementation inspired from the one in [bira theme](https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/bira.zsh-theme)