### PR TITLE
git: make git_main_branch configurable

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -181,10 +181,12 @@ plugins=(... git)
 
 ### Main branch preference
 
-Following the recent push for removing racially-charged words from our technical vocabulary, the git plugin favors using
-a branch name other than `master`. In this case, we favor the shorter, neutral and descriptive term `main`. This means
-that any aliases and functions that previously used `master`, will use `main` if that branch exists. We do this via the
-function `git_main_branch`.
+Following the recent push for removing racially-charged words from our technical vocabulary, users might favor using
+a branch name other than `master`. Now you can configure this by the environment variable `GIT_MAIN_BRANCH_PRIORITY`.
+It is a list of branch names separated by `:`. The function `git_main_branch` checks for all branches in the list and
+returns the first existing branch in the list. `git_main_branch` is used in many aliases which use `master` as the main
+branch before. The default `GIT_MAIN_BRANCH_PRIORITY` is `master:main` instead of `main:master`, and `git_main_branch`
+returns `master` if no branch in `GIT_MAIN_BRANCH_PRIORITY` exists, so that it's not a breaking change.
 
 ### Deprecated aliases
 
@@ -208,13 +210,13 @@ These are aliases that have been removed, renamed, or otherwise modified in a wa
 
 ### Current
 
-| Command                | Description                                                                  |
-|:-----------------------|:-----------------------------------------------------------------------------|
-| `grename <old> <new>`  | Rename `old` branch to `new`, including in origin remote                     |
-| current_branch         | Return the name of the current branch                                        |
-| git_current_user_name  | Returns the `user.name` config value                                         |
-| git_current_user_email | Returns the `user.email` config value                                        |
-| git_main_branch        | Returns the name of the main branch: `main` if it exists, `master` otherwise |
+| Command                | Description                                                                                                                     |
+| :--------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| `grename <old> <new>`  | Rename `old` branch to `new`, including in origin remote                                                                        |
+| current_branch         | Return the name of the current branch                                                                                           |
+| git_current_user_name  | Returns the `user.name` config value                                                                                            |
+| git_current_user_email | Returns the `user.email` config value                                                                                           |
+| git_main_branch        | Returns the first existing branch in `$GIT_MAIN_BRANCH_PRIORITY` or "master" if no branch in `$GIT_MAIN_BRANCH_PRIORITY` exists |
 
 ### Work in Progress (WIP)
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -25,13 +25,22 @@ function work_in_progress() {
   fi
 }
 
-# Check if main exists and use instead of master
+# Look for the first existing branch in GIT_MAIN_BRANCH_PRIORITY or "master" if no branch exists
 function git_main_branch() {
-  if [[ -n "$(git branch --list main)" ]]; then
-    echo main
-  else
-    echo master
-  fi
+  [[ -v GIT_MAIN_BRANCH_PRIORITY ]] || GIT_MAIN_BRANCH_PRIORITY="master:main"
+  local git_main_branch_array=("${(@s/:/)GIT_MAIN_BRANCH_PRIORITY}")
+  local git_branch_list="$(git for-each-ref --format='%(refname:short)' refs/heads/*)"
+  local git_branch_array=("${(f)git_branch_list}")
+
+  for branch in $git_main_branch_array; do
+    if (($git_branch_array[(Ie)$branch])); then
+      echo "$branch"
+      return 0
+    fi
+  done
+
+  echo master
+  return 1
 }
 
 #


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Make the function `git_main_branch` configurable. You can set the environment variable `GIT_MAIN_BRANCH_PRIORITY` which is a list of branch names separated by `:`. The function `git_main_branch` checks for all branches in the list and returns the first existing branch in the list.

The default `GIT_MAIN_BRANCH_PRIORITY` is `master:main` instead of `main:master`, and `git_main_branch` returns `master` if no branch in `GIT_MAIN_BRANCH_PRIORITY` exists, so that it's not a breaking change (compared to the version before #9049).

## Other comments:

This is an enhancement of #9049. The contributor of that PR: @adam2k. The reviewer of that PR: @mcornella.
