### PR TITLE
Cleanup git aliases

### DIFF
--- a/plugins/git-lfs/README.md
+++ b/plugins/git-lfs/README.md
@@ -19,6 +19,6 @@ plugins=(... git-lfs)
 
 ## Functions
 
-| Function | Command                                         |
-| :------- | :---------------------------------------------- |
-| `gplfs`  | `git lfs push origin "$(current_branch)" --all` |
+| Function | Command                                             |
+| :------- | :-------------------------------------------------- |
+| `gplfs`  | `git lfs push origin "$(git_current_branch)" --all` |

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -47,7 +47,7 @@ plugins=(... git)
 | gcl                  | git clone --recurse-submodules                                                                                                   |
 | gclean               | git clean -id                                                                                                                    |
 | gpristine            | git reset --hard && git clean -dffx                                                                                              |
-| gcm                  | git checkout $(git_main_branch)                                                                                                                |
+| gcm                  | git checkout $(git_main_branch)                                                                                                  |
 | gcd                  | git checkout develop                                                                                                             |
 | gcmsg                | git commit -m                                                                                                                    |
 | gco                  | git checkout                                                                                                                     |
@@ -71,21 +71,21 @@ plugins=(... git)
 | gfo                  | git fetch origin                                                                                                                 |
 | gg                   | git gui citool                                                                                                                   |
 | gga                  | git gui citool --amend                                                                                                           |
-| ggf                  | git push --force origin $(current_branch)                                                                                        |
-| ggfl                 | git push --force-with-lease origin $(current_branch)                                                                             |
-| ggl                  | git pull origin $(current_branch)                                                                                                |
-| ggp                  | git push origin $(current_branch)                                                                                                |
+| ggf                  | git push --force origin $(git_current_branch)                                                                                    |
+| ggfl                 | git push --force-with-lease origin $(git_current_branch)                                                                         |
+| ggl                  | git pull origin $(git_current_branch)                                                                                            |
+| ggp                  | git push origin $(git_current_branch)                                                                                            |
 | ggpnp                | ggl && ggp                                                                                                                       |
 | ggpull               | git pull origin "$(git_current_branch)"                                                                                          |
 | ggpur                | ggu                                                                                                                              |
 | ggpush               | git push origin "$(git_current_branch)"                                                                                          |
 | ggsup                | git branch --set-upstream-to=origin/$(git_current_branch)                                                                        |
-| ggu                  | git pull --rebase origin $(current_branch)                                                                                       |
+| ggu                  | git pull --rebase origin $(git_current_branch)                                                                                   |
 | gpsup                | git push --set-upstream origin $(git_current_branch)                                                                             |
 | ghh                  | git help                                                                                                                         |
 | gignore              | git update-index --assume-unchanged                                                                                              |
 | gignored             | git ls-files -v \| grep "^[[:lower:]]"                                                                                           |
-| git-svn-dcommit-push | git svn dcommit && git push github $(git_main_branch):svntrunk                                                                                 |
+| git-svn-dcommit-push | git svn dcommit && git push github $(git_main_branch):svntrunk                                                                   |
 | gk                   | gitk --all --branches                                                                                                            |
 | gke                  | gitk --all $(git log -g --pretty=%h)                                                                                             |
 | gl                   | git pull                                                                                                                         |
@@ -104,10 +104,10 @@ plugins=(... git)
 | gloga                | git log --oneline --decorate --graph --all                                                                                       |
 | glp                  | git log --pretty=\<format\>                                                                                                      |
 | gm                   | git merge                                                                                                                        |
-| gmom                 | git merge origin/$(git_main_branch)                                                                                                            |
+| gmom                 | git merge origin/$(git_main_branch)                                                                                              |
 | gmt                  | git mergetool --no-prompt                                                                                                        |
 | gmtvim               | git mergetool --no-prompt --tool=vimdiff                                                                                         |
-| gmum                 | git merge upstream/$(git_main_branch)                                                                                                          |
+| gmum                 | git merge upstream/$(git_main_branch)                                                                                            |
 | gma                  | git merge --abort                                                                                                                |
 | gp                   | git push                                                                                                                         |
 | gpd                  | git push --dry-run                                                                                                               |
@@ -123,7 +123,7 @@ plugins=(... git)
 | grbc                 | git rebase --continue                                                                                                            |
 | grbd                 | git rebase develop                                                                                                               |
 | grbi                 | git rebase -i                                                                                                                    |
-| grbm                 | git rebase $(git_main_branch)                                                                                                                  |
+| grbm                 | git rebase $(git_main_branch)                                                                                                    |
 | grbs                 | git rebase --skip                                                                                                                |
 | grev                 | git revert                                                                                                                       |
 | grh                  | git reset                                                                                                                        |
@@ -170,7 +170,7 @@ plugins=(... git)
 | gupv                 | git pull --rebase -v                                                                                                             |
 | gupa                 | git pull --rebase --autostash                                                                                                    |
 | gupav                | git pull --rebase --autostash -v                                                                                                 |
