### PR TITLE
emacs: add ansi-term directory tracking

### DIFF
--- a/plugins/emacs/emacs.plugin.zsh
+++ b/plugins/emacs/emacs.plugin.zsh
@@ -26,6 +26,11 @@ if "$ZSH/tools/require_tool.sh" emacsclient 24 2>/dev/null ; then
     # create a new X frame
     alias eframe='emacsclient --alternate-editor "" --create-frame'
 
+    # The commands like to C-x C-f follow the directories path of zsh prompt 
+    chpwd() { print -P "\033AnSiTc %d" }
+    print -P "\033AnSiTu %n"
+    print -P "\033AnSiTc %d"
+
 
     # Write to standard output the path to the file
     # opened in the current buffer.

--- a/plugins/emacs/emacs.plugin.zsh
+++ b/plugins/emacs/emacs.plugin.zsh
@@ -29,11 +29,12 @@ if "$ZSH/tools/require_tool.sh" emacsclient 24 2>/dev/null ; then
     # Emacs ANSI Term tracking
     if [[ -n "$INSIDE_EMACS" ]]; then
         chpwd_emacs() { print -P "\033AnSiTc %d"; }
-        autoload -Uz add-zsh-hook && add-zsh-hook chpwd chpwd_emacs
+        print -P "\033AnSiTc %d"    # Track current working directory
+        print -P "\033AnSiTu %n"    # Track username        
 
-        chpwd_emacs                 # Track current working directory
-        print -P "\033AnSiTu %n"    # Track username
-        print -P "\033AnSiTh %m"    # Track hostname
+        # add chpwd hook
+        autoload -Uz add-zsh-hook
+        add-zsh-hook chpwd chpwd_emacs
     fi    
 
     # Write to standard output the path to the file

--- a/plugins/emacs/emacs.plugin.zsh
+++ b/plugins/emacs/emacs.plugin.zsh
@@ -27,10 +27,11 @@ if "$ZSH/tools/require_tool.sh" emacsclient 24 2>/dev/null ; then
     alias eframe='emacsclient --alternate-editor "" --create-frame'
 
     # The commands like to C-x C-f follow the directories path of zsh prompt 
-    chpwd() { print -P "\033AnSiTc %d" }
-    print -P "\033AnSiTu %n"
-    print -P "\033AnSiTc %d"
-
+    if [ -n "$INSIDE_EMACS" ]; then
+       chpwd() { print -P "\033AnSiTc %d" }
+       print -P "\033AnSiTu %n"
+       print -P "\033AnSiTc %d"
+    fi    
 
     # Write to standard output the path to the file
     # opened in the current buffer.

--- a/plugins/emacs/emacs.plugin.zsh
+++ b/plugins/emacs/emacs.plugin.zsh
@@ -26,11 +26,14 @@ if "$ZSH/tools/require_tool.sh" emacsclient 24 2>/dev/null ; then
     # create a new X frame
     alias eframe='emacsclient --alternate-editor "" --create-frame'
 
-    # The commands like to C-x C-f follow the directories path of zsh prompt 
-    if [ -n "$INSIDE_EMACS" ]; then
-       chpwd() { print -P "\033AnSiTc %d" }
-       print -P "\033AnSiTu %n"
-       print -P "\033AnSiTc %d"
+    # Emacs ANSI Term tracking
+    if [[ -n "$INSIDE_EMACS" ]]; then
+        chpwd_emacs() { print -P "\033AnSiTc %d"; }
+        autoload -Uz add-zsh-hook && add-zsh-hook chpwd chpwd_emacs
+
+        chpwd_emacs                 # Track current working directory
+        print -P "\033AnSiTu %n"    # Track username
+        print -P "\033AnSiTh %m"    # Track hostname
     fi    
 
     # Write to standard output the path to the file


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
I used the prompt into emacs, with the commands M-x term, or others, when I began to use zsh, the commands as C-x C-f to find files in emacs  doesn't followed the path to file directory of the prompt, but with this change doesn't matter in which directory I stay, always the commands will follow the path of the directory.
## Other comments:

...
