### PR TITLE
sudo: keep space before the command to ignore it in the history

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -14,6 +14,14 @@
 
 sudo-command-line() {
     [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
+
+    if [[ ${LBUFFER:0:1} == " " ]] ; then 
+        WHITESPACE=" ";
+        LBUFFER=${LBUFFER:1}
+    else 
+        WHITESPACE=""; 
+    fi
+
     if [[ -n $EDITOR && $BUFFER == $EDITOR\ * ]]; then
         if [[ ${#LBUFFER} -le ${#EDITOR} ]]; then
             RBUFFER=" ${BUFFER#$EDITOR }"
@@ -38,6 +46,7 @@ sudo-command-line() {
     else
         LBUFFER="sudo $LBUFFER"
     fi
+    LBUFFER=${WHITESPACE}${LBUFFER}
 }
 zle -N sudo-command-line
 # Defined shortcut keys: [Esc] [Esc]

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -13,13 +13,15 @@
 # ------------------------------------------------------------------------------
 
 sudo-command-line() {
+    local WHITESPACE
+
     [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
 
     if [[ ${LBUFFER:0:1} == " " ]] ; then 
-        WHITESPACE=" ";
+        WHITESPACE=" "
         LBUFFER=${LBUFFER:1}
     else 
-        WHITESPACE=""; 
+        WHITESPACE="" 
     fi
 
     if [[ -n $EDITOR && $BUFFER == $EDITOR\ * ]]; then

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -17,9 +17,10 @@ sudo-command-line() {
 
     [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
 
+    # Save beginning space
     if [[ ${LBUFFER:0:1} == " " ]] ; then 
         WHITESPACE=" "
-        LBUFFER=${LBUFFER:1}
+        LBUFFER="${LBUFFER:1}"
     else 
         WHITESPACE="" 
     fi
@@ -48,7 +49,9 @@ sudo-command-line() {
     else
         LBUFFER="sudo $LBUFFER"
     fi
-    LBUFFER=${WHITESPACE}${LBUFFER}
+
+    # Preserve beginning space
+    LBUFFER="${WHITESPACE}${LBUFFER}"
 }
 zle -N sudo-command-line
 # Defined shortcut keys: [Esc] [Esc]

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -13,16 +13,13 @@
 # ------------------------------------------------------------------------------
 
 sudo-command-line() {
-    local WHITESPACE
-
     [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
 
     # Save beginning space
+    local WHITESPACE=""
     if [[ ${LBUFFER:0:1} == " " ]] ; then 
         WHITESPACE=" "
         LBUFFER="${LBUFFER:1}"
-    else 
-        WHITESPACE="" 
     fi
 
     if [[ -n $EDITOR && $BUFFER == $EDITOR\ * ]]; then


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Just the main file of the 'sudo' plugin

## Other comments:

...
