### PR TITLE
'.' no longer special, '..' only sometimes - makes completion easier

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -25,8 +25,8 @@ else
 fi
 unset CASE_SENSITIVE HYPHEN_INSENSITIVE
 
-# Complete . and .. special directories
-zstyle ':completion:*' special-dirs true
+# Only treat .. as a special directory when the prefix is empty, '.' or '../'
+zstyle -e ':completion:*' special-dirs '[[ $PREFIX = (../)#(|.|..) ]] && reply=(..)'
 
 zstyle ':completion:*' list-colors ''
 zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#) ([0-9a-z-]#)*=01;34=0=01'


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [?] The code is mine or it's from somewhere with an MIT-compatible license. - It was taken from http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Completion-Directories so I think it's fine?
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Modified the treatment of `..` and `.` as special-dirs:
- `.` no longer a special dir
- `..` a special dir only under specific circumstances - only when the prefix is empty, `.` or `../`

First I'd like to say I did not come up with this solution on my own - I found [this (ctrl-f special-dirs)](http://zsh.sourceforge.net/Doc/Release/Completion-System.html) while looking how to solve it.

Here's the original quote:

> The following example sets special-dirs to ‘..’ when the current prefix is empty, is a single ‘.’, or consists only of a path beginning with ‘../’. Otherwise the value is ‘false’.
```
zstyle -e ':completion:*' special-dirs \ 
   '[[ $PREFIX = (../)#(|.|..) ]] && reply=(..)'
```

The motivation for this is as follows:
- When the completion menu pops up, it's always much more useful to have actual files suggested and not special dirs that can anyway be easily typed (it's just `..` or `.`) and don't require any completion. It's annoying to always have them at the beginning of the list, being forced to skip them using `tab` twice to get to the actual files.

- When there's only a single file in a directory, it's much nicer having it completed directly without a menu. Instead, because `.` and `..` are always special directories, they always get suggested along with the file, forcing you to either type the first letter of the file to have it completed or skip `.` and `..` by pressing tab twice, once for each.

- The above point makes "descending" (via completion) into long chains of nested single-directories so much nicer - just tab tab tab tab. Since there are no special dirs being suggested - the only option is the single directory at each level - and it gets completed without a menu.

- The original motivation for even adding them as special dirs, according to the PR that added the line modified by this PR, is to have `..<TAB>` complete to `../` which is definitely nice. This is why if the prefix is empty, `.` or `..` then `..` is still suggested as a special dir, and thus the `/` still gets added automatically. Also, `../` is another prefix that causes `..` to be special - this makes it easier to go back `../../../` a lot of times, just . and tab . and tab to get `../../../`.

I couldn't find ways where this breaks existing behaviour in substantial ways, other than `.` and `..` being gone from completion menus... who uses the completion menu to get `..` and `.` anyway? I think the improvements are so substantial that this "breaking change" is worth it.