### PR TITLE
fix(git): silently fail in `git_main_branch` if not in a git repo

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -31,6 +31,10 @@ function work_in_progress() {
 
 # Check if main exists and use instead of master
 function git_main_branch() {
+  local ref
+  ref=$(__git_prompt_git symbolic-ref --quiet HEAD 2> /dev/null)
+  local ret=$?
+  [[ $ret == 128 ]] && return  # no git repo.
   local branch
   for branch in main trunk; do
     if command git show-ref -q --verify refs/heads/$branch; then

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -31,10 +31,7 @@ function work_in_progress() {
 
 # Check if main exists and use instead of master
 function git_main_branch() {
-  local ref
-  ref=$(__git_prompt_git symbolic-ref --quiet HEAD 2> /dev/null)
-  local ret=$?
-  [[ $ret == 128 ]] && return  # no git repo.
+  command git rev-parse --git-dir &>/dev/null || return
   local branch
   for branch in main trunk; do
     if command git show-ref -q --verify refs/heads/$branch; then


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- `git_main_branch` silently returns when executed outside of a git repo. 

## Other comments:

Mimics the same behaviour as `git_current_branch`
...
