### PR TITLE
Add kubectl kga(a)w alias

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -121,7 +121,9 @@ alias kpf="kubectl port-forward"
 
 # Tools for accessing all information
 alias kga='kubectl get all'
+alias kgaw='watch "kubectl get all"'
 alias kgaa='kubectl get all --all-namespaces'
+alias kgaaw='watch "kubectl get all --all-namespaces"'
 
 # Logs
 alias kl='kubectl logs'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add alias kgaw to use watch(1) to monitor changes in `kga` 
- Do the same with kgaa

## Other comments:
I often need to monitor multiple things in a namespace while doing another thing in another terminal.
Before i had this alias, i always had to craft the command myself manually.

kgaaw is probably a little less useful since all the information in a big k8s cluster wouldn't fit on the screen, but i added it anyways in case someone ever needs it 

