### PR TITLE
fix(genpass): check for "shuf" command  in `genpass-xkcd` for MacOS

### DIFF
--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -75,6 +75,13 @@ genpass-xkcd() {
   # Generates a 128-bit XKCD-style passphrase
   # EG, 9-mien-flood-Patti-buxom-dozes-ickier-pay-ailed-Foster
   # Can take a numerical argument for generating extra passwords
+  
+  #Check for presence of shuf command.  Not installed by default on MacOS
+  if ! command -v shuf > /dev/null 2>&1; then
+    echo "Note: you need to install shuf, depending on your OS or distribution. (For MacOS, brew install coreutils)"
+    return 1
+  fi
+  
   local -i i num
 
   [[ $1 =~ '^[0-9]+$' ]] && num=$1 || num=1


### PR DESCRIPTION
"shuf" is not a standard command on MacOS and requires installation of the brew coreutils package

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X ] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- The "shuf" command is not standard on MacOS.   It must be optionally installed from the third-party brew coreutils package.  This change checks to see if the command exists or not and displays a helpful error if not installed.

## Other comments:

...
