### PR TITLE
This PR allows for the customisation of completion dots in the .zshrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ide
+/.idea
+
 # custom files
 custom/
 

--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -60,7 +60,11 @@ zstyle '*' single-ignored show
 
 if [[ $COMPLETION_WAITING_DOTS = true ]]; then
   expand-or-complete-with-dots() {
-    print -Pn "%F{red}…%f"
+    if [[ $COMPLETION_DOTS_STYLE != "" ]]; then
+      print -Pn "$COMPLETION_DOTS_STYLE"
+    else
+      print -Pn "%F{red}…%f"
+    fi
     zle expand-or-complete
     zle redisplay
   }

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -47,6 +47,9 @@ ZSH_THEME="robbyrussell"
 # Uncomment the following line to display red dots whilst waiting for completion.
 # COMPLETION_WAITING_DOTS="true"
 
+# Uncomment if you wish to define the completion dots
+# COMPLETION_DOTS_STYLE="%F{red}…%f"
+
 # Uncomment the following line if you want to disable marking untracked files
 # under VCS as dirty. This makes repository status check for large repositories
 # much, much faster.


### PR DESCRIPTION
This allows for the customisation of the completion dots by defining a variable in the .zshrc

For example:
```
# Uncomment if you wish to define the completion dots
COMPLETION_DOTS_STYLE="%F{yellow}...%f"
```

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Allows the customisation of completion dots to be modified in the .zshrc

## Other comments:

...
