### PR TITLE
Added compile script to tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cache/
 log/
 *.swp
 .DS_Store
+
+# ZSH Compiled files
+*.zwc

--- a/tools/compile_ohmyzsh.sh
+++ b/tools/compile_ohmyzsh.sh
@@ -1,0 +1,98 @@
+#!/bin/zsh
+
+# Compile Oh My Zsh
+# This compiles the ohmyzsh files with zcompile, should be called when changing
+# a configuration file(.zshrc, .zshenv, ...) or updating ohmyzsh. Compiling a
+# those files remove the over head of the text parsing.
+
+if [[ -n $ZDOTDIR ]]; then
+	zsh_dir=$ZDOTDIR
+else
+	zsh_dir=$HOME
+fi
+
+FILE_LIST=(
+	"$zsh_dir/.zshrc"
+	"$zsh_dir/.zshenv"
+	"$zsh_dir/.zprofile"
+	"$zsh_dir/.zlogin"
+	"$zsh_dir/.zlogout"
+	"$ZSH/oh-my-zsh.sh"
+)
+
+DIRECTORY_LIST=(
+	"$ZSH/lib"
+	"$ZSH/themes"
+	"$ZSH/custom"
+)
+
+function compile_directory() {
+	if [[ ! -d $1 ]]; then
+		echo "The path \"$1\" is not a direcorty or does not exist"
+		exit
+	fi
+	for i in "$1"/**/*; do
+		if [[ -f "$i"  &&  "$i" == *.zsh || $i == *.sh || $i == *.zsh-theme ]]
+		then
+			zcompile "$i"
+		fi
+	done
+}
+
+function compile_file() {
+	[ -f "$1" ] && zcompile "$1"
+}
+
+function clean() {
+	for i in "${FILE_LIST[@]}"; do
+		rm -f "$i.zwc"
+	done
+	for i in "${DIRECTORY_LIST[@]}"; do
+		for j in "$i"/**/*; do
+			rm -f "$j.zwc"
+		done
+	done
+	exit
+}
+
+function main() {
+	for arg in "$@"; do
+		case $arg in
+			-h|--help)
+				usage
+				exit 0;;
+			--clean)
+				clean=true;;
+		esac
+	done	
+
+	if [[ -n $clean ]]; then
+		clean
+	fi
+
+	for i in "${FILE_LIST[@]}"; do
+		compile_file "$i"
+	done
+
+	for i in "${DIRECTORY_LIST[@]}"; do
+		compile_directory "$i"
+	done
+}
+
+function usage(){
+	cat <<EOF
+compile_ohmyzsh.sh 
+Compile all the configuration file for zsh and OhMyZsh
+
+USAGE:
+	require_tool.sh [OPTIONS]
+
+OPTIONS
+	-h, --help          Display this message and exit 0
+	    --clean         Removes all the compiled files
+EOF
+}
+
+
+# Main
+main "$@"

--- a/tools/theme_chooser.sh
+++ b/tools/theme_chooser.sh
@@ -47,7 +47,7 @@ function usage() {
 }
 
 function list_themes() {
-    for THEME in $(ls $THEMES_DIR); do
+    for THEME in "$THEMES_DIR"/*.zsh-theme; do
         THEME_NAME=`echo $THEME | sed s/\.zsh-theme$//`
         echo $THEME_NAME
     done
@@ -64,7 +64,7 @@ function insert_favlist() {
 }
 
 function theme_chooser() {
-    for THEME in $(ls $THEMES_DIR); do
+    for THEME in "$THEMES_DIR"/*.zsh-theme; do
         echo
         theme_preview $THEME
         echo


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added compiled files `*.zwc` to gitignore
- Added script `compile_ohmyzsh`
- Theme chooser list only `.zsh-theme` files

## Other comments:

The script compiles the files ending with `sh`, `zsh` or `zsh-theme`  with the command `zcompile`. This removes the over head of parsing the text when running the scripts. It can also clean all those files with the option `--clean`.

It doesn't compile the `ZSH_COMPDUMP`. 