### PR TITLE
feat(gentoo)!: use `vcs_info` to support other VCSs

### DIFF
--- a/themes/gentoo.zsh-theme
+++ b/themes/gentoo.zsh-theme
@@ -4,10 +4,19 @@ autoload -Uz vcs_info
 zstyle ':vcs_info:*' check-for-changes true
 zstyle ':vcs_info:*' unstagedstr '%F{red}*'   # display this when there are unstaged changes
 zstyle ':vcs_info:*' stagedstr '%F{yellow}+'  # display this when there are staged changes
-zstyle ':vcs_info:*' actionformats '%F{5}(%F{2}%b%F{3}|%F{1}%a%c%u%F{5})%f '
-zstyle ':vcs_info:*' formats '%F{5}(%F{2}%b%c%u%F{5})%f '
+zstyle ':vcs_info:*' actionformats '%F{5}(%F{2}%b%F{3}|%F{1}%a%c%u%m%F{5})%f '
+zstyle ':vcs_info:*' formats '%F{5}(%F{2}%b%c%u%m%F{5})%f '
 zstyle ':vcs_info:(sv[nk]|bzr):*' branchformat '%b%F{1}:%F{3}%r'
 zstyle ':vcs_info:*' enable git cvs svn
+zstyle ':vcs_info:git*+set-message:*' hooks untracked-git
+
++vi-untracked-git() {
+  if command git status --porcelain 2>/dev/null | command grep -q '??'; then
+    hook_com[misc]='%F{red}?'
+  else
+    hook_com[misc]=''
+  fi
+}
 
 gentoo_precmd() {
   vcs_info

--- a/themes/gentoo.zsh-theme
+++ b/themes/gentoo.zsh-theme
@@ -1,8 +1,19 @@
-function prompt_char {
-	if [ $UID -eq 0 ]; then echo "#"; else echo $; fi
+autoload -Uz colors && colors
+
+autoload -Uz vcs_info
+zstyle ':vcs_info:*' check-for-changes true
+zstyle ':vcs_info:*' unstagedstr '%F{red}*'   # display this when there are unstaged changes
+zstyle ':vcs_info:*' stagedstr '%F{yellow}+'  # display this when there are staged changes
+zstyle ':vcs_info:*' actionformats '%F{5}(%F{2}%b%F{3}|%F{1}%a%c%u%F{5})%f '
+zstyle ':vcs_info:*' formats '%F{5}(%F{2}%b%c%u%F{5})%f '
+zstyle ':vcs_info:(sv[nk]|bzr):*' branchformat '%b%F{1}:%F{3}%r'
+zstyle ':vcs_info:*' enable git cvs svn
+
+gentoo_precmd() {
+  vcs_info
 }
 
-PROMPT='%(!.%{$fg_bold[red]%}.%{$fg_bold[green]%}%n@)%m %{$fg_bold[blue]%}%(!.%1~.%~) $(git_prompt_info)$(prompt_char)%{$reset_color%} '
+autoload -U add-zsh-hook
+add-zsh-hook precmd gentoo_precmd
 
-ZSH_THEME_GIT_PROMPT_PREFIX="("
-ZSH_THEME_GIT_PROMPT_SUFFIX=") "
+PROMPT='%(!.%B%F{red}.%B%F{green}%n@)%m %F{blue}%(!.%1~.%~) ${vcs_info_msg_0_}%(!.#.$)%{$reset_color%} '


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Use `vcs_info` which supports svn and bzr and CVS
- Add vsc_info hook to show when there are untracked files

## Other comments:

Repost of #1855 with a fix for showing untracked files.

## Screenshots

**BEFORE**

![image](https://user-images.githubusercontent.com/1441704/98983467-1916b880-2521-11eb-8ae5-ef4c1253ae40.png)


**AFTER**

![image](https://user-images.githubusercontent.com/1441704/98983352-f389af00-2520-11eb-951f-46d2c09333fb.png)
