### PR TITLE
Update nvm plugin read me to better describe how to enable a setting

### DIFF
--- a/plugins/nvm/README.md
+++ b/plugins/nvm/README.md
@@ -11,8 +11,8 @@ plugins=(... nvm)
 
 ## Settings
 
-- **`NVM_DIR`**: if you have installed nvm in a directory other than `$HOME/.nvm`, set and export `NVM_DIR`
-  to be the directory where you installed nvm.
+- **`NVM_DIR`**: if you have installed nvm in a directory other than `$HOME/.nvm`, set `NVM_DIR` to be the
+  directory where you installed nvm.
   
 - **`NVM_HOMEBREW`**: if you installed nvm via Homebrew, in a directory other than `/usr/local/opt/nvm`, you
   can set `NVM_HOMEBREW` to be the directory where you installed it.
@@ -24,3 +24,5 @@ plugins=(... nvm)
 - **`NVM_AUTOLOAD`**: if `NVM_AUTOLOAD` is set to `1`, the plugin will automatically load a node version when
   if finds a [`.nvmrc` file](https://github.com/nvm-sh/nvm#nvmrc) in the current working directory indicating
   which node version to load.
+
+To enable a setting, set and export it in your zshrc file, for example `export NVM_AUTOLOAD=1`.


### PR DESCRIPTION
It wasn’t clear to me where and how I should set the `NVM_AUTOLOAD` variable, i.e. `NVM_AUTOLOAD=1` or `export NVM_AUTOLOAD=1`. It seems the clue was in one of the other values, but I skipped that as that wasn’t the setting I was looking to change. Hopefully this is a bit clearer.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Updates README.md for nvm plugin

