### PR TITLE
git: run gfa with --jobs=10 (fetch remotes in parallel)

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -1,3 +1,7 @@
+# Git version checking
+autoload -Uz is-at-least
+git_version="${(As: :)$(git version 2>/dev/null)[3]}"
+
 #
 # Functions
 #
@@ -105,8 +109,7 @@ compdef _git gdv=git-diff
 
 alias gf='git fetch'
 # --jobs=<n> was added in git 2.8
-autoload -Uz is-at-least
-is-at-least 2.8 "$(git --version 2>/dev/null | awk '{print $3}')" \
+is-at-least 2.8 "$git_version" \
   && alias gfa='git fetch --all --prune --jobs=10' \
   || alias gfa='git fetch --all --prune'
 alias gfo='git fetch origin'
@@ -244,7 +247,7 @@ alias gss='git status -s'
 alias gst='git status'
 
 # use the default stash push on git 2.13 and newer
-is-at-least 2.13 "$(git --version 2>/dev/null | awk '{print $3}')" \
+is-at-least 2.13 "$git_version" \
   && alias gsta='git stash push' \
   || alias gsta='git stash save'
 
@@ -294,3 +297,5 @@ function grename() {
     git push --set-upstream origin "$2"
   fi
 }
+
+unset git_version

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -104,7 +104,7 @@ function gdv() { git diff -w "$@" | view - }
 compdef _git gdv=git-diff
 
 alias gf='git fetch'
-alias gfa='git fetch --all --prune'
+alias gfa='git fetch --all --prune --jobs=10'
 alias gfo='git fetch origin'
 
 alias gfg='git ls-files | grep'

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -104,7 +104,11 @@ function gdv() { git diff -w "$@" | view - }
 compdef _git gdv=git-diff
 
 alias gf='git fetch'
-alias gfa='git fetch --all --prune --jobs=10'
+# --jobs=<n> was added in git 2.8
+autoload -Uz is-at-least
+is-at-least 2.8 "$(git --version 2>/dev/null | awk '{print $3}')" \
+  && alias gfa='git fetch --all --prune --jobs=10' \
+  || alias gfa='git fetch --all --prune'
 alias gfo='git fetch origin'
 
 alias gfg='git ls-files | grep'
@@ -240,7 +244,6 @@ alias gss='git status -s'
 alias gst='git status'
 
 # use the default stash push on git 2.13 and newer
-autoload -Uz is-at-least
 is-at-least 2.13 "$(git --version 2>/dev/null | awk '{print $3}')" \
   && alias gsta='git stash push' \
   || alias gsta='git stash save'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

This PR changes `gfa` to run with up to 10 jobs in parallel using `--jobs=10`. This speeds up fetching from many remotes significantly. I arbitrarily chose 10 jobs; I'm using up to 7 remotes on the projects I work with.

I can't think of any reason not to fetch remotes in parallel besides limiting bandwidth or CPU load. In my opinion the speedup is very much worth it.

I'm happy to add a separate alias (e.g. `gfaj` or `gfap`) for parallel fetching if there's opposition to my PR.