### PR TITLE
virtualenv plugin: pull into lib/prompt_info_functions

### DIFF
--- a/lib/prompt_info_functions.zsh
+++ b/lib/prompt_info_functions.zsh
@@ -40,3 +40,13 @@ ZSH_THEME_RVM_PROMPT_OPTIONS="i v g"
 function ruby_prompt_info() {
   echo $(rvm_prompt_info || rbenv_prompt_info || chruby_prompt_info)
 }
+
+# use this to enable users to see current python virtualenv name
+# `ZSH_THEME_VIRTUALENV_PREFIX`: sets the prefix of the VIRTUAL_ENV. Defaults to `[`.
+# `ZSH_THEME_VIRTUALENV_SUFFIX`: sets the suffix of the VIRTUAL_ENV. Defaults to `]`.
+# Note: to disable prompt mangling in virtual_env/bin/activate
+# use `export VIRTUAL_ENV_DISABLE_PROMPT=1``
+function virtualenv_prompt_info(){
+  [[ -n ${VIRTUAL_ENV} ]] || return
+  echo "${ZSH_THEME_VIRTUALENV_PREFIX:=[}${VIRTUAL_ENV:t}${ZSH_THEME_VIRTUALENV_SUFFIX:=]}"
+}

--- a/plugins/virtualenv/README.md
+++ b/plugins/virtualenv/README.md
@@ -1,15 +1,3 @@
 # virtualenv
 
-The plugin displays information of the created virtual container and allows background theming.
-
-To use it, add `virtualenv` to the plugins array of your zshrc file:
-```
-plugins=(... virtualenv)
-```
-
-The plugin creates a `virtualenv_prompt_info` function that you can use in your theme, which displays
-the basename of the current `$VIRTUAL_ENV`. It uses two variables to control how that is shown:
-
-- `ZSH_THEME_VIRTUALENV_PREFIX`: sets the prefix of the VIRTUAL_ENV. Defaults to `[`.
-
-- `ZSH_THEME_VIRTUALENV_SUFFIX`: sets the suffix of the VIRTUAL_ENV. Defaults to `]`.
+This plugin has been pulled into `lib/prompt_info_functions.zsh`

--- a/plugins/virtualenv/virtualenv.plugin.zsh
+++ b/plugins/virtualenv/virtualenv.plugin.zsh
@@ -1,7 +1,2 @@
-function virtualenv_prompt_info(){
-  [[ -n ${VIRTUAL_ENV} ]] || return
-  echo "${ZSH_THEME_VIRTUALENV_PREFIX:=[}${VIRTUAL_ENV:t}${ZSH_THEME_VIRTUALENV_SUFFIX:=]}"
-}
-
-# disables prompt mangling in virtual_env/bin/activate
-export VIRTUAL_ENV_DISABLE_PROMPT=1
+echo -e "\033[0;31mvirtualenv plugin is deprecated and may be safely removed from\
+ plugin list\033[0m"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

This function should be in lib. Many themes depend on it or copy its functionality.

