### PR TITLE
vscode: add support for VSCodium

### DIFF
--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -31,7 +31,7 @@ the Command Palette via (F1 or ⇧⌘P) and type shell command to find the Shell
 
 ## Using multiple flavours
 
-If for any reason, you ever require to use multiple flavours of VS Code i.e. VS Code and VS Code Insiders, you can 
+If for any reason, you ever require to use multiple flavours of VS Code i.e. VS Code (stable) and VS Code Insiders, you can 
 manually specify the flavour's executable. Add the following line to the .zshrc file (between the `ZSH_THEME` and the `plugins=()` lines).
 This will make the plugin use your manually defined executable.
 

--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -1,6 +1,6 @@
 # VS Code
 
-This plugin makes interaction between the command line and the VS Code editor easier.
+This plugin provides useful aliases to simplify the interaction between the command line and VS Code or VSCodium editor.
 
 To start using it, add the `vscode` plugin to your `plugins` array in `~/.zshrc`:
 
@@ -10,23 +10,36 @@ plugins=(... vscode)
 
 ## Requirements
 
-To use VS Code in the terminal **in macOS**, first you need to install the `code` command in the PATH,
-otherwise you might receive this message: `zsh: command not found: code`.
+This plugin requires to have a flavour of VS Code installed and it's executable available in PATH.
 
-[As the docs say](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line), open
+You can install either:
+
+* VS Code (code)
+* VS Code Insiders (code-insiders)
+* VSCodium (codium)
+
+### MacOS
+While Linux installations will add the executable to PATH, MacOS users might still have to do this manually:
+
+[For VS Code and VS Code Insiders](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line), open
 the Command Palette via (F1 or ⇧⌘P) and type shell command to find the Shell Command:
-> Install 'code' command in PATH
+> Shell Command: Install 'code' command in PATH
 
