### PR TITLE
Add endpoints to kubectl aliases

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -106,3 +106,7 @@ plugins=(... kubectl)
 | kdelss  | `kubectl delete statefulset`        | Delete the statefulset                                                                           |
 | ksss    | `kubectl scale statefulset`         | Scale a statefulset                                                                              |
 | krsss   | `kubectl rollout status statefulset`| Check the rollout status of a deployment                                                         |
+|         |                                     | **Endpoints management**                                                                         |
+| kged    | `kubectl get endpoints`             | List the endpoints resources in ps output format                                                 |
+| kgeda   | `kubectl get endpoints --all-namespaces`| List the endoints resources  across all namespaces                                           |
+| kded    | `kubectl describe endpoints`        | Describe the endpoints resources in detail                                                       |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -150,3 +150,7 @@ alias kepvc='kubectl edit pvc'
 alias kdpvc='kubectl describe pvc'
 alias kdelpvc='kubectl delete pvc'
 
+# Endpoints management
+alias kged='kubectl get endpoints'
+alias kgeda='kubectl get endpoints --all-namespaces'
+alias kded='kubectl describe endpoints'


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

```
alias kged='kubectl get endpoints'
alias kgeda='kubectl get endpoints --all-namespaces'
alias kded='kubectl describe endpoints'
```
