### PR TITLE
Option to disable loading of pyenv-virtualenv in the "pyenv" plugin

### DIFF
--- a/plugins/pyenv/README.md
+++ b/plugins/pyenv/README.md
@@ -14,3 +14,10 @@ plugins=(... pyenv)
 
 - `pyenv_prompt_info`: displays the Python version in use by pyenv; or the global Python
   version, if pyenv wasn't found.
+
+
+## Options
+
+- `PYENV_VIRTUALENV`: if set to `0`, will disable automatic activation/deactivation of
+  virtualenvs upon entering/leaving directories which contain a `.python-version` file.
+

--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -30,8 +30,10 @@ fi
 
 if [[ $FOUND_PYENV -eq 1 ]]; then
     eval "$(pyenv init - --no-rehash zsh)"
-    if (( $+commands[pyenv-virtualenv-init] )); then
-        eval "$(pyenv virtualenv-init - zsh)"
+    if [[ ${PYENV_VIRTUALENV:-1} -ne 0 ]]; then
+        if (( $+commands[pyenv-virtualenv-init] )); then
+            eval "$(pyenv virtualenv-init - zsh)"
+        fi
     fi
     function pyenv_prompt_info() {
         echo "$(pyenv version-name)"


### PR DESCRIPTION
Some people does not like automatic activation of virtualenv, something
that `pyenv virtualenv-init` implements.

The default behavior when PYENV_VIRTUALENV is not set remains the same;
the env var just adds a knob so people who dislike the auto-activation
behavior can disable that.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add test for an env var `PYENV_VIRTUALENV` to allow users to (optionally) disable the loading of the pyenv-virtualenv plugin (for pyenv)

## Other comments:

None.