### PR TITLE
Add kubectl kcvm alias

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -31,6 +31,9 @@ alias kccc='kubectl config current-context'
 # List all contexts
 alias kcgc='kubectl config get-contexts'
 
+# View current config
+alias kcvm='kubectl config view --minify'
+
 # General aliases
 alias kdel='kubectl delete'
 alias kdelf='kubectl delete -f'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add an alias `kcvm` for `kubectl config view --minify`

## Other comments:

This commands is very useful for finding out what user/cluster the current
context resolves to. It also makes it easy to lookup the api server hostname.
