### PR TITLE
mvn: add Quarkus support in mvn completion

### DIFF
--- a/plugins/mvn/README.md
+++ b/plugins/mvn/README.md
@@ -19,6 +19,7 @@ if it's found, or the mvn command otherwise.
 | `mvn!`               | `mvn -f <root>/pom.xml`                         |
 | `mvnag`              | `mvn archetype:generate`                        |
 | `mvnboot`            | `mvn spring-boot:run`                           |
+| `mvnqdev`            | `mvn quarkus:dev`                               |
 | `mvnc`               | `mvn clean`                                     |
 | `mvncd`              | `mvn clean deploy`                              |
 | `mvnce`              | `mvn clean eclipse:clean eclipse:eclipse`       |

--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -61,6 +61,7 @@ alias mvndt='mvn dependency:tree'
 alias mvne='mvn eclipse:eclipse'
 alias mvnjetty='mvn jetty:run'
 alias mvnp='mvn package'
+alias mvnqdev='mvn quarkus:dev'
 alias mvns='mvn site'
 alias mvnsrc='mvn dependency:sources'
 alias mvnt='mvn test'
@@ -183,6 +184,8 @@ function listMavenCompletions {
 		tomee:run tomee:run-war tomee:run-war-only tomee:stop tomee:deploy tomee:undeploy
 		# spring-boot
 		spring-boot:run spring-boot:repackage
+		# quarkus
+		quarkus:dev quarkus:list-extensions quarkus:add-extension quarkus:add-extensions quarkus:generate-config quarkus:help
 		# exec
 		exec:exec exec:java
 		# versions


### PR DESCRIPTION
* Add alias `mvnqdev` tu run [Quarkus](https://quarkus.io) in dev mode
* Add Quarkus plugin support in completion

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fixes #9036 
