### PR TITLE
refactor: use +commands in check_for_upgrade

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -9,7 +9,7 @@ fi
 # - git is unavailable on the system.
 if [[ "$DISABLE_AUTO_UPDATE" = true ]] \
    || [[ ! -w "$ZSH" || ! -O "$ZSH" ]] \
-   || ! command -v git &>/dev/null; then
+   || (( ${+commands[git]} )); then
   return
 fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- refactor: use "+commands" in check_for_upgrade

## Other comments:

Use `$+commands[git]` instead of `command -v git`.
