### PR TITLE
install: fix typo

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -269,7 +269,7 @@ main() {
 		                        /____/                       ....is now installed!
 
 
-		Before your scream Oh My Zsh! please look over the ~/.zshrc file to select plugins, themes, and options.
+		Before you scream Oh My Zsh! please look over the ~/.zshrc file to select plugins, themes, and options.
 
 		• Follow us on Twitter: https://twitter.com/ohmyzsh
 		• Join our Discord server: https://discord.gg/ohmyzsh


### PR DESCRIPTION
Changing 'your' to 'you' in install.sh

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Changed the 'Before **your** scream Oh My Zsh!' in install.sh to 'Before **you** scream Oh My Zsh!'

## Other comments:

😉
