### PR TITLE
kubectl: verify kubectl is installed before running compdef

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -150,22 +150,12 @@ alias kepvc='kubectl edit pvc'
 alias kdpvc='kubectl describe pvc'
 alias kdelpvc='kubectl delete pvc'
 
-# Colored JSON output
-kj() {
-  kubectl "$@" -o json | jq
-}
+# Only run if the user actually has kubectl installed
+if (( $+commands[kubectl] )); then
+  kj() { kubectl "$@" -o json | jq; }
+  kjx() { kubectl "$@" -o json | fx; }
+  ky() { kubectl "$@" -o yaml | yh; }
 
-kjx() {
-  kubectl "$@" -o json | fx
-}
-
-# Colored YAML output
-ky() {
-  kubectl "$@" -o yaml | yh
-}
-
-# only run if the user actually has kubectl installed
-if type kubectl > /dev/null; then
   compdef kj=kubectl
   compdef kjx=kubectl
   compdef ky=kubectl

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -154,15 +154,19 @@ alias kdelpvc='kubectl delete pvc'
 kj() {
   kubectl "$@" -o json | jq
 }
-compdef kj=kubectl
 
 kjx() {
   kubectl "$@" -o json | fx
 }
-compdef kjx=kubectl
 
 # Colored YAML output
 ky() {
   kubectl "$@" -o yaml | yh
 }
-compdef ky=kubectl
+
+# only run if the user actually has kubectl installed
+if type kubectl > /dev/null; then
+  compdef kj=kubectl
+  compdef kjx=kubectl
+  compdef ky=kubectl
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
This change fixes #9345.