### PR TITLE
fix(command-not-found): show error in Ubuntu when no package is found

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -1,8 +1,21 @@
 # Uses the command-not-found package zsh support
 # as seen in https://www.porcheron.info/command-not-found-for-zsh/
 # this is installed in Ubuntu
-
-[[ -e /etc/zsh_command_not_found ]] && source /etc/zsh_command_not_found
+if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-not-found ]; then
+	function command_not_found_handle {
+	        # check because c-n-f could've been removed in the meantime
+                if [ -x /usr/lib/command-not-found ]; then
+		   /usr/lib/command-not-found -- "$1"
+                   return $?
+                elif [ -x /usr/share/command-not-found/command-not-found ]; then
+		   /usr/share/command-not-found/command-not-found -- "$1"
+                   return $?
+		else
+		   printf "%s: command not found\n" "$1" >&2
+		   return 127
+		fi
+	}
+fi
 
 # Arch Linux command-not-found support, you must have package pkgfile installed
 # https://wiki.archlinux.org/index.php/Pkgfile#.22Command_not_found.22_hook

--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -1,8 +1,9 @@
 # Uses the command-not-found package zsh support
 # as seen in https://www.porcheron.info/command-not-found-for-zsh/
 # this is installed in Ubuntu
+
 if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-not-found ]; then
-	command_not_found_handler() {
+    function command_not_found_handler {
         # check because c-n-f could've been removed in the meantime
         if [ -x /usr/lib/command-not-found ]; then
             /usr/lib/command-not-found -- "$1"
@@ -11,10 +12,10 @@ if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-no
             /usr/share/command-not-found/command-not-found -- "$1"
             return $?
         else
-            printf "%s: command not found\n" "$1" >&2
+            printf "zsh: command not found: %s\n" "$1" >&2
             return 127
         fi
-		return 0
+        return 0
     }
 fi
 
@@ -24,13 +25,12 @@ fi
 
 # Fedora command-not-found support
 if [ -f /usr/libexec/pk-command-not-found ]; then
-    command_not_found_handler () {
+    command_not_found_handler() {
         runcnf=1
         retval=127
         [ ! -S /var/run/dbus/system_bus_socket ] && runcnf=0
         [ ! -x /usr/libexec/packagekitd ] && runcnf=0
-        if [ $runcnf -eq 1 ]
-            then
+        if [ $runcnf -eq 1 ]; then
             /usr/libexec/pk-command-not-found $@
             retval=$?
         fi
@@ -46,7 +46,7 @@ fi
 
 # NixOS command-not-found support
 if [ -x /run/current-system/sw/bin/command-not-found ]; then
-    command_not_found_handler () {
+    command_not_found_handler() {
         /run/current-system/sw/bin/command-not-found $@
     }
 fi

--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -2,19 +2,19 @@
 # as seen in https://www.porcheron.info/command-not-found-for-zsh/
 # this is installed in Ubuntu
 if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-not-found ]; then
-	function command_not_found_handle {
-	        # check because c-n-f could've been removed in the meantime
-                if [ -x /usr/lib/command-not-found ]; then
-		   /usr/lib/command-not-found -- "$1"
-                   return $?
-                elif [ -x /usr/share/command-not-found/command-not-found ]; then
-		   /usr/share/command-not-found/command-not-found -- "$1"
-                   return $?
-		else
-		   printf "%s: command not found\n" "$1" >&2
-		   return 127
-		fi
-	}
+    function command_not_found_handle {
+        # check because c-n-f could've been removed in the meantime
+        if [ -x /usr/lib/command-not-found ]; then
+            /usr/lib/command-not-found -- "$1"
+            return $?
+        elif [ -x /usr/share/command-not-found/command-not-found ]; then
+            /usr/share/command-not-found/command-not-found -- "$1"
+            return $?
+        else
+            printf "%s: command not found\n" "$1" >&2
+            return 127
+        fi
+    }
 fi
 
 # Arch Linux command-not-found support, you must have package pkgfile installed

--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -5,7 +5,7 @@ if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-no
 	command_not_found_handler() {
         # check because c-n-f could've been removed in the meantime
         if [ -x /usr/lib/command-not-found ]; then
-            usr/lib/command-not-found -- "$1"
+            /usr/lib/command-not-found -- "$1"
             return $?
         elif [ -x /usr/share/command-not-found/command-not-found ]; then
             /usr/share/command-not-found/command-not-found -- "$1"

--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -2,10 +2,10 @@
 # as seen in https://www.porcheron.info/command-not-found-for-zsh/
 # this is installed in Ubuntu
 if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-not-found ]; then
-    function command_not_found_handle {
+	command_not_found_handler() {
         # check because c-n-f could've been removed in the meantime
         if [ -x /usr/lib/command-not-found ]; then
-            /usr/lib/command-not-found -- "$1"
+            usr/lib/command-not-found -- "$1"
             return $?
         elif [ -x /usr/share/command-not-found/command-not-found ]; then
             /usr/share/command-not-found/command-not-found -- "$1"
@@ -14,6 +14,7 @@ if [ -x /usr/lib/command-not-found -o -x /usr/share/command-not-found/command-no
             printf "%s: command not found\n" "$1" >&2
             return 127
         fi
+		return 0
     }
 fi
 

--- a/plugins/gcc/gcc.plugin.zsh
+++ b/plugins/gcc/gcc.plugin.zsh
@@ -1,0 +1,3 @@
+# colored GCC warnings and errors
+export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
+

--- a/plugins/gcc/gcc.plugin.zsh
+++ b/plugins/gcc/gcc.plugin.zsh
@@ -1,3 +1,0 @@
-# colored GCC warnings and errors
-export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
-


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
It won't show anything when there is no match for a not-found command.  
So I changed the plugin from
![](https://zhaochongyan.github.io/img/2020-11-04%2012-41-41%20%E7%9A%84%E5%B1%8F%E5%B9%95%E6%88%AA%E5%9B%BE.png)
to
![](https://zhaochongyan.github.io/img/2020-11-04%2012-44-25%20%E7%9A%84%E5%B1%8F%E5%B9%95%E6%88%AA%E5%9B%BE.png)
"未找到命令" means "command not found", It depends on your language package.

## Other comments:

Fixes #9491