### PR TITLE
ask with lowercase y in update dialogue

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -75,7 +75,7 @@ function update_ohmyzsh() {
         while read -t -k 1 option; do true; done
         [[ "$option" != ($'\n'|"") ]] && echo
 
-        echo -n "[oh-my-zsh] Would you like to update? [Y/n] "
+        echo -n "[oh-my-zsh] Would you like to update? [y/n] "
         read -r -k 1 option
         [[ "$option" != $'\n' ]] && echo
         case "$option" in


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- changed `oh-my-zsh` update dialogue to two lowercase options

## Other comments:

It makes more sense having both yes *and* no represented in lower case, especially because `y` can be used in response to the dialogue:
```
[oh-my-zsh] Would you like to update? [Y/n] y
```