### PR TITLE
globalias: allow filtering values not to be expanded

### DIFF
--- a/plugins/globalias/README.md
+++ b/plugins/globalias/README.md
@@ -17,7 +17,8 @@ Then just press `SPACE` to trigger the expansion of a command you've written.
 If you only want to insert a space without expanding the command line, press
 `CTRL`+`SPACE`.
 
-if you would like to filter out any values from expanding set GLOBALIAS_FILTER_VALUES to an array of said values
+if you would like to filter out any values from expanding set `GLOBALIAS_FILTER_VALUES` to
+an array of said values. See [Filtered values](#filtered-values).
 
 ## Examples
 
@@ -39,7 +40,6 @@ $ ls folder/file.json anotherfolder/another.json
 $ mkdir "`date -R`"
 # expands to
 $ mkdir Tue,\ 04\ Oct\ 2016\ 13:54:03\ +0300
-
 ```
 
 #### Aliases
@@ -69,10 +69,11 @@ $ sudo systemctl
 # .zshrc
 alias l='ls -lh'
 alias la='ls --color=auto -lah'
-export GLOBALIAS_FILTER_VALUES=(l)
+GLOBALIAS_FILTER_VALUES=(l)
 
 $ l<space>
 # does not expand
 $ la<space>
 # expands to:
 $ ls --color=auto -lah
+```

--- a/plugins/globalias/README.md
+++ b/plugins/globalias/README.md
@@ -17,6 +17,8 @@ Then just press `SPACE` to trigger the expansion of a command you've written.
 If you only want to insert a space without expanding the command line, press
 `CTRL`+`SPACE`.
 
+if you would like to filter out any values from expanding set GLOBALIAS_FILTER_VALUES to an array of said values
+
 ## Examples
 
 #### Glob expressions
@@ -60,3 +62,17 @@ $ S<space>
 # expands to:
 $ sudo systemctl
 ```
+
+#### Filtered values
+
+```
+# .zshrc
+alias l='ls -lh'
+alias la='ls --color=auto -lah'
+export GLOBALIAS_FILTER_VALUES=(l)
+
+$ l<space>
+# does not expand
+$ la<space>
+# expands to:
+$ ls --color=auto -lah

--- a/plugins/globalias/globalias.plugin.zsh
+++ b/plugins/globalias/globalias.plugin.zsh
@@ -1,6 +1,8 @@
 globalias() {
-   zle _expand_alias
-   zle expand-word
+   if [[ $GLOBALIAS_FILTER_VALUES[(Ie)$LBUFFER] -eq 0 ]]; then
+      zle _expand_alias
+      zle expand-word
+   fi
    zle self-insert
 }
 zle -N globalias


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added a really simple array based check to globalias to filter out values that should not be expanded 

## Other comments:

- Inspired by multiple unwanted alias expands and closed issue #7550 
