### PR TITLE
Dirhistory plugin: add the cde command

### DIFF
--- a/plugins/dirhistory/README.md
+++ b/plugins/dirhistory/README.md
@@ -19,8 +19,7 @@ plugins=(... dirhistory)
 
 ## Usage
 
-This plugin allows you to navigate the history of previous current-working-directories using ALT-LEFT and ALT-RIGHT. ALT-LEFT moves back to directories that the user has changed to in the past, and ALT-RIGHT undoes ALT-LEFT. MAC users may alternately use OPT-LEFT and OPT-RIGHT.
-
+This plugin allows you to navigate the history of previous current-working-directories using ALT-LEFT and ALT-RIGHT. ALT-LEFT moves back to directories that the user has changed to in the past, and ALT-RIGHT undoes ALT-LEFT. MAC users may alternately use OPT-LEFT and OPT-RIGHT. 
 Also, navigate directory **hierarchy** using ALT-UP and ALT-DOWN. (mac keybindings not yet implemented). ALT-UP moves to higher hierarchy (shortcut for 'cd ..'). ALT-DOWN moves into the first directory found in alphabetical order (useful to navigate long empty directories e.g. java packages)
 
 For example, if the shell was started, and the following commands were entered:
@@ -35,5 +34,8 @@ cd doc
 Then entering ALT-LEFT at the prompt would change directory from /usr/share/doc to /usr/share, then if pressed again to /usr/, then ~. If ALT-RIGHT were pressed the directory would be changed to /usr/ again.
 
 After that, ALT-DOWN will probably go to /usr/bin (depends on your /usr structure), ALT-UP will return to /usr, then ALT-UP will get you to /
+
+The command 'cde &lt;DIR&gt;' is also provided which copies all future directories to the history and then changes to the directory, in order to preserve all history. For example, if the past directories (accessible using ALT-LEFT) were the list (/usr /usr/share) and the future directories (accessible using ALT-RIGHT) were (/usr/share/doc), then if the user were to do 'cd /tmp' then the directory /usr/share/doc would be lost from the navigation history. Instead if the user entered 'cde /tmp' then the past histories would be set to  (/usr /usr/share /usr/share/doc) as if the user had navigated as far forward as possible and then used 'cd /tmp'.
+
 
 **Currently the max history size is 30**. The navigation should work for xterm, PuTTY xterm mode, GNU screen, and on MAC with alternate keys as mentioned above.

--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -70,6 +70,15 @@ function dirhistory_cd(){
   unset DIRHISTORY_CD
 }
 
+function cde(){
+  # Reverse future
+  local reversed_future=(${(Oa)dirhistory_future})
+  push_past $PWD
+  dirhistory_past=(${dirhistory_past} $reversed_future)
+  dirhistory_future=()
+  cd $1
+}
+
 # Move backward in directory history
 function dirhistory_back() {
   local cw=""


### PR DESCRIPTION
The cde command is used to preserve future/forward directories when
changing to an arbitrary directory, instead of losing the future directories like when using 'cd DIR'.

For example say the user has navigated the directory history such that the past directories are (/tmp /tmp/a) and the future directories are (/usr /usr/bin). At this point if the user did 'cd /bin', then the past directories would become (/tmp /tmp/a /bin). That is, the future directories (/usr /usr/bin) are lost.

Instead if we were in the original state and 'cde /bin' was used then the past directories would become (/tmp /tmp/a /usr /usr/bin /bin); it is as if the user went forward in history as far as possible and then did 'cd /bin' so that the "future" directories are preserved. 

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds the cde command to the dirhistory plugin as described above.

## Other comments:

None