-| glum                 | git pull upstream $(git_main_branch)                                                                                                           |
+| glum                 | git pull upstream $(git_main_branch)                                                                                             |
 | gwch                 | git whatchanged -p --abbrev-commit --pretty=medium                                                                               |
 | gwip                 | git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"           |
 | gam                  | git am                                                                                                                           |
@@ -197,9 +197,9 @@ These are aliases that have been removed, renamed, or otherwise modified in a wa
 | gdc    | `git diff --cached`                                    | new alias `gdca`                                       |
 | gds    | `git diff --staged`                                    | use `gdca`, they are synonymous                        |
 | gdt    | `git difftool`                                         | no replacement                                         |
-| ggpull | `git pull origin $(current_branch)`                    | new alias `ggl` (`ggpull` still exists for now though) |
-| ggpur  | `git pull --rebase origin $(current_branch)`           | new alias `ggu` (`ggpur` still exists for now though)  |
-| ggpush | `git push origin $(current_branch)`                    | new alias `ggp` (`ggpush` still exists for now though) |
+| ggpull | `git pull origin $(git_current_branch)`                | new alias `ggl` (`ggpull` still exists for now though) |
+| ggpur  | `git pull --rebase origin $(git_current_branch)`       | new alias `ggu` (`ggpur` still exists for now though)  |
+| ggpush | `git push origin $(git_current_branch)`                | new alias `ggp` (`ggpush` still exists for now though) |
 | gk     | `gitk --all --branches`                                | now aliased to `gitk --all --branches`                 |
 | glg    | `git log --stat --max-count=10`                        | now aliased to `git log --stat`                        |
 | glgg   | `git log --graph --max-count=10`                       | now aliased to `git log --graph`                       |
@@ -212,7 +212,7 @@ These are aliases that have been removed, renamed, or otherwise modified in a wa
 | Command                | Description                                                                  |
 |:-----------------------|:-----------------------------------------------------------------------------|
 | `grename <old> <new>`  | Rename `old` branch to `new`, including in origin remote                     |
-| current_branch         | Return the name of the current branch                                        |
+| git_current_branch     | Return the name of the current branch                                        |
 | git_current_user_name  | Returns the `user.name` config value                                         |
 | git_current_user_email | Returns the `user.email` config value                                        |
 | git_main_branch        | Returns the name of the main branch: `main` if it exists, `master` otherwise |

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -195,6 +195,7 @@ These are aliases that have been removed, renamed, or otherwise modified in a wa
 | gap    | `git add --patch`                                      | new alias `gapa`                                       |
 | gcl    | `git config --list`                                    | new alias `gcf`                                        |
 | gdc    | `git diff --cached`                                    | new alias `gdca`                                       |
+| gds    | `git diff --staged`                                    | use `gdca`, they are synonymous                        |
 | gdt    | `git difftool`                                         | no replacement                                         |
 | ggpull | `git pull origin $(current_branch)`                    | new alias `ggl` (`ggpull` still exists for now though) |
 | ggpur  | `git pull --rebase origin $(current_branch)`           | new alias `ggu` (`ggpur` still exists for now though)  |

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -201,9 +201,9 @@ These are aliases that have been removed, renamed, or otherwise modified in a wa
 | ggpur  | `git pull --rebase origin $(current_branch)`           | new alias `ggu` (`ggpur` still exists for now though)  |
 | ggpush | `git push origin $(current_branch)`                    | new alias `ggp` (`ggpush` still exists for now though) |
 | gk     | `gitk --all --branches`                                | now aliased to `gitk --all --branches`                 |
-| glg    | `git log --stat --max-count = 10`                      | now aliased to `git log --stat --color`                |
-| glgg   | `git log --graph --max-count = 10`                     | now aliased to `git log --graph --color`               |
-| gwc    | `git whatchanged -p --abbrev-commit --pretty = medium` | new alias `gwch`                                       |
+| glg    | `git log --stat --max-count=10`                        | now aliased to `git log --stat`                        |
+| glgg   | `git log --graph --max-count=10`                       | now aliased to `git log --graph`                       |
+| gwc    | `git whatchanged -p --abbrev-commit --pretty=medium`   | new alias `gwch`                                       |
 
 ## Functions
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -127,6 +127,7 @@ function ggf() {
   git push --force origin "${b:=$1}"
 }
 compdef _git ggf=git-checkout
+
 function ggfl() {
   [[ "$#" != 1 ]] && local b="$(git_current_branch)"
   git push --force-with-lease origin "${b:=$1}"

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -99,7 +99,6 @@ alias gd='git diff'
 alias gdca='git diff --cached'
 alias gdcw='git diff --cached --word-diff'
 alias gdct='git describe --tags $(git rev-list --tags --max-count=1)'
-alias gds='git diff --staged'
 alias gdt='git diff-tree --no-commit-id --name-only -r'
 alias gdw='git diff --word-diff'
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- fix(git): change git-diff aliases
- fix(git): update deprecation notice for git aliases
- fix(git): replace remaining current_branch with git_current_branch

## Other comments:

Removal of an existing alias, albeit a duplicate, might not be desirable for old users. However it's good for new ones as it would avoid some confusion. And you shouldn't mindlessly update your zsh config without reviewing changes anyway.