### PR TITLE
Updated plugin z.sh to fix syntax error causing bug

### DIFF
--- a/plugins/z/z.sh
+++ b/plugins/z/z.sh
@@ -57,7 +57,7 @@ _z() {
         # don't track excluded directory trees
         local exclude
         for exclude in "${_Z_EXCLUDE_DIRS[@]}"; do
-            case "$*" in "$exclude*") return;; esac
+            case "$*" in "$exclude"*) return;; esac
         done
 
         # maintain the data file


### PR DESCRIPTION
Misplaced " in case command prevented excluded directories from being matched

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
