### PR TITLE
aws: get and set session token if available

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -61,7 +61,7 @@ function asp() {
     else
       aws_access_key_id="$(aws configure get aws_access_key_id --profile $1)"
       aws_secret_access_key="$(aws configure get aws_secret_access_key --profile $1)"
-      aws_session_token=""
+      aws_session_token="$(aws configure get aws_session_token --profile $1)"
     fi
 
     export AWS_DEFAULT_PROFILE=$1


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Get and set session token if available and already configured when `role_arn` is not set.

## Other comments:

Changes from https://github.com/ohmyzsh/ohmyzsh/pull/8419/ stopped setting the value for `AWS_SESSION_TOKEN` for me. Traced it back to this line of change.