### PR TITLE
fino: fix dangling "using" and clean up

### DIFF
--- a/themes/fino.zsh-theme
+++ b/themes/fino.zsh-theme
@@ -11,14 +11,13 @@
 #
 # Also borrowing from http://stevelosh.com/blog/2010/02/my-extravagant-zsh-prompt/
 
-function virtualenv_prompt_info(){
+function virtualenv_prompt_info {
   [[ -n ${VIRTUAL_ENV} ]] || return
   echo "${ZSH_THEME_VIRTUALENV_PREFIX:=[}${VIRTUAL_ENV:t}${ZSH_THEME_VIRTUALENV_SUFFIX:=]}"
 }
 
 function prompt_char {
-  git branch >/dev/null 2>/dev/null && echo "±" && return
-  echo '○'
+  command git branch &>/dev/null && echo "±" || echo '○'
 }
 
 function box_name {
@@ -27,8 +26,8 @@ function box_name {
 
 local ruby_env='$(ruby_prompt_info)'
 local git_info='$(git_prompt_info)'
-local prompt_char='$(prompt_char)'
 local virtualenv_info='$(virtualenv_prompt_info)'
+local prompt_char='$(prompt_char)'
 
 PROMPT="╭─${FG[040]}%n ${FG[239]}at ${FG[033]}$(box_name) ${FG[239]}in %B${FG[226]}%~%{$reset_color%}${git_info}${ruby_env}${virtualenv_info}
 ╰─${prompt_char}%{$reset_color%} "

--- a/themes/fino.zsh-theme
+++ b/themes/fino.zsh-theme
@@ -30,18 +30,17 @@ local git_info='$(git_prompt_info)'
 local prompt_char='$(prompt_char)'
 local virtualenv_info='$(virtualenv_prompt_info)'
 
-
-
-PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}%~%{$reset_color%}${git_info}${ruby_env}${virtualenv_info}
+PROMPT="╭─${FG[040]}%n ${FG[239]}at ${FG[033]}$(box_name) ${FG[239]}in %B${FG[226]}%~%{$reset_color%}${git_info}${ruby_env}${virtualenv_info}
 ╰─${prompt_char}%{$reset_color%} "
 
-ZSH_THEME_GIT_PROMPT_PREFIX=" %{$FG[239]%}on%{$reset_color%} %{$fg[255]%}"
+ZSH_THEME_GIT_PROMPT_PREFIX=" ${FG[239]}on%{$reset_color%} ${FG[255]}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_DIRTY="%{$FG[202]%}✘✘✘"
-ZSH_THEME_GIT_PROMPT_CLEAN="%{$FG[040]%}✔"
-ZSH_THEME_RUBY_PROMPT_PREFIX=" %{$FG[239]%}using%{$FG[243]%} ‹"
+ZSH_THEME_GIT_PROMPT_DIRTY="${FG[202]}✘✘✘"
+ZSH_THEME_GIT_PROMPT_CLEAN="${FG[040]}✔"
+
+ZSH_THEME_RUBY_PROMPT_PREFIX=" ${FG[239]}using${FG[243]} ‹"
 ZSH_THEME_RUBY_PROMPT_SUFFIX="›%{$reset_color%}"
-ZSH_THEME_VIRTUALENV_PREFIX=" %{$FG[239]%}using%{$FG[243]%} «"
-ZSH_THEME_VIRTUALENV_SUFFIX="»%{$reset_color%}"
 
 export VIRTUAL_ENV_DISABLE_PROMPT=1
+ZSH_THEME_VIRTUALENV_PREFIX=" ${FG[239]}using${FG[243]} «"
+ZSH_THEME_VIRTUALENV_SUFFIX="»%{$reset_color%}"

--- a/themes/fino.zsh-theme
+++ b/themes/fino.zsh-theme
@@ -11,26 +11,37 @@
 #
 # Also borrowing from http://stevelosh.com/blog/2010/02/my-extravagant-zsh-prompt/
 
+function virtualenv_prompt_info(){
+  [[ -n ${VIRTUAL_ENV} ]] || return
+  echo "${ZSH_THEME_VIRTUALENV_PREFIX:=[}${VIRTUAL_ENV:t}${ZSH_THEME_VIRTUALENV_SUFFIX:=]}"
+}
+
 function prompt_char {
   git branch >/dev/null 2>/dev/null && echo "±" && return
   echo '○'
 }
 
 function box_name {
-    [ -f ~/.box-name ] && cat ~/.box-name || echo ${SHORT_HOST:-$HOST}
+  [ -f ~/.box-name ] && cat ~/.box-name || echo ${SHORT_HOST:-$HOST}
 }
 
-local ruby_env='using%{$FG[243]%} $(ruby_prompt_info)'
+local ruby_env='$(ruby_prompt_info)'
 local git_info='$(git_prompt_info)'
 local prompt_char='$(prompt_char)'
+local virtualenv_info='$(virtualenv_prompt_info)'
 
 
-PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}%~%{$reset_color%}${git_info} %{$FG[239]%}${ruby_env}
+
+PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}%~%{$reset_color%}${git_info} ${ruby_env}${virtualenv_info}
 ╰─${prompt_char}%{$reset_color%} "
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$FG[239]%}on%{$reset_color%} %{$fg[255]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$FG[202]%}✘✘✘"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$FG[040]%}✔"
-ZSH_THEME_RUBY_PROMPT_PREFIX="‹"
+ZSH_THEME_RUBY_PROMPT_PREFIX="%{$FG[239]%}using%{$FG[243]%} ‹"
 ZSH_THEME_RUBY_PROMPT_SUFFIX="›%{$reset_color%}"
