### PR TITLE
dotenv: add never option to confirmation prompt

### DIFF
--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -53,24 +53,25 @@ Set `ZSH_DOTENV_PROMPT=false` in your zshrc file if you don't want the confirmat
 You can also choose the `Always` option when prompted to always allow sourcing the .env file
 in that directory. See the next section for more details.
 
-### ZSH_DOTENV_ALLOWED_LIST
+### ZSH_DOTENV_{DIS,}ALLOWED_LIST
 
 The default behavior of the plugin is to always ask whether to source a dotenv file. There's
-a **Y**es, **N**o, and **A**lways option. If you choose Always, the directory of the .env file
-will be added to an allowed list. If a directory is found in this list, the plugin won't ask
-for confirmation and will instead source the .env file directly.
+a **Y**es, **N**o, **A**lways and N**e**ver option. If you choose Always, the directory of the .env file
+will be added to an allowed list, for Never it get's added to a disallowed list respectively. If a directory is found in those lists, the plugin won't ask
+for confirmation and will instead source the .env file or proceed without action directly.
 
-This allowed list is saved by default in `$ZSH_CACHE_DIR/dotenv-allowed.list`. If you want
-to change that location, change the `$ZSH_DOTENV_ALLOWED_LIST` variable, like so:
+This (dis-)allowed list is saved by default in `$ZSH_CACHE_DIR/dotenv-{dis,}allowed.list`. If you want
+to change that location, change the `$ZSH_DOTENV_{DIS,}ALLOWED_LIST` variable, like so:
 
 ```zsh
 # in ~/.zshrc, before Oh My Zsh is sourced:
 ZSH_DOTENV_ALLOWED_LIST=/path/to/dotenv/allowed/list
+ZSH_DOTENV_DISALLOWED_LIST=/path/to/dotenv/disallowed/list
 ```
 
-This file is just a list of directories allowed, separated by a newline character. If you want
-to disallow a directory, just edit this file and remove the line for the directory you want to
-disallow.
+The file is just a list of directories, separated by a newline character. If you want
+to change your decistion, just edit the file and remove the line for the directory you want to
+change.
 
 ## Version Control
 

--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -53,15 +53,17 @@ Set `ZSH_DOTENV_PROMPT=false` in your zshrc file if you don't want the confirmat
 You can also choose the `Always` option when prompted to always allow sourcing the .env file
 in that directory. See the next section for more details.
 
-### ZSH_DOTENV_{DIS,}ALLOWED_LIST
+### ZSH_DOTENV_ALLOWED_LIST, ZSH_DOTENV_DISALLOWED_LIST
 
 The default behavior of the plugin is to always ask whether to source a dotenv file. There's
 a **Y**es, **N**o, **A**lways and N**e**ver option. If you choose Always, the directory of the .env file
-will be added to an allowed list, for Never it get's added to a disallowed list respectively. If a directory is found in those lists, the plugin won't ask
-for confirmation and will instead source the .env file or proceed without action directly.
+will be added to an allowed list; if you choose Never, it get's added to a disallowed list.
+If a directory is found in those lists, the plugin won't ask for confirmation and will instead
+either source the .env file or proceed without action respectively.
 
-This (dis-)allowed list is saved by default in `$ZSH_CACHE_DIR/dotenv-{dis,}allowed.list`. If you want
-to change that location, change the `$ZSH_DOTENV_{DIS,}ALLOWED_LIST` variable, like so:
+This allowed and disallowed lists are saved by default in `$ZSH_CACHE_DIR/dotenv-allowed.list` and
+`$ZSH_CACHE_DIR/dotenv-disallowed.list` respectively. If you want to change that location,
+change the `$ZSH_DOTENV_ALLOWED_LIST` and `$ZSH_DOTENV_DISALLOWED_LIST` variables, like so:
 
 ```zsh
 # in ~/.zshrc, before Oh My Zsh is sourced:
@@ -70,8 +72,11 @@ ZSH_DOTENV_DISALLOWED_LIST=/path/to/dotenv/disallowed/list
 ```
 
 The file is just a list of directories, separated by a newline character. If you want
