### PR TITLE
z: upgrade plugin to the latest version

### DIFF
--- a/plugins/z/README
+++ b/plugins/z/README
@@ -23,6 +23,8 @@ DESCRIPTION
 OPTIONS
        -c     restrict matches to subdirectories of the current directory
 
+       -e     echo the best match, don't cd
+
        -h     show a brief help message
 
        -l     list only
@@ -57,6 +59,8 @@ NOTES
        Optionally:
               Set $_Z_CMD to change the command name (default z).
               Set $_Z_DATA to change the datafile (default $HOME/.z).
+              Set  $_Z_MAX_SCORE  lower  to  age  entries  out faster (default
+              9000).
               Set $_Z_NO_RESOLVE_SYMLINKS to prevent symlink resolution.
               Set $_Z_NO_PROMPT_COMMAND to handle PROMPT_COMMAND/precmd  your-
               self.
@@ -64,8 +68,8 @@ NOTES
               Set $_Z_OWNER to allow usage when in 'sudo -s' mode.
               (These  settings  should  go  in  .bashrc/.zshrc before the line
               added above.)
-              Install   the   provided   man   page   z.1    somewhere    like
-              /usr/local/man/man1.
+              Install the provided man page z.1  somewhere  in  your  MANPATH,
+              like /usr/local/man/man1.
 
    Aging:
        The rank of directories maintained by z undergoes aging based on a sim-

--- a/plugins/z/z.1
+++ b/plugins/z/z.1
@@ -78,6 +78,9 @@ Set \fB$_Z_CMD\fR to change the command name (default \fBz\fR).
 Set \fB$_Z_DATA\fR to change the datafile (default \fB$HOME/.z\fR).
 .RE
 .RS
+Set \fB$_Z_MAX_SCORE\fR lower to age entries out faster (default \fB9000\fR).
+.RE
+.RS
 Set \fB$_Z_NO_RESOLVE_SYMLINKS\fR to prevent symlink resolution.
 .RE
 .RS


### PR DESCRIPTION
This PR updates the z plugin to the latest available version in the upstream repository:

Commit-id: 125f4dc47e15891739dd8262d5b23077fe8fb9ab
https://github.com/rupa/z/commit/125f4dc47e15891739dd8262d5b23077fe8fb9ab

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Before this PR, the z plugin is updated to:

https://github.com/rupa/z/commit/e77e9384937bd43eb6ca8f1ba036924f4006df07

With this PR, the z plugin is updated to:

https://github.com/rupa/z/commit/125f4dc47e15891739dd8262d5b23077fe8fb9ab

Upstream diff commits:

https://github.com/rupa/z/compare/e77e9384937bd43eb6ca8f1ba036924f4006df07...125f4dc47e15891739dd8262d5b23077fe8fb9ab

## Other comments:
