### PR TITLE
fix(magic-enter): fix various bugs in the plugin

### DIFF
--- a/plugins/magic-enter/magic-enter.plugin.zsh
+++ b/plugins/magic-enter/magic-enter.plugin.zsh
@@ -1,27 +1,20 @@
-# Bind quick stuff to enter!
-#
-# Pressing enter in a git directory runs `git status`
-# in other directories `ls`
-magic-enter () {
-  # If commands are not already set, use the defaults
-  [ -z "$MAGIC_ENTER_GIT_COMMAND" ] && MAGIC_ENTER_GIT_COMMAND="git status -u ."
-  [ -z "$MAGIC_ENTER_OTHER_COMMAND" ] && MAGIC_ENTER_OTHER_COMMAND="ls -lh ."
+# Default commands
+: ${MAGIC_ENTER_GIT_COMMAND:="git status -u ."} # run when in a git repository
+: ${MAGIC_ENTER_OTHER_COMMAND:="ls -lh ."}      # run anywhere else
 
-  if [[ -z $BUFFER ]]; then
+magic-enter() {
+  if [[ -z "$BUFFER" ]]; then
     echo ""
-    if git rev-parse --is-inside-work-tree &>/dev/null; then
+    if command git rev-parse --is-inside-work-tree &>/dev/null; then
       eval "$MAGIC_ENTER_GIT_COMMAND"
     else
       eval "$MAGIC_ENTER_OTHER_COMMAND"
     fi
     zle redisplay
   else
-    zle accept-line
+    zle .accept-line
   fi
 }
 
-zle -N magic-enter
-
-bindkey -M emacs "^M" magic-enter
-bindkey -M vicmd "^M" magic-enter
-bindkey -M viins "^M" magic-enter
+# Wrapper for the accept-line zle widget (run when pressing Enter)
+zle -N accept-line magic-enter

--- a/plugins/magic-enter/magic-enter.plugin.zsh
+++ b/plugins/magic-enter/magic-enter.plugin.zsh
@@ -3,7 +3,9 @@
 : ${MAGIC_ENTER_OTHER_COMMAND:="ls -lh ."}      # run anywhere else
 
 magic-enter() {
-  if [[ -z "$BUFFER" ]]; then
+  # Only run MAGIC_ENTER commands when in PS1 and command prompt empty
+  # http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#User_002dDefined-Widgets
+  if [[ -z "$BUFFER" && "$CONTEXT" = start ]]; then
     echo ""
     if command git rev-parse --is-inside-work-tree &>/dev/null; then
       eval "$MAGIC_ENTER_GIT_COMMAND"

--- a/plugins/magic-enter/magic-enter.plugin.zsh
+++ b/plugins/magic-enter/magic-enter.plugin.zsh
@@ -6,13 +6,12 @@ magic-enter() {
   # Only run MAGIC_ENTER commands when in PS1 and command prompt empty
   # http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#User_002dDefined-Widgets
   if [[ -z "$BUFFER" && "$CONTEXT" = start ]]; then
-    echo ""
     if command git rev-parse --is-inside-work-tree &>/dev/null; then
-      eval "$MAGIC_ENTER_GIT_COMMAND"
+      BUFFER="$MAGIC_ENTER_GIT_COMMAND"
     else
-      eval "$MAGIC_ENTER_OTHER_COMMAND"
+      BUFFER="$MAGIC_ENTER_OTHER_COMMAND"
     fi
-    zle redisplay
+    zle .accept-line
   else
     zle .accept-line
   fi

--- a/plugins/magic-enter/magic-enter.plugin.zsh
+++ b/plugins/magic-enter/magic-enter.plugin.zsh
@@ -3,19 +3,36 @@
 : ${MAGIC_ENTER_OTHER_COMMAND:="ls -lh ."}      # run anywhere else
 
 magic-enter() {
-  # Only run MAGIC_ENTER commands when in PS1 and command prompt empty
+  # Only run MAGIC_ENTER commands when in PS1 and command line is empty
   # http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#User_002dDefined-Widgets
-  if [[ -z "$BUFFER" && "$CONTEXT" = start ]]; then
-    if command git rev-parse --is-inside-work-tree &>/dev/null; then
-      BUFFER="$MAGIC_ENTER_GIT_COMMAND"
-    else
-      BUFFER="$MAGIC_ENTER_OTHER_COMMAND"
-    fi
-    zle .accept-line
+  if [[ -n "$BUFFER" || "$CONTEXT" != start ]]; then
+    return
+  fi
+
+  if command git rev-parse --is-inside-work-tree &>/dev/null; then
+    BUFFER="$MAGIC_ENTER_GIT_COMMAND"
   else
-    zle .accept-line
+    BUFFER="$MAGIC_ENTER_OTHER_COMMAND"
   fi
 }
 
 # Wrapper for the accept-line zle widget (run when pressing Enter)
-zle -N accept-line magic-enter
+
+# If the wrapper already exists don't redefine it
+(( ! ${+functions[_magic-enter_accept-line]} )) || return 0
+
+case "$widgets[accept-line]" in
+  # Override the current accept-line widget, calling the old one
+  user:*) zle -N _magic-enter_orig_accept-line "${widgets[accept-line]#user:}"
+    function _magic-enter_accept-line() {
+      magic-enter
+      zle _magic-enter_orig_accept-line -- "$@"
+    } ;;
+  # If no user widget defined, call the original accept-line widget
+  builtin) function _magic-enter_accept-line() {
+      magic-enter
+      zle .accept-line
+    } ;;
+esac
+
+zle -N accept-line _magic-enter_accept-line


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

### Fix 1: make it compatible with zsh-autosuggestions

This solution makes the magic-enter function a wrapper for the accept-line zle widget, meaning that magic-enter will be run instead of accept-line (this is usually done when pressing Enter or running `zle accept-line`).

The zsh-autosuggestions plugin will automatically notice this is a wrapper and properly assign it the "clear suggestions" action when run.

Also: refactored and changed code style of the plugin.
Related: https://github.com/marlonrichert/zsh-autocomplete/issues/131

### Fix 2: fix running of magic command when not in PS1

Checks the [`$CONTEXT` variable](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#User_002dDefined-Widgets) to see whether we're in the start of the prompt. This solves the bug where, for example, the user would have typed `echo '` and <kbd>Enter</kbd>, then zsh would be in PS2 waiting for the user to close the quote, and while the line would be empty, the user would press <kbd>Enter</kbd>, triggering the magic commands.

Fixes https://github.com/ohmyzsh/ohmyzsh/issues/9464#issuecomment-732957452

### Fix 3: emulate user typing the magic command

Use `$BUFFER` and `zle .accept-line` to make it behave nicely towards other zsh plugins.

NOTE: this changes the behavior of the magic-enter widget: instead of leaving the prompt line empty, the output appearing below it and then redrawing the prompt, now the magic command will appear in the command prompt and "type Enter" as if the user did it themselves.

Fixes https://github.com/ohmyzsh/ohmyzsh/issues/9464#issuecomment-732412867

### Fix 4: don't overwrite original accept-line widget wrappers

Fixes https://github.com/ohmyzsh/ohmyzsh/issues/9464#issuecomment-732984761

-----

Fixes #9464
