### PR TITLE
lib: figure out SHORT_HOST only when not exists

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -44,11 +44,13 @@ for plugin ($plugins); do
 done
 
 # Figure out the SHORT hostname
-if [[ "$OSTYPE" = darwin* ]]; then
-  # macOS's $HOST changes with dhcp, etc. Use ComputerName if possible.
-  SHORT_HOST=$(scutil --get ComputerName 2>/dev/null) || SHORT_HOST=${HOST/.*/}
-else
-  SHORT_HOST=${HOST/.*/}
+if [[ -z "$SHORT_HOST" ]]; then
+  if [[ "$OSTYPE" = darwin* ]]; then
+    # macOS's $HOST changes with dhcp, etc. Use ComputerName if possible.
+    SHORT_HOST=$(scutil --get ComputerName 2>/dev/null) || SHORT_HOST=${HOST/.*/}
+  else
+    SHORT_HOST=${HOST/.*/}
+  fi
 fi
 
 # Save the location of the current completion dump file.


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Check if `$SHORT_HOST` exists (not an empty string) before figure it out.

## Other comments:

There will be two benefits:

- Users could define their own `$SHORT_HOST`
- For macOS users, if they have defined their own `$SHORT_HOST`, the extra subprocess (`scutil`) could be avoided.

However:

- Those two benefits only exists if users define the `$SHORT_HOST` before `oh-my-zsh.sh` is sourced.
- Even without the PR, users can still override the `$SHORT_HOST` after `oh-my-zsh.sh` is sourced (But there won't be able to affect oh-my-zsh loaded plugins and themes).
- `$SHORT_HOST` should be considered as an internal variable for oh my zsh thus users should avoid overriding it at the first place.