### PR TITLE
[plugin: tmux] add default session name when autostart enabled

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -39,3 +39,4 @@ The plugin also supports the following:
 | `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `screen-256color`            |
 | `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`)                      |
 | `ZSH_TMUX_UNICODE`                  | Set `tmux -u` option to support unicode                                       |
+| `ZSH_TMUX_DEFAULT_SESSION_NAME`     | Set tmux default session name when autostart is enabled                       |

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -76,7 +76,10 @@ function _zsh_tmux_plugin_run() {
     elif [[ -e "$ZSH_TMUX_CONFIG" ]]; then
       tmux_cmd+=(-f "$ZSH_TMUX_CONFIG")
     fi
-    $tmux_cmd new-session
+    if [[ -n "$ZSH_TMUX_DEFAULT_SESSION_NAME" ]]; then
+        ZSH_TMUX_DEFAULT_SESSION_NAME="-s $ZSH_TMUX_DEFAULT_SESSION_NAME"
+    fi
+    $tmux_cmd new-session "$ZSH_TMUX_DEFAULT_SESSION_NAME"
   fi
 
   if [[ "$ZSH_TMUX_AUTOQUIT" == "true" ]]; then


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open. (can be a subset of #7999)
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Start tmux session with a default `session-name` if provided

## Other comments:

Similar behavior can be seen in [Prezto tmux module](https://github.com/sorin-ionescu/prezto/blob/master/modules/tmux/init.zsh)
