### PR TITLE
hide metadata into zcompdump

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -57,6 +57,7 @@ if [ -z "$ZSH_COMPDUMP" ]; then
 fi
 
 # Construct zcompdump OMZ metadata
+zcompdump_meta_lines=4
 zcompdump_meta="\
 #omz host: $SHORT_HOST
 #omz zsh version: $ZSH_VERSION
@@ -64,8 +65,8 @@ zcompdump_meta="\
 #omz fpath: $fpath"
 
 # Delete the zcompdump file if OMZ zcompdump metadata changed
-if [ 0$(command grep -c -Fx "$zcompdump_meta" "$ZSH_COMPDUMP" 2>/dev/null) -ne \
-   $(command wc -l <<<"$zcompdump_meta") ]; then
+if [[ 0$(command grep -c -Fx "$zcompdump_meta" "$ZSH_COMPDUMP" 2>/dev/null) \
+  -ne $zcompdump_meta_lines ]]; then
   command rm -f "$ZSH_COMPDUMP"
   zcompdump_refresh=1
 fi
@@ -83,12 +84,7 @@ fi
 
 # Append zcompdump metadata if missing
 if (( $zcompdump_refresh )); then
-  # Use `tee` in case the $ZSH_COMPDUMP filename is invalid, to silence the error
-  # See https://github.com/ohmyzsh/ohmyzsh/commit/dd1a7269#commitcomment-39003489
-  tee -a "$ZSH_COMPDUMP" &>/dev/null <<EOF
-
-$zcompdump_meta
-EOF
+  echo "\n$zcompdump_meta" >>| "$ZSH_COMPDUMP"
 fi
 
 unset zcompdump_meta zcompdump_refresh

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -53,16 +53,19 @@ fi
 
 # Save the location of the current completion dump file.
 if [ -z "$ZSH_COMPDUMP" ]; then
-  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump"
 fi
 
 # Construct zcompdump OMZ metadata
-zcompdump_revision="#omz revision: $(builtin cd -q "$ZSH"; git rev-parse HEAD 2>/dev/null)"
-zcompdump_fpath="#omz fpath: $fpath"
+zcompdump_meta="\
+#omz host: $SHORT_HOST
+#omz zsh version: $ZSH_VERSION
+#omz revision: $(builtin cd -q "$ZSH"; git rev-parse HEAD 2>/dev/null)
+#omz fpath: $fpath"
 
 # Delete the zcompdump file if OMZ zcompdump metadata changed
-if ! command grep -q -Fx "$zcompdump_revision" "$ZSH_COMPDUMP" 2>/dev/null \
-   || ! command grep -q -Fx "$zcompdump_fpath" "$ZSH_COMPDUMP" 2>/dev/null; then
+if [ 0$(command grep -c -Fx "$zcompdump_meta" "$ZSH_COMPDUMP" 2>/dev/null) -ne \
+   $(command wc -l <<<"$zcompdump_meta") ]; then
   command rm -f "$ZSH_COMPDUMP"
   zcompdump_refresh=1
 fi
@@ -84,12 +87,11 @@ if (( $zcompdump_refresh )); then
   # See https://github.com/ohmyzsh/ohmyzsh/commit/dd1a7269#commitcomment-39003489
   tee -a "$ZSH_COMPDUMP" &>/dev/null <<EOF
 
-$zcompdump_revision
-$zcompdump_fpath
+$zcompdump_meta
 EOF
 fi
 
-unset zcompdump_revision zcompdump_fpath zcompdump_refresh
+unset zcompdump_meta zcompdump_refresh
 
 
 # Load all of the config files in ~/oh-my-zsh that end in .zsh


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Hide metadata into zcompdump file itself, instead of its filename.

## Other comments:

`-${SHORT_HOST}-${ZSH_VERSION}` should considered as metadata, which could be merged into zcompdump file itself. This could avoid multiple zcompdump files existing, and easy to delete the one and rebuild.