### PR TITLE
Add and change some aliases for trizen, yay, pacaur and pacman

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -22,13 +22,14 @@ plugins=(... archlinux)
 | yalocs  | yay -Qs                            | Search for packages in the local database                           |
 | yalst   | yay -Qe                            | List installed packages including from AUR (tagged as "local")      |
 | yamir   | yay -Syy                           | Force refresh of all package lists after updating mirrorlist        |
-| yaorph  | yay -Qtd                           | Remove orphans using yay                                            |
+| yaorph  | yay -Yc                            | Remove orphans using yay                                            |
 | yare    | yay -R                             | Remove packages, keeping its settings and dependencies              |
 | yarem   | yay -Rns                           | Remove packages, including its settings and unneeded dependencies   |
 | yarep   | yay -Si                            | Display information about a package in the repositories             |
 | yareps  | yay -Ss                            | Search for packages in the repositories                             |
 | yaupg   | yay -Syu                           | Sync with repositories before upgrading packages                    |
 | yasu    | yay -Syu --no-confirm              | Same as `yaupg`, but without confirmation                           |
+| yacln   | yay -Sc                            | Clean all pacman and aur caches                                     |
 
 #### TRIZEN
 
@@ -53,6 +54,7 @@ plugins=(... archlinux)
 | trupd   | trizen -Sy                         | Update and refresh the local package database                       |
 | trupg   | trizen -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
 | trsu    | trizen -Syua --no-confirm          | Same as `trupg`, but without confirmation                           |
+| trcln   | trizen -Scc                        | Clean all pacman and aur caches                                     |
 | upgrade | trizen -Syu                        | Sync with repositories before upgrading packages                    |
 
 #### YAOURT
@@ -102,6 +104,7 @@ plugins=(... archlinux)
 | paupd   | pacaur -Sy                         | Update and refresh the local package database                       |
 | paupg   | pacaur -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
 | pasu    | pacaur -Syua --no-confirm          | Same as `paupg`, but without confirmation                           |
+| pacln   | pacaur -Sc                         | Clean all pacman and aur caches                                     |
 | upgrade | pacaur -Syu                        | Sync with repositories before upgrading packages                    |
 
 #### PACMAN
@@ -130,6 +133,7 @@ plugins=(... archlinux)
 | pacfiles     | pacman -F                               | Search package file names for matching strings               |
 | pacls        | pacman -Ql                              | List files in a package                                      |
 | pacown       | pacman -Qo                              | Show which package owns a file                               |
+| paccln       | pacman -Sc                              | Clean all pacman caches                                      |
 
 | Function       | Description                                          |
 |----------------|------------------------------------------------------|
@@ -152,3 +156,4 @@ plugins=(... archlinux)
 - Juraj Fiala - doctorjellyface@riseup.net
 - Majora320 (Moses Miller) - Majora320@gmail.com
 - Ybalrid (Arthur Brainville) - ybalrid@ybalrid.info
+- TahaCodes (Taha Farahani) - iotahacodes@gmail.com

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -14,6 +14,7 @@ if (( $+commands[trizen] )); then
   alias trorph='trizen -Qtd'
   alias trinsd='trizen -S --asdeps'
   alias trmir='trizen -Syy'
+  alias trcln='trizen -Scc'
 
 
   if (( $+commands[abs] && $+commands[aur] )); then
@@ -69,9 +70,10 @@ if (( $+commands[yay] )); then
   alias yaloc='yay -Qi'
   alias yalocs='yay -Qs'
   alias yalst='yay -Qe'
-  alias yaorph='yay -Qtd'
+  alias yaorph='yay -Yc'
   alias yainsd='yay -S --asdeps'
   alias yamir='yay -Syy'
+  alias yacln='yay -Sc'
 
 
   if (( $+commands[abs] && $+commands[aur] )); then
@@ -100,6 +102,8 @@ if (( $+commands[pacaur] )); then
   alias paorph='pacaur -Qtd'
   alias painsd='pacaur -S --asdeps'
   alias pamir='pacaur -Syy'
+  alias pacln='pacaur -Sc'
+
 
   if (( $+commands[abs] && $+commands[aur] )); then
     alias paupd='pacaur -Sy && sudo abs && sudo aur'
@@ -152,6 +156,7 @@ alias pacfileupg='sudo pacman -Fy'
 alias pacfiles='pacman -F'
 alias pacls='pacman -Ql'
 alias pacown='pacman -Qo'
+alias paccln='pacman -Sc'
 
 
 if (( $+commands[abs] && $+commands[aur] )); then


### PR DESCRIPTION
I added some new aliases for cleaning and removing orphans that i think they're pretty useful
and "yay -Yc" is the right command for removing orphans using Yay. I also fixed that.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added clean cache alias for trizen, yay, pacaur and pacman
- Changed yaorph alias from "yay -Qtd" to "yay -Yc"