### PR TITLE
fix(systemd): remove `sudo` from power-related aliases

### DIFF
--- a/plugins/systemd/README.md
+++ b/plugins/systemd/README.md
@@ -3,7 +3,8 @@
 The systemd plugin provides many useful aliases for systemd.
 
 To use it, add systemd to the plugins array of your zshrc file:
-```
+
+```zsh
 plugins=(... systemd)
 ```
 
@@ -22,7 +23,7 @@ plugins=(... systemd)
 | `sc-show-environment`  | `systemctl show-environment`       | Dump the systemd manager environment block                       |
 | `sc-cat`               | `systemctl cat`                    | Show backing files of one or more units                          |
 | `sc-list-timers`       | `systemctl list-timers`            | List timer units currently in memory                             |
-| **Aliases with sudo**                                                                                                          |
+| **Aliases with sudo**                                                                                                        |||
 | `sc-start`             | `sudo systemctl start`             | Start Unit(s)                                                    |
 | `sc-stop`              | `sudo systemctl stop`              | Stop Unit(s)                                                     |
 | `sc-reload`            | `sudo systemctl reload`            | Reload Unit(s)                                                   |
@@ -59,9 +60,11 @@ to your prompt, drop `$(systemd_prompt_info [unit]...)` into your prompt (more t
 may be specified).
 
 The plugin will add the following to your prompt for each `$unit`.
-```
+
+```text
 <prefix><unit>:<active|notactive><suffix>
 ```
+
 You can control these parts with the following variables:
 
 - `<prefix>`: Set `$ZSH_THEME_SYSTEMD_PROMPT_PREFIX`.
@@ -79,7 +82,7 @@ You can control these parts with the following variables:
 
 For example, if your prompt contains `PROMPT='$(systemd_prompt_info dhcpd httpd)'` and you set the following variables:
 
-```
+```sh
 ZSH_THEME_SYSTEMD_PROMPT_PREFIX="["
 ZSH_THEME_SYSTEMD_PROMPT_SUFFIX="]"
 ZSH_THEME_SYSTEMD_PROMPT_ACTIVE="+"
@@ -89,6 +92,6 @@ ZSH_THEME_SYSTEMD_PROMPT_CAPS=1
 
 If `dhcpd` is running, and `httpd` is not, then your prompt will look like this:
 
-```
+```text
 [DHCPD: +][HTTPD: X]
 ```

--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -1,3 +1,4 @@
+# systemctl aliases
 user_commands=(
   cat
   get-default
@@ -14,7 +15,8 @@ user_commands=(
   list-units
   show
   show-environment
-  status)
+  status
+)
 
 sudo_commands=(
   add-requires
@@ -53,7 +55,9 @@ sudo_commands=(
   try-reload-or-restart
   try-restart
   unmask
-  unset-environment)
+  unset-environment
+)
+
 power_commands=(
   hibernate
   hybrid-sleep
@@ -63,12 +67,24 @@ power_commands=(
   suspend
 )
 
-for c in $user_commands; do; alias sc-$c="systemctl $c"; done
-for c in $sudo_commands; do; alias sc-$c="sudo systemctl $c"; done
-for c in $user_commands; do; alias scu-$c="systemctl --user $c"; done
-for c in $sudo_commands; do; alias scu-$c="systemctl --user $c"; done
-for c in $power_commands; do; alias sc-$c="systemctl $c"; done
+for c in $user_commands; do
+  alias "sc-$c"="systemctl $c"
+  alias "scu-$c"="systemctl --user $c"
+done
 
+for c in $sudo_commands; do
+  alias "sc-$c"="sudo systemctl $c"
+  alias "scu-$c"="systemctl --user $c"
+done
+
+for c in $power_commands; do
+  alias "sc-$c"="systemctl $c"
+done
+
+unset c user_commands sudo_commands power_commands
+
+
+# --now commands
 alias sc-enable-now="sc-enable --now"
 alias sc-disable-now="sc-disable --now"
 alias sc-mask-now="sc-mask --now"
@@ -77,17 +93,24 @@ alias scu-enable-now="scu-enable --now"
 alias scu-disable-now="scu-disable --now"
 alias scu-mask-now="scu-mask --now"
 
+
 function systemd_prompt_info {
   local unit
-  for unit in $@; do
+  for unit in "$@"; do
     echo -n "$ZSH_THEME_SYSTEMD_PROMPT_PREFIX"
-    [[ -n "$ZSH_THEME_SYSTEMD_PROMPT_CAPS" ]] && echo -n "${(U)unit}:" || echo -n "$unit:"
-    if systemctl is-active $unit &>/dev/null; then
-        echo -n "$ZSH_THEME_SYSTEMD_PROMPT_ACTIVE" 
+
+    if [[ -n "$ZSH_THEME_SYSTEMD_PROMPT_CAPS" ]]; then
+      echo -n "${(U)unit:gs/%/%%}:"
     else
-        echo -n "$ZSH_THEME_SYSTEMD_PROMPT_NOTACTIVE"
+      echo -n "${unit:gs/%/%%}:"
     fi
+
+    if systemctl is-active "$unit" &>/dev/null; then
+      echo -n "$ZSH_THEME_SYSTEMD_PROMPT_ACTIVE"
+    else
+      echo -n "$ZSH_THEME_SYSTEMD_PROMPT_NOTACTIVE"
+    fi
+
     echo -n "$ZSH_THEME_SYSTEMD_PROMPT_SUFFIX"
   done
 }
-

--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -28,8 +28,6 @@ sudo_commands=(
   emergency
   enable
   halt
-  hibernate
-  hybrid-sleep
   import-environment
   isolate
   kexec
@@ -38,33 +36,38 @@ sudo_commands=(
   list-machines
   load
   mask
-  poweroff
   preset
   preset-all
-  reboot
   reenable
   reload
   reload-or-restart
   reset-failed
   rescue
-  restart
   revert
   set-default
   set-environment
   set-property
   start
   stop
-  suspend
   switch-root
   try-reload-or-restart
   try-restart
   unmask
   unset-environment)
+power_commands=(
+  hibernate
+  hybrid-sleep
+  poweroff
+  reboot
+  restart
+  suspend
+)
 
 for c in $user_commands; do; alias sc-$c="systemctl $c"; done
 for c in $sudo_commands; do; alias sc-$c="sudo systemctl $c"; done
 for c in $user_commands; do; alias scu-$c="systemctl --user $c"; done
 for c in $sudo_commands; do; alias scu-$c="systemctl --user $c"; done
+for c in $power_commands; do; alias sc-$c="systemctl $c"; done
 
 alias sc-enable-now="sc-enable --now"
 alias sc-disable-now="sc-disable --now"


### PR DESCRIPTION
All systemd power commands I've used so far (e. g. `suspend`, `hibernate`, ...) do work without root access (as in I can call `systemctl suspend` instead of `sudo systemctl suspend`).
This PR would alias those commands to not use sudo.
Also there is no user variant of the power commands so I removed that as well.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

 - I changed the systemd module to include a list of subcommands that are power-relevant (suspend, hibernate, hybrid-sleep, poweroff, reboot, restart, suspend)
- I changed the systemd module to remove the aliases from `scu-(any power-relevant command)` to `systemctl --user (any power-relevant command)` and changed the aliases from `sc-(power-relevant command)` which orginally was aliased to `sudo systemctl (prc)` to `systemctl (prc)` as the sudo is not needed. 

## Other comments:

 - hibernate currently does not work on my pc since I upgraded the ram recently, so I wasn't able to test it. If hibernate does require `sudo`, feel free to leave this change out.
