### PR TITLE
gitfast: improve command aliases

### DIFF
--- a/plugins/gitfast/_git
+++ b/plugins/gitfast/_git
@@ -275,6 +275,8 @@ _git ()
 		emulate ksh -c __${service}_main
 	elif (( $+functions[_${service}] )); then
 		emulate ksh -c _${service}
+	elif ((	$+functions[_${service//-/_}] )); then
+		emulate ksh -c _${service//-/_}
 	fi
 
 	let _ret && _default && _ret=0


### PR DESCRIPTION
So that compdefs with dashes work as well as underscores:

`  compdef _git gc=git_commit`

Or:

`  compdef _git gc=git-commit`

The official Zsh Git completion uses dashes, and this way people don't
have to change their existing definitions.

There's also the benefit that the compdefs in the standard 'git' plugin work out-of-the-box.

Fixes #9018 (possibly).

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

...
