### PR TITLE
Add Fedora/RHEL/CentOS to Installation Problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ If you have any hiccups installing, here are a few common fixes.
 switching to `oh-my-zsh`.
 - If you installed manually or changed the install location, check the `ZSH` environment variable in
 `~/.zshrc`.
+- On Fedora/RHEL/CentOS systems, `chsh` is provided by the `util-linux-user` package.
 
 ### Custom Plugins and Themes
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.

## Changes:

For the last few releases of Fedora Workstation and for other RHEL-like environments, the `chsh` command is not available by default.  Guidance should be provided on installing `util-linux-user`.  I think it makes sense to merge basic instructions into the README Installation Problems section, perhaps even adding a prompt in the `install.sh` if it can detect that yum/dnf exists.