### PR TITLE
Fix `Inappropriate ioctl for device` error when using pipenv plugin

### DIFF
--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -19,7 +19,7 @@ _togglePipenvShell() {
   if [[ "$PIPENV_ACTIVE" != 1 ]]; then
     if [[ -f "$PWD/Pipfile" ]]; then
       export pipfile_dir="$PWD"
-      pipenv shell
+      pipenv shell --fancy
     fi
   fi
 }


### PR DESCRIPTION
This makes a small change to the `pipenv` plugin. Without the `--fancy` flag, I get the error listed below when I load the `pipenv` plugin. This appears to be related to [#3615](https://github.com/pypa/pipenv/issues/3615) of pipenv. This problem may may arise because I am using `asdf` to install python (and also have that plugin loaded). From what I can tell of the issue linked above, using `--fancy` should not cause problems for other oh-my-zsh setups, but I have not tested that out extensively.

```shell
Launching subshell in virtual environment…
Traceback (most recent call last):
  File "/home/davidlittle/.asdf/installs/python/3.8.5/bin/pipenv", line 8, in <module>
    sys.exit(cli())
  File "/home/davidlittle/.asdf/installs/python/3.8.5/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/davidlittle/.asdf/installs/python/3.8.5/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/davidlittle/.asdf/installs/python/3.8.5/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/davidlittle/.asdf/installs/python/3.8.5/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/davidlittle/.asdf/installs/python/3.8.5/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/davidlittle/.asdf/installs/python/3.8.5/lib/python3.8/site-packages/pipenv/vendor/click/decorators.py", line 73, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/davidlittle/.asdf/installs/python/3.8.5/lib/python3.8/site-packages/pipenv/vendor/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/davidlittle/.asdf/installs/python/3.8.5/lib/python3.8/site-packages/pipenv/cli/command.py", line 428, in shell
    do_shell(
  File "/home/davidlittle/.asdf/installs/python/3.8.5/lib/python3.8/site-packages/pipenv/core.py", line 2387, in do_shell
    shell.fork_compat(*fork_args)
  File "/home/davidlittle/.asdf/installs/python/3.8.5/lib/python3.8/site-packages/pipenv/shells.py", line 121, in fork_compat
    c.interact(escape_character=None)
  File "/home/davidlittle/.asdf/installs/python/3.8.5/lib/python3.8/site-packages/pipenv/vendor/pexpect/pty_spawn.py", line 788, in interact
    mode = tty.tcgetattr(self.STDIN_FILENO)
termios.error: (25, 'Inappropriate ioctl for device')
```



## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
...
