### PR TITLE
feat(lib): show commit hash in `git_prompt_info`

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -29,7 +29,14 @@ function git_prompt_info() {
     && upstream=" -> ${upstream}"
   fi
 
-  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref}${upstream}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
+  # Use global ZSH_THEME_GIT_SHOW_COMMITHASH=1 for including current HEAD commit short hash
+  local commitHash
+  if (( ${+ZSH_THEME_GIT_SHOW_COMMITHASH} )); then
+    commitHash=$(__git_prompt_git rev-parse --short HEAD 2> /dev/null) \
+    && commitHash="[${commitHash}]"
+  fi
+
+  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref}${commitHash}${upstream}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
 }
 
 # Checks if working tree is dirty


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Use `ZSH_THEME_GIT_SHOW_COMMITHASH=1` 

Like `ZSH_THEME_GIT_SHOW_UPSTREAM=1`, utilizing `ZSH_THEME_GIT_SHOW_COMMITHASH=1` to show commit hash of the current HEAD commit alongside the `ref` name.

I.e: `master[394774b]` instead of `master`

This can be very useful in case of mistakenly losing or modifying local commits, as the hash will be easily retrievable from the prompt, and hence can help recovering from lost commits, or also revert amended ones.

It can help recovering from commands or use cases like:
- `git reset --hard HEAD~1`
- `git commit --amend`
