### PR TITLE
fix(battery): use `pmset` for battery percentage in macOS

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -18,10 +18,7 @@ if [[ "$OSTYPE" = darwin* ]]; then
   }
 
   function battery_pct() {
-    local battery_status="$(ioreg -rc AppleSmartBattery)"
-    local -i capacity=$(sed -n -e '/MaxCapacity/s/^.*"MaxCapacity"\ =\ //p' <<< $battery_status)
-    local -i current=$(sed -n -e '/CurrentCapacity/s/^.*"CurrentCapacity"\ =\ //p' <<< $battery_status)
-    echo $(( current * 100 / capacity ))
+    pmset -g batt | grep -Eo "\d+%" | cut -d% -f1
   }
 
   function battery_pct_remaining() {


### PR DESCRIPTION
returns the battery charge consistent with the system battery manager

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
