### PR TITLE
Add new clean cache aliases for yay, trizen, pacaur, pacman and change orphan remove alias for yay

### DIFF
--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -14,6 +14,7 @@ if (( $+commands[trizen] )); then
   alias trorph='trizen -Qtd'
   alias trinsd='trizen -S --asdeps'
   alias trmir='trizen -Syy'
+  alias trcln='trizen -Scc'
 
 
   if (( $+commands[abs] && $+commands[aur] )); then
@@ -69,9 +70,10 @@ if (( $+commands[yay] )); then
   alias yaloc='yay -Qi'
   alias yalocs='yay -Qs'
   alias yalst='yay -Qe'
-  alias yaorph='yay -Qtd'
+  alias yaorph='yay -Yc'
   alias yainsd='yay -S --asdeps'
   alias yamir='yay -Syy'
+  alias yacln='yay -Sc'
 
 
   if (( $+commands[abs] && $+commands[aur] )); then
@@ -100,6 +102,8 @@ if (( $+commands[pacaur] )); then
   alias paorph='pacaur -Qtd'
   alias painsd='pacaur -S --asdeps'
   alias pamir='pacaur -Syy'
+  alias pacln='pacaur -Sc'
+
 
   if (( $+commands[abs] && $+commands[aur] )); then
     alias paupd='pacaur -Sy && sudo abs && sudo aur'
@@ -152,6 +156,7 @@ alias pacfileupg='sudo pacman -Fy'
 alias pacfiles='pacman -F'
 alias pacls='pacman -Ql'
 alias pacown='pacman -Qo'
+alias paccln='pacman -Sc'
 
 
 if (( $+commands[abs] && $+commands[aur] )); then


### PR DESCRIPTION
I added some new aliases for cleaning and removing orphans that i think they are pretty useful
and also "yay -Yc" is the right command for removing orphans using Yay.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added clean cache alias for trizen, yay, pacaur and pacman
- Changed yaorph alias from "yay -Qtd" to "yay -Yc"