### PR TITLE
feat(last-working-dir): log separate `lwd`s for different SSH keys on the same user account

### DIFF
--- a/plugins/last-working-dir/README.md
+++ b/plugins/last-working-dir/README.md
@@ -1,14 +1,9 @@
 # last-working-dir plugin
 
-## Introduction
-
 Keeps track of the last used working directory and automatically jumps into it
-for new shells, unless:
+for new shells, unless the starting directory is not `$HOME`.
 
-- The plugin is already loaded.
-- The current `$PWD` is not `$HOME`.
-
-Also adds `lwd` function to jump to the last working directory.
+Also adds a `lwd` function to jump to the last working directory.
 
 To use it, add `last-working-dir` to the plugins array in your zshrc file:
 
@@ -18,17 +13,20 @@ plugins=(... last-working-dir)
 
 ## Features
 
-### Separate lwd with different SSH keys
+### Use separate last-working-dir files with different SSH keys
 
-Seperate working directories on a user account with different SSH keys.
+If the same user account is used by multiple users connecting via different SSH keys, you can
+configure SSH to map them to different `SSH_USER`s and the plugin will use separate lwd files
+for each one.
 
-Be sure that your SSH server allow environment variables. You can enable this feature within the `/etc/sshd/sshd_config`:
+Make sure that your SSH server allows environment variables. You can enable this feature
+within the `/etc/sshd/sshd_config` file:
 
 ```
 PermitUserEnvironment yes
 ```
 
-To use it, add `environment="SSH_USER=<SSH_USERNAME>"` ahead the SSH keys in your authorized_keys file:
+Then, add `environment="SSH_USER=<SSH_USERNAME>"` before the SSH keys in your `authorized_keys` file:
 
 ```
 environment="SSH_USER=a.test@example.com" ssh-ed25519 AAAAC3Nz...

--- a/plugins/last-working-dir/README.md
+++ b/plugins/last-working-dir/README.md
@@ -1,5 +1,7 @@
 # last-working-dir plugin
 
+## Introduction
+
 Keeps track of the last used working directory and automatically jumps into it
 for new shells, unless:
 
@@ -12,4 +14,22 @@ To use it, add `last-working-dir` to the plugins array in your zshrc file:
 
 ```zsh
 plugins=(... last-working-dir)
+```
+
+## Features
+
+### Separate lwd with different SSH keys
+
+Seperate working directories on a user account with different SSH keys.
+
+Be sure that your SSH server allow environment variables. You can enable this feature within the `/etc/sshd/sshd_config`:
+
+```
+PermitUserEnvironment yes
+```
+
+To use it, add `environment="SSH_USER=<SSH_USERNAME>"` ahead the SSH keys in your authorized_keys file:
+
+```
+environment="SSH_USER=a.test@example.com" ssh-ed25519 AAAAC3Nz...
 ```

--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -5,16 +5,24 @@ typeset -g ZSH_LAST_WORKING_DIRECTORY
 autoload -U add-zsh-hook
 add-zsh-hook chpwd chpwd_last_working_dir
 chpwd_last_working_dir() {
-	if [ "$ZSH_SUBSHELL" = 0 ]; then
-		local cache_file="$ZSH_CACHE_DIR/last-working-dir"
-		pwd >| "$cache_file"
-	fi
+  if [ "$ZSH_SUBSHELL" = 0 ]; then
+    if [ "$SSH_USER" != "" ]; then
+      local cache_file="$ZSH_CACHE_DIR/last-working-dir"
+    else
+      local cache_file="$ZSH_CACHE_DIR/$SSH_USER-last-working-dir"
+    fi
+    pwd >| "$cache_file"
+  fi
 }
 
 # Changes directory to the last working directory
 lwd() {
-	local cache_file="$ZSH_CACHE_DIR/last-working-dir"
-	[[ -r "$cache_file" ]] && cd "$(cat "$cache_file")"
+  if [ "$SSH_USER" != "" ]; then
+    local cache_file="$ZSH_CACHE_DIR/last-working-dir"
+  else
+    local cache_file="$ZSH_CACHE_DIR/$SSH_USER-last-working-dir"
+  fi
+  [[ -r "$cache_file" ]] && cd "$(cat "$cache_file")"
 }
 
 # Jump to last directory automatically unless:

--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -7,9 +7,9 @@ add-zsh-hook chpwd chpwd_last_working_dir
 chpwd_last_working_dir() {
   if [ "$ZSH_SUBSHELL" = 0 ]; then
     if [ "$SSH_USER" != "" ]; then
-      local cache_file="$ZSH_CACHE_DIR/last-working-dir"
+      local cache_file="$ZSH_CACHE_DIR/last-working-dir-$SSH_USER"
     else
-      local cache_file="$ZSH_CACHE_DIR/$SSH_USER-last-working-dir"
+      local cache_file="$ZSH_CACHE_DIR/last-working-dir"
     fi
     pwd >| "$cache_file"
   fi
@@ -18,9 +18,9 @@ chpwd_last_working_dir() {
 # Changes directory to the last working directory
 lwd() {
   if [ "$SSH_USER" != "" ]; then
-    local cache_file="$ZSH_CACHE_DIR/last-working-dir"
+    local cache_file="$ZSH_CACHE_DIR/last-working-dir-$SSH_USER"
   else
-    local cache_file="$ZSH_CACHE_DIR/$SSH_USER-last-working-dir"
+    local cache_file="$ZSH_CACHE_DIR/last-working-dir"
   fi
   [[ -r "$cache_file" ]] && cd "$(cat "$cache_file")"
 }

--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -5,23 +5,17 @@ typeset -g ZSH_LAST_WORKING_DIRECTORY
 autoload -U add-zsh-hook
 add-zsh-hook chpwd chpwd_last_working_dir
 chpwd_last_working_dir() {
-  if [ "$ZSH_SUBSHELL" = 0 ]; then
-    if [ "$SSH_USER" != "" ]; then
-      local cache_file="$ZSH_CACHE_DIR/last-working-dir-$SSH_USER"
-    else
-      local cache_file="$ZSH_CACHE_DIR/last-working-dir"
-    fi
-    pwd >| "$cache_file"
-  fi
+  # Don't run in subshells
+  [[ "$ZSH_SUBSHELL" -eq 0 ]] || return 0
+  # Add ".$SSH_USER" suffix to cache file if $SSH_USER is set and non-empty
+  local cache_file="$ZSH_CACHE_DIR/last-working-dir${SSH_USER:+.$SSH_USER}"
+  pwd >| "$cache_file"
 }
 
 # Changes directory to the last working directory
 lwd() {
-  if [ "$SSH_USER" != "" ]; then
-    local cache_file="$ZSH_CACHE_DIR/last-working-dir-$SSH_USER"
-  else
-    local cache_file="$ZSH_CACHE_DIR/last-working-dir"
-  fi
+  # Add ".$SSH_USER" suffix to cache file if $SSH_USER is set and non-empty
+  local cache_file="$ZSH_CACHE_DIR/last-working-dir${SSH_USER:+.$SSH_USER}"
   [[ -r "$cache_file" ]] && cd "$(cat "$cache_file")"
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Modified condition at ```chpwd_last_workind_dir``` and ```lwd```.