### PR TITLE
feat(wp-cli): add aliases for DB management

### DIFF
--- a/plugins/wp-cli/README.md
+++ b/plugins/wp-cli/README.md
@@ -1,115 +1,109 @@
 # WP-CLI
 
+The [WordPress CLI](https://wp-cli.org/) is a command-line tool for managing WordPress installations. You can update plugins, set up multisite installs and much more, without using a web browser.
+
+This plugin adds [tab completion](https://wp-cli.org/#tab-completions) for `wp-cli` as well as several aliases for commonly used commands.
+
+To use it, add `wp-cli` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... wp-cli)
+```
+
 **Maintainer:** [joshmedeski](https://github.com/joshmedeski)
 
-WordPress Command Line Interface (https://wp-cli.org/)
+## Aliases
 
-WP-CLI is a set of command-line tools for managing WordPress installations. You can update plugins, set up multisite installs and much more, without using a web browser.
+The entire list of `wp-cli` commands can be found here: https://developer.wordpress.org/cli/commands/
 
-This plugin adds [tab completion](https://wp-cli.org/#tab-completions) for `wp-cli` as well as several aliases.
-
-## List of Aliases
-
-### Core
-- wpcc='wp core config'
-- wpcd='wp core download'
-- wpci='wp core install'
-- wpcii='wp core is-installed'
-- wpcmc='wp core multisite-convert'
-- wpcmi='wp core multisite-install'
-- wpcu='wp core update'
-- wpcudb='wp core update-db'
-- wpcvc='wp core verify-checksums'
-
-### Cron
-- wpcre='wp cron event'
-- wpcrs='wp cron schedule'
-- wpcrt='wp cron test'
-
-### Database
-- wpdbe='wp db export'
-- wpdbi='wp db import'
-- wpdbcr='wp db create'
-- wpdbs='wp db search'
-- wpdbch='wp db check'
-- wpdbr='wp db repair'
-
-### Menu
-- wpmc='wp menu create'
-- wpmd='wp menu delete'
-- wpmi='wp menu item'
-- wpml='wp menu list'
-- wpmlo='wp menu location'
-
-### Plugin
-- wppa='activate'
-- wppda='deactivate'
-- wppd='delete'
-- wppg='get'
-- wppi='install'
-- wppis='is-installed'
-- wppl='list'
-- wppp='path'
-- wpps='search'
-- wppst='status'
-- wppt='toggle'
-- wppun='uninstall'
-- wppu='update'
-
-### Post
-- wppoc='wp post create'
-- wppod='wp post delete'
-- wppoe='wp post edit'
-- wppogen='wp post generate'
-- wppog='wp post get'
-- wppol='wp post list'
-- wppom='wp post meta'
-- wppou='wp post update'
-- wppourl='wp post url'
-
-### Sidebar
-- wpsbl='wp sidebar list'
-
-### Theme
-- wpta='wp theme activate'
-- wptd='wp theme delete'
-- wptdis='wp theme disable'
-- wpte='wp theme enable'
-- wptg='wp theme get'
-- wpti='wp theme install'
-- wptis='wp theme is-installed'
-- wptl='wp theme list'
-- wptm='wp theme mod'
-- wptp='wp theme path'
-- wpts='wp theme search'
-- wptst='wp theme status'
-- wptu='wp theme update'
-
-### User
-- wpuac='wp user add-cap'
-- wpuar='wp user add-role'
-- wpuc='wp user create'
-- wpud='wp user delete'
-- wpugen='wp user generate'
-- wpug='wp user get'
-- wpui='wp user import-csv'
-- wpul='wp user list'
-- wpulc='wp user list-caps'
-- wpum='wp user meta'
-- wpurc='wp user remove-cap'
-- wpurr='wp user remove-role'
-- wpusr='wp user set-role'
-- wpuu='wp user update'
-
-### Widget
-- wpwa='wp widget add'
-- wpwda='wp widget deactivate'
-- wpwd='wp widget delete'
-- wpwl='wp widget list'
-- wpwm='wp widget move'
-- wpwu='wp widget update'
-
-The entire list of wp-cli commands can be found here: https://wp-cli.org/commands/
-
-I only included the commands that are most used. Please feel free to contribute to this project if you want more commands.
-
+| Alias     | Command                     |
+|-----------|-----------------------------|
+| **Core**                                |
+| `wpcc`    | `wp core config`            |
+| `wpcd`    | `wp core download`          |
+| `wpci`    | `wp core install`           |
+| `wpcii`   | `wp core is-installed`      |
+| `wpcmc`   | `wp core multisite-convert` |
+| `wpcmi`   | `wp core multisite-install` |
+| `wpcu`    | `wp core update`            |
+| `wpcudb`  | `wp core update-db`         |
+| `wpcvc`   | `wp core verify-checksums`  |
+| **Cron**                                |
+| `wpcre`   | `wp cron event`             |
+| `wpcrs`   | `wp cron schedule`          |
+| `wpcrt`   | `wp cron test`              |
+| **Database**                            |
+| `wpdbe`   | `wp db export`              |
+| `wpdbi`   | `wp db import`              |
+| `wpdbcr`  | `wp db create`              |
+| `wpdbs`   | `wp db search`              |
+| `wpdbch`  | `wp db check`               |
+| `wpdbr`   | `wp db repair`              |
+| **Menu**                                |
+| `wpmc`    | `wp menu create`            |
+| `wpmd`    | `wp menu delete`            |
+| `wpmi`    | `wp menu item`              |
+| `wpml`    | `wp menu list`              |
+| `wpmlo`   | `wp menu location`          |
+| **Plugin**                              |
+| `wppa`    | `wp plugin activate`        |
+| `wppda`   | `wp plugin deactivate`      |
+| `wppd`    | `wp plugin delete`          |
+| `wppg`    | `wp plugin get`             |
+| `wppi`    | `wp plugin install`         |
+| `wppis`   | `wp plugin is-installed`    |
+| `wppl`    | `wp plugin list`            |
+| `wppp`    | `wp plugin path`            |
+| `wpps`    | `wp plugin search`          |
+| `wppst`   | `wp plugin status`          |
+| `wppt`    | `wp plugin toggle`          |
+| `wppun`   | `wp plugin uninstall`       |
+| `wppu`    | `wp plugin update`          |
+| **Post**                                |
+| `wppoc`   | `wp post create`            |
+| `wppod`   | `wp post delete`            |
+| `wppoe`   | `wp post edit`              |
+| `wppogen` | `wp post generate`          |
+| `wppog`   | `wp post get`               |
+| `wppol`   | `wp post list`              |
+| `wppom`   | `wp post meta`              |
+| `wppou`   | `wp post update`            |
+| `wppourl` | `wp post url`               |
+| **Sidebar**                             |
+| `wpsbl`   | `wp sidebar list`           |
+| **Theme**                               |
+| `wpta`    | `wp theme activate`         |
+| `wptd`    | `wp theme delete`           |
+| `wptdis`  | `wp theme disable`          |
+| `wpte`    | `wp theme enable`           |
+| `wptg`    | `wp theme get`              |
+| `wpti`    | `wp theme install`          |
+| `wptis`   | `wp theme is-installed`     |
+| `wptl`    | `wp theme list`             |
+| `wptm`    | `wp theme mod`              |
+| `wptp`    | `wp theme path`             |
+| `wpts`    | `wp theme search`           |
+| `wptst`   | `wp theme status`           |
+| `wptu`    | `wp theme update`           |
+| **User**                                |
+| `wpuac`   | `wp user add-cap`           |
+| `wpuar`   | `wp user add-role`          |
+| `wpuc`    | `wp user create`            |
+| `wpud`    | `wp user delete`            |
+| `wpugen`  | `wp user generate`          |
+| `wpug`    | `wp user get`               |
+| `wpui`    | `wp user import-csv`        |
+| `wpul`    | `wp user list`              |
+| `wpulc`   | `wp user list-caps`         |
+| `wpum`    | `wp user meta`              |
+| `wpurc`   | `wp user remove-cap`        |
+| `wpurr`   | `wp user remove-role`       |
+| `wpusr`   | `wp user set-role`          |
+| `wpuu`    | `wp user update`            |
+| **Widget**                              |
+| `wpwa`    | `wp widget add`             |
+| `wpwda`   | `wp widget deactivate`      |
+| `wpwd`    | `wp widget delete`          |
+| `wpwl`    | `wp widget list`            |
+| `wpwm`    | `wp widget move`            |
+| `wpwu`    | `wp widget update`          |

--- a/plugins/wp-cli/README.md
+++ b/plugins/wp-cli/README.md
@@ -26,6 +26,14 @@ This plugin adds [tab completion](https://wp-cli.org/#tab-completions) for `wp-c
 - wpcrs='wp cron schedule'
 - wpcrt='wp cron test'
 
+### Database
+- wpdbe='wp db export'
+- wpdbi='wp db import'
+- wpdbcr='wp db create'
+- wpdbs='wp db search'
+- wpdbch='wp db check'
+- wpdbr='wp db repair'
+
 ### Menu
 - wpmc='wp menu create'
 - wpmd='wp menu delete'

--- a/plugins/wp-cli/wp-cli.plugin.zsh
+++ b/plugins/wp-cli/wp-cli.plugin.zsh
@@ -2,14 +2,6 @@
 # A command line interface for WordPress
 # https://wp-cli.org/
 
-# Cache
-
-# Cap
-
-# CLI
-
-# Comment
-
 # Core
 alias wpcc='wp core config'
 alias wpcd='wp core download'
@@ -34,28 +26,12 @@ alias wpdbs='wp db search'
 alias wpdbch='wp db check'
 alias wpdbr='wp db repair'
 
-# Eval
-
-# Eval-File
-
-# Export
-
-# Help
-
-# Import
-
-# Media
-
 # Menu
 alias wpmc='wp menu create'
 alias wpmd='wp menu delete'
 alias wpmi='wp menu item'
 alias wpml='wp menu list'
 alias wpmlo='wp menu location'
-
-# Network
-
-# Option
 
 # Plugin
 alias wppa='wp plugin activate'
@@ -83,24 +59,8 @@ alias wppom='wp post meta'
 alias wppou='wp post update'
 alias wppourl='wp post url'
 
-# Rewrite
-
-# Role
-
-# Scaffold
-
-# Search-Replace
-
-# Shell
-
 # Sidebar
 alias wpsbl='wp sidebar list'
-
-# Site
-
-# Super-Admin
-
-# Term
 
 # Theme
 alias wpta='wp theme activate'
@@ -116,8 +76,6 @@ alias wptp='wp theme path'
 alias wpts='wp theme search'
 alias wptst='wp theme status'
 alias wptu='wp theme update'
-
-# Transient
 
 # User
 alias wpuac='wp user add-cap'
@@ -144,9 +102,8 @@ alias wpwm='wp widget move'
 alias wpwu='wp widget update'
 
 
+# Completion for wp
 autoload -U +X bashcompinit && bashcompinit
-# bash completion for the `wp` command
-
 _wp_complete() {
 	local cur=${COMP_WORDS[COMP_CWORD]}
 

--- a/plugins/wp-cli/wp-cli.plugin.zsh
+++ b/plugins/wp-cli/wp-cli.plugin.zsh
@@ -27,6 +27,12 @@ alias wpcrs='wp cron schedule'
 alias wpcrt='wp cron test'
 
 # Db
+alias wpdbe='wp db export'
+alias wpdbi='wp db import'
+alias wpdbcr='wp db create'
+alias wpdbs='wp db search'
+alias wpdbch='wp db check'
+alias wpdbr='wp db repair'
 
 # Eval
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added aliases for some frequently used 'wp db' commands

## Other comments:

...
