### PR TITLE
git-prompt: document Python prerequisite in README

### DIFF
--- a/plugins/git-prompt/README.md
+++ b/plugins/git-prompt/README.md
@@ -11,6 +11,9 @@ plugins=(... git-prompt)
 
 See the [original repository](https://github.com/olivierverdier/zsh-git-prompt).
 
+## Prerequisites
+This plugin uses `python`, so your host needs to have it installed
+
 ## Examples
 
 The prompt may look like the following:


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Updated the README file to add `python` as a prerequisite

## Other comments:
I've installed a new OS (PopOS), based on Ubuntu 20.04, and the `gti-prompt` plugin was not working and no error was shown. After digging, I've found that `python` is a requirement for this plugin and it is not statted anywhere (not even on oh my zsh docs) so I though in saving someone else time, by statting more clearlly this prerequisites
