### PR TITLE
minikube: fix spelling

### DIFF
--- a/plugins/minikube/minikube.plugin.zsh
+++ b/plugins/minikube/minikube.plugin.zsh
@@ -1,13 +1,13 @@
 # Autocompletion for Minikube.
 #
 if (( $+commands[minikube] )); then
-    __MINICUBE_COMPLETION_FILE="${ZSH_CACHE_DIR}/minicube_completion"
+    __MINIKUBE_COMPLETION_FILE="${ZSH_CACHE_DIR}/minikube_completion"
 
-    if [[ ! -f $__MINICUBE_COMPLETION_FILE ]]; then
-        minikube completion zsh >! $__MINICUBE_COMPLETION_FILE
+    if [[ ! -f $__MINIKUBE_COMPLETION_FILE ]]; then
+        minikube completion zsh >! $__MINIKUBE_COMPLETION_FILE
     fi
 
-    [[ -f $__MINICUBE_COMPLETION_FILE ]] && source $__MINICUBE_COMPLETION_FILE
+    [[ -f $__MINIKUBE_COMPLETION_FILE ]] && source $__MINIKUBE_COMPLETION_FILE
 
-    unset __MINICUBE_COMPLETION_FILE
+    unset __MINIKUBE_COMPLETION_FILE
 fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Replace "minicube" by correct spelling, "minikube" (cf https://minikube.sigs.k8s.io)
