### PR TITLE
AWS plugin: Fix default session duration when assuming an IAM role

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -34,7 +34,7 @@ function asp() {
         echo "Please enter the session duration in seconds (900-43200; default: 3600, which is the default maximum for a role):"
         read sess_duration
         if [[ -z $sess_duration ]]; then
-          sess_duration = 3600
+          sess_duration="3600"
         fi
         mfa_opt="--serial-number $mfa_serial --token-code $mfa_token --duration-seconds $sess_duration"
       fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- default session duration for the assumed IAM role is now correctly assigned

## Other comments:
This PR fixes the otherwise untracked bug raised in one of the comments in #9394 here: https://github.com/ohmyzsh/ohmyzsh/issues/9394#issuecomment-718183787
...
