### PR TITLE
globalias: expand filtering to anywhere in the command

### DIFF
--- a/plugins/globalias/globalias.plugin.zsh
+++ b/plugins/globalias/globalias.plugin.zsh
@@ -1,5 +1,7 @@
 globalias() {
-   if [[ $GLOBALIAS_FILTER_VALUES[(Ie)${${(A)=LBUFFER}[-1]}] -eq 0 ]]; then
+   # Get last word to the left of the cursor
+   local word=${${(A)=LBUFFER}[-1]}
+   if [[ $GLOBALIAS_FILTER_VALUES[(Ie)$word] -eq 0 ]]; then
       zle _expand_alias
       zle expand-word
    fi

--- a/plugins/globalias/globalias.plugin.zsh
+++ b/plugins/globalias/globalias.plugin.zsh
@@ -1,5 +1,5 @@
 globalias() {
-   if [[ $GLOBALIAS_FILTER_VALUES[(Ie)$LBUFFER] -eq 0 ]]; then
+   if [[ $GLOBALIAS_FILTER_VALUES[(Ie)${${(A)=LBUFFER}[-1]}] -eq 0 ]]; then
       zle _expand_alias
       zle expand-word
    fi


### PR DESCRIPTION
I loved the new feature in #9331 but it had a small problem for me - it only worked when the entirety of LBUFFER matched, meaning that it only prevented expansion when the alias was the first word on the line. This uses parameter expansion to perform a word split on LBUFFER and then match on the last entry in the array, so it will filter expansion regardless of where the alias occurs in the line.

Currently, given:
```
alias grep='grep --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn,.idea,.tox}'
GLOBALIAS_FILTER_VALUES=(grep)
```

An initial grep won't be expanded (because LBUFFER="grep" and that matches an item in GLOBALIAS_FILTER_VALUES):
```
> grep forthis file.txt
```

But a piped grep would (because LBUFFER='curl mywebsite.com | grep' which doesn't match):
```
> curl mywebsite.com | \grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn --exclude-dir=.idea --exclude-dir=.tox forthis
```

With this change, `$LBUFFER` is replaced by `${${(A)=LBUFFER}[-1]}`, which does the following:

- =LBUFFER performs a word split on LBUFFER using the rules for SH_WORD_SPLIT
- (A) converts the substitution into an array expression, even if it would otherwise be scalar (this is necessary so that subscripting works even when there's only one word; without it you'd only get the last character if LBUFFER was a single word)
- [-1] returns the last item in the array, which is the string right before the cursor.

And thus GLOBALIAS_FILTER_VALUES now works anywhere in the command.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Updated the array check in globalias to work anywhere in the command line instead of just for the first word.

## Other comments:

Thanks for adding this, @VectorWpl - I was looking for something like it.