### PR TITLE
Fix prompt update on git changes in steeef theme

### DIFF
--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -93,7 +93,7 @@ function steeef_precmd {
         zstyle ':vcs_info:*:prompt:*' formats "${FMT_BRANCH} "
 
         vcs_info 'prompt'
-        PR_GIT_UPDATE=
+        PR_GIT_UPDATE=1
     fi
 }
 add-zsh-hook precmd steeef_precmd

--- a/themes/steeef.zsh-theme
+++ b/themes/steeef.zsh-theme
@@ -12,7 +12,6 @@ export VIRTUAL_ENV_DISABLE_PROMPT=1
 function virtualenv_info {
     [ $VIRTUAL_ENV ] && echo '('%F{blue}`basename $VIRTUAL_ENV`%f') '
 }
-PR_GIT_UPDATE=1
 
 setopt prompt_subst
 
@@ -60,41 +59,16 @@ zstyle ':vcs_info:*:prompt:*' actionformats "${FMT_BRANCH}${FMT_ACTION}"
 zstyle ':vcs_info:*:prompt:*' formats       "${FMT_BRANCH}"
 zstyle ':vcs_info:*:prompt:*' nvcsformats   ""
 
-
-function steeef_preexec {
-    case "$2" in
-        *git*)
-            PR_GIT_UPDATE=1
-            ;;
-        *hub*)
-            PR_GIT_UPDATE=1
-            ;;
-        *svn*)
-            PR_GIT_UPDATE=1
-            ;;
-    esac
-}
-add-zsh-hook preexec steeef_preexec
-
-function steeef_chpwd {
-    PR_GIT_UPDATE=1
-}
-add-zsh-hook chpwd steeef_chpwd
-
 function steeef_precmd {
-    if [[ -n "$PR_GIT_UPDATE" ]] ; then
-        # check for untracked files or updated submodules, since vcs_info doesn't
-        if git ls-files --other --exclude-standard 2> /dev/null | grep -q "."; then
-            PR_GIT_UPDATE=1
-            FMT_BRANCH="(%{$turquoise%}%b%u%c%{$hotpink%}●${PR_RST})"
-        else
-            FMT_BRANCH="(%{$turquoise%}%b%u%c${PR_RST})"
-        fi
-        zstyle ':vcs_info:*:prompt:*' formats "${FMT_BRANCH} "
-
-        vcs_info 'prompt'
-        PR_GIT_UPDATE=1
+    # check for untracked files or updated submodules, since vcs_info doesn't
+    if [[ -n $(git status -s 2> /dev/null | grep "??") ]]; then
+        FMT_BRANCH="(%{$turquoise%}%b%u%c%{$hotpink%}●${PR_RST})"
+    else
+        FMT_BRANCH="(%{$turquoise%}%b%u%c${PR_RST})"
     fi
+    zstyle ':vcs_info:*:prompt:*' formats "${FMT_BRANCH} "
+
+    vcs_info 'prompt'
 }
 add-zsh-hook precmd steeef_precmd
 


### PR DESCRIPTION
Without this fix, the prompt does not update the marker indicating the status of the current branch after any change until either a `git status` is executed or a new tab is opened. It also was not able to detect changes if you were inside a directory in the repo that has nothing to do with the changes.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Removed `steeef_preexec` and `steeef_chpwd` functions as they are no longer needed.
- Changed the condition based on which a git change is detected. The previous one made it unable to see changes outside the current directory.

## Other comments:

The expected behavior of making changes in a clean branch in a git repo is that a marker gets added next to the branch name in the prompt. To reproduce the issue I am talking about, create a new git repo, make changes, say `touch` a file, and notice that no marker gets added next to the branch name in the prompt until you either execute any `git` command or open a new tab. The other issue of not detecting changes outside the current directory can be reproduced by making a change, say create a new file, then create a new directory and `cd` into it.