### PR TITLE
update: only update on a valid affirmative input

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -75,8 +75,15 @@ function update_ohmyzsh() {
         while read -t -k 1 option; do true; done
         [[ "$option" != ($'\n'|"") ]] && echo
 
-        echo -n "[oh-my-zsh] Would you like to update? [Y/n] "
-        read -r -k 1 option
+        # reset option to avoid autoaccept if enter was the last character
+        option=""
+
+        while [[ ! $option =~ [nNyY$'\n'] ]]
+        do
+            [[ "$option" != ($'\n'|"") ]] && echo
+            echo -n "[oh-my-zsh] Would you like to update? [Y/n] "
+            read -r -k 1 option
+        done
         [[ "$option" != $'\n' ]] && echo
         case "$option" in
             [nN]) update_last-updated_file ;;

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -75,19 +75,12 @@ function update_ohmyzsh() {
         while read -t -k 1 option; do true; done
         [[ "$option" != ($'\n'|"") ]] && echo
 
-        # reset option to avoid autoaccept if enter was the last character
-        option=""
-
-        while [[ ! $option =~ [nNyY$'\n'] ]]
-        do
-            [[ "$option" != ($'\n'|"") ]] && echo
-            echo -n "[oh-my-zsh] Would you like to update? [Y/n] "
-            read -r -k 1 option
-        done
+        echo -n "[oh-my-zsh] Would you like to update? [Y/n] "
+        read -r -k 1 option
         [[ "$option" != $'\n' ]] && echo
         case "$option" in
-            [nN]) update_last-updated_file ;;
-            *) update_ohmyzsh ;;
+            [yY$'\n']) update_ohmyzsh ;;
+            *) update_last-updated_file ;;
         esac
     fi
 }

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -80,7 +80,7 @@ function update_ohmyzsh() {
         [[ "$option" != $'\n' ]] && echo
         case "$option" in
             [yY$'\n']) update_ohmyzsh ;;
-            *) update_last-updated_file ;;
+            [nN]) update_last-updated_file ;;
         esac
     fi
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- When prompt to update ohmyzsh, the input accepted is: yY and enter to proceed and nN to deny, if an invalid input is given the user gets prompted again

## Other comments:

It fixes #9057 
