### PR TITLE
adding needed drupal 8 drush commands to `drush` plugin

### DIFF
--- a/plugins/drush/drush.plugin.zsh
+++ b/plugins/drush/drush.plugin.zsh
@@ -97,6 +97,12 @@ alias drv="drush version"
 alias drvd="drush variable-del"
 alias drvg="drush variable-get"
 alias drvs="drush variable-set"
+alias druli="drush uli"
+alias drcex="drush cex -y"
+alias drcim="drush cim -y"
+alias drws="drush ws"
+alias drwse="drush ws --extended"
+alias drwst="drush ws --tail"
 
 # Enable drush autocomplete support
 autoload bashcompinit


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Added the following aliases to the drush module in order to support Drupal 8 (and Drupal 7) development practices and troubleshooting:
- druli: provide link to log in to the drupal instance
- drcex: export drupal 8 config
- drcim: import drupal 8 config
- drws: display the last 10 watchdog entries (abbreviated by default)
- drwse: display the last 10 watchdog entries with full text
- drwst: set a `watch` of the last 10 watching entries (abbreviated by default)

## Other comments:

This is an excellent and useful ohmyzsh module, but a lot more could and should be done with the aliases for this particular module, aaand I may dedicate some time later to making that happen.
