### PR TITLE
pip plugin: Default cache to $XDG_CACHE_HOME/pip

### DIFF
--- a/plugins/pip/pip.plugin.zsh
+++ b/plugins/pip/pip.plugin.zsh
@@ -9,7 +9,13 @@
 # If you would like to clear your cache, go ahead and do a
 # "zsh-pip-clear-cache".
 
-ZSH_PIP_CACHE_FILE=~/.pip/zsh-cache
+if [[ ! -z "$XDG_CACHE_HOME" ]] && [[ -d $XDG_CACHE_HOME/pip ]]; then
+  ZSH_PIP_CACHE_FILE=$XDG_CACHE_HOME/pip/zsh-cache
+elif [[ -d $HOME/.cache/pip ]]; then
+  ZSH_PIP_CACHE_FILE=$HOME/.cache/pip/zsh-cache
+else
+  ZSH_PIP_CACHE_FILE=~/.pip/zsh-cache
+fi
 ZSH_PIP_INDEXES=(https://pypi.org/simple/)
 
 zsh-pip-clear-cache() {


### PR DESCRIPTION
 $XDG_CACHE_HOME/pip is ~/.cache/pip by default.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Default cache to $XDG_CACHE_HOME/pip
- if $XDG_CACHE_HOME environment variable is not set then fallback to ~/.cache/pip
- if ~/.cache/pip doesn't exist then fallback to ~/.pip

## Other comments:
[reference](https://pip.pypa.io/en/latest/reference/pip_install/#caching) :
```
The default location for the cache directory depends on the operating system:

Unix
~/.cache/pip and it respects the XDG_CACHE_HOME directory.
```
