### PR TITLE
feat(git): support trunk branches in `git_main_branch`

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -33,7 +33,7 @@ function work_in_progress() {
 function git_main_branch() {
   local branch
   for branch in main trunk; do
-    if git show-ref -q --verify refs/heads/$branch; then
+    if command git show-ref -q --verify refs/heads/$branch; then
       echo $branch
       return
     fi

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -33,6 +33,8 @@ function work_in_progress() {
 function git_main_branch() {
   if [[ -n "$(git branch --list main)" ]]; then
     echo main
+  elif [[ -n "$(git branch --list trunk)" ]]; then
+    echo trunk
   else
     echo master
   fi

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -31,13 +31,14 @@ function work_in_progress() {
 
 # Check if main exists and use instead of master
 function git_main_branch() {
-  if [[ -n "$(git branch --list main)" ]]; then
-    echo main
-  elif [[ -n "$(git branch --list trunk)" ]]; then
-    echo trunk
-  else
-    echo master
-  fi
+  local branch
+  for branch in main trunk; do
+    if git show-ref -q --verify refs/heads/$branch; then
+      echo $branch
+      return
+    fi
+  done
+  echo master
 }
 
 #


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
It adds `trunk` branch name as option in case the repository uses it as default branch.
- [...]

## Other comments:

...
