### PR TITLE
aws: improve check for aws_completer - unhardcode path

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -63,7 +63,7 @@ fi
 # Load awscli completions
 
 # AWS CLI v2 comes with its own autocompletion. Check if that is there, otherwise fall back
-if [[ -x /usr/local/bin/aws_completer ]]; then
+if command -v aws_completer &> /dev/null; then
   autoload -Uz bashcompinit && bashcompinit
   complete -C aws_completer aws
 else


### PR DESCRIPTION
Closes #9122

The current check is assuming that the aws_completer is installed
globally, it then runs the command without that path

I have aws_completer in ~/.local/bin/aws_completer

This changes the check to see if the command exists instead of
concerning itself with where it in installed. This test matches the
behavior of just running the command.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- use `command` to check for aws_completer instead of hardcoded path