### PR TITLE
add alias for git diff upstream

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -62,6 +62,7 @@ plugins=(... git)
 | gdct                 | git describe --tags $(git rev-list --tags --max-count=1)                                                                         |
 | gds                  | git diff --staged                                                                                                                |
 | gdt                  | git diff-tree --no-commit-id --name-only -r                                                                                      |
+| gdu                  | git diff @{u} -- $(git diff --name-only $(git_main_branch))
 | gdnolock             | git diff $@ ":(exclude)package-lock.json" ":(exclude)&ast;.lock"                                                                 |
 | gdv                  | git diff -w $@ \| view -                                                                                                         |
 | gdw                  | git diff --word-diff                                                                                                             |

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -62,7 +62,7 @@ plugins=(... git)
 | gdct                 | git describe --tags $(git rev-list --tags --max-count=1)                                                                         |
 | gds                  | git diff --staged                                                                                                                |
 | gdt                  | git diff-tree --no-commit-id --name-only -r                                                                                      |
-| gdu                  | git diff @{u} -- $(git diff --name-only $(git_main_branch))
+| gdu                  | git diff @{u} -- $(git diff --name-only $(git_main_branch)) $(git diff --name-only $(git merge-base @{u} $(git_main_branch)) @{u})
 | gdnolock             | git diff $@ ":(exclude)package-lock.json" ":(exclude)&ast;.lock"                                                                 |
 | gdv                  | git diff -w $@ \| view -                                                                                                         |
 | gdw                  | git diff --word-diff                                                                                                             |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -101,7 +101,7 @@ alias gdcw='git diff --cached --word-diff'
 alias gdct='git describe --tags $(git rev-list --tags --max-count=1)'
 alias gds='git diff --staged'
 alias gdt='git diff-tree --no-commit-id --name-only -r'
-alias gdu='git diff @{u} -- $(git diff --name-only $(git_main_branch))'
+alias gdu='git diff @{u} -- $(git diff --name-only $(git_main_branch)) $(git diff --name-only $(git merge-base @{u} $(git_main_branch)) @{u})'
 alias gdw='git diff --word-diff'
 
 function gdnolock() {

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -101,6 +101,7 @@ alias gdcw='git diff --cached --word-diff'
 alias gdct='git describe --tags $(git rev-list --tags --max-count=1)'
 alias gds='git diff --staged'
 alias gdt='git diff-tree --no-commit-id --name-only -r'
+alias gdu='git diff @{u} -- $(git diff --name-only $(git_main_branch))'
 alias gdw='git diff --word-diff'
 
 function gdnolock() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

In this PR I contribute an alias `gdu` which produces the diff between the current branch and its upstream tracking branch.  

What's special about this is that it restricts the diff to only those files which where either (1) changed in upstream branch or (2) changed in local branch relative to their merge bases.

This is particularly helpful after a rebase if you want to verify that you didn't make any mistakes in your rebase.  

After a rebase, you might have a lot of files in your local branch that are not on the remote branch but which are totally unrelated to your branch.

This command ignores any files changed in main branch which were not modified in either the upstream branch or the local branch, allowing you to compare your branch with the remote without any irrelevant noise from main branch.

## Other comments:

I am open to suggestions re alias name.  I imagine some might think that `gdu` should simply be `git diff @{u}`, and so maybe this should be `gduu` or something.... but my vote would be simply `gdu` because it seems more useful to me.
