### PR TITLE
Add: allow keymap other than emacs after safe-paste

### DIFF
--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -30,9 +30,16 @@ function _start_paste() {
 # command line. this has the nice effect of making the whole paste be
 # a single undo/redo event.
 function _end_paste() {
-#use bindkey -v here with vi mode probably. maybe you want to track
-#if you were in ins or cmd mode and restore the right one.
-  bindkey -e
+  # by default, safe-paste set keymap to emacs after paste
+  # you could set $KEYMAP_AFTER_PASTE to specify a prefered keymap, such as viins, after paste
+  # if you have a variable tracking keymap, you could set $KEYMAP_VAR_AFTER_PASTE as its name
+  if [[ ! -z "$KEYMAP_AFTER_PASTE" ]]; then
+    bindkey -A $KEYMAP_AFTER_PASTE main
+  elif [[ -z "$KEYMAP_VAR_AFTER_PASTE" ]]; then
+    bindkey -A ${!KEYMAP_VAR_AFTER_PASTE} main
+  else
+    bindkey -e
+  fi
   LBUFFER+=$_paste_content
   unset _paste_content
 }

--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -35,7 +35,7 @@ function _end_paste() {
   # if you have a variable tracking keymap, you could set $KEYMAP_VAR_AFTER_PASTE as its name
   if [[ ! -z "$KEYMAP_AFTER_PASTE" ]]; then
     bindkey -A $KEYMAP_AFTER_PASTE main
-  elif [[ -z "$KEYMAP_VAR_AFTER_PASTE" ]]; then
+  elif [[ ! -z "$KEYMAP_VAR_AFTER_PASTE" ]]; then
     bindkey -A ${!KEYMAP_VAR_AFTER_PASTE} main
   else
     bindkey -e


### PR DESCRIPTION
Close #8886 #8749 #7883
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Currently safe-paste set keymap to `emacs` after paste. It is annoying.
So I add two variables for better control:
 - `KEYMAP_AFTER_PASTE`, which specify a keymap after paste
 - `KEYMAP_VAR_AFTER_PASTE`, which specify a defined variable tracking keymap
