### PR TITLE
archlinux: add aliases for paru

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -131,6 +131,25 @@ plugins=(... archlinux)
 | pacls        | pacman -Ql                              | List files in a package                                      |
 | pacown       | pacman -Qo                              | Show which package owns a file                               |
 
+#### PARU
+
+| Alias   | Command                            | Description                                                         |
+|---------|------------------------------------|---------------------------------------------------------------------|
+| pain    | paru -S                            | Install packages from the repositories                              |
+| pains   | paru -U                            | Install a package from a local file                                 |
+| painsd  | paru -S --asdeps                   | Install packages as dependencies of another package                 |
+| paloc   | paru -Qi                           | Display information about a package in the local database           |
+| palocs  | paru -Qs                           | Search for packages in the local database                           |
+| palst   | paru -Qe                           | List installed packages including from AUR (tagged as "local")      |
+| pamir   | paru -Syy                          | Force refresh of all package lists after updating mirrorlist        |
+| paorph  | paru -Qtd                          | Remove orphans using paru                                           |
+| pare    | paru -R                            | Remove packages, keeping its settings and dependencies              |
+| parem   | paru -Rns                          | Remove packages, including its settings and unneeded dependencies   |
+| parep   | paru -Si                           | Display information about a package in the repositories             |
+| pareps  | paru -Ss                           | Search for packages in the repositories                             |
+| paupg   | paru -Syu                          | Sync with repositories before upgrading packages                    |
+| pasu    | paru -Syu --no-confirm             | Same as `paupg`, but without confirmation                           |
+
 | Function       | Description                                          |
 |----------------|------------------------------------------------------|
 | pacdisowned    | List all disowned files in your system               |
@@ -152,3 +171,4 @@ plugins=(... archlinux)
 - Juraj Fiala - doctorjellyface@riseup.net
 - Majora320 (Moses Miller) - Majora320@gmail.com
 - Ybalrid (Arthur Brainville) - ybalrid@ybalrid.info
+- kattjevfel (Magnus Boman) - magunasu.b97@gmail.com

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -112,6 +112,35 @@ if (( $+commands[pacaur] )); then
   fi
 fi
 
+if (( $+commands[paru] )); then
+  alias paconf='paru -Pg'
+  alias paupg='paru -Syu'
+  alias pasu='paru -Syu --noconfirm'
+  alias pain='paru -S'
+  alias pains='paru -U'
+  alias pare='paru -R'
+  alias parem='paru -Rns'
+  alias parep='paru -Si'
+  alias pareps='paru -Ss'
+  alias paloc='paru -Qi'
+  alias palocs='paru -Qs'
+  alias palst='paru -Qe'
+  alias paorph='paru -Qtd'
+  alias painsd='paru -S --asdeps'
+  alias pamir='paru -Syy'
+
+
+  if (( $+commands[abs] && $+commands[aur] )); then
+    alias paupd='paru -Sy && sudo abs && sudo aur'
+  elif (( $+commands[abs] )); then
+    alias paupd='paru -Sy && sudo abs'
+  elif (( $+commands[aur] )); then
+    alias paupd='paru -Sy && sudo aur'
+  else
+    alias paupd='paru -Sy'
+  fi
+fi
+
 if (( $+commands[trizen] )); then
   function upgrade() {
     trizen -Syu
@@ -127,6 +156,10 @@ elif (( $+commands[yaourt] )); then
 elif (( $+commands[yay] )); then
   function upgrade() {
     yay -Syu
+  }
+elif (( $+commands[paru] )); then
+  function upgrade() {
+    paru -Syu
   }
 else
   function upgrade() {


### PR DESCRIPTION
##  Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds alises for [paru](https://github.com/Morganamilo/paru)

## Other comments:

99% copied from yay since it's based on it