### PR TITLE
feat(plugins): add grc plugin for Generic Colouriser

### DIFF
--- a/plugins/grc/README.md
+++ b/plugins/grc/README.md
@@ -1,0 +1,9 @@
+# Generic Colouriser plugin
+
+This plugin adds completion for [Generic Colouriser](https://github.com/garabik/grc):
+
+To use it, add `grc` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... grc)
+```

--- a/plugins/grc/README.md
+++ b/plugins/grc/README.md
@@ -1,9 +1,37 @@
 # Generic Colouriser plugin
 
-This plugin adds completion for [Generic Colouriser](https://github.com/garabik/grc):
+This plugin adds wrappers for commands supported by [Generic Colouriser](https://github.com/garabik/grc):
 
 To use it, add `grc` to the plugins array in your zshrc file:
 
 ```zsh
 plugins=(... grc)
 ```
+
+## Commands
+
+The following commands are wrapped by `grc` so that their output is automatically colored:
+
+- `cc`
+- `configure`
+- `cvs`
+- `df`
+- `diff`
+- `dig`
+- `gcc`
+- `gmake`
+- `ifconfig`
+- `iwconfig`
+- `last`
+- `ldap`
+- `make`
+- `mount`
+- `mtr`
+- `netstat`
+- `ping`
+- `ping6`
+- `ps`
+- `traceroute`
+- `traceroute6`
+- `wdiff`
+- `whois`

--- a/plugins/grc/grc.plugin.zsh
+++ b/plugins/grc/grc.plugin.zsh
@@ -1,0 +1,41 @@
+# Source: https://github.com/garabik/grc/blob/master/grc.zsh
+if [[ "$TERM" != dumb ]] && (( $+commands[grc] )) ; then
+
+  # Supported commands
+  cmds=(
+    cc \
+    configure \
+    cvs \
+    df \
+    diff \
+    dig \
+    gcc \
+    gmake \
+    ifconfig \
+    last \
+    ldap \
+    ls \
+    make \
+    mount \
+    mtr \
+    netstat \
+    ping \
+    ping6 \
+    ps \
+    traceroute \
+    traceroute6 \
+    wdiff \
+    whois \
+    iwconfig \
+  );
+
+  # Set alias for available commands.
+  for cmd in $cmds ; do
+    if (( $+commands[$cmd] )) ; then
+      alias $cmd="grc --colour=auto $(whence $cmd)"
+    fi
+  done
+
+  # Clean up variables
+  unset cmds cmd
+fi

--- a/plugins/grc/grc.plugin.zsh
+++ b/plugins/grc/grc.plugin.zsh
@@ -1,41 +1,44 @@
-# Source: https://github.com/garabik/grc/blob/master/grc.zsh
-if [[ "$TERM" != dumb ]] && (( $+commands[grc] )) ; then
+# Adapted from: https://github.com/garabik/grc/blob/master/grc.zsh
 
-  # Supported commands
-  cmds=(
-    cc \
-    configure \
-    cvs \
-    df \
-    diff \
-    dig \
-    gcc \
-    gmake \
-    ifconfig \
-    last \
-    ldap \
-    ls \
-    make \
-    mount \
-    mtr \
-    netstat \
-    ping \
-    ping6 \
-    ps \
-    traceroute \
-    traceroute6 \
-    wdiff \
-    whois \
-    iwconfig \
-  );
-
-  # Set alias for available commands.
-  for cmd in $cmds ; do
-    if (( $+commands[$cmd] )) ; then
-      alias $cmd="grc --colour=auto $(whence $cmd)"
-    fi
-  done
-
-  # Clean up variables
-  unset cmds cmd
+if [[ "$TERM" = dumb ]] || (( ! $+commands[grc] )); then
+  return
 fi
+
+# Supported commands
+cmds=(
+  cc
+  configure
+  cvs
+  df
+  diff
+  dig
+  gcc
+  gmake
+  ifconfig
+  iwconfig
+  last
+  ldap
+  make
+  mount
+  mtr
+  netstat
+  ping
+  ping6
+  ps
+  traceroute
+  traceroute6
+  wdiff
+  whois
+)
+
+# Set alias for supported commands
+for cmd in $cmds; do
+  if (( $+commands[$cmd] )); then
+    eval "function $cmd {
+      grc --colour=auto \"${commands[$cmd]}\" \"\$@\"
+    }"
+  fi
+done
+
+# Clean up variables
+unset cmds cmd


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- No changes, adds a new plugin (grc)

## Other comments:

```zsh
❯ grep ^plugins ~/.zshrc
plugins=(direnv fzf git kubectl pipenv ssh-agent tmux pyenv grc)

❯ whence ping
grc --colour=auto /sbin/ping
```
