### PR TITLE
fix(git-prompt): make `gitstatus.py` python3-compatible

### DIFF
--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -11,11 +11,11 @@ def get_tagname_or_hash():
     """return tagname if exists else hash"""
     # get hash
     hash_cmd = ['git', 'rev-parse', '--short', 'HEAD']
-    hash_ = check_output(hash_cmd).strip()
+    hash_ = check_output(hash_cmd).decode('utf-8').strip()
 
     # get tagname
     tags_cmd = ['git', 'for-each-ref', '--points-at=HEAD', '--count=2', '--sort=-version:refname', '--format=%(refname:short)', 'refs/tags']
-    tags = check_output(tags_cmd).split()
+    tags = check_output(tags_cmd).decode('utf-8').split()
 
     if tags:
         return tags[0] + ('+' if len(tags) > 1 else '')


### PR DESCRIPTION
check_output() in get_tagname_or_hash() returns bytes instead of str in
python3.  Decode the return value to utf-8, this works in both python2
and python3.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Make plugins/git-prompt/gitstats.py python3 compatible.

...
