### PR TITLE
init: run update check in the same zsh process

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -5,9 +5,7 @@ if [[ -z "$ZSH_CACHE_DIR" ]]; then
 fi
 
 # Check for updates on initial load...
-if [ "$DISABLE_AUTO_UPDATE" != "true" ]; then
-  env ZSH=$ZSH ZSH_CACHE_DIR=$ZSH_CACHE_DIR DISABLE_UPDATE_PROMPT=$DISABLE_UPDATE_PROMPT zsh -f $ZSH/tools/check_for_upgrade.sh
-fi
+source $ZSH/tools/check_for_upgrade.sh
 
 # Initializes Oh My Zsh
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

After #8939, the update process is definitely sure to be run just once, and a user cancellation is local to only the update process. This means that we can run it inside the current zsh session without fear of messing with it. This PR removes the external zsh call and just runs it inside the current one with a `source` call.

Fixes #5162
Fixes #6732