### PR TITLE
[git autocomplete] Git version is taken from system, instead of hard-coded

### DIFF
--- a/plugins/gitfast/update
+++ b/plugins/gitfast/update
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 url="https://git.kernel.org/pub/scm/git/git.git/plain/contrib/completion"
-version="2.16.0"
+version=$(git --version | awk '{print $3}')
 
 curl -s -o _git "${url}/git-completion.zsh?h=v${version}" &&
 curl -s -o git-completion.bash "${url}/git-completion.bash?h=v${version}" &&


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Git autocomplete was missing some commands of new version. Quick check reveals that autocomplete uses specific version of git.
Changed the git `version` variable to take it from the installed version, and autocomplete is working as expected now.
- I'm aware of #7918, but no reason is given to *not* use the installed version.