### PR TITLE
Adds key:generate to Laravel development commands

### DIFF
--- a/plugins/laravel/laravel.plugin.zsh
+++ b/plugins/laravel/laravel.plugin.zsh
@@ -4,6 +4,7 @@ alias bob='php artisan bob::build'
 
 # Development
 alias pas='php artisan serve'
+alias pakg='php artisan key:generate'
 
 # Database
 alias pam='php artisan migrate'


### PR DESCRIPTION
Might come in handy, I needed this today so thought I'd create a pull request for others.

`pakg` will generate the key for your `.env` file.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- adds `pakg` to run `php artisan key:generate`

## Other comments:

Thought this would be useful. Needed something like this today, so thought I'd create a pull req.