### PR TITLE
fix(genpass): fix grep regex in `genpass-xkcd` for FreeBSD version

### DIFF
--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -80,7 +80,7 @@ genpass-xkcd() {
   [[ $1 =~ '^[0-9]+$' ]] && num=$1 || num=1
 
   # Get all alphabetic words of at most 6 characters in length
-  local dict=$(LC_ALL=C grep -E '^[a-zA-Z]{,6}$' /usr/share/dict/words)
+  local dict=$(LC_ALL=C grep -E '^[a-zA-Z]{1,6}$' /usr/share/dict/words)
 
   # Calculate the base-2 entropy of each word in $dict
   # Entropy is e = L * log2(C), where L is the length of the password (here,


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- there was a minor typo in the regular expression sent to `grep` in `genpass-xkcd`, such that `dict` was always empty. I have fixed it by adding a lower bound to the regex range. Fixes #9513.

## Other comments:

oh my zsh rocks!