### PR TITLE
VI-Mode Plugin: Keybindings 

### DIFF
--- a/plugins/vi-mode/README.md
+++ b/plugins/vi-mode/README.md
@@ -4,6 +4,8 @@ This plugin increase `vi-like` zsh functionality.
 
 Use `ESC` or `CTRL-[` to enter `Normal mode`.
 
+Use `v` once in normal mode to get visual mode. 
+
 
 History
 -------
@@ -24,7 +26,7 @@ wasn't defined by theme.
 Vim edition
 -----------
 
-- `v`   : Edit current command line in Vim
+- `^v`   : Edit current command line in Vim
 
 
 Movement


### PR DESCRIPTION
## Changes:

- Introduces a helper function to map key bindings to different vim modes in zsh (e.g., `vicmd`, `visual`)
- Adds support for `ysiw"` kind of operators like the vim-surround plugin.
- Makes some of the old Emacs keybindings (e.g., `C-a`, `C-e`) available only a subset of modes.
- Moves the `edit-command-line` command to `^v` and allows entering `visual` mode from `vicmd` mode using the `v`. 

