### PR TITLE
Ruby gem no doc tweak

### DIFF
--- a/plugins/bgnotify/README.md
+++ b/plugins/bgnotify/README.md
@@ -11,7 +11,7 @@ Standalone homepage: [t413/zsh-background-notify](https://github.com/t413/zsh-ba
 Just add bgnotify to your plugins list in your `.zshrc`
 
 - On OS X you'll need [terminal-notifier](https://github.com/alloy/terminal-notifier)
-  * `brew install terminal-notifier` (or `gem install terminal-notifier`)
+  * `brew install terminal-notifier` (or `gem install --no-document terminal-notifier`)
 - On ubuntu you're already all set!
 - On windows you can use [notifu](https://www.paralint.com/projects/notifu/) or the Cygwin Ports libnotify package
 

--- a/plugins/ruby/README.md
+++ b/plugins/ruby/README.md
@@ -15,6 +15,6 @@ plugins=(... ruby)
 | rb    | `ruby`                                 | The Ruby command                                     |
 | sgem  | `sudo gem`                             | Run sudo gem on the system ruby, not the active ruby |
 | rfind | `find . -name "*.rb" \| xargs grep -n` | Find ruby file                                       |
-| gin   | `gem install`                          | Install a gem into the local repository              |
+| gin   | `gem install --no-document`                          | Install a gem into the local repository              |
 | gun   | `gem uninstall`                        | Uninstall gems from the local repository             |
 | gli   | `gem list`                             | Display gems installed locally                       |

--- a/plugins/ruby/ruby.plugin.zsh
+++ b/plugins/ruby/ruby.plugin.zsh
@@ -9,6 +9,6 @@ alias rfind='find . -name "*.rb" | xargs grep -n'
 alias rb="ruby"
 
 # Gem Command Shorthands
-alias gin="gem install"
+alias gin="gem install --no-document"
 alias gun="gem uninstall"
 alias gli="gem list"


### PR DESCRIPTION
Optimization tweak for ruby gems no doc while gems installation using
 "--no-document" . Also removal of depricated "--no-ri" and "--no-rdoc".

 More detail can be found at
 https://guides.rubygems.org/command-reference/#installupdate-options-2

 Signed-off-by: Pratik raj <rajpratik71@gmail.com>