### PR TITLE
kubectl: add wrappers for colorized output in JSON and YAML

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -109,10 +109,8 @@ plugins=(... kubectl)
 
 ## Wrappers
 
-This plugin provides two wrappers to colorize kubectl output in JSON and YAML:
+This plugin provides 3 wrappers to colorize kubectl output in JSON and YAML using various tools (which must be installed):
 
-- `kj` outputs as JSON, colorized with [`jq`](https://stedolan.github.io/jq/) (must be installed)
-- `kjx` outputs as JSON, colorized with [`fx`](https://github.com/antonmedv/fx) (must be installed)
-- `ky` outputs as YAML, colorized with [`yh`](https://github.com/andreazorzetto/yh) (must be installed)
-
-
+- `kj`: JSON, colorized with [`jq`](https://stedolan.github.io/jq/).
+- `kjx`: JSON, colorized with [`fx`](https://github.com/antonmedv/fx).
+- `ky`: YAML, colorized with [`yh`](https://github.com/andreazorzetto/yh).

--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -106,3 +106,12 @@ plugins=(... kubectl)
 | kdelss  | `kubectl delete statefulset`        | Delete the statefulset                                                                           |
 | ksss    | `kubectl scale statefulset`         | Scale a statefulset                                                                              |
 | krsss   | `kubectl rollout status statefulset`| Check the rollout status of a deployment                                                         |
+
+## Wrappers
+
+This plugin provides two wrappers to colorize kubectl output in JSON and YAML:
+
+- `kj` outputs as JSON, colorized with [`jq`](https://stedolan.github.io/jq/) (must be installed)
+- `ky` outputs as YAML, colorized with [`yh`](https://github.com/andreazorzetto/yh) (must be installed)
+
+

--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -112,6 +112,7 @@ plugins=(... kubectl)
 This plugin provides two wrappers to colorize kubectl output in JSON and YAML:
 
 - `kj` outputs as JSON, colorized with [`jq`](https://stedolan.github.io/jq/) (must be installed)
+- `kjx` outputs as JSON, colorized with [`fx`](https://github.com/antonmedv/fx) (must be installed)
 - `ky` outputs as YAML, colorized with [`yh`](https://github.com/andreazorzetto/yh) (must be installed)
 
 

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -156,6 +156,11 @@ kj() {
 }
 compdef kj=kubectl
 
+kjx() {
+  kubectl "$@" -o json | fx
+}
+compdef kjx=kubectl
+
 # Colored YAML output
 ky() {
   kubectl "$@" -o yaml | yh

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -150,3 +150,14 @@ alias kepvc='kubectl edit pvc'
 alias kdpvc='kubectl describe pvc'
 alias kdelpvc='kubectl delete pvc'
 
+# Colored JSON output
+kj() {
+  kubectl "$@" -o json | jq
+}
+compdef kj=kubectl
+
+# Colored YAML output
+ky() {
+  kubectl "$@" -o yaml | yh
+}
+compdef ky=kubectl


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add two wrapper functions to the kubectl plugin for colorized output
