### PR TITLE
docs(nvm): clarify how to enable settings

### DIFF
--- a/plugins/nvm/README.md
+++ b/plugins/nvm/README.md
@@ -11,9 +11,11 @@ plugins=(... nvm)
 
 ## Settings
 
-- **`NVM_DIR`**: if you have installed nvm in a directory other than `$HOME/.nvm`, set and export `NVM_DIR`
-  to be the directory where you installed nvm.
-  
+If you installed nvm in a directory other than `$HOME/.nvm`, set and export `NVM_DIR` to be the directory
+where you installed nvm.
+
+These settings should go in your zshrc file, before Oh My Zsh is sourced:
+
 - **`NVM_HOMEBREW`**: if you installed nvm via Homebrew, in a directory other than `/usr/local/opt/nvm`, you
   can set `NVM_HOMEBREW` to be the directory where you installed it.
 


### PR DESCRIPTION
It wasn’t clear where I should set the `NVM_AUTOLOAD` variable. The clue was to be found in [the docs for another plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/fzf). It seems setting values need to come before Oh My Zsh is sourced.

Updated read me to reflect this, and the fact that one of the settings mentioned is specific to nvm, not this plugin.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Update README.md for nvm plugin

## Other comments:

Replaces #9541
