### PR TITLE
fix(vim-interaction): look up the newest GVim instance

### DIFF
--- a/plugins/vim-interaction/vim-interaction.plugin.zsh
+++ b/plugins/vim-interaction/vim-interaction.plugin.zsh
@@ -22,7 +22,8 @@ EOH
   local cmd=""
   local before="<esc>"
   local after=""
-  local name="GVIM"
+  # Look up the newest instance
+  local name="$(gvim --serverlist | tail -n 1)"
   while getopts ":b:a:n:" option
   do
     case $option in


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Instead of relying on a hardcoded instance-name existing for the default-value, let's look up the latest instance by getting the latest line from `gvim --serverlist`. This also resolves my problem where MacVim uses a servername of "VIM" instead of "GVIM".