### PR TITLE
feat(terraform): add autocompletion for Terraform 0.13

### DIFF
--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -299,6 +299,11 @@ __validate() {
     '-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]'
 }
 
+__version() {
+    _arguments \
+    '-json[Output the version information as a JSON object.]'
+}
+
 __workspace() {
     local -a __workspace_cmds
     __workspace_cmds=(
@@ -370,6 +375,8 @@ case "$words[1]" in
     __untaint ;;
   validate)
     __validate ;;
+  version)
+    __version ;;
   workspace)
     test $CURRENT -lt 3 && __workspace ;;
 esac

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -54,14 +54,14 @@ __apply() {
         '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
         '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files'
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
 }
 
 __console() {
     _arguments \
         '-state=[(terraform.tfstate) Path to read state.]' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files'
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
 }
 
 __destroy() {
@@ -78,7 +78,7 @@ __destroy() {
         '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
         '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files'
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
 }
 
 __fmt() {
@@ -119,7 +119,7 @@ __import() {
         '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]' \
         '-state-out=[(PATH) Path to the destination state file to write to. If this is not specified, the source state file will be used. This can be a new or existing path.]' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times. This is only useful with the "-config" flag.]' \
-        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files'
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
 }
 
 __init() {
@@ -172,7 +172,7 @@ __plan() {
         '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]' \
         '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files'
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
 }
 
 __providers() {
@@ -209,7 +209,7 @@ __refresh() {
         '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
         '*-target=[(resource) A Resource Address to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '*-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]:file:_files'
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
 }
 
 __show() {

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -51,16 +51,16 @@ __apply() {
         '-refresh=[(true) Update state prior to checking for differences. This has no effect if a plan file is given to apply.]' \
         '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]' \
         '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
-        '-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
-        '-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
+        '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
 }
 
 __console() {
     _arguments \
         '-state=[(terraform.tfstate) Path to read state.]' \
-        '-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
 }
 
 __destroy() {
@@ -75,9 +75,9 @@ __destroy() {
         '-refresh=[(true) Update state prior to checking for differences. This has no effect if a plan file is given to apply.]' \
         '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]' \
         '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
-        '-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
-        '-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
+        '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
 }
 
 __fmt() {
@@ -119,8 +119,8 @@ __import() {
         '-provider=[(provider) Specific provider to use for import. This is used for specifying aliases, such as "aws.eu". Defaults to the normal provider prefix of the resource being imported.]' \
         '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]' \
         '-state-out=[(PATH) Path to the destination state file to write to. If this is not specified, the source state file will be used. This can be a new or existing path.]' \
-        '-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times. This is only useful with the "-config" flag.]' \
-        '-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times. This is only useful with the "-config" flag.]' \
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
 }
 
 __init() {
@@ -172,9 +172,9 @@ __plan() {
         '-parallelism=[(10) Limit the number of concurrent operations.]' \
         '-refresh=[(true) Update state prior to checking for differences.]' \
         '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]' \
-        '-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
-        '-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]' \
+        '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files'
 }
 
 __providers() {
@@ -208,9 +208,9 @@ __refresh() {
         '-no-color[If specified, output will not contain any color.]' \
         '-state=[(path) Path to read and save state (unless state-out is specified). Defaults to "terraform.tfstate".]' \
         '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
-        '-target=[(resource) A Resource Address to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
-        '-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]'
+        '*-target=[(resource) A Resource Address to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
+        '*-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]'
 }
 
 __show() {
@@ -323,8 +323,8 @@ __validate() {
     _arguments \
     '-check-variables=[(true) If set to true (default), the command will check whether all required variables have been specified.]' \
     '-no-color[If specified, output will not contain any color.]' \
-    '-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-    '-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]'
+    '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
+    '*-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]'
 }
 
 __version() {

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -178,8 +178,25 @@ __plan() {
 }
 
 __providers() {
-    _arguments \
+    local -a __providers_cmds
+    __providers_cmds=(
+      'mirror:Mirrors the provider plugins needed for the current configuration'
+      'schema:Prints the schemas of the providers used in the configuration'
+    )
+    _describe -t providers "providers commands" __providers_cmds
 
+}
+
+__providers_mirror() {
+    _arguments \
+      '-platform=[(os_arch) Choose which target platform to build a mirror for.]' \
+      "*:target_dir:_files -/"
+}
+
+__providers_schema() {
+    _arguments \
+      '-json[]' \
+      '::'
 }
 
 __refresh() {
@@ -367,7 +384,10 @@ case "$words[1]" in
   plan)
     __plan ;;
   providers)
-    __providers ;;
+    test $CURRENT -lt 3 && __providers
+    [[ $words[2] = "mirror" ]] && __providers_mirror
+    [[ $words[2] = "schema" ]] && __providers_schema
+    ;;
   refresh)
     __refresh ;;
   show)

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -50,8 +50,8 @@ __apply() {
         '-no-color[If specified, output wil be colorless.]' \
         '-parallelism=[(10) Limit the number of parallel resource operations.]' \
         '-refresh=[(true) Update state prior to checking for differences. This has no effect if a plan file is given to apply.]' \
-        '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]' \
-        '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
+        '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]:statefile:_files -g "*.tfstate"' \
+        '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -g "*.tfstate"' \
         '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
         '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
@@ -74,8 +74,8 @@ __destroy() {
         '-no-color[If specified, output will contain no color.]' \
         '-parallelism=[(10) Limit the number of concurrent operations.]' \
         '-refresh=[(true) Update state prior to checking for differences. This has no effect if a plan file is given to apply.]' \
-        '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]' \
-        '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
+        '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]:statefile:_files -g "*.tfstate"' \
+        '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -g "*.tfstate"' \
         '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
         '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
@@ -116,8 +116,8 @@ __import() {
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-no-color[If specified, output will contain no color.]' \
-        '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]' \
-        '-state-out=[(PATH) Path to the destination state file to write to. If this is not specified, the source state file will be used. This can be a new or existing path.]' \
+        '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -g "*.tfstate"' \
+        '-state-out=[(PATH) Path to the destination state file to write to. If this is not specified, the source state file will be used. This can be a new or existing path.]:statefile:_files -g "*.tfstate"' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times. This is only useful with the "-config" flag.]' \
         '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
 }
@@ -152,7 +152,7 @@ __logout() {
 
 __output() {
     _arguments \
-        '-state=[(path) Path to the state file to read. Defaults to "terraform.tfstate".]' \
+        '-state=[(path) Path to the state file to read. Defaults to "terraform.tfstate".]:statefile:_files -g "*.tfstate"' \
         '-no-color[If specified, output will contain no color.]' \
         '-json[If specified, machine readable output will be printed in JSON format]'
 }
@@ -169,7 +169,7 @@ __plan() {
         '-out=[(path) Write a plan file to the given path. This can be used as input to the "apply" command.]' \
         '-parallelism=[(10) Limit the number of concurrent operations.]' \
         '-refresh=[(true) Update state prior to checking for differences.]' \
-        '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]' \
+        '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]:statefile:_files -g "*.tfstate"' \
         '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
         '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
@@ -205,8 +205,8 @@ __refresh() {
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-no-color[If specified, output will not contain any color.]' \
-        '-state=[(path) Path to read and save state (unless state-out is specified). Defaults to "terraform.tfstate".]' \
-        '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
+        '-state=[(path) Path to read and save state (unless state-out is specified). Defaults to "terraform.tfstate".]:statefile:_files -g "*.tfstate"' \
+        '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -g "*.tfstate"' \
         '*-target=[(resource) A Resource Address to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
         '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
@@ -246,8 +246,8 @@ __state_mv() {
     "-backup-out=[(PATH) Path where Terraform should write the backup for the destination state. This can't be disabled. If not set, Terraform will write it to the same path as the destination state file with a backup extension. This only needs to be specified if -state-out is set to a different path than -state.]:file:_files" \
     "-lock=[(true) Lock the state files when locking is supported.]:lock:(true false)" \
     "-lock-timeout=[(0s) Duration to retry a state lock.]" \
-    '-state=[(path) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:file:_files' \
-    "-state-out=[(path) Path to the destination state file to write to. If this isn't specified, the source state file will be used. This can be a new or existing path.]:file:_files" \
+    '-state=[(path) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -g "*.tfstate"' \
+    '-state-out=[(path) Path to the destination state file to write to. If this isn"t specified, the source state file will be used. This can be a new or existing path.]:statefile:_files -g "*.tfstate"' \
     "::" \
     ":source:__statelist" \
     ":destination: " 
@@ -268,7 +268,7 @@ __state_replace_provider() {
     "-backup=[(PATH) Path where Terraform should write the backup for the state file. This can't be disabled. If not set, Terraform will write it to the same path as the state file with a \".backup\" extension.]:file:_files" \
     "-lock=[(true) Lock the state files when locking is supported.]:lock:(true false)" \
     "-lock-timeout=[(0s) Duration to retry a state lock.]" \
-    '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:file:_files' \
+    '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -g "*.tfstate"' \
     ":from_provider_fqn:" \
     ":to_provider_fqn:"
 }
@@ -279,14 +279,14 @@ __state_rm() {
     "-backup=[(PATH) Path where Terraform should write the backup for the original state.]:file:_files" \
     "-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)" \
     "-lock-timeout=[(0s) Duration to retry a state lock.]" \
-    '-state=[(PATH) Path to the state file to update. Defaults to the current workspace state.]:file:_files' \
+    '-state=[(PATH) Path to the state file to update. Defaults to the current workspace state.]:statefile:_files -g "*.tfstate"' \
     "*:address:__statelist" 
 }
 
 
 __state_show() {
   _arguments \
-    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]' \
+    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]:statefile:_files -g "*.tfstate"' \
     "*:address:__statelist" 
 }
 
@@ -301,8 +301,8 @@ __taint() {
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-module=[(path)  The module path where the resource lives. By default this will be root. Child modules can be specified by names. Ex. "consul" or "consul.vpc" (nested modules).]' \
-        '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]' \
-        '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]' \
+        '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]:statefile:_files -g "*.tfstate"' \
+        '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]:statefile:_files -g "*.tfstate"' \
         "*:address:__statelist" 
 }
 
@@ -313,8 +313,8 @@ __untaint() {
     '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
     '-module=[(path)  The module path where the resource lives. By default this will be root. Child modules can be specified by names. Ex. "consul" or "consul.vpc" (nested modules).]' \
-    '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]' \
-    '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]'
+    '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]:statefile:_files -g "*.tfstate"' \
+    '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]:statefile:_files -g "*.tfstate"'
 }
 
 __validate() {

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -16,7 +16,6 @@ _terraform_cmds=(
     'output:Read an output from a state file'
     'plan:Generate and show an execution plan'
     'providers:Prints a tree of the providers used in the configuration'
-    'push:Upload this Terraform module to Atlas to run'
     'refresh:Update local state file against real resources'
     'show:Inspect Terraform state or plan'
     'state:Advanced state management'
@@ -181,19 +180,6 @@ __plan() {
 __providers() {
     _arguments \
 
-}
-
-__push() {
-    _arguments \
-        '-atlas-address=[(url) An alternate address to an Atlas instance. Defaults to https://atlas.hashicorp.com.]' \
-        '-upload-modules=[(true) If true (default), then the modules being used are all locked at their current checkout and uploaded completely to Atlas. This prevents Atlas from running terraform get for you.]' \
-        '-name=[(name) Name of the infrastructure configuration in Atlas. The format of this is: "username/name" so that you can upload configurations not just to your account but to other accounts and organizations. This setting can also be set in the configuration in the Atlas section.]' \
-        '-no-color[Disables output with coloring]' \
-        '-overwrite=[(foo) Marks a specific variable to be updated on Atlas. Normally, if a variable is already set in Atlas, Terraform will not send the local value (even if it is different). This forces it to send the local value to Atlas. This flag can be repeated multiple times.]' \
-        '-token=[(token) Atlas API token to use to authorize the upload. If blank or unspecified, the ATLAS_TOKEN environmental variable will be used.]' \
-        '-var=[("foo=bar") Set the value of a variable for the Terraform configuration.]' \
-        '-var-file=[(foo) Set the value of variables using a variable file.]' \
-        '-vcs=[(true) If true (default), then Terraform will detect if a VCS is in use, such as Git, and will only upload files that are committed to version control. If no version control system is detected, Terraform will upload all files in path (parameter to the command).]'
 }
 
 __refresh() {
@@ -366,8 +352,6 @@ case "$words[1]" in
     __plan ;;
   providers)
     __providers ;;
-  push)
-    __push ;;
   refresh)
     __refresh ;;
   show)

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -215,7 +215,7 @@ __refresh() {
 
 __show() {
     _arguments \
-        '-module-depth=[(n) The maximum depth to expand modules. By default this is zero, which will not expand modules at all.]' \
+        '-json[If specified, output the Terraform plan or state in a machine-readable form.]' \
         '-no-color[If specified, output will not contain any color.]'
 }
 

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -26,12 +26,18 @@ _terraform_cmds=(
     'version:Prints the Terraform version'
     'workspace:Workspace management'
     '0.12upgrade:Rewrites pre-0.12 module source code for v0.12'
+    '0.13upgrade:Rewrites pre-0.13 module source code for v0.13'
 )
 
 __012upgrade() {
   _arguments \
     '-yes[Skip the initial introduction messages and interactive confirmation. This can be used to run this command in batch from a script.]' \
     '-force[ Override the heuristic that attempts to detect if a configuration is already written for v0.12 or later.  Some of the transformations made by this command are not idempotent, so re-running against the same module may change the meanings expressions in the module.]'
+}
+
+__013upgrade() {
+  _arguments \
+    '-yes[Skip the initial introduction messages and interactive confirmation. This can be used to run this command in batch from a script.]'
 }
 
 __apply() {
@@ -330,6 +336,8 @@ local -a _command_args
 case "$words[1]" in
   0.12upgrade)
     __012upgrade ;;
+  0.13upgrade)
+    __013upgrade ;;
   apply)
     __apply ;;
   console)

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -53,14 +53,14 @@ __apply() {
         '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
         '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files'
 }
 
 __console() {
     _arguments \
         '-state=[(terraform.tfstate) Path to read state.]' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files'
 }
 
 __destroy() {
@@ -77,7 +77,7 @@ __destroy() {
         '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
         '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files'
 }
 
 __fmt() {
@@ -120,7 +120,7 @@ __import() {
         '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]' \
         '-state-out=[(PATH) Path to the destination state file to write to. If this is not specified, the source state file will be used. This can be a new or existing path.]' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times. This is only useful with the "-config" flag.]' \
-        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files'
 }
 
 __init() {
@@ -210,7 +210,7 @@ __refresh() {
         '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
         '*-target=[(resource) A Resource Address to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '*-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]'
+        '*-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]:file:_files'
 }
 
 __show() {
@@ -324,7 +324,7 @@ __validate() {
     '-check-variables=[(true) If set to true (default), the command will check whether all required variables have been specified.]' \
     '-no-color[If specified, output will not contain any color.]' \
     '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-    '*-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]'
+    '*-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]:file:_files'
 }
 
 __version() {

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -44,7 +44,7 @@ __apply() {
         '-auto-approve[Skip interactive approval of plan before applying.]' \
         '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
         '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
-        '-lock=[(true) Lock the state file when locking is supported.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-input=[(true) Ask for input for variables if not directly set.]' \
         '-no-color[If specified, output wil be colorless.]' \
@@ -69,7 +69,7 @@ __destroy() {
         '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
         '-auto-approve[Skip interactive approval before destroying.]' \
         '-force[Deprecated: same as auto-approve.]' \
-        '-lock=[(true) Lock the state file when locking is supported.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-no-color[If specified, output will contain no color.]' \
         '-parallelism=[(10) Limit the number of concurrent operations.]' \
@@ -114,7 +114,7 @@ __import() {
         '-config=[(path) Path to a directory of Terraform configuration files to use to configure the provider. Defaults to pwd. If no config files are present, they must be provided via the input prompts or env vars.]' \
         '-allow-missing-config[Allow import when no resource configuration block exists.]' \
         '-input=[(true) Ask for input for variables if not directly set.]' \
-        '-lock=[(true) Lock the state file when locking is supported.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-no-color[If specified, output will contain no color.]' \
         '-provider=[(provider) Specific provider to use for import. This is used for specifying aliases, such as "aws.eu". Defaults to the normal provider prefix of the resource being imported.]' \
@@ -133,7 +133,7 @@ __init() {
         '-get=[(true) Download any modules for this configuration.]' \
         '-get-plugins=[(true) Download any missing plugins for this configuration.]' \
         '-input=[(true) Ask for input if necessary. If false, will error if input was required.]' \
-        '-lock=[(true) Lock the state file when locking is supported.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-no-color[If specified, output will contain no color.]' \
         '-plugin-dir[Directory containing plugin binaries. This overrides all default search paths for plugins, and prevents the automatic installation of plugins. This flag can be used multiple times.]' \
@@ -165,7 +165,7 @@ __plan() {
         '-destroy[() If set, a plan will be generated to destroy all resources managed by the given configuration and state.]' \
         '-detailed-exitcode[() Return detailed exit codes when the command exits. This will change the meaning of exit codes to: 0 - Succeeded, diff is empty (no changes); 1 - Errored, 2 - Succeeded; there is a diff]' \
         '-input=[(true) Ask for input for variables if not directly set.]' \
-        '-lock=[(true) Lock the state file when locking is supported.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-module-depth=[(n) Specifies the depth of modules to show in the output. This does not affect the plan itself, only the output shown. By default, this is -1, which will expand all.]' \
         '-no-color[() If specified, output will contain no color.]' \
@@ -204,7 +204,7 @@ __refresh() {
     _arguments \
         '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
         '-input=[(true) Ask for input for variables if not directly set.]' \
-        '-lock=[(true) Lock the state file when locking is supported.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-no-color[If specified, output will not contain any color.]' \
         '-state=[(path) Path to read and save state (unless state-out is specified). Defaults to "terraform.tfstate".]' \
@@ -244,10 +244,10 @@ __state_list() {
 __state_mv() {
   _arguments \
     "-dry-run[If set, prints out what would've been moved but doesn't actually move anything.]" \
-    "-backup=[(path) Path where Terraform should write the backup for the original state. This can't be disabled. If not set, Terraform will write it to the same path as the statefile with a \".backup\" extension.]:file:_files" \
-    "-backup-out=[(path) Path where Terraform should write the backup for the destination state. This can't be disabled. If not set, Terraform will write it to the same path as the destination state file with a backup extension. This only needs to be specified if -state-out is set to a different path than -state.]:file:_files" \
-    "-lock=[(true|false) Lock the state files when locking is supported.]:lock:(true false)" \
-    "-lock-timeout=[(seconds) Duration to retry a state lock.]" \
+    "-backup=[(PATH) Path where Terraform should write the backup for the original state. This can't be disabled. If not set, Terraform will write it to the same path as the statefile with a \".backup\" extension.]:file:_files" \
+    "-backup-out=[(PATH) Path where Terraform should write the backup for the destination state. This can't be disabled. If not set, Terraform will write it to the same path as the destination state file with a backup extension. This only needs to be specified if -state-out is set to a different path than -state.]:file:_files" \
+    "-lock=[(true) Lock the state files when locking is supported.]:lock:(true false)" \
+    "-lock-timeout=[(0s) Duration to retry a state lock.]" \
     '-state=[(path) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:file:_files' \
     "-state-out=[(path) Path to the destination state file to write to. If this isn't specified, the source state file will be used. This can be a new or existing path.]:file:_files" \
     "::" \
@@ -258,8 +258,8 @@ __state_mv() {
 __state_push() {
   _arguments \
     "-force[Write the state even if lineages don't match or the remote serial is higher.]" \
-    '-lock=[(true|false) Lock the state file when locking is supported.]:lock:(true false)' \
-    "-lock-timeout=[(seconds) Duration to retry a state lock.]" \
+    '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
+    "-lock-timeout=[(0s) Duration to retry a state lock.]" \
     "::" \
     ":destination:_files"
 }
@@ -267,9 +267,10 @@ __state_push() {
 __state_replace_provider() {
   _arguments \
     '-auto-approve[Skip interactive approval.]' \
-    "-backup=[(path) PPath where Terraform should write the backup for the state file. This can't be disabled. If not set, Terraform will write it to the same path as the state file with a \".backup\" extension.]:file:_files" \
-    "-lock=[(true|false) Lock the state files when locking is supported.]:lock:(true false)" \
-    "-lock-timeout=[(seconds) Duration to retry a state lock.]" \
+    "-backup=[(PATH) Path where Terraform should write the backup for the state file. This can't be disabled. If not set, Terraform will write it to the same path as the state file with a \".backup\" extension.]:file:_files" \
+    "-lock=[(true) Lock the state files when locking is supported.]:lock:(true false)" \
+    "-lock-timeout=[(0s) Duration to retry a state lock.]" \
+    '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:file:_files' \
     ":from_provider_fqn:" \
     ":to_provider_fqn:"
 }
@@ -277,10 +278,10 @@ __state_replace_provider() {
 __state_rm() {
   _arguments \
     "-dry-run[If set, prints out what would've been removed but doesn't actually remove anything.]" \
-    "-backup=[(path) Path where Terraform should write the backup for the original state.]:file:_files" \
-    "-lock=[(true|false) Lock the state files when locking is supported.]:lock:(true false)" \
-    "-lock-timeout=[(seconds) Duration to retry a state lock.]" \
-    '-state=[(path) Path to the state file to update. Defaults to the current workspace state.]:file:_files' \
+    "-backup=[(PATH) Path where Terraform should write the backup for the original state.]:file:_files" \
+    "-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)" \
+    "-lock-timeout=[(0s) Duration to retry a state lock.]" \
+    '-state=[(PATH) Path to the state file to update. Defaults to the current workspace state.]:file:_files' \
     "*:address:__statelist" 
 }
 
@@ -299,7 +300,7 @@ __taint() {
     _arguments \
         '-allow-missing[If specified, the command will succeed (exit code 0) even if the resource is missing.]' \
         '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
-        '-lock=[(true) Lock the state file when locking is supported.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-module=[(path)  The module path where the resource lives. By default this will be root. Child modules can be specified by names. Ex. "consul" or "consul.vpc" (nested modules).]' \
         '-no-color[If specified, output will not contain any color.]' \
@@ -312,7 +313,7 @@ __untaint() {
     _arguments \
     '-allow-missing[If specified, the command will succeed (exit code 0) even if the resource is missing.]' \
     '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
-    '-lock=[(true) Lock the state file when locking is supported.]' \
+    '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
     '-module=[(path)  The module path where the resource lives. By default this will be root. Child modules can be specified by names. Ex. "consul" or "consul.vpc" (nested modules).]' \
     '-no-color[If specified, output will not contain any color.]' \

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -6,10 +6,13 @@ _terraform_cmds=(
     'console:Interactive console for Terraform interpolations'
     'destroy:Destroy Terraform-managed infrastructure'
     'fmt:Rewrites config files to canonical format'
+    'force-unlock:Manually unlock the terraform state'
     'get:Download and install modules for the configuration'
     'graph:Create a visual graph of Terraform resources'
     'import:Import existing infrastructure into Terraform'
     'init:Initialize a Terraform working directory'
+    'login:Obtain and save credentials for a remote host'
+    'logout:Remove locally-stored credentials for a remote host'
     'output:Read an output from a state file'
     'plan:Generate and show an execution plan'
     'providers:Prints a tree of the providers used in the configuration'
@@ -81,6 +84,11 @@ __fmt() {
         '-recursive=[(false) Also process files in subdirectories. By default, only the given directory (or current directory) is processed.]'
 }
 
+__force_unlock() {
+    _arguments \
+        "-force[Don't ask for input for unlock confirmation.]"
+}
+
 __get() {
     _arguments \
         '-update=[(false) If true, modules already downloaded will be checked for updates and updated if necessary.]' \
@@ -126,6 +134,16 @@ __init() {
         '-reconfigure[Reconfigure the backend, ignoring any saved configuration.]' \
         '-upgrade=[(false) If installing modules (-get) or plugins (-get-plugins), ignore previously-downloaded objects and install the latest version allowed within configured constraints.]' \
         '-verify-plugins=[(true) Verify the authenticity and integrity of automatically downloaded plugins.]'
+}
+
+__login() {
+    _arguments \
+
+}
+
+__logout() {
+    _arguments \
+
 }
 
 __output() {
@@ -320,6 +338,8 @@ case "$words[1]" in
     __destroy ;;
   fmt)
     __fmt;;
+  force-unlock)
+    __force_unlock;;
   get)
     __get ;;
   graph)
@@ -328,6 +348,10 @@ case "$words[1]" in
     __import;;
   init)
     __init ;;
+  login)
+    __login ;;
+  logout)
+    __logout ;;
   output)
     __output ;;
   plan)

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -42,7 +42,7 @@ __013upgrade() {
 __apply() {
     _arguments \
         '-auto-approve[Skip interactive approval of plan before applying.]' \
-        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
+        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
         '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
@@ -66,7 +66,7 @@ __console() {
 
 __destroy() {
     _arguments \
-        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
+        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
         '-auto-approve[Skip interactive approval before destroying.]' \
         '-force[Deprecated: same as auto-approve.]' \
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
@@ -109,7 +109,7 @@ __graph() {
 
 __import() {
     _arguments \
-        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
+        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
         '-config=[(path) Path to a directory of Terraform configuration files to use to configure the provider. Defaults to pwd. If no config files are present, they must be provided via the input prompts or env vars.]' \
         '-allow-missing-config[Allow import when no resource configuration block exists.]' \
         '-input=[(true) Ask for input for variables if not directly set.]' \
@@ -199,7 +199,7 @@ __providers_schema() {
 
 __refresh() {
     _arguments \
-        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
+        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]::backupfile:_files -g "*.backup"' \
         '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
         '-input=[(true) Ask for input for variables if not directly set.]' \
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
@@ -242,8 +242,8 @@ __state_list() {
 __state_mv() {
   _arguments \
     "-dry-run[If set, prints out what would've been moved but doesn't actually move anything.]" \
-    "-backup=[(PATH) Path where Terraform should write the backup for the original state. This can't be disabled. If not set, Terraform will write it to the same path as the statefile with a \".backup\" extension.]:file:_files" \
-    "-backup-out=[(PATH) Path where Terraform should write the backup for the destination state. This can't be disabled. If not set, Terraform will write it to the same path as the destination state file with a backup extension. This only needs to be specified if -state-out is set to a different path than -state.]:file:_files" \
+    '-backup=[(PATH) Path where Terraform should write the backup for the original state. This can"t be disabled. If not set, Terraform will write it to the same path as the statefile with a ".backup" extension.]:backupfile:_files -g "*.backup"' \
+    '-backup-out=[(PATH) Path where Terraform should write the backup for the destination state. This can"t be disabled. If not set, Terraform will write it to the same path as the destination state file with a backup extension. This only needs to be specified if -state-out is set to a different path than -state.]:backupfile:_files -g "*.backup"' \
     "-lock=[(true) Lock the state files when locking is supported.]:lock:(true false)" \
     "-lock-timeout=[(0s) Duration to retry a state lock.]" \
     '-state=[(path) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -g "*.tfstate"' \
@@ -265,7 +265,7 @@ __state_push() {
 __state_replace_provider() {
   _arguments \
     '-auto-approve[Skip interactive approval.]' \
-    "-backup=[(PATH) Path where Terraform should write the backup for the state file. This can't be disabled. If not set, Terraform will write it to the same path as the state file with a \".backup\" extension.]:file:_files" \
+    '-backup=[(PATH) Path where Terraform should write the backup for the state file. This can"t be disabled. If not set, Terraform will write it to the same path as the state file with a ".backup" extension.]:backupfile:_files -g "*.backup"' \
     "-lock=[(true) Lock the state files when locking is supported.]:lock:(true false)" \
     "-lock-timeout=[(0s) Duration to retry a state lock.]" \
     '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -g "*.tfstate"' \
@@ -276,7 +276,7 @@ __state_replace_provider() {
 __state_rm() {
   _arguments \
     "-dry-run[If set, prints out what would've been removed but doesn't actually remove anything.]" \
-    "-backup=[(PATH) Path where Terraform should write the backup for the original state.]:file:_files" \
+    '-backup=[(PATH) Path where Terraform should write the backup for the original state.]::backupfile:_files -g "*.backup"' \
     "-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)" \
     "-lock-timeout=[(0s) Duration to retry a state lock.]" \
     '-state=[(PATH) Path to the state file to update. Defaults to the current workspace state.]:statefile:_files -g "*.tfstate"' \
@@ -297,7 +297,7 @@ __statelist() {
 __taint() {
     _arguments \
         '-allow-missing[If specified, the command will succeed (exit code 0) even if the resource is missing.]' \
-        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
+        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-module=[(path)  The module path where the resource lives. By default this will be root. Child modules can be specified by names. Ex. "consul" or "consul.vpc" (nested modules).]' \
@@ -309,7 +309,7 @@ __taint() {
 __untaint() {
     _arguments \
     '-allow-missing[If specified, the command will succeed (exit code 0) even if the resource is missing.]' \
-    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
+    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
     '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
     '-module=[(path)  The module path where the resource lives. By default this will be root. Child modules can be specified by names. Ex. "consul" or "consul.vpc" (nested modules).]' \

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -209,6 +209,7 @@ __state() {
       'mv:Move an item in the state'
       'pull:Pull current state and output to stdout'
       'push:Update remote state from a local state file'
+      'replace-provider:Replace provider for resources in the Terraform state'
       'rm:Remove instances from the state' 
       'show:Show a resource in the state'
     )
@@ -243,6 +244,16 @@ __state_push() {
     "-lock-timeout=[(seconds) Duration to retry a state lock.]" \
     "::" \
     ":destination:_files"
+}
+
+__state_replace_provider() {
+  _arguments \
+    '-auto-approve[Skip interactive approval.]' \
+    "-backup=[(path) PPath where Terraform should write the backup for the state file. This can't be disabled. If not set, Terraform will write it to the same path as the state file with a \".backup\" extension.]:file:_files" \
+    "-lock=[(true|false) Lock the state files when locking is supported.]:lock:(true false)" \
+    "-lock-timeout=[(seconds) Duration to retry a state lock.]" \
+    ":from_provider_fqn:" \
+    ":to_provider_fqn:"
 }
 
 __state_rm() {
@@ -366,6 +377,7 @@ case "$words[1]" in
     [[ $words[2] = "list" ]] && __state_list
     [[ $words[2] = "mv" ]] && __state_mv
     [[ $words[2] = "push" ]] && __state_push
+    [[ $words[2] = "replace-provider" ]] && __state_replace_provider
     [[ $words[2] = "rm" ]] && __state_rm
     [[ $words[2] = "show" ]] && __state_show
     ;;

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -104,7 +104,6 @@ __get() {
 __graph() {
     _arguments \
         '-draw-cycles[Highlight any cycles in the graph with colored edges. This helps when diagnosing cycle errors.]' \
-        '-no-color[If specified, output will contain no color.]' \
         '-type=[(plan) Type of graph to output. Can be: plan, plan-destroy, apply, validate, input, refresh.]'
 }
 
@@ -117,7 +116,6 @@ __import() {
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-no-color[If specified, output will contain no color.]' \
-        '-provider=[(provider) Specific provider to use for import. This is used for specifying aliases, such as "aws.eu". Defaults to the normal provider prefix of the resource being imported.]' \
         '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]' \
         '-state-out=[(PATH) Path to the destination state file to write to. If this is not specified, the source state file will be used. This can be a new or existing path.]' \
         '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times. This is only useful with the "-config" flag.]' \
@@ -155,8 +153,7 @@ __logout() {
 __output() {
     _arguments \
         '-state=[(path) Path to the state file to read. Defaults to "terraform.tfstate".]' \
-        '-no-color[ If specified, output will contain no color.]' \
-        '-module=[(name) If specified, returns the outputs for a specific module]' \
+        '-no-color[If specified, output will contain no color.]' \
         '-json[If specified, machine readable output will be printed in JSON format]'
 }
 
@@ -167,7 +164,6 @@ __plan() {
         '-input=[(true) Ask for input for variables if not directly set.]' \
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
-        '-module-depth=[(n) Specifies the depth of modules to show in the output. This does not affect the plan itself, only the output shown. By default, this is -1, which will expand all.]' \
         '-no-color[() If specified, output will contain no color.]' \
         '-out=[(path) Write a plan file to the given path. This can be used as input to the "apply" command.]' \
         '-parallelism=[(10) Limit the number of concurrent operations.]' \
@@ -303,7 +299,6 @@ __taint() {
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-module=[(path)  The module path where the resource lives. By default this will be root. Child modules can be specified by names. Ex. "consul" or "consul.vpc" (nested modules).]' \
-        '-no-color[If specified, output will not contain any color.]' \
         '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]' \
         '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]' \
         "*:address:__statelist" 
@@ -316,14 +311,12 @@ __untaint() {
     '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
     '-module=[(path)  The module path where the resource lives. By default this will be root. Child modules can be specified by names. Ex. "consul" or "consul.vpc" (nested modules).]' \
-    '-no-color[If specified, output will not contain any color.]' \
     '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]' \
     '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]'
 }
 
 __validate() {
     _arguments \
-    '-check-variables=[(true) If set to true (default), the command will check whether all required variables have been specified.]' \
     '-no-color[If specified, output will not contain any color.]' \
     '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
     '*-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]:file:_files'

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -41,8 +41,9 @@ __013upgrade() {
 
 __apply() {
     _arguments \
-        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
         '-auto-approve[Skip interactive approval of plan before applying.]' \
+        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
+        '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
         '-lock=[(true) Lock the state file when locking is supported.]' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-input=[(true) Ask for input for variables if not directly set.]' \

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -98,7 +98,7 @@ __force_unlock() {
 __get() {
     _arguments \
         '-update=[(false) If true, modules already downloaded will be checked for updates and updated if necessary.]' \
-        '-no-color[If specified, output will contain no color.]'
+        '-no-color[Disable text coloring in the output.]'
 }
 
 __graph() {
@@ -127,14 +127,14 @@ __init() {
         '-backend=[(true) Configure the backend for this configuration.]' \
         '-backend-config=[This can be either a path to an HCL file with key/value assignments (same format as terraform.tfvars) or a 'key=value' format. This is merged with what is in the configuration file. This can be specified multiple times. The backend type must be in the configuration itself.]' \
         '-force-copy[Suppress prompts about copying state data. This is equivalent to providing a "yes" to all confirmation prompts.]' \
-        '-from-module=[Copy the contents of the given module into the target directory before initialization.]' \
+        '-from-module=[(SOURCE) Copy the contents of the given module into the target directory before initialization.]' \
         '-get=[(true) Download any modules for this configuration.]' \
         '-get-plugins=[(true) Download any missing plugins for this configuration.]' \
         '-input=[(true) Ask for input if necessary. If false, will error if input was required.]' \
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
         '-no-color[If specified, output will contain no color.]' \
-        '-plugin-dir[Directory containing plugin binaries. This overrides all default search paths for plugins, and prevents the automatic installation of plugins. This flag can be used multiple times.]' \
+        '-plugin-dir[Directory containing plugin binaries. This overrides all default search paths for plugins, and prevents the automatic installation of plugins. This flag can be used multiple times.]:plugin_dir:_files -/' \
         '-reconfigure[Reconfigure the backend, ignoring any saved configuration.]' \
         '-upgrade=[(false) If installing modules (-get) or plugins (-get-plugins), ignore previously-downloaded objects and install the latest version allowed within configured constraints.]' \
         '-verify-plugins=[(true) Verify the authenticity and integrity of automatically downloaded plugins.]'
@@ -159,7 +159,8 @@ __output() {
 
 __plan() {
     _arguments \
-        '-destroy[() If set, a plan will be generated to destroy all resources managed by the given configuration and state.]' \
+        '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
+        '-destroy[If set, a plan will be generated to destroy all resources managed by the given configuration and state.]' \
         '-detailed-exitcode[() Return detailed exit codes when the command exits. This will change the meaning of exit codes to: 0 - Succeeded, diff is empty (no changes); 1 - Errored, 2 - Succeeded; there is a diff]' \
         '-input=[(true) Ask for input for variables if not directly set.]' \
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
@@ -199,6 +200,7 @@ __providers_schema() {
 __refresh() {
     _arguments \
         '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]' \
+        '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
         '-input=[(true) Ask for input for variables if not directly set.]' \
         '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
         '-lock-timeout=[(0s) Duration to retry a state lock.]' \
@@ -232,7 +234,7 @@ __state() {
 
 __state_list() {
   _arguments \
-    '-state=[(path) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]' \
+    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default, Terraform will consult the state of the currently-selected workspace.]' \
     '-id=[(id) Filters the results to include only instances whose resource types have an attribute named id whose value equals the given id string.]' \
     "*:address:__statelist" 
 }
@@ -284,7 +286,7 @@ __state_rm() {
 
 __state_show() {
   _arguments \
-    '-state=[(path) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]' \
+    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]' \
     "*:address:__statelist" 
 }
 
@@ -318,8 +320,8 @@ __untaint() {
 __validate() {
     _arguments \
     '-no-color[If specified, output will not contain any color.]' \
-    '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-    '*-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]:file:_files'
+    '-json[Produce output in a machine-readable JSON format, suitable for use in text editor integrations and other automated systems.]' \
+    ':dir:_files -/'
 }
 
 __version() {


### PR DESCRIPTION
As of Terraform ~0.12.29~ 0.13.3

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add autocompletion for login/logout and force-unlock
- Add completion for 0.13upgrade
- Remove legacy push command
- Add -json flag to version command