### PR TITLE
possible avoid 3 times of git execution per cd

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -11,6 +11,17 @@ function __git_prompt_git() {
 
 # Outputs current branch info in prompt format
 function git_prompt_info() {
+  local cwd=$(pwd)
+  while [[ "$cwd" != '' ]];do
+    if [[ -f "$cwd/.git/HEAD" ||  -f "$cwd/HEAD" ]];then
+      break
+    fi
+    cwd=${cwd%/*}
+  done
+  if [[ "$cwd" == '' ]];then
+    return
+  fi
+
   local ref
   if [[ "$(__git_prompt_git config --get oh-my-zsh.hide-status 2>/dev/null)" != "1" ]]; then
     ref=$(__git_prompt_git symbolic-ref HEAD 2> /dev/null) || \


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
- possible avoid 3 times of git execution per cd

## Other comments:
- Now, every time we cd, we don't have to fork and execute git for 3 times, unless current directory seems to be within a git repository. The probe sequence is identical to git (as show by bpftrace), so we won't get false negatives.
- The command use for inspect: 
   - sudo bpftrace -e 'tracepoint:syscalls:sys_enter_newstat /comm=="git"/ {printf("%s\n", str(args->filename))}'
   - sudo bpftrace -e 'tracepoint:syscalls:sys_enter_newstat /comm=="zsh"/ {printf("%s\n", str(args->filename))}'
