### PR TITLE
 mvn: fix typo in comment

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -33,7 +33,7 @@ mvn-color() {
 	)
 }
 
-# either use orignal mvn or the mvn wrapper
+# either use original mvn or the mvn wrapper
 alias mvn="mvn-or-mvnw"
 
 # Run mvn against the pom found in a project's root directory (assumes a git repo)


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fixed comment typo
## Other comments:

`orignal` -> `original`
