### PR TITLE
AWS plugin: Read inputs in the same line

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -50,10 +50,8 @@ function acp() {
 
   if [[ -n $mfa_serial ]]; then
     local mfa_token=""
-    echo "Please enter your MFA token for $mfa_serial:"
-    read -r mfa_token
-    echo "Please enter the session duration in seconds (900-43200; default: 3600, which is the default maximum for a role):"
-    read -r sess_duration
+    vared -p "Please enter your MFA token for $mfa_serial: " -c mfa_token
+    vared -p "Please enter the session duration in seconds (900-43200; default: 3600, which is the default maximum for a role): " -c sess_duration
     if [[ -z $sess_duration ]]; then
       sess_duration="3600"
     fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Changed `read` with built-it `vared` to read MFA token and the session duration it the same line.

## Other comments:

Was:
```
Please enter your MFA token for arn:aws:iam::11111111111:mfa/user:
12346
Please enter the session duration in seconds (900-43200; default: 3600, which is the default maximum for a role):

Assuming role arn:aws:iam::222222222222:role/AdminAccess using profile with-mfa
Switched to AWS Profile: with-mfa
```
Became:
```
Please enter your MFA token for arn:aws:iam::11111111111:mfa/user: 12346
Please enter the session duration in seconds (900-43200; default: 3600, which is the default maximum for a role):
Assuming role arn:aws:iam::222222222222:role/AdminAccess using profile with-mfa
Switched to AWS Profile: with-mfa
```
