### PR TITLE
Added a Lumin (fish-shell theme) port to Oh-My-ZSH.

### DIFF
--- a/themes/lumin.zsh-theme
+++ b/themes/lumin.zsh-theme
@@ -1,0 +1,8 @@
+PROMPT="$fg[blue]⌊$fg[green] %~ $reset_color$fg[blue]⌉$reset_color"
+PROMPT+=' %{$fg[blue]%}%c%{$reset_color%} $(git_prompt_info)
+▲ '
+
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}(%{$fg[magenta]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%})"

--- a/themes/lumin.zsh-theme
+++ b/themes/lumin.zsh-theme
@@ -1,5 +1,5 @@
 PROMPT="$fg[blue]⌊$fg[green] %~ $reset_color$fg[blue]⌉$reset_color"
-PROMPT+=' %{$fg[blue]%}%c%{$reset_color%} $(git_prompt_info)
+PROMPT+=' $(git_prompt_info)
 ▲ '
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}(%{$fg[magenta]%}"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The PR title is descriptive.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Created `lumin.zsh-theme`

## Other comments:
- Link to the [original fish theme](https://github.com/Ovyerus/lumin)
- Does not support changing the symbol or disabling the leading bracket, unlike the fish theme.