-to change your decistion, just edit the file and remove the line for the directory you want to
+to change your decision, just edit the file and remove the line for the directory you want to
 change.
+
+NOTE: if a directory is found in both the allowed and disallowed lists, the disallowed list
+takes preference, _i.e._ the .env file will never be sourced.
 
 ## Version Control
 

--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -57,11 +57,11 @@ in that directory. See the next section for more details.
 
 The default behavior of the plugin is to always ask whether to source a dotenv file. There's
 a **Y**es, **N**o, **A**lways and N**e**ver option. If you choose Always, the directory of the .env file
-will be added to an allowed list; if you choose Never, it get's added to a disallowed list.
-If a directory is found in those lists, the plugin won't ask for confirmation and will instead
-either source the .env file or proceed without action respectively.
+will be added to an allowed list; if you choose Never, it will be added to a disallowed list.
+If a directory is found in either of those lists, the plugin won't ask for confirmation and will
+instead either source the .env file or proceed without action respectively.
 
-This allowed and disallowed lists are saved by default in `$ZSH_CACHE_DIR/dotenv-allowed.list` and
+The allowed and disallowed lists are saved by default in `$ZSH_CACHE_DIR/dotenv-allowed.list` and
 `$ZSH_CACHE_DIR/dotenv-disallowed.list` respectively. If you want to change that location,
 change the `$ZSH_DOTENV_ALLOWED_LIST` and `$ZSH_DOTENV_DISALLOWED_LIST` variables, like so:
 

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -5,6 +5,7 @@
 
 # Path to the file containing allowed paths
 : ${ZSH_DOTENV_ALLOWED_LIST:="${ZSH_CACHE_DIR:-$ZSH/cache}/dotenv-allowed.list"}
+: ${ZSH_DOTENV_DISALLOWED_LIST:="${ZSH_CACHE_DIR:-$ZSH/cache}/dotenv-disallowed.list"}
 
 
 ## Functions
@@ -14,19 +15,26 @@ source_env() {
     if [[ "$ZSH_DOTENV_PROMPT" != false ]]; then
       local confirmation dirpath="${PWD:A}"
 
-      # make sure there is an allowed file
+      # make sure there is an (dis-)allowed file
       touch "$ZSH_DOTENV_ALLOWED_LIST"
+      touch "$ZSH_DOTENV_DISALLOWED_LIST"
+
+      # early return if disallowed
+      if grep -q "$dirpath" "$ZSH_DOTENV_DISALLOWED_LIST" &>/dev/null; then
+        return;
+      fi
 
       # check if current directory's .env file is allowed or ask for confirmation
       if ! grep -q "$dirpath" "$ZSH_DOTENV_ALLOWED_LIST" &>/dev/null; then
         # print same-line prompt and output newline character if necessary
-        echo -n "dotenv: found '$ZSH_DOTENV_FILE' file. Source it? ([Y]es/[n]o/[a]lways) "
+        echo -n "dotenv: found '$ZSH_DOTENV_FILE' file. Source it? ([Y]es/[n]o/[a]lways/n[e]ver) "
         read -k 1 confirmation; [[ "$confirmation" != $'\n' ]] && echo
 
         # check input
         case "$confirmation" in
           [nN]) return ;;
           [aA]) echo "$dirpath" >> "$ZSH_DOTENV_ALLOWED_LIST" ;;
+          [eE]) echo "$dirpath" >> "$ZSH_DOTENV_DISALLOWED_LIST"; return ;;
           *) ;; # interpret anything else as a yes
         esac
       fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- change prompt from `Source it? ([Y]es/[n]o/[a]lways)` to  `Source it? ([Y]es/[n]o/[a]lways/n[e]ver)` (I couldn't find a synonym to never which doesn't start with **n**, suggestions welcome)
- add parallel to `ZSH_DOTENV_ALLOWED_LIST`: `ZSH_DOTENV_DISALLOWED_LIST`
- write disallowed dirs to that file and skip sourcing if directory is in that file
- update README

---

fixes #9101 