### PR TITLE
Suppress the problematic trap output in check_for_upgrade.sh

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -51,7 +51,7 @@ function update_ohmyzsh() {
     #  The return status from the function is handled specially. If it is zero, the signal is
     #  assumed to have been handled, and execution continues normally. Otherwise, the shell
     #  will behave as interrupted except that the return status of the trap is retained.
-    trap "rm -rf '$ZSH/log/update.lock' >/dev/null; return 1" EXIT INT QUIT
+    trap "command rm -rf '$ZSH/log/update.lock'; return 1" EXIT INT QUIT
 
     # Create or update .zsh-update file if missing or malformed
     if ! source "${ZSH_CACHE_DIR}/.zsh-update" 2>/dev/null || [[ -z "$LAST_EPOCH" ]]; then

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -51,7 +51,7 @@ function update_ohmyzsh() {
     #  The return status from the function is handled specially. If it is zero, the signal is
     #  assumed to have been handled, and execution continues normally. Otherwise, the shell
     #  will behave as interrupted except that the return status of the trap is retained.
-    trap "rm -rf '$ZSH/log/update.lock'; return 1" EXIT INT QUIT
+    trap "rm -rf '$ZSH/log/update.lock' >/dev/null; return 1" EXIT INT QUIT
 
     # Create or update .zsh-update file if missing or malformed
     if ! source "${ZSH_CACHE_DIR}/.zsh-update" 2>/dev/null || [[ -z "$LAST_EPOCH" ]]; then


### PR DESCRIPTION
The newly added trap, in systems where `rm` is aliased to `rm="rm -v"`,
shows a message stating that "update.lock" has been removed each time `zsh` is called.

## Changes:

- Suppressed the trap `rm` with directing the output to `/dev/null`. (prevents extra alerts in more verbose systems)

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

Fixes #9109