### PR TITLE
Use GRADLE_USER_HOME for completion cache if set

### DIFF
--- a/plugins/gradle/_gradle
+++ b/plugins/gradle/_gradle
@@ -36,7 +36,7 @@ __gradle-set-project-root-dir() {
 }
 
 __gradle-init-cache-dir() {
-    cache_dir="$HOME/.gradle/completion"
+    cache_dir="${GRADLE_USER_HOME:-${HOME}/.gradle}/completion"
     mkdir -p $cache_dir
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Use the `$GRADLE_USER_HOME` environment variable if set, otherwise use `$HOME/.gradle`
