### PR TITLE
feat(plugins): add genpass plugin with 3 distinct password generators

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Plugin owners
 plugins/aws/                        @maksyms
+plugins/genpass/                    @atoponce
 plugins/git-lfs/                    @vietduc01100001
 plugins/gitfast/                    @felipec
 plugins/sdk/                        @rgoldberg

--- a/plugins/genpass/README.md
+++ b/plugins/genpass/README.md
@@ -15,46 +15,46 @@ Install:
 
     plugins=(... genpass)
 
-### gen-apple-pass
+### gennpass-apple
 Generates a pronounceable pseudoword passphrase of the "cvccvc" consonant/vowel
 syntax, inspired by [Apple's iCloud Keychain password generator][1]. Each
 pseudoword has exactly 1 digit placed at the edge of a "word" and exactly 1
 capital letter to satisfy most password security requirements.
 
-    % gen-apple-pass 
+    % gennpass-apple
     gelcyv-foqtam-fotqoh-viMleb-lexduv-6ixfuk
 
-    % gen-apple-pass 3
+    % gennpass-apple 3
     japvyz-qyjti4-kajrod-nubxaW-hukkan-dijcaf
     vydpig-fucnul-3ukpog-voggom-zygNad-jepgad
     zocmez-byznis-hegTaj-jecdyq-qiqmiq-5enwom
 
 [1]: https://developer.apple.com/password-rules/
 
-### gen-monkey-pass
+### gennpass-monkey
 Generates visually unambiguous random meaningless strings using [Crockford's
 base32][2].
 
-    % gen-monkey-pass 
+    % gennpass-monkey
     xt7gn976e7jj3fstgpy27330x3
 
-    % gen-monkey-pass 3
+    % gennpass-monkey 3
     n1qqwtzgejwgqve9yzf2gxvx4m
     r2n3f5s6vbqs2yx7xjnmahqewy
     296w9y9rts3p5r9yay0raek8e5
 
 [2]: https://www.crockford.com/base32.html
 
-### gen-xkcd-pass
+### gennpass-xkcd
 Generates passphrases from `/usr/share/dict/words` inspired by the [famous (and
 slightly misleading) XKCD comic][3]. Each passphrase is prepended with a digit
 showing the number of words in the passphrase to adhere to password security
 requirements that require digits. Each word is 6 characters or less.
 
-    % gen-xkcd-pass
+    % gennpass-xkcd
     9-eaten-Slav-rife-aired-hill-cordon-splits-welsh-napes
 
-    % gen-xkcd-pass 3
+    % gennpass-xkcd 3
     9-worker-Vlad-horde-shrubs-smite-thwart-paw-alters-prawns
     9-tutors-stink-rhythm-junk-snappy-hooray-barbs-mewl-clomp
     9-vital-escape-Angkor-Huff-wet-Mayra-abbés-putts-guzzle

--- a/plugins/genpass/README.md
+++ b/plugins/genpass/README.md
@@ -1,5 +1,5 @@
-# README
-## genpass
+# genpass
+
 This plugin provides three unique password generators for ZSH. Each generator
 has at least a 128-bit security margin and generates passwords from the
 cryptographically secure `/dev/urandom`. Each generator can also take an
@@ -11,11 +11,12 @@ Requirements:
 * GNU coreutils (or appropriate for your system)
 * Word list providing `/usr/share/dict/words`
 
-Install:
+To use it, add `genpass` to the plugins array in your zshrc file:
 
     plugins=(... genpass)
 
-### genpass-apple
+## genpass-apple
+
 Generates a pronounceable pseudoword passphrase of the "cvccvc" consonant/vowel
 syntax, inspired by [Apple's iCloud Keychain password generator][1]. Each
 pseudoword has exactly 1 digit placed at the edge of a "word" and exactly 1
@@ -31,7 +32,8 @@ capital letter to satisfy most password security requirements.
 
 [1]: https://developer.apple.com/password-rules/
 
-### genpass-monkey
+## genpass-monkey
+
 Generates visually unambiguous random meaningless strings using [Crockford's
 base32][2].
 
@@ -45,7 +47,8 @@ base32][2].
 
 [2]: https://www.crockford.com/base32.html
 
-### genpass-xkcd
+## genpass-xkcd
+
 Generates passphrases from `/usr/share/dict/words` inspired by the [famous (and
 slightly misleading) XKCD comic][3]. Each passphrase is prepended with a digit
 showing the number of words in the passphrase to adhere to password security

--- a/plugins/genpass/README.md
+++ b/plugins/genpass/README.md
@@ -1,0 +1,62 @@
+# README
+## genpass
+This plugin provides three unique password generators for ZSH. Each generator
+has at least a 128-bit security margin and generates passwords from the
+cryptographically secure `/dev/urandom`. Each generator can also take an
+optional numeric argument to generate multiple passwords.
+
+Requirements:
+
+* `grep(1)`
+* GNU coreutils (or appropriate for your system)
+* Word list providing `/usr/share/dict/words`
+
+Install:
+
+    plugins=(... genpass)
+
+### gen-apple-pass
+Generates a pronounceable pseudoword passphrase of the "cvccvc" consonant/vowel
+syntax, inspired by [Apple's iCloud Keychain password generator][1]. Each
+pseudoword has exactly 1 digit placed at the edge of a "word" and exactly 1
+capital letter to satisfy most password security requirements.
+
+    % gen-apple-pass 
+    gelcyv-foqtam-fotqoh-viMleb-lexduv-6ixfuk
+
+    % gen-apple-pass 3
+    japvyz-qyjti4-kajrod-nubxaW-hukkan-dijcaf
+    vydpig-fucnul-3ukpog-voggom-zygNad-jepgad
+    zocmez-byznis-hegTaj-jecdyq-qiqmiq-5enwom
+
+[1]: https://developer.apple.com/password-rules/
+
+### gen-monkey-pass
+Generates visually unambiguous random meaningless strings using [Crockford's
+base32][2].
+
+    % gen-monkey-pass 
+    xt7gn976e7jj3fstgpy27330x3
+
+    % gen-monkey-pass 3
+    n1qqwtzgejwgqve9yzf2gxvx4m
+    r2n3f5s6vbqs2yx7xjnmahqewy
+    296w9y9rts3p5r9yay0raek8e5
+
+[2]: https://www.crockford.com/base32.html
+
+### gen-xkcd-pass
+Generates passphrases from `/usr/share/dict/words` inspired by the [famous (and
+slightly misleading) XKCD comic][3]. Each passphrase is prepended with a digit
+showing the number of words in the passphrase to adhere to password security
+requirements that require digits. Each word is 6 characters or less.
+
+    % gen-xkcd-pass
+    9-eaten-Slav-rife-aired-hill-cordon-splits-welsh-napes
+
+    % gen-xkcd-pass 3
+    9-worker-Vlad-horde-shrubs-smite-thwart-paw-alters-prawns
+    9-tutors-stink-rhythm-junk-snappy-hooray-barbs-mewl-clomp
+    9-vital-escape-Angkor-Huff-wet-Mayra-abbés-putts-guzzle
+
+[3]: https://xkcd.com/936/

--- a/plugins/genpass/README.md
+++ b/plugins/genpass/README.md
@@ -15,46 +15,46 @@ Install:
 
     plugins=(... genpass)
 
-### gennpass-apple
+### genpass-apple
 Generates a pronounceable pseudoword passphrase of the "cvccvc" consonant/vowel
 syntax, inspired by [Apple's iCloud Keychain password generator][1]. Each
 pseudoword has exactly 1 digit placed at the edge of a "word" and exactly 1
 capital letter to satisfy most password security requirements.
 
-    % gennpass-apple
+    % genpass-apple
     gelcyv-foqtam-fotqoh-viMleb-lexduv-6ixfuk
 
-    % gennpass-apple 3
+    % genpass-apple 3
     japvyz-qyjti4-kajrod-nubxaW-hukkan-dijcaf
     vydpig-fucnul-3ukpog-voggom-zygNad-jepgad
     zocmez-byznis-hegTaj-jecdyq-qiqmiq-5enwom
 
 [1]: https://developer.apple.com/password-rules/
 
-### gennpass-monkey
+### genpass-monkey
 Generates visually unambiguous random meaningless strings using [Crockford's
 base32][2].
 
-    % gennpass-monkey
+    % genpass-monkey
     xt7gn976e7jj3fstgpy27330x3
 
-    % gennpass-monkey 3
+    % genpass-monkey 3
     n1qqwtzgejwgqve9yzf2gxvx4m
     r2n3f5s6vbqs2yx7xjnmahqewy
     296w9y9rts3p5r9yay0raek8e5
 
 [2]: https://www.crockford.com/base32.html
 
-### gennpass-xkcd
+### genpass-xkcd
 Generates passphrases from `/usr/share/dict/words` inspired by the [famous (and
 slightly misleading) XKCD comic][3]. Each passphrase is prepended with a digit
 showing the number of words in the passphrase to adhere to password security
 requirements that require digits. Each word is 6 characters or less.
 
-    % gennpass-xkcd
+    % genpass-xkcd
     9-eaten-Slav-rife-aired-hill-cordon-splits-welsh-napes
 
-    % gennpass-xkcd 3
+    % genpass-xkcd 3
     9-worker-Vlad-horde-shrubs-smite-thwart-paw-alters-prawns
     9-tutors-stink-rhythm-junk-snappy-hooray-barbs-mewl-clomp
     9-vital-escape-Angkor-Huff-wet-Mayra-abbés-putts-guzzle

--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -2,9 +2,10 @@ autoload -U regexp-replace
 zmodload zsh/mathfunc
 
 genpass-apple() {
-  [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
+  typeset -i i j num
 
-  local i j
+  [[ $1 =~ '^[0-9]+$' ]] && num=$1 || num=1
+
   local c="$(LC_ALL=C tr -cd b-df-hj-np-tv-xz < /dev/urandom | head -c $((24*$num)))"
   local v="$(LC_ALL=C tr -cd aeiouy < /dev/urandom | head -c $((12*$num)))"
   local n="$(LC_ALL=C tr -cd 0-9 < /dev/urandom | head -c $num)"
@@ -23,8 +24,8 @@ genpass-apple() {
       pseudo="${pseudo}${c:$((24*$i+2*${j}-25)):1}"   # consonant
     done
 
-    local digit_pos=$base36[$p[$i]]
-    local char_pos=$digit_pos
+    typeset -i digit_pos=$base36[$p[$i]]
+    typeset -i char_pos=$digit_pos
 
     while [[ "$digit_pos" -eq "$char_pos" ]]; do
       char_pos=$base36[$(LC_ALL=C tr -cd 0-9a-z < /dev/urandom | head -c 1)]
@@ -42,9 +43,10 @@ genpass-apple() {
 }
 
 genpass-monkey() {
-  [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
+  typeset -i i num
 
-  local i
+  [[ $1 =~ '^[0-9]+$' ]] && num=$1 || num=1
+
   local pass=$(LC_ALL=C tr -cd '0-9a-hjkmnp-tv-z' < /dev/urandom | head -c $((26*$num)))
 
   for i in {1.."$num"}; do
@@ -53,11 +55,12 @@ genpass-monkey() {
 }
 
 genpass-xkcd() {
-  [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
+  typeset -i i num
 
-  local i
+  [[ $1 =~ '^[0-9]+$' ]] && num=$1 || num=1
+
   local dict=$(grep -E '^[a-zA-Z]{,6}$' /usr/share/dict/words)
-  local n=$((int(ceil(128*log(2)/log(${(w)#dict})))))
+  typeset -i n=$((int(ceil(128*log(2)/log(${(w)#dict})))))
 
   for i in {1.."$num"}; do
     printf "$n-"

--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -2,17 +2,18 @@ autoload -U regexp-replace
 zmodload zsh/mathfunc
 
 genpass-apple() {
-  typeset -i i j num
+  local -i i j num
 
   [[ $1 =~ '^[0-9]+$' ]] && num=$1 || num=1
 
-  local c="$(LC_ALL=C tr -cd b-df-hj-np-tv-xz < /dev/urandom | head -c $((24*$num)))"
+  local c="$(LC_ALL=C tr -cd b-df-hj-np-tv-xz < /dev/urandom \
+    | head -c $((24*$num)))"
   local v="$(LC_ALL=C tr -cd aeiouy < /dev/urandom | head -c $((12*$num)))"
   local n="$(LC_ALL=C tr -cd 0-9 < /dev/urandom | head -c $num)"
   local p="$(LC_ALL=C tr -cd 056bchinotuz < /dev/urandom | head -c $num)"
-  typeset -A base36=(0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 8 8 9 9 a 10 b 11 c 12 \
-    d 13 e 14 f 15 g 16 h 17 i 18 j 19 k 20 l 21 m 22 n 23 o 24 p 25 q 26 r 27 \
-    s 28 t 29 u 30 v 31 w 32 x 33 y 34 z 35)
+  local -A base36=(0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 8 8 9 9 a 10 b 11 c 12 d 13 \
+    e 14 f 15 g 16 h 17 i 18 j 19 k 20 l 21 m 22 n 23 o 24 p 25 q 26 r 27 s 28 \
+    t 29 u 30 v 31 w 32 x 33 y 34 z 35)
 
   for i in {1.."$num"}; do
     local pseudo=""
@@ -24,8 +25,8 @@ genpass-apple() {
       pseudo="${pseudo}${c:$((24*$i+2*${j}-25)):1}"   # consonant
     done
 
-    typeset -i digit_pos=$base36[$p[$i]]
-    typeset -i char_pos=$digit_pos
+    local -i digit_pos=$base36[$p[$i]]
+    local -i char_pos=$digit_pos
 
     while [[ "$digit_pos" -eq "$char_pos" ]]; do
       char_pos=$base36[$(LC_ALL=C tr -cd 0-9a-z < /dev/urandom | head -c 1)]
@@ -43,11 +44,12 @@ genpass-apple() {
 }
 
 genpass-monkey() {
-  typeset -i i num
+  local -i i num
 
   [[ $1 =~ '^[0-9]+$' ]] && num=$1 || num=1
 
-  local pass=$(LC_ALL=C tr -cd '0-9a-hjkmnp-tv-z' < /dev/urandom | head -c $((26*$num)))
+  local pass=$(LC_ALL=C tr -cd '0-9a-hjkmnp-tv-z' < /dev/urandom \
+    | head -c $((26*$num)))
 
   for i in {1.."$num"}; do
     printf "${pass:$((26*($i-1))):26}\n"
@@ -55,12 +57,12 @@ genpass-monkey() {
 }
 
 genpass-xkcd() {
-  typeset -i i num
+  local -i i num
 
   [[ $1 =~ '^[0-9]+$' ]] && num=$1 || num=1
 
   local dict=$(grep -E '^[a-zA-Z]{,6}$' /usr/share/dict/words)
-  typeset -i n=$((int(ceil(128*log(2)/log(${(w)#dict})))))
+  local -i n=$((int(ceil(128*log(2)/log(${(w)#dict})))))
 
   for i in {1.."$num"}; do
     printf "$n-"

--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -2,15 +2,20 @@ autoload -U regexp-replace
 zmodload zsh/mathfunc
 
 genpass-apple() {
+  # Generates a 128-bit password of 6 pseudowords of 6 characters each
+  # EG, xudmec-4ambyj-tavric-mumpub-mydVop-bypjyp
+  # Can take a numerical argument for generating extra passwords
   local -i i j num
 
   [[ $1 =~ '^[0-9]+$' ]] && num=$1 || num=1
 
-  local c="$(LC_ALL=C tr -cd b-df-hj-np-tv-xz < /dev/urandom \
+  local consonants="$(LC_ALL=C tr -cd b-df-hj-np-tv-xz < /dev/urandom \
     | head -c $((24*$num)))"
-  local v="$(LC_ALL=C tr -cd aeiouy < /dev/urandom | head -c $((12*$num)))"
-  local n="$(LC_ALL=C tr -cd 0-9 < /dev/urandom | head -c $num)"
-  local p="$(LC_ALL=C tr -cd 056bchinotuz < /dev/urandom | head -c $num)"
+  local vowels="$(LC_ALL=C tr -cd aeiouy < /dev/urandom | head -c $((12*$num)))"
+  local digits="$(LC_ALL=C tr -cd 0-9 < /dev/urandom | head -c $num)"
+
+  # The digit is placed on a pseudoword edge using $base36. IE, Dvccvc or cvccvD
+  local position="$(LC_ALL=C tr -cd 056bchinotuz < /dev/urandom | head -c $num)"
   local -A base36=(0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 8 8 9 9 a 10 b 11 c 12 d 13 \
     e 14 f 15 g 16 h 17 i 18 j 19 k 20 l 21 m 22 n 23 o 24 p 25 q 26 r 27 s 28 \
     t 29 u 30 v 31 w 32 x 33 y 34 z 35)
@@ -19,23 +24,30 @@ genpass-apple() {
     local pseudo=""
 
     for j in {1..12}; do
-      # uniformly iterate through $c and $v for each $i and $j
-      pseudo="${pseudo}${c:$((24*$i+2*${j}-26)):1}"   # consonant
-      pseudo="${pseudo}${v:$((12*$i+${j}-13)):1}"     # vowel
-      pseudo="${pseudo}${c:$((24*$i+2*${j}-25)):1}"   # consonant
+      # Uniformly iterate through $consonants and $vowels for each $i and $j
+      # Creates cvccvccvccvccvccvccvccvccvccvccvccvc for each $num
+      pseudo="${pseudo}${consonants:$((24*$i+2*${j}-26)):1}"
+      pseudo="${pseudo}${vowels:$((12*$i+${j}-13)):1}"
+      pseudo="${pseudo}${consonants:$((24*$i+2*${j}-25)):1}"
     done
 
-    local -i digit_pos=$base36[$p[$i]]
+    local -i digit_pos=${base36[${position[$i]}]}
     local -i char_pos=$digit_pos
 
+    # The digit and uppercase character must be in different locations
     while [[ $digit_pos == $char_pos ]]; do
       char_pos=$base36[$(LC_ALL=C tr -cd 0-9a-z < /dev/urandom | head -c 1)]
     done
 
+    # Places the digit on a pseudoword edge
     regexp-replace pseudo "^(.{$digit_pos}).(.*)$" \
-      '${match[1]}${n[$i]}${match[2]}'
+      '${match[1]}${digits[$i]}${match[2]}'
+
+    # Uppercase a random character (that is not a digit)
     regexp-replace pseudo "^(.{$char_pos})(.)(.*)$" \
       '${match[1]}${(U)match[2]}${match[3]}'
+
+    # Hyphenate each 6-character pseudoword
     regexp-replace pseudo '^(.{6})(.{6})(.{6})(.{6})(.{6})(.{6})$' \
       '${match[1]}-${match[2]}-${match[3]}-${match[4]}-${match[5]}-${match[6]}'
 
@@ -44,6 +56,9 @@ genpass-apple() {
 }
 
 genpass-monkey() {
+  # Generates a 128-bit base32 password as if monkeys banged the keyboard
+  # EG, nz5ej2kypkvcw0rn5cvhs6qxtm
+  # Can take a numerical argument for generating extra passwords
   local -i i num
 
   [[ $1 =~ '^[0-9]+$' ]] && num=$1 || num=1
@@ -57,11 +72,19 @@ genpass-monkey() {
 }
 
 genpass-xkcd() {
+  # Generates a 128-bit XKCD-style passphrase
+  # EG, 9-mien-flood-Patti-buxom-dozes-ickier-pay-ailed-Foster
+  # Can take a numerical argument for generating extra passwords
   local -i i num
 
   [[ $1 =~ '^[0-9]+$' ]] && num=$1 || num=1
 
+  # Get all alphabetic words of at most 6 characters in length
   local dict=$(grep -E '^[a-zA-Z]{,6}$' /usr/share/dict/words)
+
+  # Calculate the base-2 entropy of each word in $dict
+  # Entropy = log2($dict). For 128-bits, solve: 128 = entropy * log2($dict)
+  # Recall log2(n) = log(n)/log(2)
   local -i n=$((int(ceil(128*log(2)/log(${(w)#dict})))))
 
   for i in {1..$num}; do

--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -83,8 +83,9 @@ genpass-xkcd() {
   local dict=$(grep -E '^[a-zA-Z]{,6}$' /usr/share/dict/words)
 
   # Calculate the base-2 entropy of each word in $dict
-  # Entropy = log2($dict). For 128-bits, solve: 128 = entropy * log2($dict)
-  # Recall log2(n) = log(n)/log(2)
+  # Entropy is e = L * log2(C), where L is the length of the password (here,
+  # in words) and C the size of the character set (here, words in $dict).
+  # Solve for e = 128 bits of entropy. Recall: log2(n) = log(n)/log(2).
   local -i n=$((int(ceil(128*log(2)/log(${(w)#dict})))))
 
   for i in {1..$num}; do

--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -61,6 +61,6 @@ gen-xkcd-pass() {
 
   for i in {1.."$num"}; do
     printf "$n-"
-    printf "$dict" | shuf --random-source=/dev/urandom -n "$n" | paste -sd '-'
+    printf "$dict" | shuf -n "$n" | paste -sd '-'
   done
 }

--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -1,7 +1,7 @@
 autoload -U regexp-replace
 zmodload zsh/mathfunc
 
-gen-apple-pass() {
+gennpass-apple() {
   [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
 
   local i j
@@ -41,7 +41,7 @@ gen-apple-pass() {
   done
 }
 
-gen-monkey-pass() {
+gennpass-monkey() {
   [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
 
   local i
@@ -52,7 +52,7 @@ gen-monkey-pass() {
   done
 }
 
-gen-xkcd-pass() {
+gennpass-xkcd() {
   [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
 
   local i

--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -1,7 +1,7 @@
 autoload -U regexp-replace
 zmodload zsh/mathfunc
 
-gennpass-apple() {
+genpass-apple() {
   [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
 
   local i j
@@ -41,7 +41,7 @@ gennpass-apple() {
   done
 }
 
-gennpass-monkey() {
+genpass-monkey() {
   [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
 
   local i
@@ -52,7 +52,7 @@ gennpass-monkey() {
   done
 }
 
-gennpass-xkcd() {
+genpass-xkcd() {
   [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
 
   local i

--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -15,7 +15,7 @@ genpass-apple() {
     e 14 f 15 g 16 h 17 i 18 j 19 k 20 l 21 m 22 n 23 o 24 p 25 q 26 r 27 s 28 \
     t 29 u 30 v 31 w 32 x 33 y 34 z 35)
 
-  for i in {1.."$num"}; do
+  for i in {1..$num}; do
     local pseudo=""
 
     for j in {1..12}; do
@@ -28,7 +28,7 @@ genpass-apple() {
     local -i digit_pos=$base36[$p[$i]]
     local -i char_pos=$digit_pos
 
-    while [[ "$digit_pos" -eq "$char_pos" ]]; do
+    while [[ $digit_pos == $char_pos ]]; do
       char_pos=$base36[$(LC_ALL=C tr -cd 0-9a-z < /dev/urandom | head -c 1)]
     done
 
@@ -51,7 +51,7 @@ genpass-monkey() {
   local pass=$(LC_ALL=C tr -cd '0-9a-hjkmnp-tv-z' < /dev/urandom \
     | head -c $((26*$num)))
 
-  for i in {1.."$num"}; do
+  for i in {1..$num}; do
     printf "${pass:$((26*($i-1))):26}\n"
   done
 }
@@ -64,7 +64,7 @@ genpass-xkcd() {
   local dict=$(grep -E '^[a-zA-Z]{,6}$' /usr/share/dict/words)
   local -i n=$((int(ceil(128*log(2)/log(${(w)#dict})))))
 
-  for i in {1.."$num"}; do
+  for i in {1..$num}; do
     printf "$n-"
     printf "$dict" | shuf -n "$n" | paste -sd '-'
   done

--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -1,0 +1,66 @@
+autoload -U regexp-replace
+zmodload zsh/mathfunc
+
+gen-apple-pass() {
+  [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
+
+  local i j
+  local c="$(LC_ALL=C tr -cd b-df-hj-np-tv-xz < /dev/urandom | head -c $((24*$num)))"
+  local v="$(LC_ALL=C tr -cd aeiouy < /dev/urandom | head -c $((12*$num)))"
+  local n="$(LC_ALL=C tr -cd 0-9 < /dev/urandom | head -c $num)"
+  local p="$(LC_ALL=C tr -cd 056bchinotuz < /dev/urandom | head -c $num)"
+  typeset -A base36=(0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 8 8 9 9 a 10 b 11 c 12 \
+    d 13 e 14 f 15 g 16 h 17 i 18 j 19 k 20 l 21 m 22 n 23 o 24 p 25 q 26 r 27 \
+    s 28 t 29 u 30 v 31 w 32 x 33 y 34 z 35)
+
+  for i in {1.."$num"}; do
+    local pseudo=""
+
+    for j in {1..12}; do
+      # uniformly iterate through $c and $v for each $i and $j
+      pseudo="${pseudo}${c:$((24*$i+2*${j}-26)):1}"   # consonant
+      pseudo="${pseudo}${v:$((12*$i+${j}-13)):1}"     # vowel
+      pseudo="${pseudo}${c:$((24*$i+2*${j}-25)):1}"   # consonant
+    done
+
+    local digit_pos=$base36[$p[$i]]
+    local char_pos=$digit_pos
+
+    while [[ "$digit_pos" -eq "$char_pos" ]]; do
+      char_pos=$base36[$(LC_ALL=C tr -cd 0-9a-z < /dev/urandom | head -c 1)]
+    done
+
+    regexp-replace pseudo "^(.{$digit_pos}).(.*)$" \
+      '${match[1]}${n[$i]}${match[2]}'
+    regexp-replace pseudo "^(.{$char_pos})(.)(.*)$" \
+      '${match[1]}${(U)match[2]}${match[3]}'
+    regexp-replace pseudo '^(.{6})(.{6})(.{6})(.{6})(.{6})(.{6})$' \
+      '${match[1]}-${match[2]}-${match[3]}-${match[4]}-${match[5]}-${match[6]}'
+
+    printf "${pseudo}\n"
+  done
+}
+
+gen-monkey-pass() {
+  [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
+
+  local i
+  local pass=$(LC_ALL=C tr -cd '0-9a-hjkmnp-tv-z' < /dev/urandom | head -c $((26*$num)))
+
+  for i in {1.."$num"}; do
+    printf "${pass:$((26*($i-1))):26}\n"
+  done
+}
+
+gen-xkcd-pass() {
+  [[ $1 =~ '^[0-9]+$' ]] && local num=$1 || local num=1
+
+  local i
+  local dict=$(grep -E '^[a-zA-Z]{,6}$' /usr/share/dict/words)
+  local n=$((int(ceil(128*log(2)/log(${(w)#dict})))))
+
+  for i in {1.."$num"}; do
+    printf "$n-"
+    printf "$dict" | shuf --random-source=/dev/urandom -n "$n" | paste -sd '-'
+  done
+}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- 
    Add genpass plugin providing `gen-apple-pass`, `gen-monkey-pass`, and `gen-xkcd-pass` password generators

## Other comments:
These password generators help minimize the mistake people make thinking they can "design" good passwords in the shell. Instead, each password generator provided by this plugin generates passwords with at least a 128-bit security margin, suitable even for cryptographic keys. The user can provide a numerical argument to generate more passwords if needed. No external 3rd party software is required.
...
