### PR TITLE
fix(fzf): consistently ignore .git directory in `FZF_DEFAULT_COMMAND`

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -154,10 +154,10 @@ unset -f setup_using_opensuse_package setup_using_debian_package setup_using_bas
 
 if [[ -z "$FZF_DEFAULT_COMMAND" ]]; then
     if (( $+commands[rg] )); then
-        export FZF_DEFAULT_COMMAND='rg --files --hidden'
+        export FZF_DEFAULT_COMMAND='rg --files --hidden --glob "!.git/*"'
     elif (( $+commands[fd] )); then
         export FZF_DEFAULT_COMMAND='fd --type f --hidden --exclude .git'
     elif (( $+commands[ag] )); then
-        export FZF_DEFAULT_COMMAND='ag -l --hidden -g ""'
+        export FZF_DEFAULT_COMMAND='ag -l --hidden -g "" --ignore .git'
     fi
 fi


### PR DESCRIPTION
Be consistent and ignore contents of `.git` directory no matter how FZF_DEFAULT_COMMAND is set.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Be consistent and ignore contents of `.git` directory no matter how FZF_DEFAULT_COMMAND is set.

## Other comments:

Currently `FZF_DEFAULT_COMMAND` is configured to ignore `.git` directory contents when `fd` command is used. Make this consistent and also ignore `.git` when setting `FZF_DEFAULT_COMMAND` with `rg` and `ag`