### PR TITLE
nvm: consolidate many changes

### DIFF
--- a/lib/nvm.zsh
+++ b/lib/nvm.zsh
@@ -1,9 +1,8 @@
-# get the node.js version
+# get the nvm-controlled node.js version
 function nvm_prompt_info() {
-  [[ -f "$NVM_DIR/nvm.sh" ]] || return
   local nvm_prompt
-  nvm_prompt=$(node -v 2>/dev/null)
-  [[ "${nvm_prompt}x" == "x" ]] && return
-  nvm_prompt=${nvm_prompt:1}
+  which nvm &>/dev/null || return
+  nvm_prompt=$(nvm current)
+  nvm_prompt=${nvm_prompt#v}
   echo "${ZSH_THEME_NVM_PROMPT_PREFIX}${nvm_prompt}${ZSH_THEME_NVM_PROMPT_SUFFIX}"
 }

--- a/lib/nvm.zsh
+++ b/lib/nvm.zsh
@@ -1,8 +1,6 @@
 # get the nvm-controlled node.js version
 function nvm_prompt_info() {
-  local nvm_prompt
   which nvm &>/dev/null || return
-  nvm_prompt=$(nvm current)
-  nvm_prompt=${nvm_prompt#v}
+  local nvm_prompt=${$(nvm current)#v}
   echo "${ZSH_THEME_NVM_PROMPT_PREFIX}${nvm_prompt}${ZSH_THEME_NVM_PROMPT_SUFFIX}"
 }

--- a/plugins/nvm/README.md
+++ b/plugins/nvm/README.md
@@ -16,3 +16,7 @@ plugins=(... nvm)
   
 - **`NVM_HOMEBREW`**: if you installed nvm via Homebrew, in a directory other than `/usr/local/opt/nvm`, you
   can set `NVM_HOMEBREW` to be the directory where you installed it.
+
+- **`NVM_LAZY`**: if you want the plugin to defer the load of nvm to speed-up the start of your zsh session,
+  set `NVM_LAZY` to `1`. This will use the `--no-use` parameter when loading nvm, and will create a function
+  for `node`, `npm` and `yarn`, so when you call either of these three, nvm will load with `nvm use default`.

--- a/plugins/nvm/README.md
+++ b/plugins/nvm/README.md
@@ -20,3 +20,7 @@ plugins=(... nvm)
 - **`NVM_LAZY`**: if you want the plugin to defer the load of nvm to speed-up the start of your zsh session,
   set `NVM_LAZY` to `1`. This will use the `--no-use` parameter when loading nvm, and will create a function
   for `node`, `npm` and `yarn`, so when you call either of these three, nvm will load with `nvm use default`.
+
+- **`NVM_AUTOLOAD`**: if `NVM_AUTOLOAD` is set to `1`, the plugin will automatically load a node version when
+  if finds a [`.nvmrc` file](https://github.com/nvm-sh/nvm#nvmrc) in the current working directory indicating
+  which node version to load.

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -35,6 +35,33 @@ if (( $+NVM_LAZY )); then
   }
 fi
 
+# Autoload nvm when finding a .nvmrc file in the current directory
+# Adapted from: https://github.com/nvm-sh/nvm#zsh
+if (( $+NVM_AUTOLOAD )); then
+  load-nvmrc() {
+    local node_version="$(nvm version)"
+    local nvmrc_path="$(nvm_find_nvmrc)"
+
+    if [[ -n "$nvmrc_path" ]]; then
+      local nvmrc_node_version=$(nvm version "$(cat "${nvmrc_path}")")
+
+      if [[ "$nvmrc_node_version" = "N/A" ]]; then
+        nvm install
+      elif [[ "$nvmrc_node_version" != "$node_version" ]]; then
+        nvm use
+      fi
+    elif [[ "$node_version" != "$(nvm version default)" ]]; then
+      echo "Reverting to nvm default version"
+      nvm use default
+    fi
+  }
+
+  autoload -U add-zsh-hook
+  add-zsh-hook chpwd load-nvmrc
+
+  load-nvmrc
+fi
+
 # Load nvm bash completion
 for nvm_completion in "$NVM_DIR/bash_completion" "$NVM_HOMEBREW/etc/bash_completion.d/nvm"; do
   if [[ -f "$nvm_completion" ]]; then
@@ -47,4 +74,4 @@ for nvm_completion in "$NVM_DIR/bash_completion" "$NVM_HOMEBREW/etc/bash_complet
   fi
 done
 
-unset NVM_HOMEBREW NVM_LAZY nvm_completion
+unset NVM_HOMEBREW NVM_LAZY NVM_AUTOLOAD nvm_completion

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -12,14 +12,21 @@ which nvm &> /dev/null && return
 
 if [[ -f "$NVM_DIR/nvm.sh" ]]; then
   # Load nvm if it exists in $NVM_DIR
-  source "$NVM_DIR/nvm.sh"
+  source "$NVM_DIR/nvm.sh" --no-use
 else
   # Otherwise try to load nvm installed via Homebrew
   # User can set this if they have an unusual Homebrew setup
   NVM_HOMEBREW="${NVM_HOMEBREW:-/usr/local/opt/nvm}"
   # Load nvm from Homebrew location if it exists
-  [[ -f "$NVM_HOMEBREW/nvm.sh" ]] && source "$NVM_HOMEBREW/nvm.sh"
+  [[ -f "$NVM_HOMEBREW/nvm.sh" ]] && source "$NVM_HOMEBREW/nvm.sh" --no-use
 fi
+
+# Call nvm when first using node, npm or yarn
+function node npm yarn {
+  unfunction node npm yarn
+  nvm use default
+  command "$0" "$@"
+}
 
 # Load nvm bash completion
 for nvm_completion in "$NVM_DIR/bash_completion" "$NVM_HOMEBREW/etc/bash_completion.d/nvm"; do

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -12,21 +12,23 @@ which nvm &> /dev/null && return
 
 if [[ -f "$NVM_DIR/nvm.sh" ]]; then
   # Load nvm if it exists in $NVM_DIR
-  source "$NVM_DIR/nvm.sh" --no-use
+  source "$NVM_DIR/nvm.sh" ${NVM_LAZY+"--no-use"}
 else
   # Otherwise try to load nvm installed via Homebrew
   # User can set this if they have an unusual Homebrew setup
   NVM_HOMEBREW="${NVM_HOMEBREW:-/usr/local/opt/nvm}"
   # Load nvm from Homebrew location if it exists
-  [[ -f "$NVM_HOMEBREW/nvm.sh" ]] && source "$NVM_HOMEBREW/nvm.sh" --no-use
+  [[ -f "$NVM_HOMEBREW/nvm.sh" ]] && source "$NVM_HOMEBREW/nvm.sh" ${NVM_LAZY+"--no-use"}
 fi
 
 # Call nvm when first using node, npm or yarn
-function node npm yarn {
-  unfunction node npm yarn
-  nvm use default
-  command "$0" "$@"
-}
+if (( $+NVM_LAZY )); then
+  function node npm yarn {
+    unfunction node npm yarn
+    nvm use default
+    command "$0" "$@"
+  }
+fi
 
 # Load nvm bash completion
 for nvm_completion in "$NVM_DIR/bash_completion" "$NVM_HOMEBREW/etc/bash_completion.d/nvm"; do

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -1,5 +1,11 @@
-# Set NVM_DIR if it isn't already defined
-[[ -z "$NVM_DIR" ]] && export NVM_DIR="$HOME/.nvm"
+# See https://github.com/nvm-sh/nvm#installation-and-update
+if [[ -z "$NVM_DIR" ]]; then
+  if [[ -d "$HOME/.nvm" ]]; then
+    export NVM_DIR="$HOME/.nvm"
+  elif [[ -d "${XDG_CONFIG_HOME:-$HOME/.config}/nvm" ]]; then
+    export NVM_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nvm"
+  fi
+fi
 
 # Don't try to load nvm if command already available
 which nvm &> /dev/null && return

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -1,45 +1,30 @@
-# nvm
-#
-# This plugin locates and loads nvm, looking for it in well-known locations.
+# Set NVM_DIR if it isn't already defined
+[[ -z "$NVM_DIR" ]] && export NVM_DIR="$HOME/.nvm"
 
-() {
-  emulate -L zsh
-  local nvm_install_dir="" dir install_locations
-  if [[ -n $NVM_INSTALL_DIR ]]; then
-    # User-specified path
-    nvm_install_dir=$NVM_INSTALL_DIR
-  else
-    # Well-known common installation locations for NVM
-    install_locations=( ~/.nvm )
-    [[ -n $NVM_DIR ]] && install_locations=($NVM_DIR $install_locations)
-    # Mac Homebrew sticks 
-    which brew &>/dev/null && install_locations+=$(brew --prefix nvm)
-    for dir ($install_locations); do
-      if [[ -s $dir/nvm.sh ]]; then
-        nvm_install_dir=$dir
-        break
-      fi
-    done
-  fi
+# Don't try to load nvm if command already available
+which nvm &> /dev/null && return
 
-  if [[ -n $nvm_install_dir ]]; then
-    source $nvm_install_dir/nvm.sh
-  else
-    # No NVM installation found
-    return 0
-  fi
+if [[ -f "$NVM_DIR/nvm.sh" ]]; then
+  # Load nvm if it exists in $NVM_DIR
+  source "$NVM_DIR/nvm.sh"
+else
+  # Otherwise try to load nvm installed via Homebrew
+  # User can set this if they have an unusual Homebrew setup
+  NVM_HOMEBREW="${NVM_HOMEBREW:-/usr/local/opt/nvm}"
+  # Load nvm from Homebrew location if it exists
+  [[ -f "$NVM_HOMEBREW/nvm.sh" ]] && source "$NVM_HOMEBREW/nvm.sh"
+fi
 
-  # Locate and use the completion file shipped with NVM, instead of this
-  # plugin's completion
-  # (Their bash completion file has zsh portability support)
-  if [[ $ZSH_NVM_BUNDLED_COMPLETION == true ]]; then
-    local bash_comp_file
-    # Homebrew relocates the bash completion file, so look multiple places
-    for bash_comp_file ( bash_completion etc/bash_completion.d/nvm ); do
-      if [[ -s $nvm_install_dir/$bash_comp_file ]]; then
-        source $nvm_install_dir/$bash_comp_file
-        break;
-      fi
-    done
+# Load nvm bash completion
+for nvm_completion in "$NVM_DIR/bash_completion" "$NVM_HOMEBREW/etc/bash_completion.d/nvm"; do
+  if [[ -f "$nvm_completion" ]]; then
+    # Load bashcompinit
+    autoload -U +X bashcompinit && bashcompinit
+    # Bypass compinit call in nvm bash completion script. See:
+    # https://github.com/nvm-sh/nvm/blob/4436638/bash_completion#L86-L93
+    ZSH_VERSION= source "$nvm_completion"
+    break
   fi
-}
+done
+
+unset NVM_HOMEBREW nvm_completion

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -1,23 +1,45 @@
-# Set NVM_DIR if it isn't already defined
-[[ -z "$NVM_DIR" ]] && export NVM_DIR="$HOME/.nvm"
+# nvm
+#
+# This plugin locates and loads nvm, looking for it in well-known locations.
 
-# Don't try to load nvm if command already available
-type "nvm" &> /dev/null && return
+() {
+  emulate -L zsh
+  local nvm_install_dir="" dir install_locations
+  if [[ -n $NVM_INSTALL_DIR ]]; then
+    # User-specified path
+    nvm_install_dir=$NVM_INSTALL_DIR
+  else
+    # Well-known common installation locations for NVM
+    install_locations=( ~/.nvm )
+    [[ -n $NVM_DIR ]] && install_locations=($NVM_DIR $install_locations)
+    # Mac Homebrew sticks 
+    which brew &>/dev/null && install_locations+=$(brew --prefix nvm)
+    for dir ($install_locations); do
+      if [[ -s $dir/nvm.sh ]]; then
+        nvm_install_dir=$dir
+        break
+      fi
+    done
+  fi
 
-# Load nvm if it exists in $NVM_DIR
-if [[ -f "$NVM_DIR/nvm.sh" ]]; then
-    source "$NVM_DIR/nvm.sh"
-    return
-fi
+  if [[ -n $nvm_install_dir ]]; then
+    source $nvm_install_dir/nvm.sh
+  else
+    # No NVM installation found
+    return 0
+  fi
 
-# Otherwise try to load nvm installed via Homebrew
-
-# User can set this if they have an unusual Homebrew setup
-NVM_HOMEBREW="${NVM_HOMEBREW:-/usr/local/opt/nvm}"
-# Load nvm from Homebrew location if it exists
-[[ -f "$NVM_HOMEBREW/nvm.sh" ]] && source "$NVM_HOMEBREW/nvm.sh"
-# Load nvm bash completion from Homebrew if it exists
-if [[ -f "$NVM_HOMEBREW/etc/bash_completion.d/nvm" ]]; then
-    autoload -U +X bashcompinit && bashcompinit
-    source "$NVM_HOMEBREW/etc/bash_completion.d/nvm"
-fi
+  # Locate and use the completion file shipped with NVM, instead of this
+  # plugin's completion
+  # (Their bash completion file has zsh portability support)
+  if [[ $ZSH_NVM_BUNDLED_COMPLETION == true ]]; then
+    local bash_comp_file
+    # Homebrew relocates the bash completion file, so look multiple places
+    for bash_comp_file ( bash_completion etc/bash_completion.d/nvm ); do
+      if [[ -s $nvm_install_dir/$bash_comp_file ]]; then
+        source $nvm_install_dir/$bash_comp_file
+        break;
+      fi
+    done
+  fi
+}

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -18,7 +18,12 @@ else
   # User can set this if they have an unusual Homebrew setup
   NVM_HOMEBREW="${NVM_HOMEBREW:-/usr/local/opt/nvm}"
   # Load nvm from Homebrew location if it exists
-  [[ -f "$NVM_HOMEBREW/nvm.sh" ]] && source "$NVM_HOMEBREW/nvm.sh" ${NVM_LAZY+"--no-use"}
+  if [[ -f "$NVM_HOMEBREW/nvm.sh" ]]; then
+    source "$NVM_HOMEBREW/nvm.sh" ${NVM_LAZY+"--no-use"}
+  else
+    # Exit the plugin if we couldn't find nvm
+    return
+  fi
 fi
 
 # Call nvm when first using node, npm or yarn
@@ -42,4 +47,4 @@ for nvm_completion in "$NVM_DIR/bash_completion" "$NVM_HOMEBREW/etc/bash_complet
   fi
 done
 
-unset NVM_HOMEBREW nvm_completion
+unset NVM_HOMEBREW NVM_LAZY nvm_completion


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- nvm: use `nvm current` in nvm_prompt_info and look in alternate install locations

  This makes it work regardless of where nvm is loaded from. And it uses nvm's version strings, which distinguish the "system" and "none" NVM environments, instead of reporting the specific version of the system node.js or erroring, respectively.

  Fixes #4336
  Closes #4338

- nvm: simplify nvm.sh and bash completion loading

- nvm: check $XDG_CONFIG_HOME/nvm for an nvm installation

  Closes #7807

- nvm: speed-up nvm loading with `--no-use`
  Closes #7138

- nvm: only lazy-load nvm if the NVM_LAZY setting is set

- nvm: exit the plugin if the nvm loading script wasn't found

- nvm: add autoloading of nvm version in .nvmrc

  Closes #5782
  Fixes #8959
  Closes #8976
