### PR TITLE
command fix(genpass): Add compatibility for MacOS paste command in `genpass-xkcd`

### DIFF
--- a/plugins/genpass/genpass.plugin.zsh
+++ b/plugins/genpass/genpass.plugin.zsh
@@ -88,8 +88,16 @@ genpass-xkcd() {
   # Solve for e = 128 bits of entropy. Recall: log2(n) = log(n)/log(2).
   local -i n=$((int(ceil(128*log(2)/log(${(w)#dict})))))
 
-  for i in {1..$num}; do
+  # MacOS compatibility for paste command
+  if [[ "$OSTYPE" = darwin* ]]; then
+   for i in {1..$num}; do
+     printf "$n-"
+     printf "$dict" | shuf -n "$n" | paste -sd '-' -
+   done
+  else
+   for i in {1..$num}; do
     printf "$n-"
     printf "$dict" | shuf -n "$n" | paste -sd '-'
-  done
+   done
+  fi
 }


### PR DESCRIPTION
"paste" on MacOS requires a '-' to signify that the standard input is used.  Without the '-' character, the command errors out.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Check if command is running under MacOS (darwin*) and use a mac compatible format instead.

## Other comments:

"paste" on MacOS requires a '-' to signify that the standard input is used.  Without the '-' character, the command errors out.