+ZSH_THEME_VIRTUALENV_PREFIX="%{$FG[239]%}using%{$FG[243]%} «"
+ZSH_THEME_VIRTUALENV_SUFFIX="»%{$reset_color%}"
+
+export VIRTUAL_ENV_DISABLE_PROMPT=1

--- a/themes/fino.zsh-theme
+++ b/themes/fino.zsh-theme
@@ -32,16 +32,16 @@ local virtualenv_info='$(virtualenv_prompt_info)'
 
 
 
-PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}%~%{$reset_color%}${git_info} ${ruby_env}${virtualenv_info}
+PROMPT="╭─%{$FG[040]%}%n%{$reset_color%} %{$FG[239]%}at%{$reset_color%} %{$FG[033]%}$(box_name)%{$reset_color%} %{$FG[239]%}in%{$reset_color%} %{$terminfo[bold]$FG[226]%}%~%{$reset_color%}${git_info}${ruby_env}${virtualenv_info}
 ╰─${prompt_char}%{$reset_color%} "
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$FG[239]%}on%{$reset_color%} %{$fg[255]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$FG[202]%}✘✘✘"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$FG[040]%}✔"
-ZSH_THEME_RUBY_PROMPT_PREFIX="%{$FG[239]%}using%{$FG[243]%} ‹"
+ZSH_THEME_RUBY_PROMPT_PREFIX=" %{$FG[239]%}using%{$FG[243]%} ‹"
 ZSH_THEME_RUBY_PROMPT_SUFFIX="›%{$reset_color%}"
-ZSH_THEME_VIRTUALENV_PREFIX="%{$FG[239]%}using%{$FG[243]%} «"
+ZSH_THEME_VIRTUALENV_PREFIX=" %{$FG[239]%}using%{$FG[243]%} «"
 ZSH_THEME_VIRTUALENV_SUFFIX="»%{$reset_color%}"
 
 export VIRTUAL_ENV_DISABLE_PROMPT=1


### PR DESCRIPTION
Fix dangling "using" word. Add support for python virtualenv.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Currently fino theme has some problems:
![2020-10-03_17-46](https://user-images.githubusercontent.com/26824900/94994868-13819680-05a3-11eb-89aa-5002e2f7c9f2.png)

1. dangling "using". It should appear only when using ruby or python virtual env, but it is always shown
2. wrong color of the prompt

This PR removes these problems are adds support for python virtualenv:
![2020-10-03_17-47](https://user-images.githubusercontent.com/26824900/94994920-622f3080-05a3-11eb-882f-b658c7d8cdab.png)
![2020-10-03_17-48](https://user-images.githubusercontent.com/26824900/94994922-65c2b780-05a3-11eb-9f08-ee23415d1fc6.png)

Most of the code changes are borrowed from fino-time theme.