### PR TITLE
fzf: add check for Cygwin packages

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -136,6 +136,30 @@ function setup_using_openbsd_package() {
     return 0
 }
 
+function setup_using_cygwin_package() {
+    # Cygwin installs fzf in /usr/local/bin/fzf
+    if [[ "$OSTYPE" != cygwin* ]] || (( ! $+commands[fzf] )); then
+        return 1
+    fi
+
+    # The fzf-zsh-completion package installs the auto-completion in
+    local completions="/etc/profile.d/fzf-completion.zsh"
+    # The fzf-zsh package installs the key-bindings file in
+    local key_bindings="/etc/profile.d/fzf.zsh"
+
+    # Auto-completion
+    if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
+        source "$completions" 2>/dev/null
+    fi
+
+    # Key bindings
+    if [[ "$DISABLE_FZF_KEY_BINDINGS" != "true" ]]; then
+        source "$key_bindings" 2>/dev/null
+    fi
+
+    return 0
+}
+
 function indicate_error() {
     cat >&2 <<EOF
 [oh-my-zsh] fzf plugin: Cannot find fzf installation directory.
@@ -147,12 +171,14 @@ EOF
 setup_using_openbsd_package \
     || setup_using_debian_package \
     || setup_using_opensuse_package \
+    || setup_using_cygwin_package \
     || setup_using_base_dir \
     || indicate_error
 
 unset -f setup_using_openbsd_package \
     setup_using_debian_package \
     setup_using_opensuse_package \
+    setup_using_cygwin_package \
     setup_using_base_dir \
     indicate_error
 

--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -150,7 +150,11 @@ setup_using_openbsd_package \
     || setup_using_base_dir \
     || indicate_error
 
-unset -f setup_using_opensuse_package setup_using_debian_package setup_using_base_dir indicate_error
+unset -f setup_using_openbsd_package \
+    setup_using_debian_package \
+    setup_using_opensuse_package \
+    setup_using_base_dir \
+    indicate_error
 
 if [[ -z "$FZF_DEFAULT_COMMAND" ]]; then
     if (( $+commands[rg] )); then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki. **(Except that this file uses 4 spaces, so I stayed consistent.)**
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- clear function after use: setup_using_openbsd_package (bug fix)
- add check for Cygwin packages


## Other comments:

...
