### PR TITLE
shar format support for extract plugin

### DIFF
--- a/plugins/extract/README.md
+++ b/plugins/extract/README.md
@@ -31,6 +31,7 @@ plugins=(... extract)
 | `lzma`            | LZMA archive                         |
 | `rar`             | WinRAR archive                       |
 | `rpm`             | RPM package                          |
+| `shar`            | Shell archive                        |
 | `sublime-package` | Sublime Text package                 |
 | `tar`             | Tarball                              |
 | `tar.bz2`         | Tarball with bzip2 compression       |

--- a/plugins/extract/_extract
+++ b/plugins/extract/_extract
@@ -3,5 +3,5 @@
 
 _arguments \
   '(-r --remove)'{-r,--remove}'[Remove archive.]' \
-  "*::archive file:_files -g '(#i)*.(7z|Z|apk|aar|bz2|deb|gz|ipa|ipsw|jar|lrz|lz4|lzma|rar|rpm|sublime-package|tar|tar.bz2|tar.gz|tar.lrz|tar.lz|tar.lz4|tar.xz|tar.zma|tar.zst|tbz|tbz2|tgz|tlz|txz|tzst|war|whl|xpi|xz|zip|zst)(-.)'" \
+  "*::archive file:_files -g '(#i)*.(7z|Z|apk|aar|bz2|deb|gz|ipa|ipsw|jar|lrz|lz4|lzma|rar|rpm|shar|sublime-package|tar|tar.bz2|tar.gz|tar.lrz|tar.lz|tar.lz4|tar.xz|tar.zma|tar.zst|tbz|tbz2|tgz|tlz|txz|tzst|war|whl|xpi|xz|zip|zst)(-.)'" \
     && return 0

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -69,6 +69,7 @@ extract() {
 				cd ..
 			;;
 			(*.zst) unzstd "$1" ;;
+			(*.shar) sh "$1" ;;
 			(*)
 				echo "extract: '$1' cannot be extracted" >&2
 				success=1


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- The `.shar` format is still occasionally found in the wild, and it is quite easy to add support for it to the `extract` plugin.

## Other comments:

...
