### PR TITLE
colorize: add compatibility for zsh < 5.1

### DIFF
--- a/plugins/colorize/colorize.plugin.zsh
+++ b/plugins/colorize/colorize.plugin.zsh
@@ -6,7 +6,8 @@ alias cless="colorize_less"
 ZSH_COLORIZE_PLUGIN_PATH=$0:A
 
 colorize_check_requirements() {
-    local available_tools=("chroma" "pygmentize")
+    local -a available_tools
+    available_tools=("chroma" "pygmentize")
 
     if [ -z "$ZSH_COLORIZE_TOOL" ]; then
         if (( $+commands[pygmentize] )); then


### PR DESCRIPTION
The direct assignment of a local array is not possible in older ZSH version, as used by RHEL/CentOS 7.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- minor change in assignment of local array

## Other comments:

Fixes #9389 
