### PR TITLE
Plugin: Sudo - Make the behavior more in line with expectations

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -13,15 +13,28 @@
 # ------------------------------------------------------------------------------
 
 sudo-command-line() {
-    [[ -z $BUFFER ]] && zle up-history
-    if [[ $BUFFER == sudo\ * ]]; then
-        LBUFFER="${LBUFFER#sudo }"
-    elif [[ $BUFFER == $EDITOR\ * ]]; then
-        LBUFFER="${LBUFFER#$EDITOR }"
-        LBUFFER="sudoedit $LBUFFER"
+    [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
+    if [[ -n $EDITOR && $BUFFER == $EDITOR\ * ]]; then
+        if [[ ${#LBUFFER} -le ${#EDITOR} ]]; then
+            RBUFFER=" ${BUFFER#$EDITOR }"
+            LBUFFER="sudoedit"
+        else
+            LBUFFER="sudoedit ${LBUFFER#$EDITOR }"
+        fi
     elif [[ $BUFFER == sudoedit\ * ]]; then
-        LBUFFER="${LBUFFER#sudoedit }"
-        LBUFFER="$EDITOR $LBUFFER"
+        if [[ ${#LBUFFER} -le 8 ]]; then
+            RBUFFER=" ${BUFFER#sudoedit }"
+            LBUFFER="$EDITOR"
+        else
+            LBUFFER="$EDITOR ${LBUFFER#sudoedit }"
+        fi
+    elif [[ $BUFFER == sudo\ * ]]; then
+        if [[ ${#LBUFFER} -le 4 ]]; then
+            RBUFFER="${BUFFER#sudo }"
+            LBUFFER=""
+        else
+            LBUFFER="${LBUFFER#sudo }"
+        fi
     else
         LBUFFER="sudo $LBUFFER"
     fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- `[[ -z $BUFFER ]] && zle up-history` -> `[[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"`
  In the previous version, if you clear the buffer and press esc-esc again, you will get the history before last. And then the third to last, the fourth to last... It is fixed now.

- `[[ $BUFFER == sudo\ * ]]` -> `[[ -n $EDITOR && $BUFFER == $EDITOR\ * ]]`
  In the previous version, if you accidentally add a space in the font of the buffer and you haven't specified `$EDITOR`, the `sudoedit` will be added. It is fixed now.

- `...`
  In the previous version, if you put your cursor within `sudo` `sudoedit` `$EDITOR`, you will get a wrong result. It is fixed now.

## Other comments:

Here is a more simple version:

```bash
sudo-command-line() {
    [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
    if [[ -n $EDITOR && $BUFFER == $EDITOR\ * ]]; then
        LBUFFER="sudoedit ${BUFFER#$EDITOR }"
    elif [[ $BUFFER == sudoedit\ * ]]; then
        LBUFFER="$EDITOR ${BUFFER#sudoedit }"
    elif [[ $BUFFER == sudo\ * ]]; then
        LBUFFER="${BUFFER#sudo }"
    else
        LBUFFER="sudo $BUFFER"
    fi
    RBUFFER=""
}
```

This one will not maintain the cursor position.

I have a question on code style. The code style says to use 2 spaces indentation, but all of the commits of this file use 4 spaces indentation. I don't know which one to choose.

And I don't know whether there is a need to add `-n $EDITOR &&` in front of `$BUFFER == sudoedit\ *`.