### PR TITLE
Support using mvnw in multi-module projects

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -1,8 +1,12 @@
 # Calls ./mvnw if found, otherwise execute the original mvn
 mvn-or-mvnw() {
-	if [ -x ./mvnw ]; then
+	if [ -x ./mvnw ] || [ -x ../mvnw ]; then
 		echo "executing mvnw instead of mvn"
-		./mvnw "$@"
+		if [ -x ./mvnw ]; then
+			./mvnw "$@"
+		else
+		  ../mvnw "$@"
+		fi
 	else
 		command mvn "$@"
 	fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Frequently Maven projects are multi-module, so there's a top level directory that has the `mvnw `script and a parent POM file and a number of subdirectories that have the their own POM files but no `mvnw` wrapper. Walk one directory up to see if there's a `mvnw` and execute it, supporting this use case.

Fixes #8557

## Other comments:

I had attempted to make a recursive function that walks up to the `/` directory looking for a `mvnw` wrapper script but couldn't get it working. I figure since a 1 level deep multi-module is the most common scenario, this should be sufficient.
