### PR TITLE
Add function wrapper around compinit logic in oh-my-zsh.sh

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -95,7 +95,7 @@ $zcompdump_fpath
 EOF
   fi
 }
-if [[ "$DISABLE_COMPINIT" != "true" ]]; then
+if [[ "$ZSH_DISABLE_COMPINIT" != "true" ]]; then
   run_compinit
 fi
 

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -95,9 +95,9 @@ $zcompdump_fpath
 EOF
   fi
 }
-
-run_compinit
-
+if [[ "$DISABLE_COMPINIT" != "true" ]]; then
+  run_compinit
+fi
 
 # Load all of the config files in ~/oh-my-zsh that end in .zsh
 # TIP: Add files you don't want in git to .gitignore

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -59,40 +59,44 @@ if [ -z "$ZSH_COMPDUMP" ]; then
   ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
-# Construct zcompdump OMZ metadata
-zcompdump_revision="#omz revision: $(builtin cd -q "$ZSH"; git rev-parse HEAD 2>/dev/null)"
-zcompdump_fpath="#omz fpath: $fpath"
+(( $+functions[run_compinit] )) ||
+function run_compinit() {
+  # Construct zcompdump OMZ metadata
+  local zcompdump_revision="#omz revision: $(builtin cd -q "$ZSH"; git rev-parse HEAD 2>/dev/null)"
+  local zcompdump_fpath="#omz fpath: $fpath"
+  local zcompdump_refresh
 
-# Delete the zcompdump file if OMZ zcompdump metadata changed
-if ! command grep -q -Fx "$zcompdump_revision" "$ZSH_COMPDUMP" 2>/dev/null \
-   || ! command grep -q -Fx "$zcompdump_fpath" "$ZSH_COMPDUMP" 2>/dev/null; then
-  command rm -f "$ZSH_COMPDUMP"
-  zcompdump_refresh=1
-fi
+  # Delete the zcompdump file if OMZ zcompdump metadata changed
+  if ! command grep -q -Fx "$zcompdump_revision" "$ZSH_COMPDUMP" 2>/dev/null \
+    || ! command grep -q -Fx "$zcompdump_fpath" "$ZSH_COMPDUMP" 2>/dev/null; then
+    command rm -f "$ZSH_COMPDUMP"
+    zcompdump_refresh=1
+  fi
 
-if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
-  source $ZSH/lib/compfix.zsh
-  # If completion insecurities exist, warn the user
-  handle_completion_insecurities
-  # Load only from secure directories
-  compinit -i -C -d "${ZSH_COMPDUMP}"
-else
-  # If the user wants it, load from all found directories
-  compinit -u -C -d "${ZSH_COMPDUMP}"
-fi
+  if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
+    source $ZSH/lib/compfix.zsh
+    # If completion insecurities exist, warn the user
+    handle_completion_insecurities
+    # Load only from secure directories
+    compinit -i -C -d "${ZSH_COMPDUMP}"
+  else
+    # If the user wants it, load from all found directories
+    compinit -u -C -d "${ZSH_COMPDUMP}"
+  fi
 
-# Append zcompdump metadata if missing
-if (( $zcompdump_refresh )); then
-  # Use `tee` in case the $ZSH_COMPDUMP filename is invalid, to silence the error
-  # See https://github.com/ohmyzsh/ohmyzsh/commit/dd1a7269#commitcomment-39003489
-  tee -a "$ZSH_COMPDUMP" &>/dev/null <<EOF
+  # Append zcompdump metadata if missing
+  if (( $zcompdump_refresh )); then
+    # Use `tee` in case the $ZSH_COMPDUMP filename is invalid, to silence the error
+    # See https://github.com/ohmyzsh/ohmyzsh/commit/dd1a7269#commitcomment-39003489
+    tee -a "$ZSH_COMPDUMP" &>/dev/null <<EOF
 
 $zcompdump_revision
 $zcompdump_fpath
 EOF
-fi
+  fi
+}
 
-unset zcompdump_revision zcompdump_fpath zcompdump_refresh
+run_compinit
 
 
 # Load all of the config files in ~/oh-my-zsh that end in .zsh


### PR DESCRIPTION
By adding run_compinit as a function wrapper that first checks for its existence, it then becomes possible to override the run_compinit function by defining it before OMZ is sourced.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Moves compinit logic into lib allowing advanced users to override compinit logic with standard $ZSH_CUSTOM methods
- Fixes longstanding issue of lib/compfix.zsh being double loaded
- Simplifies oh-my-zsh.sh into core functionality, without changing its logic
- Minor whitespace formatting changes for consistency

## Other comments:
See issue for discussion: https://github.com/ohmyzsh/ohmyzsh/issues/9258
This is a much simpler and lower risk change, and replaces the need for https://github.com/ohmyzsh/ohmyzsh/pull/9257
Be sure to view the diff ignoring whitespace changes, as that better shows the simplicity of this change (https://github.com/ohmyzsh/ohmyzsh/pull/9537/files?diff=unified&w=1)