### PR TITLE
battery: add acpi requirement to README

### DIFF
--- a/plugins/battery/README.md
+++ b/plugins/battery/README.md
@@ -9,7 +9,7 @@ To use, add `battery` to the list of plugins in your `.zshrc` file:
 Then, add the `battery_pct_prompt` function to your custom theme. For example:
 
 ```
-RPROMPT='$(battery_pct_prompt)  ...'
+RPROMPT='$(battery_pct_prompt) ...'
 ```
 
 ## Requirements

--- a/plugins/battery/README.md
+++ b/plugins/battery/README.md
@@ -6,8 +6,13 @@ To use, add `battery` to the list of plugins in your `.zshrc` file:
 
 `plugins=(... battery)`
 
+Make sure the acpi tool is installed by running the following command:
+```
+sudo apt-get install acpi
+```
+
 Then, add the `battery_pct_prompt` function to your custom theme. For example:
 
 ```
-RPROMPT='$(battery_pct_prompt)'
+RPROMPT='$(battery_pct_prompt)  ...'
 ```

--- a/plugins/battery/README.md
+++ b/plugins/battery/README.md
@@ -6,7 +6,9 @@ To use, add `battery` to the list of plugins in your `.zshrc` file:
 
 `plugins=(... battery)`
 
-Make sure the acpi tool is installed by running the following command:
+You must have the acpi tool installed on your operating system.
+
+Here's an example of how to install with apt:
 ```
 sudo apt-get install acpi
 ```

--- a/plugins/battery/README.md
+++ b/plugins/battery/README.md
@@ -6,15 +6,17 @@ To use, add `battery` to the list of plugins in your `.zshrc` file:
 
 `plugins=(... battery)`
 
-You must have the acpi tool installed on your operating system.
-
-Here's an example of how to install with apt:
-```
-sudo apt-get install acpi
-```
-
 Then, add the `battery_pct_prompt` function to your custom theme. For example:
 
 ```
 RPROMPT='$(battery_pct_prompt)  ...'
+```
+
+## Requirements
+
+On Linux, you must have the `acpi` tool installed on your operating system.
+
+Here's an example of how to install with apt:
+```
+sudo apt-get install acpi
 ```


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Update read from battery plugin. Adds information for installing the acpi tool to display the battery percentage
