### PR TITLE
lib: don't override bigger HISTSIZE and SAVEHIST values

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -27,8 +27,8 @@ esac
 
 ## History file configuration
 [ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history"
-HISTSIZE=50000
-SAVEHIST=10000
+[ "$HISTSIZE" -lt 50000 ] && HISTSIZE=50000
+[ "$SAVEHIST" -lt 10000 ] && SAVEHIST=10000
 
 ## History command configuration
 setopt extended_history       # record timestamp of command in HISTFILE


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Only set `HISTSIZE` and `SAVEHIST` values if a bigger one is not already set

## Other comments:

oh-my-zsh Changes the HISTSIZE and SAVEHIST values to fixed sizes,
however if a bigger value is set in ~/.zshrc, it will override it,
potentially causing the user history to be deleted.

So, only set these values if no other is set and if it is lower than the
default ones.
