### PR TITLE
dotenv plugin: Hide "[a]lways" and "n[e]ver" when the list files do not exist

### DIFF
--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -61,6 +61,11 @@ will be added to an allowed list; if you choose Never, it will be added to a dis
 If a directory is found in either of those lists, the plugin won't ask for confirmation and will
 instead either source the .env file or proceed without action respectively.
 
+If both `$ZSH_CACHE_DIR` and `$ZSH` are undefined the `[a]lways` and `n[e]ver`
+options will not be displayed as attempting to append to a missing file would
+result in an error everytime the plugin ran until you define the variables
+mentioned
+
 The allowed and disallowed lists are saved by default in `$ZSH_CACHE_DIR/dotenv-allowed.list` and
 `$ZSH_CACHE_DIR/dotenv-disallowed.list` respectively. If you want to change that location,
 change the `$ZSH_DOTENV_ALLOWED_LIST` and `$ZSH_DOTENV_DISALLOWED_LIST` variables, like so:

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -16,8 +16,20 @@ source_env() {
       local confirmation dirpath="${PWD:A}"
 
       # make sure there is an (dis-)allowed file
-      touch "$ZSH_DOTENV_ALLOWED_LIST"
-      touch "$ZSH_DOTENV_DISALLOWED_LIST"
+      # Will fail if $ZSH and $ZSH_CACHE_DIR are both undefined but the script
+      # will keep going
+      touch "$ZSH_DOTENV_ALLOWED_LIST" 2>/dev/null
+      touch "$ZSH_DOTENV_DISALLOWED_LIST" 2>/dev/null
+
+      local allowed_list_opt=''
+      local disallowed_list_opt=''
+      if [ -f "$ZSH_DOTENV_ALLOWED_LIST" ] ; then
+        allowed_list_opt='/[a]lways'
+      fi
+
+      if [ -f "$ZSH_DOTENV_DISALLOWED_LIST" ] ; then
+        disallowed_list_opt='/n[e]ver'
+      fi
 
       # early return if disallowed
       if grep -q "$dirpath" "$ZSH_DOTENV_DISALLOWED_LIST" &>/dev/null; then
@@ -27,14 +39,14 @@ source_env() {
       # check if current directory's .env file is allowed or ask for confirmation
       if ! grep -q "$dirpath" "$ZSH_DOTENV_ALLOWED_LIST" &>/dev/null; then
         # print same-line prompt and output newline character if necessary
-        echo -n "dotenv: found '$ZSH_DOTENV_FILE' file. Source it? ([Y]es/[n]o/[a]lways/n[e]ver) "
+        echo -n "dotenv: found '$ZSH_DOTENV_FILE' file. Source it? ([Y]es/[n]o${allowed_list_opt}${disallowed_list_opt})"
         read -k 1 confirmation; [[ "$confirmation" != $'\n' ]] && echo
 
         # check input
         case "$confirmation" in
           [nN]) return ;;
-          [aA]) echo "$dirpath" >> "$ZSH_DOTENV_ALLOWED_LIST" ;;
-          [eE]) echo "$dirpath" >> "$ZSH_DOTENV_DISALLOWED_LIST"; return ;;
+          [aA]) if [ -f "$ZSH_DOTENV_ALLOWED_LIST" ] ; then echo "$dirpath" >> "$ZSH_DOTENV_ALLOWED_LIST" ; fi ;;
+          [eE]) if [ -f "$ZSH_DOTENV_DISALLOWED_LIST" ] ; then echo "$dirpath" >> "$ZSH_DOTENV_DISALLOWED_LIST" ; fi ; return ;;
           *) ;; # interpret anything else as a yes
         esac
       fi


### PR DESCRIPTION
# Plugin: dotenv

## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Hide "[a]lways" and "n[e]ver" when the list files do not exist
- Updates the readme

## Other comments:

So I had my `$ZSH` and `$ZSH_CACHE_DIR` undefined, and I'm perfectly happy with that.
Now the `dotenv` plugin assumes that a `touch $ZSH_DOTENV_[DIS]ALLOWED_LIST` will create the files. But if the env vars I mentioned are undefined the touch command will assume root directory and in my case it won't have permissions for it.
This will print:

```
touch: /cache/dotenv-allowed.list: No such file or directory
touch: /cache/dotenv-disallowed.list: No such file or directory
dotenv: found '.env' file. Source it? ([Y]es/[n]o/[a]lways/n[e]ver) e
source_env:24: no such file or directory: /cache/dotenv-disallowed.list
```

And since it doesn't record this failure, this will happen everytime.

This PR is a less obstrusive way of dealing with this: if the files don't exist don't try to append to them.

For users like me who don't need to keep a state regarding allowed or not, having the prompt every time is perfectly fine as it will.