### PR TITLE
Defer nvm plugin from loading until it is needed

### DIFF
--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -4,5 +4,5 @@
 # Try to load nvm only if command not already available
 if ! type "nvm" &> /dev/null; then
     # Load nvm if it exists
-    [[ -f "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
+    [[ -f "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh" --no-use
 fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Add the `--no-use` option to the nvm loading script. This dramatically improves the shell startup speed. Note that this addition is by no means original, as can be seen found [here](https://til-engineering.nulogy.com/Lazy-load-NVM-to-speed-up-zsh-initialization/).

Before addition of `--no-use` flag:
```
~ for i in $(seq 1 5); do time zsh -i -c exit; done
zsh -i -c exit  0.85s user 1.00s system 108% cpu 1.698 total
zsh -i -c exit  0.84s user 0.97s system 110% cpu 1.629 total
zsh -i -c exit  0.84s user 0.97s system 111% cpu 1.626 total
zsh -i -c exit  0.84s user 0.97s system 111% cpu 1.631 total
zsh -i -c exit  0.82s user 0.97s system 110% cpu 1.630 total
```

After addition of `--no-use` flag:
```
~ for i in $(seq 1 5); do time zsh -i -c exit; done
zsh -i -c exit  0.26s user 0.20s system 100% cpu 0.457 total
zsh -i -c exit  0.26s user 0.20s system 100% cpu 0.449 total
zsh -i -c exit  0.26s user 0.21s system 101% cpu 0.465 total
zsh -i -c exit  0.25s user 0.20s system 100% cpu 0.448 total
zsh -i -c exit  0.26s user 0.20s system 101% cpu 0.454 total
```

## Other comments:

_None._
