### PR TITLE
Grammar: remove hyphens from predicate adjective “up to date”

### DIFF
--- a/plugins/cargo/_cargo
+++ b/plugins/cargo/_cargo
@@ -12,8 +12,8 @@ _cargo() {
         '(-q --quiet)*'{-v,--verbose}'[use verbose output]'
         '(-q --quiet -v --verbose)'{-q,--quiet}'[no output printed to stdout]'
         '-Z+[pass unstable (nightly-only) flags to cargo]: :_cargo_unstable_flags'
-        '--frozen[require that Cargo.lock and cache are up-to-date]'
-        '--locked[require that Cargo.lock is up-to-date]'
+        '--frozen[require that Cargo.lock and cache are up to date]'
+        '--locked[require that Cargo.lock is up to date]'
         '--color=[specify colorization option]:coloring:(auto always never)'
         '(- 1 *)'{-h,--help}'[show help message]'
     )

--- a/plugins/golang/golang.plugin.zsh
+++ b/plugins/golang/golang.plugin.zsh
@@ -41,7 +41,7 @@ __go_tool_complete() {
     return
   fi
   build_flags=(
-    '-a[force reinstallation of packages that are already up-to-date]'
+    '-a[force reinstallation of packages that are already up to date]'
     '-n[print the commands but do not run them]'
     '-p[number of parallel builds]:number'
     '-race[enable data race detection]'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
- replace instances of “up‑to‑date” with “up to date” when it’s a predicate adjective that follows what it describes[¹](https://english.stackexchange.com/a/180617)&#8239;[²](https://web.archive.org/web/20190728053012id_/grammarist.com/usage/up-to-date/#text-60)
- retain “up‑to‑date”, with hyphens, otherwise, such as at https://github.com/ohmyzsh/ohmyzsh/blob/5b717ab3e4bfb627a936d7c04367a39867734d63/plugins/golang/golang.plugin.zsh#L135