### PR TITLE
git: add alias for switching to master and develop

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -161,6 +161,8 @@ plugins=(... git)
 | gsu                  | git submodule update                                                                                                             |
 | gsw                  | git switch                                                                                                                       |
 | gswc                 | git switch -c                                                                                                                    |
+| gswm                 | git switch master                                                                                                                |
+| gswd                 | git switch develop                                                                                                               |
 | gts                  | git tag -s                                                                                                                       |
 | gtv                  | git tag \| sort -V                                                                                                               |
 | gtl                  | gtl(){ git tag --sort=-v:refname -n -l ${1}* }; noglob gtl                                                                       |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -247,6 +247,8 @@ alias gstall='git stash --all'
 alias gsu='git submodule update'
 alias gsw='git switch'
 alias gswc='git switch -c'
+alias gswm='git switch master'
+alias gswd='git switch develop'
 
 alias gts='git tag -s'
 alias gtv='git tag | sort -V'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

```sh
alias gswm='git switch master'
alias gswd='git switch develop'
```

## Other comments:

Add the aliases `gswm` and `gswd` to reflect existing aliases `gcm` and `gcd` in
terms of the new switch construct in git.