### PR TITLE
Add docker-compose --env-file argument 

### DIFF
--- a/plugins/docker-compose/_docker-compose
+++ b/plugins/docker-compose/_docker-compose
@@ -342,6 +342,7 @@ _docker-compose() {
         '*'{-f,--file}"[${file_description}]:file:_files -g '*.yml'" \
         '(-p --project-name)'{-p,--project-name}'[Specify an alternate project name (default: directory name)]:project name:' \
         "--compatibility[If set, Compose will attempt to convert keys in v3 files to their non-Swarm equivalent]" \
+        "--env-file[Specify custom .env file (default: .env)]:file:_files -g '*'" \
         '(- :)'{-v,--version}'[Print version and exit]' \
         '--verbose[Show more output]' \
         '--log-level=[Set log level]:level:(DEBUG INFO WARNING ERROR CRITICAL)' \


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- **plugins/docker-compose/_docker-compose**: added support for `--env-file` argument according to [official documentation](https://docs.docker.com/compose/environment-variables/#substitute-environment-variables-in-compose-files) 

## Other comments:

...
