### PR TITLE
Use 3+ dots named directories instead of aliases

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -3,10 +3,13 @@ setopt auto_pushd
 setopt pushd_ignore_dups
 setopt pushdminus
 
-alias -g ...='../..'
-alias -g ....='../../..'
-alias -g .....='../../../..'
-alias -g ......='../../../../..'
+# If a directory named ... (up to 6 dots) exists then changing directory should
+# lead to a change to that directory, otherwise the corresponding alias should
+# be used.
+alias -g ...='$([ -d "..." ] && echo "..." || echo "../..")'
+alias -g ....='$([ -d "...." ] && echo "...." || echo "../../..")'
+alias -g .....='$([ -d "....." ] && echo "....." || echo "../../../..")'
+alias -g ......='$([ -d "......" ] && echo "......" || echo "../../../../..")'
 
 alias -- -='cd -'
 alias 1='cd -'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- If a directory named ... (up to 6 dots) exists then changing directory should
lead to a change to that directory, otherwise the corresponding alias should be
used.

Resolves: #8344 

## Other comments:

This is my first pull request ever in github or to any open source project. 😊 
