### PR TITLE
feat(macports): add 'reclaim' to completion list for Macports

### DIFF
--- a/plugins/macports/_port
+++ b/plugins/macports/_port
@@ -43,6 +43,7 @@ subcmds=(
 'provides'
 'rdependents'
 'rdeps'
+'reclaim'
 'rpmpackage'
 'search'
 'selfupdate'


### PR DESCRIPTION
The sub-command `reclaim` is quite useful for freeing up disk space.

`reclaim` is missing from the list of completions in the `macports` plugin.

The description for the `reclaim` sub-command is:
"port reclaim will find files that can be removed to reclaim disk space by uninstalling inactive ports on your system as well as unnecessary unrequested ports, and removing unneeded or unused installation files. The user is then provided interactive options for files to remove. No files are removed initially, until the user selects them from the provided list."

For all the details use this command on a system with Macports installed:

`port help reclaim`

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add `reclaim` to subcmds list
