### PR TITLE
feat(sudo): support aliases to $EDITOR

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -14,6 +14,16 @@
 #
 # ------------------------------------------------------------------------------
 
+__sudo-replace-buffer() {
+    local old=$1 new=$2
+    if [[ ${#LBUFFER} -le ${#old} ]]; then
+        RBUFFER=" ${BUFFER#$old }"
+        LBUFFER="$new"
+    else
+        LBUFFER="$new ${LBUFFER#$old }"
+    fi
+}
+
 sudo-command-line() {
     [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
 
@@ -33,28 +43,14 @@ sudo-command-line() {
         fi
     fi
 
-
-    if [[ -n $EDITOR && $BUFFER == $EDITOR\ * ]]; then
-        if [[ ${#LBUFFER} -le ${#EDITOR} ]]; then
-            RBUFFER=" ${BUFFER#$EDITOR }"
-            LBUFFER="sudoedit"
-        else
-            LBUFFER="sudoedit ${LBUFFER#$EDITOR }"
-        fi
-    elif [[ $BUFFER == sudoedit\ * ]]; then
-        if [[ ${#LBUFFER} -le 8 ]]; then
-            RBUFFER=" ${BUFFER#sudoedit }"
-            LBUFFER="$EDITOR"
-        else
-            LBUFFER="$EDITOR ${LBUFFER#sudoedit }"
-        fi
-    elif [[ $BUFFER == sudo\ * ]]; then
-        if [[ ${#LBUFFER} -le 4 ]]; then
-            RBUFFER="${BUFFER#sudo }"
-            LBUFFER=""
-        else
-            LBUFFER="${LBUFFER#sudo }"
-        fi
+    if [[ -n $EDITOR && $BUFFER = $EDITOR\ * ]]; then
+        __sudo-replace-buffer "$EDITOR" "sudoedit"
+    elif [[ -n $EDITOR && $BUFFER = \$EDITOR\ * ]]; then
+        __sudo-replace-buffer "\$EDITOR" "sudoedit"
+    elif [[ $BUFFER = sudoedit\ * ]]; then
+        __sudo-replace-buffer "sudoedit" "$EDITOR"
+    elif [[ $BUFFER = sudo\ * ]]; then
+        __sudo-replace-buffer "sudo" ""
     else
         LBUFFER="sudo $LBUFFER"
     fi

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -15,12 +15,12 @@
 # ------------------------------------------------------------------------------
 
 __sudo-replace-buffer() {
-    local old=$1 new=$2
+    local old=$1 new=$2 space=${2:+ }
     if [[ ${#LBUFFER} -le ${#old} ]]; then
-        RBUFFER=" ${BUFFER#$old }"
-        LBUFFER="$new"
+        RBUFFER="${space}${BUFFER#$old }"
+        LBUFFER="${new}"
     else
-        LBUFFER="$new ${LBUFFER#$old }"
+        LBUFFER="${new}${space}${LBUFFER#$old }"
     fi
 }
 

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -37,7 +37,7 @@ sudo-command-line() {
     # Get the first part of the typed command and check if it's an alias to $EDITOR
     # If so, locally change $EDITOR to the alias so that it matches below
     if [[ -n "$EDITOR" ]]; then
-        local cmd="${(Az)BUFFER[1]}"
+        local cmd="${${(Az)BUFFER}[1]}"
         if [[ "${aliases[$cmd]} " = (\$EDITOR|$EDITOR)\ * ]]; then
             local EDITOR="$cmd"
         fi

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -9,6 +9,7 @@
 # -------
 #
 # * Dongweiming <ciici123@gmail.com>
+# * Subhaditya Nath <github.com/subnut>
 #
 # ------------------------------------------------------------------------------
 
@@ -17,10 +18,59 @@ sudo-command-line() {
 
     # Save beginning space
     local WHITESPACE=""
-    if [[ ${LBUFFER:0:1} == " " ]] ; then 
+    if [[ ${LBUFFER:0:1} == " " ]] ; then
         WHITESPACE=" "
         LBUFFER="${LBUFFER:1}"
     fi
+
+    # Support for aliases to $EDITOR
+    () {
+        if [[ -z $EDITOR ]]; then                       # EDITOR not set, so no work
+            return
+        fi
+        _EDITOR=$EDITOR                                 # To later restore the original value
+        _CURRENT=$(echo -n $BUFFER | cut -d' ' -f1)     # Get current command (to check for alias)
+        if [[ $_CURRENT == $EDITOR ]]; then             # If current command is same as EDITOR, no need to check further.
+            return 0
+        fi
+        if [[ $_CURRENT == 'sudoedit' ]]; then          # If current command is sudoedit, no need to check further.
+            return 0
+        fi
+        if [[ $EDITOR =~ ' ' ]]; then
+            EDITOR="'$EDITOR"                           # If EDITOR has spaces, then alias will be wrapped in ''
+        fi
+
+        # Check for aliases that match the value of $EDITOR
+        if
+            () {
+                for alias in $(alias | grep "=$EDITOR" | cut -d= -f1)
+                do  if [[ $alias = $_CURRENT ]]; then
+                        EDITOR=$alias   # set EDITOR to the alias
+                        return 0
+                    fi
+                done
+                return 1    # none of these aliases match
+            };
+        then
+            return
+
+        # Maybe alias is set to the variable instead of it's value
+        elif
+            () {
+                for alias in $(alias | grep \=\'\$EDITOR | cut -d= -f1)
+                do  if [[ $alias = $_CURRENT ]]; then
+                        EDITOR=$alias   # set EDITOR to the alias
+                        return 0
+                    fi
+                done
+                return 1    # none of these aliases match
+            }
+        then
+            return
+        fi
+
+        EDITOR=$_EDITOR     # Nothing matched. Restore $EDITOR
+    }
 
     if [[ -n $EDITOR && $BUFFER == $EDITOR\ * ]]; then
         if [[ ${#LBUFFER} -le ${#EDITOR} ]]; then
@@ -49,9 +99,16 @@ sudo-command-line() {
 
     # Preserve beginning space
     LBUFFER="${WHITESPACE}${LBUFFER}"
+
+    # Restore EDITOR if previously changed
+    if [[ -n $_EDITOR ]]; then
+        EDITOR=$_EDITOR
+    fi
 }
 zle -N sudo-command-line
 # Defined shortcut keys: [Esc] [Esc]
 bindkey -M emacs '\e\e' sudo-command-line
 bindkey -M vicmd '\e\e' sudo-command-line
 bindkey -M viins '\e\e' sudo-command-line
+
+# vim: et ts=4

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -10,6 +10,7 @@
 #
 # * Dongweiming <ciici123@gmail.com>
 # * Subhaditya Nath <github.com/subnut>
+# * Marc Cornellà <github.com/mcornella>
 #
 # ------------------------------------------------------------------------------
 
@@ -18,59 +19,20 @@ sudo-command-line() {
 
     # Save beginning space
     local WHITESPACE=""
-    if [[ ${LBUFFER:0:1} == " " ]] ; then
+    if [[ ${LBUFFER:0:1} = " " ]]; then
         WHITESPACE=" "
         LBUFFER="${LBUFFER:1}"
     fi
 
-    # Support for aliases to $EDITOR
-    () {
-        if [[ -z $EDITOR ]]; then                       # EDITOR not set, so no work
-            return
+    # Get the first part of the typed command and check if it's an alias to $EDITOR
+    # If so, locally change $EDITOR to the alias so that it matches below
+    if [[ -n "$EDITOR" ]]; then
+        local cmd="${(Az)BUFFER[1]}"
+        if [[ "${aliases[$cmd]} " = (\$EDITOR|$EDITOR)\ * ]]; then
+            local EDITOR="$cmd"
         fi
-        _EDITOR=$EDITOR                                 # To later restore the original value
-        _CURRENT=$(echo -n $BUFFER | cut -d' ' -f1)     # Get current command (to check for alias)
-        if [[ $_CURRENT == $EDITOR ]]; then             # If current command is same as EDITOR, no need to check further.
-            return 0
-        fi
-        if [[ $_CURRENT == 'sudoedit' ]]; then          # If current command is sudoedit, no need to check further.
-            return 0
-        fi
-        if [[ $EDITOR =~ ' ' ]]; then
-            EDITOR="'$EDITOR"                           # If EDITOR has spaces, then alias will be wrapped in ''
-        fi
+    fi
 
-        # Check for aliases that match the value of $EDITOR
-        if
-            () {
-                for alias in $(alias | grep "=$EDITOR" | cut -d= -f1)
-                do  if [[ $alias = $_CURRENT ]]; then
-                        EDITOR=$alias   # set EDITOR to the alias
-                        return 0
-                    fi
-                done
-                return 1    # none of these aliases match
-            };
-        then
-            return
-
-        # Maybe alias is set to the variable instead of it's value
-        elif
-            () {
-                for alias in $(alias | grep \=\'\$EDITOR | cut -d= -f1)
-                do  if [[ $alias = $_CURRENT ]]; then
-                        EDITOR=$alias   # set EDITOR to the alias
-                        return 0
-                    fi
-                done
-                return 1    # none of these aliases match
-            }
-        then
-            return
-        fi
-
-        EDITOR=$_EDITOR     # Nothing matched. Restore $EDITOR
-    }
 
     if [[ -n $EDITOR && $BUFFER == $EDITOR\ * ]]; then
         if [[ ${#LBUFFER} -le ${#EDITOR} ]]; then
@@ -99,16 +61,11 @@ sudo-command-line() {
 
     # Preserve beginning space
     LBUFFER="${WHITESPACE}${LBUFFER}"
-
-    # Restore EDITOR if previously changed
-    if [[ -n $_EDITOR ]]; then
-        EDITOR=$_EDITOR
-    fi
 }
+
 zle -N sudo-command-line
+
 # Defined shortcut keys: [Esc] [Esc]
 bindkey -M emacs '\e\e' sudo-command-line
 bindkey -M vicmd '\e\e' sudo-command-line
 bindkey -M viins '\e\e' sudo-command-line
-
-# vim: et ts=4


### PR DESCRIPTION
If you use some alias for your $EDITOR, say `e`. You type `e /to/file`.
But that file needs sudo permission. You naturally do `<Esc><Esc><Enter>`.
But, to your dismay, it errors out `command not found`, because it
didn't detect your alias to $EDITOR, thereby failing to convert it to
`sudoedit`.

This commit tries to detect your alias and convert it to sudoedit.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Removed a trailing whitespace
- Added vim modeline
- Added my name and GitHub user URL under Authors
- Added the actual functionality this PR is intended for


## Other comments:

NONE
