### PR TITLE
Add completion plugin for 'just'

### DIFF
--- a/plugins/just/README.md
+++ b/plugins/just/README.md
@@ -1,0 +1,10 @@
+# plugin for 'just'
+
+This plugin adds completion for [just](https://github.com/casey/just).
+
+To use it, add `just` to the plugins array in your .zshrc file:
+
+```zsh
+plugins=(... just)
+```
+

--- a/plugins/just/_just
+++ b/plugins/just/_just
@@ -1,0 +1,5 @@
+# Autocompletion for just
+#
+if [ $commands[just] ]; then
+  source <(just --completions=zsh)
+fi


### PR DESCRIPTION
This give completion for the 'just' command.
This is using the completion for zsh provided by just itself.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Sources the `just --completions=zsh` output.

## Other comments:
...
...
