### PR TITLE
AWS plugin: split out changing profile from asp into a separate function (acp)

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -15,6 +15,13 @@ plugins=(... aws)
   It also sets `$AWS_EB_PROFILE` to `<profile>` for the Elastic Beanstalk CLI.
   Run `asp` without arguments to clear the profile.
 
+* `acp [<profile>]`: in addition to `asp` functionality, it actually changes the profile by
+   assuming the role specified in the `<profile>` configuration. It supports MFA and sets
+   `$AWS_ACCESS_KEY_ID`, `$AWS_SECRET_ACCESS_KEY` and `$AWS_SESSION_TOKEN`, if obtained. It
+   requires the roles to be configured as per the
+   [official guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html).
+   Run `acp` without arguments to clear the profile.
+
 * `agp`: gets the current value of `$AWS_PROFILE`.
 
 * `aws_change_access_key`: changes the AWS access key of a profile.


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fixes #9394 by splitting the `asp` function into two: `asp` behaving like the original one, and `acp`, which actually changes the profile by assuming the associated role.

## Other comments:
Addresses #9394 
