### PR TITLE
archlinux: fix pacweb breaking when multiple packages found

### DIFF
--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -212,8 +212,8 @@ if (( $+commands[xdg-open] )); then
     if [[ -z "$infos" ]]; then
       return
     fi
-    repo="$(grep '^Repo' <<< "$infos" | grep -oP '[^ ]+$')"
-    arch="$(grep '^Arch' <<< "$infos" | grep -oP '[^ ]+$')"
+    repo="$(grep -m 1 '^Repo' <<< "$infos" | grep -oP '[^ ]+$')"
+    arch="$(grep -m 1 '^Arch' <<< "$infos" | grep -oP '[^ ]+$')"
     xdg-open "https://www.archlinux.org/packages/$repo/$arch/$pkg/" &>/dev/null
   }
 fi


### PR DESCRIPTION
…repos

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fix so that `pacweb` doesn't produce an invalid URL when package is available in multiple repos.

## Other comments:

Tested with rsync and works as intended.
Previously: <https://www.archlinux.org/packages/testing%0Aextra/x86_64%0Ax86_64/rsync/>
This PR: <https://www.archlinux.org/packages/testing/x86_64/rsync/>
