### PR TITLE
update: return git error code on failure

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -79,4 +79,4 @@ case "$resetAutoStash" in
 esac
 
 # Exit with `1` if the update failed
-exit $status && unset status
+exit $status

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -68,10 +68,8 @@ then
   printf "${BLUE}${BOLD}%s ${UNDER}%s${RESET}\n" "Want to get involved in the community? Join our Discord:" "https://discord.gg/ohmyzsh"
   printf "${BLUE}${BOLD}%s ${UNDER}%s${RESET}\n" "Get your Oh My Zsh swag at:" "https://shop.planetargon.com/collections/oh-my-zsh"
 else
+  status=$?
   printf "${RED}%s${RESET}\n" 'There was an error updating. Try again later?'
-
-  # Prepare to return an error exit code
-  status=1
 fi
 
 # Unset git-config values set just for the upgrade

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -69,6 +69,7 @@ then
   printf "${BLUE}${BOLD}%s ${UNDER}%s${RESET}\n" "Get your Oh My Zsh swag at:" "https://shop.planetargon.com/collections/oh-my-zsh"
 else
   printf "${RED}%s${RESET}\n" 'There was an error updating. Try again later?'
+  exit 1
 fi
 
 # Unset git-config values set just for the upgrade

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -69,7 +69,9 @@ then
   printf "${BLUE}${BOLD}%s ${UNDER}%s${RESET}\n" "Get your Oh My Zsh swag at:" "https://shop.planetargon.com/collections/oh-my-zsh"
 else
   printf "${RED}%s${RESET}\n" 'There was an error updating. Try again later?'
-  exit 1
+
+  # Prepare to return an error exit code
+  status=1
 fi
 
 # Unset git-config values set just for the upgrade
@@ -77,3 +79,6 @@ case "$resetAutoStash" in
   "") git config --unset rebase.autoStash ;;
   *) git config rebase.autoStash "$resetAutoStash" ;;
 esac
+
+# Exit with `1` if the update failed
+exit $status && unset status


### PR DESCRIPTION
##  Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
Add `exit 1` to return an error status if `omz update` fails. This replaces an implicit `0`.