-## VS Code Insiders
+[For VSCodium](https://github.com/VSCodium/vscodium/blob/master/DOCS.md#how-do-i-open-vscodium-from-the-terminal), open
+the Command Palette via (F1 or ⇧⌘P) and type shell command to find the Shell Command:
+> Shell Command: Install 'codium' command in PATH
 
-🍏 **If you are only using [VS Code Insiders](https://code.visualstudio.com/insiders/), the plugin will automatically bind to your Insiders installation.**
+## Using multiple flavours
 
-But, if you have both Stable and Insiders versions and want to configure the plugin to just use the Insiders version, add the following line in the oh-my-zsh settings section (between the `ZSH_THEME` and the `plugins=()` line). This will make the plugin use the Insiders version instead.
+If for any reason, you ever require to use multiple flavours of VS Code i.e. VS Code and VS Code Insiders, you can 
+manually specify the flavour's executable. Add the following line to the .zshrc file (between the `ZSH_THEME` and the `plugins=()` lines).
+This will make the plugin use your manually defined executable.
 
 ```zsh
 ZSH_THEME=...
 
-# Add this line to use code-insiders instead of code
+# Choose between one [code, code-insiders or codium]
+# The following line will make the plugin to open VS Code Insiders
 VSCODE=code-insiders
 
 plugins=(... vscode)

--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -40,6 +40,7 @@ ZSH_THEME=...
 
 # Choose between one [code, code-insiders or codium]
 # The following line will make the plugin to open VS Code Insiders
+# Invalid entries will be ignored, no aliases will be added
 VSCODE=code-insiders
 
 plugins=(... vscode)

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -28,6 +28,8 @@ _vscode-register-aliases () {
 if ! [ -z ${VSCODE+x} ] && which $VSCODE > /dev/null; then
   _vscode-register-aliases
 else
+  unset VSCODE
+
   if which code > /dev/null; then
     : ${VSCODE:=code}
   elif which code-insiders > /dev/null; then

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -2,6 +2,7 @@
 # Authors:
 #   https://github.com/MarsiBarsi (original author)
 #   https://github.com/babakks
+#   https://github.com/SteelShot
 
 # This will pick an appropriate executable in order:
 # VSCode > VSCode Insiders > VSCodium

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -5,8 +5,13 @@
 #   https://github.com/SteelShot
 
 # Verify if any manual user choice of VS Code exists first.
+if [[ -n "$VSCODE" ]] && ! which $VSCODE &>/dev/null; then
+  echo "'$VSCODE' flavour of VS Code not detected."
+  unset VSCODE
+fi
+
 # Otherwise, try to detect a flavour of VS Code.
-if [[ -z "$VSCODE" ]] || ! which $VSCODE &>/dev/null; then
+if [[ -z "$VSCODE" ]]; then
   if which code &>/dev/null; then
     VSCODE=code
   elif which code-insiders &>/dev/null; then
@@ -18,8 +23,7 @@ if [[ -z "$VSCODE" ]] || ! which $VSCODE &>/dev/null; then
   fi
 fi
 
-alias vsc="$VSCODE"
-alias vsc.="$VSCODE ."
+alias vsc="$VSCODE ."
 alias vsca="$VSCODE --add"
 alias vscd="$VSCODE --diff"
 alias vscg="$VSCODE --goto"

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -3,28 +3,33 @@
 #   https://github.com/MarsiBarsi (original author)
 #   https://github.com/babakks
 
-# Use the stable VS Code release, unless the Insiders version is the only
-# available installation
-if ! which code > /dev/null && which code-insiders > /dev/null; then
-  : ${VSCODE:=code-insiders}
-else
+# This will pick an appropriate executable in order:
+# VSCode > VSCode Insiders > VSCodium
+if which code > /dev/null; then
   : ${VSCODE:=code}
+elif which code-insiders > /dev/null; then
+  : ${VSCODE:=code-insiders}
+elif which codium > /dev/null; then
+  : ${VSCODE:=codium}
 fi
 
-# Define aliases
-alias vsc="$VSCODE ."
-alias vsca="$VSCODE --add"
-alias vscd="$VSCODE --diff"
-alias vscg="$VSCODE --goto"
-alias vscn="$VSCODE --new-window"
-alias vscr="$VSCODE --reuse-window"
-alias vscw="$VSCODE --wait"
-alias vscu="$VSCODE --user-data-dir"
+# Only if a flavour of VSCode is available the aliases
+# will be available
+if ! [ -z ${VSCODE+x} ]; then
+  alias vsc="$VSCODE ."
+  alias vsca="$VSCODE --add"
+  alias vscd="$VSCODE --diff"
+  alias vscg="$VSCODE --goto"
+  alias vscn="$VSCODE --new-window"
+  alias vscr="$VSCODE --reuse-window"
+  alias vscw="$VSCODE --wait"
+  alias vscu="$VSCODE --user-data-dir"
 
-alias vsced="$VSCODE --extensions-dir"
-alias vscie="$VSCODE --install-extension"
-alias vscue="$VSCODE --uninstall-extension"
+  alias vsced="$VSCODE --extensions-dir"
+  alias vscie="$VSCODE --install-extension"
+  alias vscue="$VSCODE --uninstall-extension"
 
-alias vscv="$VSCODE --verbose"
-alias vscl="$VSCODE --log"
-alias vscde="$VSCODE --disable-extensions"
+  alias vscv="$VSCODE --verbose"
+  alias vscl="$VSCODE --log"
+  alias vscde="$VSCODE --disable-extensions"
+fi

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -16,7 +16,7 @@ fi
 
 # Only if a flavour of VSCode is available the aliases
 # will be available
-if ! [ -z ${VSCODE+x} ]; then
+if ! [ -z ${VSCODE+x} ] && which $VSCODE > /dev/null; then
   alias vsc="$VSCODE ."
   alias vsca="$VSCODE --add"
   alias vscd="$VSCODE --diff"

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -1,22 +1,10 @@
-# VScode zsh plugin
+# VS Code (stable / insiders) / VSCodium zsh plugin
 # Authors:
 #   https://github.com/MarsiBarsi (original author)
 #   https://github.com/babakks
 #   https://github.com/SteelShot
 
-# This will pick an appropriate executable in order:
-# VSCode > VSCode Insiders > VSCodium
-if which code > /dev/null; then
-  : ${VSCODE:=code}
-elif which code-insiders > /dev/null; then
-  : ${VSCODE:=code-insiders}
-elif which codium > /dev/null; then
-  : ${VSCODE:=codium}
-fi
-
-# Only if a flavour of VSCode is available the aliases
-# will be available
-if ! [ -z ${VSCODE+x} ] && which $VSCODE > /dev/null; then
+_vscode-register-aliases () {
   alias vsc="$VSCODE ."
   alias vsca="$VSCODE --add"
   alias vscd="$VSCODE --diff"
@@ -33,4 +21,22 @@ if ! [ -z ${VSCODE+x} ] && which $VSCODE > /dev/null; then
   alias vscv="$VSCODE --verbose"
   alias vscl="$VSCODE --log"
   alias vscde="$VSCODE --disable-extensions"
+}
+
+# Verify if any manual user choice of VS Code exists first.
+# Otherwise, try to detect a flavour of VS Code.
+if ! [ -z ${VSCODE+x} ] && which $VSCODE > /dev/null; then
+  _vscode-register-aliases
+else
+  if which code > /dev/null; then
+    : ${VSCODE:=code}
+  elif which code-insiders > /dev/null; then
+    : ${VSCODE:=code-insiders}
+  elif which codium > /dev/null; then
+    : ${VSCODE:=codium}
+  else
+    return -1
+  fi
+
+  _vscode-register-aliases
 fi

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -4,41 +4,34 @@
 #   https://github.com/babakks
 #   https://github.com/SteelShot
 
-_vscode-register-aliases () {
-  alias vsc="$VSCODE ."
-  alias vsca="$VSCODE --add"
-  alias vscd="$VSCODE --diff"
-  alias vscg="$VSCODE --goto"
-  alias vscn="$VSCODE --new-window"
-  alias vscr="$VSCODE --reuse-window"
-  alias vscw="$VSCODE --wait"
-  alias vscu="$VSCODE --user-data-dir"
-
-  alias vsced="$VSCODE --extensions-dir"
-  alias vscie="$VSCODE --install-extension"
-  alias vscue="$VSCODE --uninstall-extension"
-
-  alias vscv="$VSCODE --verbose"
-  alias vscl="$VSCODE --log"
-  alias vscde="$VSCODE --disable-extensions"
-}
-
 # Verify if any manual user choice of VS Code exists first.
 # Otherwise, try to detect a flavour of VS Code.
-if ! [ -z ${VSCODE+x} ] && which $VSCODE > /dev/null; then
-  _vscode-register-aliases
-else
-  unset VSCODE
-
-  if which code > /dev/null; then
-    : ${VSCODE:=code}
-  elif which code-insiders > /dev/null; then
-    : ${VSCODE:=code-insiders}
-  elif which codium > /dev/null; then
-    : ${VSCODE:=codium}
+if [[ -z "$VSCODE" ]] || ! which $VSCODE &>/dev/null; then
+  if which code &>/dev/null; then
+    VSCODE=code
+  elif which code-insiders &>/dev/null; then
+    VSCODE=code-insiders
+  elif which codium &>/dev/null; then
+    VSCODE=codium
   else
-    return -1
+    return
   fi
-
-  _vscode-register-aliases
 fi
+
+alias vsc="$VSCODE"
+alias vsc.="$VSCODE ."
+alias vsca="$VSCODE --add"
+alias vscd="$VSCODE --diff"
+alias vscg="$VSCODE --goto"
+alias vscn="$VSCODE --new-window"
+alias vscr="$VSCODE --reuse-window"
+alias vscw="$VSCODE --wait"
+alias vscu="$VSCODE --user-data-dir"
+
+alias vsced="$VSCODE --extensions-dir"
+alias vscie="$VSCODE --install-extension"
+alias vscue="$VSCODE --uninstall-extension"
+
+alias vscv="$VSCODE --verbose"
+alias vscl="$VSCODE --log"
+alias vscde="$VSCODE --disable-extensions"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
* Added support to detect VSCodium, the plugin will now choose in the order of VS Code > VS Code Insiders > VSCodium which executable to use for the aliases, ofc this can still be overriden as before by adding the variable manually to .zshrc file. 
* Added a check in case all 3 editors are missing, then the aliases wont be added. 
* Refactored the README quite a bit to match the changes and hopefully improve it.

## Other comments:
@MarsiBarsi, @babakks
