### PR TITLE
optimize Git plugin’s `grename` logic by reducing `if` conditions

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -279,7 +279,7 @@ alias gama='git am --abort'
 alias gamscp='git am --show-current-patch'
 
 function grename() {
-  if [[ -z "$1" || -z "$2" ]]; then
+  if [[ -z "$2" ]]; then
     echo "Usage: $0 old_branch new_branch"
     return 1
   fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

This is an optimization. The function to rename a Git branch using @ujwaldhakal’s `grename` (#8622, e8609b857caf730c626ab27910ece30420bc6693) requires both arguments `$1` and `$2`, but the existence of `$2` occurs only when `$1` exists. Only one check for the existence of `$2` (the new name of the branch) is needed.