### PR TITLE
agnoster: fix git working tree check

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -106,7 +106,7 @@ prompt_git() {
   }
   local ref dirty mode repo_path
 
-  if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
+   if [[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]]; then
     repo_path=$(git rev-parse --git-dir 2>/dev/null)
     dirty=$(parse_git_dirty)
     ref=$(git symbolic-ref HEAD 2> /dev/null) || ref="➦ $(git rev-parse --short HEAD 2> /dev/null)"


### PR DESCRIPTION

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

`git rev-parse --is-inside-work-tree` does not have a different exit
code when not within a work tree; the difference is in the output,
either "true" when in a work tree, or "false" when not.

The if was modified similarly to the check for the hide-status config,
which also parses command output rather than exit code.