### PR TITLE
git: Enable customization of main branch name (non-breaking)

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -208,14 +208,14 @@ These are aliases that have been removed, renamed, or otherwise modified in a wa
 
 ### Current
 
-| Command                | Description                                                                                     |
-|:-----------------------|:------------------------------------------------------------------------------------------------|
-| `grename <old> <new>`  | Rename `old` branch to `new`, including in origin remote                                        |
-| current_branch         | Return the name of the current branch                                                           |
-| git_current_user_name  | Returns the `user.name` config value                                                            |
-| git_current_user_email | Returns the `user.email` config value                                                           |
+| Command                | Description                                                                                  |
+|:-----------------------|:---------------------------------------------------------------------------------------------|
+| `grename <old> <new>`  | Rename `old` branch to `new`, including in origin remote                                     |
+| current_branch         | Return the name of the current branch                                                        |
+| git_current_user_name  | Returns the `user.name` config value                                                         |
+| git_current_user_email | Returns the `user.email` config value                                                        |
 | git_main_branch        | Returns the name of the main branch: the value of `git config omz.git.mainBranch` if that key has been set, or `main` if a `main` branch exists, or `master` otherwise |
-| set_main_branch        | Sets the name of the main branch in your local repository using `git config omz.git.mainBranch` |
+| set_main_branch        | Sets the name of the main branch in a local repository using `git config omz.git.mainBranch` |
 
 ### Work in Progress (WIP)
 

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -208,13 +208,14 @@ These are aliases that have been removed, renamed, or otherwise modified in a wa
 
 ### Current
 
-| Command                | Description                                                                  |
-|:-----------------------|:-----------------------------------------------------------------------------|
-| `grename <old> <new>`  | Rename `old` branch to `new`, including in origin remote                     |
-| current_branch         | Return the name of the current branch                                        |
-| git_current_user_name  | Returns the `user.name` config value                                         |
-| git_current_user_email | Returns the `user.email` config value                                        |
-| git_main_branch        | Returns the name of the main branch: `main` if it exists, `master` otherwise |
+| Command                | Description                                                                                     |
+|:-----------------------|:------------------------------------------------------------------------------------------------|
+| `grename <old> <new>`  | Rename `old` branch to `new`, including in origin remote                                        |
+| current_branch         | Return the name of the current branch                                                           |
+| git_current_user_name  | Returns the `user.name` config value                                                            |
+| git_current_user_email | Returns the `user.email` config value                                                           |
+| git_main_branch        | Returns the name of the main branch: the value of `git config omz.git.mainBranch` if that key has been set, or `main` if a `main` branch exists, or `master` otherwise |
+| set_main_branch        | Sets the name of the main branch in your local repository using `git config omz.git.mainBranch` |
 
 ### Work in Progress (WIP)
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -29,13 +29,22 @@ function work_in_progress() {
   fi
 }
 
-# Check if main exists and use instead of master
+# Check if user specified main branch in config, then check if "main" exists,
+# then default to "master"
 function git_main_branch() {
-  if [[ -n "$(git branch --list main)" ]]; then
+  main_branch=`git config omz.git.mainBranch`
+  if [[ -n "$main_branch" ]]; then
+    echo "$main_branch"
+  elif [[ -n "$(git branch --list main)" ]]; then
     echo main
   else
     echo master
   fi
+}
+
+# Set the name of the main branch in this local repository
+function set_main_branch() {
+  git config --local omz.git.mainBranch "$1"
 }
 
 #

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -42,7 +42,7 @@ function git_main_branch() {
   fi
 }
 
-# Set the name of the main branch in this local repository
+# Set the name of the main branch in a local repository
 function set_main_branch() {
   git config --local omz.git.mainBranch "$1"
 }

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -32,7 +32,7 @@ function work_in_progress() {
 # Check if user specified main branch in config, then check if "main" exists,
 # then default to "master"
 function git_main_branch() {
-  main_branch=`git config omz.git.mainBranch`
+  local main_branch=$(git config omz.git.mainBranch)
   if [[ -n "$main_branch" ]]; then
     echo "$main_branch"
   elif [[ -n "$(git branch --list main)" ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Hello! Following up on #9049 and #9091, I had an idea for a non-breaking way to let users specify the name of their main branch in a given repo: using a custom `git config` field called `omz.git.mainBranch` (which I don't think anyone would already be using for any other purpose).

I adjusted `git_main_branch` to check this field first before falling back to its previous functionality, and I added a new function `set_main_branch` as a shortcut for `git config --local omz.git.mainBranch`. And I adjusted the plugin's readme to reflect these changes.

Is this a good solution? Should `set_main_branch` be an alias instead of a function? Should it have a nicer, more abbreviated name? I figured it'd be a command people wouldn't be typing too often, since you can pretty much set it and forget it for any individual repo that doesn't already use `main` or `master`.

### Updated `git_main_branch`:

```zsh
# Check if user specified main branch in config, then check if "main" exists,
# then default to "master"
function git_main_branch() {
  local main_branch=$(git config omz.git.mainBranch)
  if [[ -n "$main_branch" ]]; then
    echo "$main_branch"
  elif [[ -n "$(git branch --list main)" ]]; then
    echo main
  else
    echo master
  fi
}
```

### New `set_main_branch`:

```zsh
# Set the name of the main branch in a local repository
function set_main_branch() {
  git config --local omz.git.mainBranch "$1"
}
```