### PR TITLE
lib: follow standards in window title

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -42,7 +42,7 @@ function title {
 }
 
 ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD
-ZSH_THEME_TERM_TITLE_IDLE="%n@%m: %~"
+ZSH_THEME_TERM_TITLE_IDLE="%n@%m:%~"
 # Avoid duplication of directory in terminals with independent dir display
 if [[ "$TERM_PROGRAM" == Apple_Terminal ]]; then
   ZSH_THEME_TERM_TITLE_IDLE="%n@%m"


### PR DESCRIPTION
In Ubuntu and Debian, in scp, and in rsync the prompt is by default specified as in `user@hostname:/path/to/directory`

Before this patch, ohmyzsh set the title of the window to `user@hostname: /path/to/directory` (notice the space)
This PR unifies makes the window title to be set accordingly to the standards above.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- See above