### PR TITLE
pygmalion: use pure zsh instead of perl

### DIFF
--- a/themes/pygmalion-virtualenv.zsh-theme
+++ b/themes/pygmalion-virtualenv.zsh-theme
@@ -25,8 +25,8 @@ prompt_setup_pygmalion(){
   base_prompt='$(_virtualenv_prompt_info)%{$fg[magenta]%}%n%{$reset_color%}%{$fg[cyan]%}@%{$reset_color%}%{$fg[yellow]%}%m%{$reset_color%}%{$fg[red]%}:%{$reset_color%}%{$fg[cyan]%}%0~%{$reset_color%}%{$fg[red]%}|%{$reset_color%}'
   post_prompt='%{$fg[cyan]%}⇒%{$reset_color%}  '
 
-  base_prompt_nocolor=$(echo "$base_prompt" | perl -pe "s/%\{[^}]+\}//g")
-  post_prompt_nocolor=$(echo "$post_prompt" | perl -pe "s/%\{[^}]+\}//g")
+  base_prompt_nocolor=${base_prompt//\%\{[^\}]##\}}
+  post_prompt_nocolor=${post_prompt//\%\{[^\}]##\}}
 
   autoload -U add-zsh-hook
   add-zsh-hook precmd prompt_pygmalion_precmd
@@ -34,7 +34,7 @@ prompt_setup_pygmalion(){
 
 prompt_pygmalion_precmd(){
   local gitinfo=$(git_prompt_info)
-  local gitinfo_nocolor=$(echo "$gitinfo" | perl -pe "s/%\{[^}]+\}//g")
+  local gitinfo_nocolor=${gitinfo//\%\{[^\}]##\}}
   local exp_nocolor="$(print -P \"$base_prompt_nocolor$gitinfo_nocolor$post_prompt_nocolor\")"
   local prompt_length=${#exp_nocolor}
 

--- a/themes/pygmalion-virtualenv.zsh-theme
+++ b/themes/pygmalion-virtualenv.zsh-theme
@@ -17,6 +17,8 @@ function _virtualenv_prompt_info {
 }
 
 prompt_setup_pygmalion(){
+  setopt localoptions extendedglob
+
   ZSH_THEME_GIT_PROMPT_PREFIX="%{$reset_color%}%{$fg[green]%}"
   ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
   ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[yellow]%}⚡%{$reset_color%}"
@@ -33,6 +35,8 @@ prompt_setup_pygmalion(){
 }
 
 prompt_pygmalion_precmd(){
+  setopt localoptions extendedglob
+
   local gitinfo=$(git_prompt_info)
   local gitinfo_nocolor=${gitinfo//\%\{[^\}]##\}}
   local exp_nocolor="$(print -P \"$base_prompt_nocolor$gitinfo_nocolor$post_prompt_nocolor\")"

--- a/themes/pygmalion.zsh-theme
+++ b/themes/pygmalion.zsh-theme
@@ -1,6 +1,8 @@
 # Yay! High voltage and arrows!
 
 prompt_setup_pygmalion(){
+  setopt localoptions extendedglob
+
   ZSH_THEME_GIT_PROMPT_PREFIX="%{$reset_color%}%{$fg[green]%}"
   ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
   ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[yellow]%}⚡%{$reset_color%}"
@@ -17,6 +19,8 @@ prompt_setup_pygmalion(){
 }
 
 prompt_pygmalion_precmd(){
+  setopt localoptions extendedglob
+
   local gitinfo=$(git_prompt_info)
   local gitinfo_nocolor=${gitinfo//\%\{[^\}]##\}}
   local exp_nocolor="$(print -P \"$base_prompt_nocolor$gitinfo_nocolor$post_prompt_nocolor\")"

--- a/themes/pygmalion.zsh-theme
+++ b/themes/pygmalion.zsh-theme
@@ -9,8 +9,8 @@ prompt_setup_pygmalion(){
   base_prompt='%{$fg[magenta]%}%n%{$reset_color%}%{$fg[cyan]%}@%{$reset_color%}%{$fg[yellow]%}%m%{$reset_color%}%{$fg[red]%}:%{$reset_color%}%{$fg[cyan]%}%0~%{$reset_color%}%{$fg[red]%}|%{$reset_color%}'
   post_prompt='%{$fg[cyan]%}⇒%{$reset_color%}  '
 
-  base_prompt_nocolor=$(echo "$base_prompt" | perl -pe "s/%\{[^}]+\}//g")
-  post_prompt_nocolor=$(echo "$post_prompt" | perl -pe "s/%\{[^}]+\}//g")
+  base_prompt_nocolor=${base_prompt//\%\{[^\}]##\}}
+  post_prompt_nocolor=${post_prompt//\%\{[^\}]##\}}
 
   autoload -U add-zsh-hook
   add-zsh-hook precmd prompt_pygmalion_precmd
@@ -18,7 +18,7 @@ prompt_setup_pygmalion(){
 
 prompt_pygmalion_precmd(){
   local gitinfo=$(git_prompt_info)
-  local gitinfo_nocolor=$(echo "$gitinfo" | perl -pe "s/%\{[^}]+\}//g")
+  local gitinfo_nocolor=${gitinfo//\%\{[^\}]##\}}
   local exp_nocolor="$(print -P \"$base_prompt_nocolor$gitinfo_nocolor$post_prompt_nocolor\")"
   local prompt_length=${#exp_nocolor}
 


### PR DESCRIPTION
My system doesn't have `perl` in $PATH, so using this theme clutters the
shell output quite a bit.

Given these are simple regexp substitutions, these can be done by `sed`,
which is more likely to be available.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- use `sed` instead of `perl` to do the regexp substitution.

## Other comments:

I'm not sure if this works with the `sed` coming with MacOS, so probably should be tested there as well.
