### PR TITLE
Change default ZSH_COMPDUMP directory to ZSH_CACHE_DIR

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -53,7 +53,7 @@ fi
 
 # Save the location of the current completion dump file.
 if [ -z "$ZSH_COMPDUMP" ]; then
-  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+  ZSH_COMPDUMP="${ZSH_CACHE_DIR}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
 # Construct zcompdump OMZ metadata


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fixes issue #7332
- Approach taken from a comment by @mcornella at https://github.com/ohmyzsh/ohmyzsh/issues/7332#issuecomment-624221366
- Seemed like an easy fix that I was also interested in, so I thought I'd contribute
