### PR TITLE
Some more and slightly modified pacman query aliases

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -115,6 +115,7 @@ plugins=(... archlinux)
 | paclocs      | pacman -Qs                              | Search for packages in the local database                    |
 | paclsorphans | sudo pacman -Qdt                        | List all orphaned packages                                   |
 | pacmir       | sudo pacman -Syy                        | Force refresh of all package lists after updating mirrorlist |
+| pacq         | pacman -Q                               | List all installed packages                                  |
 | pacre        | sudo pacman -R                          | Remove packages, keeping its settings and dependencies       |
 | pacrem       | sudo pacman -Rns                        | Remove packages, including its settings and dependencies     |
 | pacrep       | pacman -Si                              | Display information about a package in the repositories      |
@@ -135,6 +136,7 @@ plugins=(... archlinux)
 |----------------|------------------------------------------------------|
 | pacdisowned    | List all disowned files in your system               |
 | paclist        | List all installed packages with a short description |
+| paclexp        | List all explicitly installed packages               |
 | pacmanallkeys  | Get all keys for developers and trusted users        |
 | pacmansignkeys | Locally trust all keys passed as parameters          |
 | pacweb         | Open the website of an ArchLinux package             |

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -146,6 +146,7 @@ alias pacloc='pacman -Qi'
 alias paclocs='pacman -Qs'
 alias pacinsd='sudo pacman -S --asdeps'
 alias pacmir='sudo pacman -Syy'
+alias pacq='pacman -Q'
 alias paclsorphans='sudo pacman -Qdt'
 alias pacrmorphans='sudo pacman -Rs $(pacman -Qtdq)'
 alias pacfileupg='sudo pacman -Fy'
@@ -165,6 +166,11 @@ else
 fi
 
 function paclist() {
+  LC_ALL=C pacman -Qi $(pacman -Q | cut -d " " -f 1) | \
+    awk 'BEGIN {FS=":"} /^Name/{printf("\033[1;36m%s\033[1;37m", $2)} /^Description/{print $2}'
+}
+
+function paclexp() {
   # Source: https://bbs.archlinux.org/viewtopic.php?id=93683
   LC_ALL=C pacman -Qei $(pacman -Qu | cut -d " " -f 1) | \
     awk 'BEGIN {FS=":"} /^Name/{printf("\033[1;36m%s\033[1;37m", $2)} /^Description/{print $2}'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added `pacq` alias for basic pacman query
- Renamed `paclist` to `paclexp`, since this command only shows **explicitly** installed packages with a short description
- Added new `paclist` implementation, which actually shows **all** installed packages with a short description