### PR TITLE
Fix per-directory-history plugin to use local history in new shell

### DIFF
--- a/plugins/per-directory-history/per-directory-history.zsh
+++ b/plugins/per-directory-history/per-directory-history.zsh
@@ -118,6 +118,15 @@ function _per-directory-history-addhistory() {
   fi
 }
 
+function _per-directory-history-precmd() {
+  if [[ $_per_directory_history_initialized == false ]]; then
+    # start in directory mode
+    mkdir -p ${_per_directory_history_directory:h}
+    _per_directory_history_is_global=true
+    _per-directory-history-set-directory-history
+    _per_directory_history_initialized=true
+  fi
+}
 
 function _per-directory-history-set-directory-history() {
   if [[ $_per_directory_history_is_global == true ]]; then
@@ -149,8 +158,7 @@ function _per-directory-history-set-global-history() {
 autoload -U add-zsh-hook
 add-zsh-hook chpwd _per-directory-history-change-directory
 add-zsh-hook zshaddhistory _per-directory-history-addhistory
+add-zsh-hook precmd _per-directory-history-precmd
 
-#start in directory mode
-mkdir -p ${_per_directory_history_directory:h}
-_per_directory_history_is_global=true
-_per-directory-history-set-directory-history
+# set initialized flag to false
+_per_directory_history_initialized=false


### PR DESCRIPTION
This patch fixes the problem that in a newly created shell, the global
history would be used instead of the per-directory on. It does this by
delaying the loading of the per-directory history until just before the
prompt is created.

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fixes #9007.
- The bug seems to be caused by ZSH loading the history from HISTFILE *after* the plugin is initialized, thus overriding the local history loaded by the plugin with the global history.
- This PR fixes this problem by delaying the plugin initialization.

## Other comments:
- This might also fix https://github.com/jimhester/per-directory-history/issues/5.
- @jimhester might want to review this.
