### PR TITLE
refactor(archlinux): fix name & scripts; reorder aliases

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -31,11 +31,11 @@ plugins=(... archlinux)
 | pacupd[¹](#f1) | sudo pacman -Sy && sudo aur             | Update and refresh the local package and AUR databases       |
 | pacupd[¹](#f1) | sudo pacman -Sy                         | Update and refresh the local package database                |
 | pacupg         | sudo pacman -Syu                        | Sync with repositories before upgrading packages             |
-| upgrade        | sudo pacman -Syu                        | Sync with repositories before upgrading packages             |
 | pacfileupg     | sudo pacman -Fy                         | Download fresh package databases from the server             |
 | pacfiles       | pacman -F                               | Search package file names for matching strings               |
 | pacls          | pacman -Ql                              | List files in a package                                      |
 | pacown         | pacman -Qo                              | Show which package owns a file                               |
+| upgrade[³](#f3) | sudo pacman -Syu                       | Sync with repositories before upgrading packages             |
 
 | Function       | Description                                          |
 |----------------|------------------------------------------------------|
@@ -51,110 +51,120 @@ Note: paclist used to print packages with a description which are (1) explicitly
 
 #### Pacaur
 
-| Alias   | Command                            | Description                                                         |
-|---------|------------------------------------|---------------------------------------------------------------------|
-| pain    | pacaur -S                          | Install packages from the repositories                              |
-| pains   | pacaur -U                          | Install a package from a local file                                 |
-| painsd  | pacaur -S --asdeps                 | Install packages as dependencies of another package                 |
-| paloc   | pacaur -Qi                         | Display information about a package in the local database           |
-| palocs  | pacaur -Qs                         | Search for packages in the local database                           |
-| palst   | pacaur -Qe                         | List installed packages including from AUR (tagged as "local")      |
-| pamir   | pacaur -Syy                        | Force refresh of all package lists after updating mirrorlist        |
-| paorph  | pacaur -Qtd                        | Remove orphans using pacaur                                         |
-| pare    | pacaur -R                          | Remove packages, keeping its settings and dependencies              |
-| parem   | pacaur -Rns                        | Remove packages, including its settings and unneeded dependencies   |
-| parep   | pacaur -Si                         | Display information about a package in the repositories             |
-| pareps  | pacaur -Ss                         | Search for packages in the repositories                             |
-| paupd[¹](#f1) | pacaur -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases       |
-| paupd[¹](#f1) | pacaur -Sy && sudo abs             | Update and refresh the local package and ABS databases        |
-| paupd[¹](#f1) | pacaur -Sy && sudo aur             | Update and refresh the local package and AUR databases        |
-| paupd[¹](#f1) | pacaur -Sy                         | Update and refresh the local package database                 |
-| paupg   | pacaur -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
-| pasu    | pacaur -Syua --no-confirm          | Same as `paupg`, but without confirmation                           |
-| upgrade | pacaur -Syu                        | Sync with repositories before upgrading packages                    |
+| Alias   | Command                              | Description                                                         |
+|---------|--------------------------------------|---------------------------------------------------------------------|
+| pain    | `pacaur -S`                          | Install packages from the repositories                              |
+| pains   | `pacaur -U`                          | Install a package from a local file                                 |
+| painsd  | `pacaur -S --asdeps`                 | Install packages as dependencies of another package                 |
+| paloc   | `pacaur -Qi`                         | Display information about a package in the local database           |
+| palocs  | `pacaur -Qs`                         | Search for packages in the local database                           |
+| palst   | `pacaur -Qe`                         | List installed packages including from AUR (tagged as "local")      |
+| pamir   | `pacaur -Syy`                        | Force refresh of all package lists after updating mirrorlist        |
+| paorph  | `pacaur -Qtd`                        | Remove orphans using pacaur                                         |
+| pare    | `pacaur -R`                          | Remove packages, keeping its settings and dependencies              |
+| parem   | `pacaur -Rns`                        | Remove packages, including its settings and unneeded dependencies   |
+| parep   | `pacaur -Si`                         | Display information about a package in the repositories             |
+| pareps  | `pacaur -Ss`                         | Search for packages in the repositories                             |
+| paupd[¹](#f1) | `pacaur -Sy && sudo abs && sudo aur` | Update and refresh local package, ABS and AUR databases       |
+| paupd[¹](#f1) | `pacaur -Sy && sudo abs`             | Update and refresh the local package and ABS databases        |
+| paupd[¹](#f1) | `pacaur -Sy && sudo aur`             | Update and refresh the local package and AUR databases        |
+| paupd[¹](#f1) | `pacaur -Sy`                         | Update and refresh the local package database                 |
+| paupg   | `pacaur -Syua`                       | Sync with repositories before upgrading all packages (from AUR too) |
+| pasu    | `pacaur -Syua --no-confirm`          | Same as `paupg`, but without confirmation                           |
+| upgrade[³](#f3) | `pacaur -Syu`                | Sync with repositories before upgrading packages                    |
 
 #### Trizen
 
-| Alias   | Command                            | Description                                                         |
-|---------|------------------------------------|---------------------------------------------------------------------|
-| trconf  | trizen -C                          | Fix all configuration files with vimdiff                            |
-| trin    | trizen -S                          | Install packages from the repositories                              |
-| trins   | trizen -U                          | Install a package from a local file                                 |
-| trinsd  | trizen -S --asdeps                 | Install packages as dependencies of another package                 |
-| trloc   | trizen -Qi                         | Display information about a package in the local database           |
-| trlocs  | trizen -Qs                         | Search for packages in the local database                           |
-| trlst   | trizen -Qe                         | List installed packages including from AUR (tagged as "local")      |
-| trmir   | trizen -Syy                        | Force refresh of all package lists after updating mirrorlist        |
-| trorph  | trizen -Qtd                        | Remove orphans using yaourt                                         |
-| trre    | trizen -R                          | Remove packages, keeping its settings and dependencies              |
-| trrem   | trizen -Rns                        | Remove packages, including its settings and unneeded dependencies   |
-| trrep   | trizen -Si                         | Display information about a package in the repositories             |
-| trreps  | trizen -Ss                         | Search for packages in the repositories                             |
-| trupd[¹](#f1) | trizen -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases       |
-| trupd[¹](#f1) | trizen -Sy && sudo abs             | Update and refresh the local package and ABS databases        |
-| trupd[¹](#f1) | trizen -Sy && sudo aur             | Update and refresh the local package and AUR databases        |
-| trupd[¹](#f1) | trizen -Sy                         | Update and refresh the local package database                 |
-| trupg   | trizen -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
-| trsu    | trizen -Syua --no-confirm          | Same as `trupg`, but without confirmation                           |
-| upgrade | trizen -Syu                        | Sync with repositories before upgrading packages                    |
+| Alias   | Command                              | Description                                                         |
+|---------|--------------------------------------|---------------------------------------------------------------------|
+| trconf  | `trizen -C`                          | Fix all configuration files with vimdiff                            |
+| trin    | `trizen -S`                          | Install packages from the repositories                              |
+| trins   | `trizen -U`                          | Install a package from a local file                                 |
+| trinsd  | `trizen -S --asdeps`                 | Install packages as dependencies of another package                 |
+| trloc   | `trizen -Qi`                         | Display information about a package in the local database           |
+| trlocs  | `trizen -Qs`                         | Search for packages in the local database                           |
+| trlst   | `trizen -Qe`                         | List installed packages including from AUR (tagged as "local")      |
+| trmir   | `trizen -Syy`                        | Force refresh of all package lists after updating mirrorlist        |
+| trorph  | `trizen -Qtd`                        | Remove orphans using yaourt                                         |
+| trre    | `trizen -R`                          | Remove packages, keeping its settings and dependencies              |
+| trrem   | `trizen -Rns`                        | Remove packages, including its settings and unneeded dependencies   |
+| trrep   | `trizen -Si`                         | Display information about a package in the repositories             |
+| trreps  | `trizen -Ss`                         | Search for packages in the repositories                             |
+| trupd[¹](#f1) | `trizen -Sy && sudo abs && sudo aur` | Update and refresh local package, ABS and AUR databases       |
+| trupd[¹](#f1) | `trizen -Sy && sudo abs`             | Update and refresh the local package and ABS databases        |
+| trupd[¹](#f1) | `trizen -Sy && sudo aur`             | Update and refresh the local package and AUR databases        |
+| trupd[¹](#f1) | `trizen -Sy`                         | Update and refresh the local package database                 |
+| trupg   | `trizen -Syua`                       | Sync with repositories before upgrading all packages (from AUR too) |
+| trsu    | `trizen -Syua --no-confirm`          | Same as `trupg`, but without confirmation                           |
+| upgrade[³](#f3) | `trizen -Syu`                | Sync with repositories before upgrading packages                    |
 
 #### Yaourt[²](#f2)
 
-| Alias   | Command                            | Description                                                         |
-|---------|------------------------------------|---------------------------------------------------------------------|
-| yaconf  | yaourt -C                          | Fix all configuration files with vimdiff                            |
-| yain    | yaourt -S                          | Install packages from the repositories                              |
-| yains   | yaourt -U                          | Install a package from a local file                                 |
-| yainsd  | yaourt -S --asdeps                 | Install packages as dependencies of another package                 |
-| yaloc   | yaourt -Qi                         | Display information about a package in the local database           |
-| yalocs  | yaourt -Qs                         | Search for packages in the local database                           |
-| yalst   | yaourt -Qe                         | List installed packages including from AUR (tagged as "local")      |
-| yamir   | yaourt -Syy                        | Force refresh of all package lists after updating mirrorlist        |
-| yaorph  | yaourt -Qtd                        | Remove orphans using yaourt                                         |
-| yare    | yaourt -R                          | Remove packages, keeping its settings and dependencies              |
-| yarem   | yaourt -Rns                        | Remove packages, including its settings and unneeded dependencies   |
-| yarep   | yaourt -Si                         | Display information about a package in the repositories             |
-| yareps  | yaourt -Ss                         | Search for packages in the repositories                             |
-| yaupd[¹](#f1) | yaourt -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases       |
-| yaupd[¹](#f1) | yaourt -Sy && sudo abs             | Update and refresh the local package and ABS databases        |
-| yaupd[¹](#f1) | yaourt -Sy && sudo aur             | Update and refresh the local package and AUR databases        |
-| yaupd[¹](#f1) | yaourt -Sy                         | Update and refresh the local package database                 |
-| yaupg   | yaourt -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
-| yasu    | yaourt -Syua --no-confirm          | Same as `yaupg`, but without confirmation                           |
-| upgrade | yaourt -Syu                        | Sync with repositories before upgrading packages                    |
+| Alias   | Command                              | Description                                                         |
+|---------|--------------------------------------|---------------------------------------------------------------------|
+| yaconf  | `yaourt -C`                          | Fix all configuration files with vimdiff                            |
+| yain    | `yaourt -S`                          | Install packages from the repositories                              |
+| yains   | `yaourt -U`                          | Install a package from a local file                                 |
+| yainsd  | `yaourt -S --asdeps`                 | Install packages as dependencies of another package                 |
+| yaloc   | `yaourt -Qi`                         | Display information about a package in the local database           |
+| yalocs  | `yaourt -Qs`                         | Search for packages in the local database                           |
+| yalst   | `yaourt -Qe`                         | List installed packages including from AUR (tagged as "local")      |
+| yamir   | `yaourt -Syy`                        | Force refresh of all package lists after updating mirrorlist        |
+| yaorph  | `yaourt -Qtd`                        | Remove orphans using yaourt                                         |
+| yare    | `yaourt -R`                          | Remove packages, keeping its settings and dependencies              |
+| yarem   | `yaourt -Rns`                        | Remove packages, including its settings and unneeded dependencies   |
+| yarep   | `yaourt -Si`                         | Display information about a package in the repositories             |
+| yareps  | `yaourt -Ss`                         | Search for packages in the repositories                             |
+| yaupd[¹](#f1) | `yaourt -Sy && sudo abs && sudo aur` | Update and refresh local package, ABS and AUR databases       |
+| yaupd[¹](#f1) | `yaourt -Sy && sudo abs`             | Update and refresh the local package and ABS databases        |
+| yaupd[¹](#f1) | `yaourt -Sy && sudo aur`             | Update and refresh the local package and AUR databases        |
+| yaupd[¹](#f1) | `yaourt -Sy`                         | Update and refresh the local package database                 |
+| yaupg   | `yaourt -Syua`                       | Sync with repositories before upgrading all packages (from AUR too) |
+| yasu    | `yaourt -Syua --no-confirm`          | Same as `yaupg`, but without confirmation                           |
+| upgrade[³](#f3) | `yaourt -Syu`                | Sync with repositories before upgrading packages                    |
 
 #### Yay[²](#f2)
 
-| Alias   | Command                            | Description                                                         |
-|---------|------------------------------------|---------------------------------------------------------------------|
-| yaconf  | yay -Pg                            | Print current configuration                                         |
-| yain    | yay -S                             | Install packages from the repositories                              |
-| yains   | yay -U                             | Install a package from a local file                                 |
-| yainsd  | yay -S --asdeps                    | Install packages as dependencies of another package                 |
-| yaloc   | yay -Qi                            | Display information about a package in the local database           |
-| yalocs  | yay -Qs                            | Search for packages in the local database                           |
-| yalst   | yay -Qe                            | List installed packages including from AUR (tagged as "local")      |
-| yamir   | yay -Syy                           | Force refresh of all package lists after updating mirrorlist        |
-| yaorph  | yay -Qtd                           | Remove orphans using yay                                            |
-| yare    | yay -R                             | Remove packages, keeping its settings and dependencies              |
-| yarem   | yay -Rns                           | Remove packages, including its settings and unneeded dependencies   |
-| yarep   | yay -Si                            | Display information about a package in the repositories             |
-| yareps  | yay -Ss                            | Search for packages in the repositories                             |
-| yaupd[¹](#f1) | yay -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases          |
-| yaupd[¹](#f1) | yay -Sy && sudo abs             | Update and refresh the local package and ABS databases           |
-| yaupd[¹](#f1) | yay -Sy && sudo aur             | Update and refresh the local package and AUR databases           |
-| yaupd[¹](#f1) | yay -Sy                         | Update and refresh the local package database                    |
-| yaupg   | yay -Syu                           | Sync with repositories before upgrading packages                    |
-| yasu    | yay -Syu --no-confirm              | Same as `yaupg`, but without confirmation                           |
-| upgrade | yay -Syu                           | Sync with repositories before upgrading packages                    |
+| Alias   | Command                              | Description                                                         |
+|---------|--------------------------------------|---------------------------------------------------------------------|
+| yaconf  | `yay -Pg`                            | Print current configuration                                         |
+| yain    | `yay -S`                             | Install packages from the repositories                              |
+| yains   | `yay -U`                             | Install a package from a local file                                 |
+| yainsd  | `yay -S --asdeps`                    | Install packages as dependencies of another package                 |
+| yaloc   | `yay -Qi`                            | Display information about a package in the local database           |
+| yalocs  | `yay -Qs`                            | Search for packages in the local database                           |
+| yalst   | `yay -Qe`                            | List installed packages including from AUR (tagged as "local")      |
+| yamir   | `yay -Syy`                           | Force refresh of all package lists after updating mirrorlist        |
+| yaorph  | `yay -Qtd`                           | Remove orphans using yay                                            |
+| yare    | `yay -R`                             | Remove packages, keeping its settings and dependencies              |
+| yarem   | `yay -Rns`                           | Remove packages, including its settings and unneeded dependencies   |
+| yarep   | `yay -Si`                            | Display information about a package in the repositories             |
+| yareps  | `yay -Ss`                            | Search for packages in the repositories                             |
+| yaupd[¹](#f1) | `yay -Sy && sudo abs && sudo aur` | Update and refresh local package, ABS and AUR databases          |
+| yaupd[¹](#f1) | `yay -Sy && sudo abs`             | Update and refresh the local package and ABS databases           |
+| yaupd[¹](#f1) | `yay -Sy && sudo aur`             | Update and refresh the local package and AUR databases           |
+| yaupd[¹](#f1) | `yay -Sy`                         | Update and refresh the local package database                    |
+| yaupg   | `yay -Syu`                           | Sync with repositories before upgrading packages                    |
+| yasu    | `yay -Syu --no-confirm`              | Same as `yaupg`, but without confirmation                           |
+| upgrade[³](#f3) | `yay -Syu`                   | Sync with repositories before upgrading packages                    |
 
 ---
 
 <span id="f1">¹</span>
 Which alias is selected depends on avaliability of the corresponding commands in PATH.
-<br/>
+
 <span id="f2">²</span>
 Yay and Yaourt aliases overlap. If both are installed, yay will take precedence.
+
+<span id="f3">³</span>
+The `upgrade` alias is set for all package managers. Its value will depend on
+whether the package manager is installed, checked in the following order:
+
+1. `yay`
+2. `yaourt`
+3. `trizen`
+4. `pacaur`
+5. `pacman`
 
 ## Contributors
 

--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -12,146 +12,134 @@ plugins=(... archlinux)
 
 ### Pacman
 
-| Alias          | Command                                 | Description                                                  |
-|----------------|-----------------------------------------|--------------------------------------------------------------|
-| pacin          | sudo pacman -S                          | Install packages from the repositories                       |
-| pacins         | sudo pacman -U                          | Install a package from a local file                          |
-| pacinsd        | sudo pacman -S --asdeps                 | Install packages as dependencies of another package          |
-| pacloc         | pacman -Qi                              | Display information about a package in the local database    |
-| paclocs        | pacman -Qs                              | Search for packages in the local database                    |
-| paclsorphans   | sudo pacman -Qdt                        | List all orphaned packages                                   |
-| pacmir         | sudo pacman -Syy                        | Force refresh of all package lists after updating mirrorlist |
-| pacre          | sudo pacman -R                          | Remove packages, keeping its settings and dependencies       |
-| pacrem         | sudo pacman -Rns                        | Remove packages, including its settings and dependencies     |
-| pacrep         | pacman -Si                              | Display information about a package in the repositories      |
-| pacreps        | pacman -Ss                              | Search for packages in the repositories                      |
-| pacrmorphans   | sudo pacman -Rs $(pacman -Qtdq)         | Delete all orphaned packages                                 |
-| pacupd[¹](#f1) | sudo pacman -Sy && sudo abs && sudo aur | Update and refresh the local package, ABS and AUR databases  |
-| pacupd[¹](#f1) | sudo pacman -Sy && sudo abs             | Update and refresh the local package and ABS databases       |
-| pacupd[¹](#f1) | sudo pacman -Sy && sudo aur             | Update and refresh the local package and AUR databases       |
-| pacupd[¹](#f1) | sudo pacman -Sy                         | Update and refresh the local package database                |
-| pacupg         | sudo pacman -Syu                        | Sync with repositories before upgrading packages             |
-| pacfileupg     | sudo pacman -Fy                         | Download fresh package databases from the server             |
-| pacfiles       | pacman -F                               | Search package file names for matching strings               |
-| pacls          | pacman -Ql                              | List files in a package                                      |
-| pacown         | pacman -Qo                              | Show which package owns a file                               |
-| upgrade[³](#f3) | sudo pacman -Syu                       | Sync with repositories before upgrading packages             |
+| Alias        | Command                                | Description                                                      |
+|--------------|----------------------------------------|------------------------------------------------------------------|
+| pacin        | `sudo pacman -S`                       | Install packages from the repositories                           |
+| pacins       | `sudo pacman -U`                       | Install a package from a local file                              |
+| pacinsd      | `sudo pacman -S --asdeps`              | Install packages as dependencies of another package              |
+| pacloc       | `pacman -Qi`                           | Display information about a package in the local database        |
+| paclocs      | `pacman -Qs`                           | Search for packages in the local database                        |
+| paclsorphans | `sudo pacman -Qdt`                     | List all orphaned packages                                       |
+| pacmir       | `sudo pacman -Syy`                     | Force refresh of all package lists after updating mirrorlist     |
+| pacre        | `sudo pacman -R`                       | Remove packages, keeping its settings and dependencies           |
+| pacrem       | `sudo pacman -Rns`                     | Remove packages, including its settings and dependencies         |
+| pacrep       | `pacman -Si`                           | Display information about a package in the repositories          |
+| pacreps      | `pacman -Ss`                           | Search for packages in the repositories                          |
+| pacrmorphans | `sudo pacman -Rs $(pacman -Qtdq)`      | Delete all orphaned packages                                     |
+| pacupd       | `sudo pacman -Sy && <abs/aur refresh>`[¹](#f1) | Update and refresh local package, ABS and AUR databases  |
+| pacupg       | `sudo pacman -Syu`                     | Sync with repositories before upgrading packages                 |
+| pacfileupg   | `sudo pacman -Fy`                      | Download fresh package databases from the server                 |
+| pacfiles     | `pacman -F`                            | Search package file names for matching strings                   |
+| pacls        | `pacman -Ql`                           | List files in a package                                          |
+| pacown       | `pacman -Qo`                           | Show which package owns a file                                   |
+| upgrade[³](#f3) | `sudo pacman -Syu`                  | Sync with repositories before upgrading packages                 |
 
-| Function       | Description                                          |
-|----------------|------------------------------------------------------|
-| pacdisowned    | List all disowned files in your system               |
+| Function       | Description                                               |
+|----------------|-----------------------------------------------------------|
+| pacdisowned    | List all disowned files in your system                    |
 | paclist        | List all explicitly installed packages with a description |
-| pacmanallkeys  | Get all keys for developers and trusted users        |
-| pacmansignkeys | Locally trust all keys passed as parameters          |
-| pacweb         | Open the website of an ArchLinux package             |
+| pacmanallkeys  | Get all keys for developers and trusted users             |
+| pacmansignkeys | Locally trust all keys passed as parameters               |
+| pacweb         | Open the website of an ArchLinux package                  |
 
-Note: paclist used to print packages with a description which are (1) explicitly installed and (2) available for upgrade. Due to flawed scripting, it also printed all packages if no upgrades were available. Use `pacman -Que` instead.
+Note: paclist used to print packages with a description which are (1) explicitly installed
+and (2) available for upgrade. Due to flawed scripting, it also printed all packages if no
+upgrades were available. Use `pacman -Que` instead.
 
 ### AUR helpers
 
 #### Pacaur
 
-| Alias   | Command                              | Description                                                         |
-|---------|--------------------------------------|---------------------------------------------------------------------|
-| pain    | `pacaur -S`                          | Install packages from the repositories                              |
-| pains   | `pacaur -U`                          | Install a package from a local file                                 |
-| painsd  | `pacaur -S --asdeps`                 | Install packages as dependencies of another package                 |
-| paloc   | `pacaur -Qi`                         | Display information about a package in the local database           |
-| palocs  | `pacaur -Qs`                         | Search for packages in the local database                           |
-| palst   | `pacaur -Qe`                         | List installed packages including from AUR (tagged as "local")      |
-| pamir   | `pacaur -Syy`                        | Force refresh of all package lists after updating mirrorlist        |
-| paorph  | `pacaur -Qtd`                        | Remove orphans using pacaur                                         |
-| pare    | `pacaur -R`                          | Remove packages, keeping its settings and dependencies              |
-| parem   | `pacaur -Rns`                        | Remove packages, including its settings and unneeded dependencies   |
-| parep   | `pacaur -Si`                         | Display information about a package in the repositories             |
-| pareps  | `pacaur -Ss`                         | Search for packages in the repositories                             |
-| paupd[¹](#f1) | `pacaur -Sy && sudo abs && sudo aur` | Update and refresh local package, ABS and AUR databases       |
-| paupd[¹](#f1) | `pacaur -Sy && sudo abs`             | Update and refresh the local package and ABS databases        |
-| paupd[¹](#f1) | `pacaur -Sy && sudo aur`             | Update and refresh the local package and AUR databases        |
-| paupd[¹](#f1) | `pacaur -Sy`                         | Update and refresh the local package database                 |
-| paupg   | `pacaur -Syua`                       | Sync with repositories before upgrading all packages (from AUR too) |
-| pasu    | `pacaur -Syua --no-confirm`          | Same as `paupg`, but without confirmation                           |
-| upgrade[³](#f3) | `pacaur -Syu`                | Sync with repositories before upgrading packages                    |
+| Alias   | Command                           | Description                                                         |
+|---------|-----------------------------------|---------------------------------------------------------------------|
+| pain    | `pacaur -S`                       | Install packages from the repositories                              |
+| pains   | `pacaur -U`                       | Install a package from a local file                                 |
+| painsd  | `pacaur -S --asdeps`              | Install packages as dependencies of another package                 |
+| paloc   | `pacaur -Qi`                      | Display information about a package in the local database           |
+| palocs  | `pacaur -Qs`                      | Search for packages in the local database                           |
+| palst   | `pacaur -Qe`                      | List installed packages including from AUR (tagged as "local")      |
+| pamir   | `pacaur -Syy`                     | Force refresh of all package lists after updating mirrorlist        |
+| paorph  | `pacaur -Qtd`                     | Remove orphans using pacaur                                         |
+| pare    | `pacaur -R`                       | Remove packages, keeping its settings and dependencies              |
+| parem   | `pacaur -Rns`                     | Remove packages, including its settings and unneeded dependencies   |
+| parep   | `pacaur -Si`                      | Display information about a package in the repositories             |
+| pareps  | `pacaur -Ss`                      | Search for packages in the repositories                             |
+| paupd   | `pacaur -Sy && <abs/aur refresh>`[¹](#f1) | Update and refresh local package, ABS and AUR databases     |
+| paupg   | `pacaur -Syua`                    | Sync with repositories before upgrading all packages (from AUR too) |
+| pasu    | `pacaur -Syua --no-confirm`       | Same as `paupg`, but without confirmation                           |
+| upgrade[³](#f3) | `pacaur -Syu`             | Sync with repositories before upgrading packages                    |
 
 #### Trizen
 
-| Alias   | Command                              | Description                                                         |
-|---------|--------------------------------------|---------------------------------------------------------------------|
-| trconf  | `trizen -C`                          | Fix all configuration files with vimdiff                            |
-| trin    | `trizen -S`                          | Install packages from the repositories                              |
-| trins   | `trizen -U`                          | Install a package from a local file                                 |
-| trinsd  | `trizen -S --asdeps`                 | Install packages as dependencies of another package                 |
-| trloc   | `trizen -Qi`                         | Display information about a package in the local database           |
-| trlocs  | `trizen -Qs`                         | Search for packages in the local database                           |
-| trlst   | `trizen -Qe`                         | List installed packages including from AUR (tagged as "local")      |
-| trmir   | `trizen -Syy`                        | Force refresh of all package lists after updating mirrorlist        |
-| trorph  | `trizen -Qtd`                        | Remove orphans using yaourt                                         |
-| trre    | `trizen -R`                          | Remove packages, keeping its settings and dependencies              |
-| trrem   | `trizen -Rns`                        | Remove packages, including its settings and unneeded dependencies   |
-| trrep   | `trizen -Si`                         | Display information about a package in the repositories             |
-| trreps  | `trizen -Ss`                         | Search for packages in the repositories                             |
-| trupd[¹](#f1) | `trizen -Sy && sudo abs && sudo aur` | Update and refresh local package, ABS and AUR databases       |
-| trupd[¹](#f1) | `trizen -Sy && sudo abs`             | Update and refresh the local package and ABS databases        |
-| trupd[¹](#f1) | `trizen -Sy && sudo aur`             | Update and refresh the local package and AUR databases        |
-| trupd[¹](#f1) | `trizen -Sy`                         | Update and refresh the local package database                 |
-| trupg   | `trizen -Syua`                       | Sync with repositories before upgrading all packages (from AUR too) |
-| trsu    | `trizen -Syua --no-confirm`          | Same as `trupg`, but without confirmation                           |
-| upgrade[³](#f3) | `trizen -Syu`                | Sync with repositories before upgrading packages                    |
+| Alias   | Command                           | Description                                                         |
+|---------|-----------------------------------|---------------------------------------------------------------------|
+| trconf  | `trizen -C`                       | Fix all configuration files with vimdiff                            |
+| trin    | `trizen -S`                       | Install packages from the repositories                              |
+| trins   | `trizen -U`                       | Install a package from a local file                                 |
+| trinsd  | `trizen -S --asdeps`              | Install packages as dependencies of another package                 |
+| trloc   | `trizen -Qi`                      | Display information about a package in the local database           |
+| trlocs  | `trizen -Qs`                      | Search for packages in the local database                           |
+| trlst   | `trizen -Qe`                      | List installed packages including from AUR (tagged as "local")      |
+| trmir   | `trizen -Syy`                     | Force refresh of all package lists after updating mirrorlist        |
+| trorph  | `trizen -Qtd`                     | Remove orphans using yaourt                                         |
+| trre    | `trizen -R`                       | Remove packages, keeping its settings and dependencies              |
+| trrem   | `trizen -Rns`                     | Remove packages, including its settings and unneeded dependencies   |
+| trrep   | `trizen -Si`                      | Display information about a package in the repositories             |
+| trreps  | `trizen -Ss`                      | Search for packages in the repositories                             |
+| trupd   | `trizen -Sy && <abs/aur refresh>`[¹](#f1) | Update and refresh local package, ABS and AUR databases     |
+| trupg   | `trizen -Syua`                    | Sync with repositories before upgrading all packages (from AUR too) |
+| trsu    | `trizen -Syua --no-confirm`       | Same as `trupg`, but without confirmation                           |
+| upgrade[³](#f3) | `trizen -Syu`             | Sync with repositories before upgrading packages                    |
 
 #### Yaourt[²](#f2)
 
-| Alias   | Command                              | Description                                                         |
-|---------|--------------------------------------|---------------------------------------------------------------------|
-| yaconf  | `yaourt -C`                          | Fix all configuration files with vimdiff                            |
-| yain    | `yaourt -S`                          | Install packages from the repositories                              |
-| yains   | `yaourt -U`                          | Install a package from a local file                                 |
-| yainsd  | `yaourt -S --asdeps`                 | Install packages as dependencies of another package                 |
-| yaloc   | `yaourt -Qi`                         | Display information about a package in the local database           |
-| yalocs  | `yaourt -Qs`                         | Search for packages in the local database                           |
-| yalst   | `yaourt -Qe`                         | List installed packages including from AUR (tagged as "local")      |
-| yamir   | `yaourt -Syy`                        | Force refresh of all package lists after updating mirrorlist        |
-| yaorph  | `yaourt -Qtd`                        | Remove orphans using yaourt                                         |
-| yare    | `yaourt -R`                          | Remove packages, keeping its settings and dependencies              |
-| yarem   | `yaourt -Rns`                        | Remove packages, including its settings and unneeded dependencies   |
-| yarep   | `yaourt -Si`                         | Display information about a package in the repositories             |
-| yareps  | `yaourt -Ss`                         | Search for packages in the repositories                             |
-| yaupd[¹](#f1) | `yaourt -Sy && sudo abs && sudo aur` | Update and refresh local package, ABS and AUR databases       |
-| yaupd[¹](#f1) | `yaourt -Sy && sudo abs`             | Update and refresh the local package and ABS databases        |
-| yaupd[¹](#f1) | `yaourt -Sy && sudo aur`             | Update and refresh the local package and AUR databases        |
-| yaupd[¹](#f1) | `yaourt -Sy`                         | Update and refresh the local package database                 |
-| yaupg   | `yaourt -Syua`                       | Sync with repositories before upgrading all packages (from AUR too) |
-| yasu    | `yaourt -Syua --no-confirm`          | Same as `yaupg`, but without confirmation                           |
-| upgrade[³](#f3) | `yaourt -Syu`                | Sync with repositories before upgrading packages                    |
+| Alias   | Command                           | Description                                                         |
+|---------|-----------------------------------|---------------------------------------------------------------------|
+| yaconf  | `yaourt -C`                       | Fix all configuration files with vimdiff                            |
+| yain    | `yaourt -S`                       | Install packages from the repositories                              |
+| yains   | `yaourt -U`                       | Install a package from a local file                                 |
+| yainsd  | `yaourt -S --asdeps`              | Install packages as dependencies of another package                 |
+| yaloc   | `yaourt -Qi`                      | Display information about a package in the local database           |
+| yalocs  | `yaourt -Qs`                      | Search for packages in the local database                           |
+| yalst   | `yaourt -Qe`                      | List installed packages including from AUR (tagged as "local")      |
+| yamir   | `yaourt -Syy`                     | Force refresh of all package lists after updating mirrorlist        |
+| yaorph  | `yaourt -Qtd`                     | Remove orphans using yaourt                                         |
+| yare    | `yaourt -R`                       | Remove packages, keeping its settings and dependencies              |
+| yarem   | `yaourt -Rns`                     | Remove packages, including its settings and unneeded dependencies   |
+| yarep   | `yaourt -Si`                      | Display information about a package in the repositories             |
+| yareps  | `yaourt -Ss`                      | Search for packages in the repositories                             |
+| yaupd   | `yaourt -Sy && <abs/aur refresh>`[¹](#f1) | Update and refresh local package, ABS and AUR databases     |
+| yaupg   | `yaourt -Syua`                    | Sync with repositories before upgrading all packages (from AUR too) |
+| yasu    | `yaourt -Syua --no-confirm`       | Same as `yaupg`, but without confirmation                           |
+| upgrade[³](#f3) | `yaourt -Syu`             | Sync with repositories before upgrading packages                    |
 
 #### Yay[²](#f2)
 
-| Alias   | Command                              | Description                                                         |
-|---------|--------------------------------------|---------------------------------------------------------------------|
-| yaconf  | `yay -Pg`                            | Print current configuration                                         |
-| yain    | `yay -S`                             | Install packages from the repositories                              |
-| yains   | `yay -U`                             | Install a package from a local file                                 |
-| yainsd  | `yay -S --asdeps`                    | Install packages as dependencies of another package                 |
-| yaloc   | `yay -Qi`                            | Display information about a package in the local database           |
-| yalocs  | `yay -Qs`                            | Search for packages in the local database                           |
-| yalst   | `yay -Qe`                            | List installed packages including from AUR (tagged as "local")      |
-| yamir   | `yay -Syy`                           | Force refresh of all package lists after updating mirrorlist        |
-| yaorph  | `yay -Qtd`                           | Remove orphans using yay                                            |
-| yare    | `yay -R`                             | Remove packages, keeping its settings and dependencies              |
-| yarem   | `yay -Rns`                           | Remove packages, including its settings and unneeded dependencies   |
-| yarep   | `yay -Si`                            | Display information about a package in the repositories             |
-| yareps  | `yay -Ss`                            | Search for packages in the repositories                             |
-| yaupd[¹](#f1) | `yay -Sy && sudo abs && sudo aur` | Update and refresh local package, ABS and AUR databases          |
-| yaupd[¹](#f1) | `yay -Sy && sudo abs`             | Update and refresh the local package and ABS databases           |
-| yaupd[¹](#f1) | `yay -Sy && sudo aur`             | Update and refresh the local package and AUR databases           |
-| yaupd[¹](#f1) | `yay -Sy`                         | Update and refresh the local package database                    |
-| yaupg   | `yay -Syu`                           | Sync with repositories before upgrading packages                    |
-| yasu    | `yay -Syu --no-confirm`              | Same as `yaupg`, but without confirmation                           |
-| upgrade[³](#f3) | `yay -Syu`                   | Sync with repositories before upgrading packages                    |
+| Alias   | Command                        | Description                                                       |
+|---------|--------------------------------|-------------------------------------------------------------------|
+| yaconf  | `yay -Pg`                      | Print current configuration                                       |
+| yain    | `yay -S`                       | Install packages from the repositories                            |
+| yains   | `yay -U`                       | Install a package from a local file                               |
+| yainsd  | `yay -S --asdeps`              | Install packages as dependencies of another package               |
+| yaloc   | `yay -Qi`                      | Display information about a package in the local database         |
+| yalocs  | `yay -Qs`                      | Search for packages in the local database                         |
+| yalst   | `yay -Qe`                      | List installed packages including from AUR (tagged as "local")    |
+| yamir   | `yay -Syy`                     | Force refresh of all package lists after updating mirrorlist      |
+| yaorph  | `yay -Qtd`                     | Remove orphans using yay                                          |
+| yare    | `yay -R`                       | Remove packages, keeping its settings and dependencies            |
+| yarem   | `yay -Rns`                     | Remove packages, including its settings and unneeded dependencies |
+| yarep   | `yay -Si`                      | Display information about a package in the repositories           |
+| yareps  | `yay -Ss`                      | Search for packages in the repositories                           |
+| yaupd   | `yay -Sy && <abs/aur refresh>`[¹](#f1) | Update and refresh local package, ABS and AUR databases   |
+| yaupg   | `yay -Syu`                     | Sync with repositories before upgrading packages                  |
+| yasu    | `yay -Syu --no-confirm`        | Same as `yaupg`, but without confirmation                         |
+| upgrade[³](#f3) | `yay -Syu`             | Sync with repositories before upgrading packages                  |
 
 ---
 
 <span id="f1">¹</span>
-Which alias is selected depends on avaliability of the corresponding commands in PATH.
+If the `abs` and/or `aur` commands are present, `sudo abs` and `sudo aur` are also
+called to update the ABS and AUR databases.
 
 <span id="f2">²</span>
 Yay and Yaourt aliases overlap. If both are installed, yay will take precedence.

--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -1,4 +1,4 @@
-# Archlinux plugin
+# Arch Linux plugin
 
 This plugin adds some aliases and functions to work with Arch Linux.
 
@@ -10,27 +10,70 @@ plugins=(... archlinux)
 
 ## Features
 
-#### YAY
+### Pacman
+
+| Alias          | Command                                 | Description                                                  |
+|----------------|-----------------------------------------|--------------------------------------------------------------|
+| pacin          | sudo pacman -S                          | Install packages from the repositories                       |
+| pacins         | sudo pacman -U                          | Install a package from a local file                          |
+| pacinsd        | sudo pacman -S --asdeps                 | Install packages as dependencies of another package          |
+| pacloc         | pacman -Qi                              | Display information about a package in the local database    |
+| paclocs        | pacman -Qs                              | Search for packages in the local database                    |
+| paclsorphans   | sudo pacman -Qdt                        | List all orphaned packages                                   |
+| pacmir         | sudo pacman -Syy                        | Force refresh of all package lists after updating mirrorlist |
+| pacre          | sudo pacman -R                          | Remove packages, keeping its settings and dependencies       |
+| pacrem         | sudo pacman -Rns                        | Remove packages, including its settings and dependencies     |
+| pacrep         | pacman -Si                              | Display information about a package in the repositories      |
+| pacreps        | pacman -Ss                              | Search for packages in the repositories                      |
+| pacrmorphans   | sudo pacman -Rs $(pacman -Qtdq)         | Delete all orphaned packages                                 |
+| pacupd[¹](#f1) | sudo pacman -Sy && sudo abs && sudo aur | Update and refresh the local package, ABS and AUR databases  |
+| pacupd[¹](#f1) | sudo pacman -Sy && sudo abs             | Update and refresh the local package and ABS databases       |
+| pacupd[¹](#f1) | sudo pacman -Sy && sudo aur             | Update and refresh the local package and AUR databases       |
+| pacupd[¹](#f1) | sudo pacman -Sy                         | Update and refresh the local package database                |
+| pacupg         | sudo pacman -Syu                        | Sync with repositories before upgrading packages             |
+| upgrade        | sudo pacman -Syu                        | Sync with repositories before upgrading packages             |
+| pacfileupg     | sudo pacman -Fy                         | Download fresh package databases from the server             |
+| pacfiles       | pacman -F                               | Search package file names for matching strings               |
+| pacls          | pacman -Ql                              | List files in a package                                      |
+| pacown         | pacman -Qo                              | Show which package owns a file                               |
+
+| Function       | Description                                          |
+|----------------|------------------------------------------------------|
+| pacdisowned    | List all disowned files in your system               |
+| paclist        | List all explicitly installed packages with a description |
+| pacmanallkeys  | Get all keys for developers and trusted users        |
+| pacmansignkeys | Locally trust all keys passed as parameters          |
+| pacweb         | Open the website of an ArchLinux package             |
+
+Note: paclist used to print packages with a description which are (1) explicitly installed and (2) available for upgrade. Due to flawed scripting, it also printed all packages if no upgrades were available. Use `pacman -Que` instead.
+
+### AUR helpers
+
+#### Pacaur
 
 | Alias   | Command                            | Description                                                         |
 |---------|------------------------------------|---------------------------------------------------------------------|
-| yaconf  | yay -Pg                            | Print current configuration                                         |
-| yain    | yay -S                             | Install packages from the repositories                              |
-| yains   | yay -U                             | Install a package from a local file                                 |
-| yainsd  | yay -S --asdeps                    | Install packages as dependencies of another package                 |
-| yaloc   | yay -Qi                            | Display information about a package in the local database           |
-| yalocs  | yay -Qs                            | Search for packages in the local database                           |
-| yalst   | yay -Qe                            | List installed packages including from AUR (tagged as "local")      |
-| yamir   | yay -Syy                           | Force refresh of all package lists after updating mirrorlist        |
-| yaorph  | yay -Qtd                           | Remove orphans using yay                                            |
-| yare    | yay -R                             | Remove packages, keeping its settings and dependencies              |
-| yarem   | yay -Rns                           | Remove packages, including its settings and unneeded dependencies   |
-| yarep   | yay -Si                            | Display information about a package in the repositories             |
-| yareps  | yay -Ss                            | Search for packages in the repositories                             |
-| yaupg   | yay -Syu                           | Sync with repositories before upgrading packages                    |
-| yasu    | yay -Syu --no-confirm              | Same as `yaupg`, but without confirmation                           |
+| pain    | pacaur -S                          | Install packages from the repositories                              |
+| pains   | pacaur -U                          | Install a package from a local file                                 |
+| painsd  | pacaur -S --asdeps                 | Install packages as dependencies of another package                 |
+| paloc   | pacaur -Qi                         | Display information about a package in the local database           |
+| palocs  | pacaur -Qs                         | Search for packages in the local database                           |
+| palst   | pacaur -Qe                         | List installed packages including from AUR (tagged as "local")      |
+| pamir   | pacaur -Syy                        | Force refresh of all package lists after updating mirrorlist        |
+| paorph  | pacaur -Qtd                        | Remove orphans using pacaur                                         |
+| pare    | pacaur -R                          | Remove packages, keeping its settings and dependencies              |
+| parem   | pacaur -Rns                        | Remove packages, including its settings and unneeded dependencies   |
+| parep   | pacaur -Si                         | Display information about a package in the repositories             |
+| pareps  | pacaur -Ss                         | Search for packages in the repositories                             |
+| paupd[¹](#f1) | pacaur -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases       |
+| paupd[¹](#f1) | pacaur -Sy && sudo abs             | Update and refresh the local package and ABS databases        |
+| paupd[¹](#f1) | pacaur -Sy && sudo aur             | Update and refresh the local package and AUR databases        |
+| paupd[¹](#f1) | pacaur -Sy                         | Update and refresh the local package database                 |
+| paupg   | pacaur -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
+| pasu    | pacaur -Syua --no-confirm          | Same as `paupg`, but without confirmation                           |
+| upgrade | pacaur -Syu                        | Sync with repositories before upgrading packages                    |
 
-#### TRIZEN
+#### Trizen
 
 | Alias   | Command                            | Description                                                         |
 |---------|------------------------------------|---------------------------------------------------------------------|
@@ -47,15 +90,15 @@ plugins=(... archlinux)
 | trrem   | trizen -Rns                        | Remove packages, including its settings and unneeded dependencies   |
 | trrep   | trizen -Si                         | Display information about a package in the repositories             |
 | trreps  | trizen -Ss                         | Search for packages in the repositories                             |
-| trupd   | trizen -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases             |
-| trupd   | trizen -Sy && sudo abs             | Update and refresh the local package and ABS databases              |
-| trupd   | trizen -Sy && sudo aur             | Update and refresh the local package and AUR databases              |
-| trupd   | trizen -Sy                         | Update and refresh the local package database                       |
+| trupd[¹](#f1) | trizen -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases       |
+| trupd[¹](#f1) | trizen -Sy && sudo abs             | Update and refresh the local package and ABS databases        |
+| trupd[¹](#f1) | trizen -Sy && sudo aur             | Update and refresh the local package and AUR databases        |
+| trupd[¹](#f1) | trizen -Sy                         | Update and refresh the local package database                 |
 | trupg   | trizen -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
 | trsu    | trizen -Syua --no-confirm          | Same as `trupg`, but without confirmation                           |
 | upgrade | trizen -Syu                        | Sync with repositories before upgrading packages                    |
 
-#### YAOURT
+#### Yaourt[²](#f2)
 
 | Alias   | Command                            | Description                                                         |
 |---------|------------------------------------|---------------------------------------------------------------------|
@@ -72,83 +115,56 @@ plugins=(... archlinux)
 | yarem   | yaourt -Rns                        | Remove packages, including its settings and unneeded dependencies   |
 | yarep   | yaourt -Si                         | Display information about a package in the repositories             |
 | yareps  | yaourt -Ss                         | Search for packages in the repositories                             |
-| yaupd   | yaourt -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases             |
-| yaupd   | yaourt -Sy && sudo abs             | Update and refresh the local package and ABS databases              |
-| yaupd   | yaourt -Sy && sudo aur             | Update and refresh the local package and AUR databases              |
-| yaupd   | yaourt -Sy                         | Update and refresh the local package database                       |
+| yaupd[¹](#f1) | yaourt -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases       |
+| yaupd[¹](#f1) | yaourt -Sy && sudo abs             | Update and refresh the local package and ABS databases        |
+| yaupd[¹](#f1) | yaourt -Sy && sudo aur             | Update and refresh the local package and AUR databases        |
+| yaupd[¹](#f1) | yaourt -Sy                         | Update and refresh the local package database                 |
 | yaupg   | yaourt -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
 | yasu    | yaourt -Syua --no-confirm          | Same as `yaupg`, but without confirmation                           |
 | upgrade | yaourt -Syu                        | Sync with repositories before upgrading packages                    |
 
-#### PACAUR
+#### Yay[²](#f2)
 
 | Alias   | Command                            | Description                                                         |
 |---------|------------------------------------|---------------------------------------------------------------------|
-| pain    | pacaur -S                          | Install packages from the repositories                              |
-| pains   | pacaur -U                          | Install a package from a local file                                 |
-| painsd  | pacaur -S --asdeps                 | Install packages as dependencies of another package                 |
-| paloc   | pacaur -Qi                         | Display information about a package in the local database           |
-| palocs  | pacaur -Qs                         | Search for packages in the local database                           |
-| palst   | pacaur -Qe                         | List installed packages including from AUR (tagged as "local")      |
-| pamir   | pacaur -Syy                        | Force refresh of all package lists after updating mirrorlist        |
-| paorph  | pacaur -Qtd                        | Remove orphans using pacaur                                         |
-| pare    | pacaur -R                          | Remove packages, keeping its settings and dependencies              |
-| parem   | pacaur -Rns                        | Remove packages, including its settings and unneeded dependencies   |
-| parep   | pacaur -Si                         | Display information about a package in the repositories             |
-| pareps  | pacaur -Ss                         | Search for packages in the repositories                             |
-| paupd   | pacaur -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases             |
-| paupd   | pacaur -Sy && sudo abs             | Update and refresh the local package and ABS databases              |
-| paupd   | pacaur -Sy && sudo aur             | Update and refresh the local package and AUR databases              |
-| paupd   | pacaur -Sy                         | Update and refresh the local package database                       |
-| paupg   | pacaur -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
-| pasu    | pacaur -Syua --no-confirm          | Same as `paupg`, but without confirmation                           |
-| upgrade | pacaur -Syu                        | Sync with repositories before upgrading packages                    |
-
-#### PACMAN
-
-| Alias        | Command                                 | Description                                                  |
-|--------------|-----------------------------------------|--------------------------------------------------------------|
-| pacin        | sudo pacman -S                          | Install packages from the repositories                       |
-| pacins       | sudo pacman -U                          | Install a package from a local file                          |
-| pacinsd      | sudo pacman -S --asdeps                 | Install packages as dependencies of another package          |
-| pacloc       | pacman -Qi                              | Display information about a package in the local database    |
-| paclocs      | pacman -Qs                              | Search for packages in the local database                    |
-| paclsorphans | sudo pacman -Qdt                        | List all orphaned packages                                   |
-| pacmir       | sudo pacman -Syy                        | Force refresh of all package lists after updating mirrorlist |
-| pacre        | sudo pacman -R                          | Remove packages, keeping its settings and dependencies       |
-| pacrem       | sudo pacman -Rns                        | Remove packages, including its settings and dependencies     |
-| pacrep       | pacman -Si                              | Display information about a package in the repositories      |
-| pacreps      | pacman -Ss                              | Search for packages in the repositories                      |
-| pacrmorphans | sudo pacman -Rs $(pacman -Qtdq)         | Delete all orphaned packages                                 |
-| pacupd       | sudo pacman -Sy && sudo abs && sudo aur | Update and refresh the local package, ABS and AUR databases  |
-| pacupd       | sudo pacman -Sy && sudo abs             | Update and refresh the local package and ABS databases       |
-| pacupd       | sudo pacman -Sy && sudo aur             | Update and refresh the local package and AUR databases       |
-| pacupd       | sudo pacman -Sy                         | Update and refresh the local package database                |
-| pacupg       | sudo pacman -Syu                        | Sync with repositories before upgrading packages             |
-| upgrade      | sudo pacman -Syu                        | Sync with repositories before upgrading packages             |
-| pacfileupg   | sudo pacman -Fy                         | Download fresh package databases from the server             |
-| pacfiles     | pacman -F                               | Search package file names for matching strings               |
-| pacls        | pacman -Ql                              | List files in a package                                      |
-| pacown       | pacman -Qo                              | Show which package owns a file                               |
-
-| Function       | Description                                          |
-|----------------|------------------------------------------------------|
-| pacdisowned    | List all disowned files in your system               |
-| paclist        | List all installed packages with a short description |
-| pacmanallkeys  | Get all keys for developers and trusted users        |
-| pacmansignkeys | Locally trust all keys passed as parameters          |
-| pacweb         | Open the website of an ArchLinux package             |
+| yaconf  | yay -Pg                            | Print current configuration                                         |
+| yain    | yay -S                             | Install packages from the repositories                              |
+| yains   | yay -U                             | Install a package from a local file                                 |
+| yainsd  | yay -S --asdeps                    | Install packages as dependencies of another package                 |
+| yaloc   | yay -Qi                            | Display information about a package in the local database           |
+| yalocs  | yay -Qs                            | Search for packages in the local database                           |
+| yalst   | yay -Qe                            | List installed packages including from AUR (tagged as "local")      |
+| yamir   | yay -Syy                           | Force refresh of all package lists after updating mirrorlist        |
+| yaorph  | yay -Qtd                           | Remove orphans using yay                                            |
+| yare    | yay -R                             | Remove packages, keeping its settings and dependencies              |
+| yarem   | yay -Rns                           | Remove packages, including its settings and unneeded dependencies   |
+| yarep   | yay -Si                            | Display information about a package in the repositories             |
+| yareps  | yay -Ss                            | Search for packages in the repositories                             |
+| yaupd[¹](#f1) | yay -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases          |
+| yaupd[¹](#f1) | yay -Sy && sudo abs             | Update and refresh the local package and ABS databases           |
+| yaupd[¹](#f1) | yay -Sy && sudo aur             | Update and refresh the local package and AUR databases           |
+| yaupd[¹](#f1) | yay -Sy                         | Update and refresh the local package database                    |
+| yaupg   | yay -Syu                           | Sync with repositories before upgrading packages                    |
+| yasu    | yay -Syu --no-confirm              | Same as `yaupg`, but without confirmation                           |
+| upgrade | yay -Syu                           | Sync with repositories before upgrading packages                    |
 
 ---
+
+<span id="f1">¹</span>
+Which alias is selected depends on avaliability of the corresponding commands in PATH.
+<br/>
+<span id="f2">²</span>
+Yay and Yaourt aliases overlap. If both are installed, yay will take precedence.
 
 ## Contributors
 
 - Benjamin Boudreau - dreurmail@gmail.com
 - Celso Miranda - contacto@celsomiranda.net
+- ratijas (ivan tkachenko) - me@ratijas.tk
+- Juraj Fiala - doctorjellyface@riseup.net
 - KhasMek - Boushh@gmail.com
+- Majora320 (Moses Miller) - Majora320@gmail.com
 - Martin Putniorz - mputniorz@gmail.com
 - MatthR3D - matthr3d@gmail.com
 - ornicar - thibault.duplessis@gmail.com
-- Juraj Fiala - doctorjellyface@riseup.net
-- Majora320 (Moses Miller) - Majora320@gmail.com
 - Ybalrid (Arthur Brainville) - ybalrid@ybalrid.info

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -1,3 +1,127 @@
+#######################################
+#               Pacman                #
+#######################################
+
+# Pacman - https://wiki.archlinux.org/index.php/Pacman_Tips
+alias pacupg='sudo pacman -Syu'
+alias pacin='sudo pacman -S'
+alias pacins='sudo pacman -U'
+alias pacre='sudo pacman -R'
+alias pacrem='sudo pacman -Rns'
+alias pacrep='pacman -Si'
+alias pacreps='pacman -Ss'
+alias pacloc='pacman -Qi'
+alias paclocs='pacman -Qs'
+alias pacinsd='sudo pacman -S --asdeps'
+alias pacmir='sudo pacman -Syy'
+alias paclsorphans='sudo pacman -Qdt'
+alias pacrmorphans='sudo pacman -Rs $(pacman -Qtdq)'
+alias pacfileupg='sudo pacman -Fy'
+alias pacfiles='pacman -F'
+alias pacls='pacman -Ql'
+alias pacown='pacman -Qo'
+alias upgrade='sudo pacman -Syu'
+
+if (( $+commands[abs] && $+commands[aur] )); then
+  alias pacupd='sudo pacman -Sy && sudo abs && sudo aur'
+elif (( $+commands[abs] )); then
+  alias pacupd='sudo pacman -Sy && sudo abs'
+elif (( $+commands[aur] )); then
+  alias pacupd='sudo pacman -Sy && sudo aur'
+else
+  alias pacupd='sudo pacman -Sy'
+fi
+
+function paclist() {
+  # Based on https://bbs.archlinux.org/viewtopic.php?id=93683
+  pacman -Qqe | \
+    xargs -I '{}' \
+      expac "${bold_color}% 20n ${fg_no_bold[white]}%d${reset_color}" '{}'
+}
+
+function pacdisowned() {
+  local tmp db fs
+  tmp=${TMPDIR-/tmp}/pacman-disowned-$UID-$$
+  db=$tmp/db
+  fs=$tmp/fs
+
+  mkdir "$tmp"
+  trap 'rm -rf "$tmp"' EXIT
+
+  pacman -Qlq | sort -u > "$db"
+
+  find /bin /etc /lib /sbin /usr ! -name lost+found \
+    \( -type d -printf '%p/\n' -o -print \) | sort > "$fs"
+
+  comm -23 "$fs" "$db"
+}
+
+alias pacmanallkeys='sudo pacman-key --refresh-keys'
+
+function pacmansignkeys() {
+  local key
+  for key in $@; do
+    sudo pacman-key --recv-keys $key
+    sudo pacman-key --lsign-key $key
+    printf 'trust\n3\n' | sudo gpg --homedir /etc/pacman.d/gnupg \
+      --no-permission-warning --command-fd 0 --edit-key $key
+  done
+}
+
+if (( $+commands[xdg-open] )); then
+  function pacweb() {
+    if [[ $# = 0 || "$1" =~ '--help|-h' ]]; then
+      local underline_color="\e[${color[underline]}m"
+      echo "$0 - open the website of an ArchLinux package"
+      echo
+      echo "Usage:"
+      echo "    $bold_color$0$reset_color ${underline_color}target${reset_color}"
+      return 1
+    fi
+
+    local pkg="$1"
+    local infos="$(LANG=C pacman -Si "$pkg")"
+    if [[ -z "$infos" ]]; then
+      return
+    fi
+    local repo="$(grep -m 1 '^Repo' <<< "$infos" | grep -oP '[^ ]+$')"
+    local arch="$(grep -m 1 '^Arch' <<< "$infos" | grep -oP '[^ ]+$')"
+    xdg-open "https://www.archlinux.org/packages/$repo/$arch/$pkg/" &>/dev/null
+  }
+fi
+
+#######################################
+#             AUR helpers             #
+#######################################
+
+if (( $+commands[pacaur] )); then
+  alias paupg='pacaur -Syu'
+  alias pasu='pacaur -Syu --noconfirm'
+  alias pain='pacaur -S'
+  alias pains='pacaur -U'
+  alias pare='pacaur -R'
+  alias parem='pacaur -Rns'
+  alias parep='pacaur -Si'
+  alias pareps='pacaur -Ss'
+  alias paloc='pacaur -Qi'
+  alias palocs='pacaur -Qs'
+  alias palst='pacaur -Qe'
+  alias paorph='pacaur -Qtd'
+  alias painsd='pacaur -S --asdeps'
+  alias pamir='pacaur -Syy'
+  alias upgrade='pacaur -Syu'
+
+  if (( $+commands[abs] && $+commands[aur] )); then
+    alias paupd='pacaur -Sy && sudo abs && sudo aur'
+  elif (( $+commands[abs] )); then
+    alias paupd='pacaur -Sy && sudo abs'
+  elif (( $+commands[aur] )); then
+    alias paupd='pacaur -Sy && sudo aur'
+  else
+    alias paupd='pacaur -Sy'
+  fi
+fi
+
 if (( $+commands[trizen] )); then
   alias trconf='trizen -C'
   alias trupg='trizen -Syua'
@@ -14,7 +138,7 @@ if (( $+commands[trizen] )); then
   alias trorph='trizen -Qtd'
   alias trinsd='trizen -S --asdeps'
   alias trmir='trizen -Syy'
-
+  alias upgrade='trizen -Syu'
 
   if (( $+commands[abs] && $+commands[aur] )); then
     alias trupd='trizen -Sy && sudo abs && sudo aur'
@@ -43,7 +167,7 @@ if (( $+commands[yaourt] )); then
   alias yaorph='yaourt -Qtd'
   alias yainsd='yaourt -S --asdeps'
   alias yamir='yaourt -Syy'
-
+  alias upgrade='yaourt -Syu'
 
   if (( $+commands[abs] && $+commands[aur] )); then
     alias yaupd='yaourt -Sy && sudo abs && sudo aur'
@@ -72,7 +196,7 @@ if (( $+commands[yay] )); then
   alias yaorph='yay -Qtd'
   alias yainsd='yay -S --asdeps'
   alias yamir='yay -Syy'
-
+  alias upgrade='yay -Syu'
 
   if (( $+commands[abs] && $+commands[aur] )); then
     alias yaupd='yay -Sy && sudo abs && sudo aur'
@@ -83,135 +207,4 @@ if (( $+commands[yay] )); then
   else
     alias yaupd='yay -Sy'
   fi
-fi
-
-if (( $+commands[pacaur] )); then
-  alias paupg='pacaur -Syu'
-  alias pasu='pacaur -Syu --noconfirm'
-  alias pain='pacaur -S'
-  alias pains='pacaur -U'
-  alias pare='pacaur -R'
-  alias parem='pacaur -Rns'
-  alias parep='pacaur -Si'
-  alias pareps='pacaur -Ss'
-  alias paloc='pacaur -Qi'
-  alias palocs='pacaur -Qs'
-  alias palst='pacaur -Qe'
-  alias paorph='pacaur -Qtd'
-  alias painsd='pacaur -S --asdeps'
-  alias pamir='pacaur -Syy'
-
-  if (( $+commands[abs] && $+commands[aur] )); then
-    alias paupd='pacaur -Sy && sudo abs && sudo aur'
-  elif (( $+commands[abs] )); then
-    alias paupd='pacaur -Sy && sudo abs'
-  elif (( $+commands[aur] )); then
-    alias paupd='pacaur -Sy && sudo aur'
-  else
-    alias paupd='pacaur -Sy'
-  fi
-fi
-
-if (( $+commands[trizen] )); then
-  function upgrade() {
-    trizen -Syu
-  }
-elif (( $+commands[pacaur] )); then
-  function upgrade() {
-    pacaur -Syu
-  }
-elif (( $+commands[yaourt] )); then
-  function upgrade() {
-    yaourt -Syu
-  }
-elif (( $+commands[yay] )); then
-  function upgrade() {
-    yay -Syu
-  }
-else
-  function upgrade() {
-    sudo pacman -Syu
-  }
-fi
-
-# Pacman - https://wiki.archlinux.org/index.php/Pacman_Tips
-alias pacupg='sudo pacman -Syu'
-alias pacin='sudo pacman -S'
-alias pacins='sudo pacman -U'
-alias pacre='sudo pacman -R'
-alias pacrem='sudo pacman -Rns'
-alias pacrep='pacman -Si'
-alias pacreps='pacman -Ss'
-alias pacloc='pacman -Qi'
-alias paclocs='pacman -Qs'
-alias pacinsd='sudo pacman -S --asdeps'
-alias pacmir='sudo pacman -Syy'
-alias paclsorphans='sudo pacman -Qdt'
-alias pacrmorphans='sudo pacman -Rs $(pacman -Qtdq)'
-alias pacfileupg='sudo pacman -Fy'
-alias pacfiles='pacman -F'
-alias pacls='pacman -Ql'
-alias pacown='pacman -Qo'
-
-
-if (( $+commands[abs] && $+commands[aur] )); then
-  alias pacupd='sudo pacman -Sy && sudo abs && sudo aur'
-elif (( $+commands[abs] )); then
-  alias pacupd='sudo pacman -Sy && sudo abs'
-elif (( $+commands[aur] )); then
-  alias pacupd='sudo pacman -Sy && sudo aur'
-else
-  alias pacupd='sudo pacman -Sy'
-fi
-
-function paclist() {
-  # Source: https://bbs.archlinux.org/viewtopic.php?id=93683
-  LC_ALL=C pacman -Qei $(pacman -Qu | cut -d " " -f 1) | \
-    awk 'BEGIN {FS=":"} /^Name/{printf("\033[1;36m%s\033[1;37m", $2)} /^Description/{print $2}'
-}
-
-function pacdisowned() {
-  local tmp db fs
-  tmp=${TMPDIR-/tmp}/pacman-disowned-$UID-$$
-  db=$tmp/db
-  fs=$tmp/fs
-
-  mkdir "$tmp"
-  trap 'rm -rf "$tmp"' EXIT
-
-  pacman -Qlq | sort -u > "$db"
-
-  find /bin /etc /lib /sbin /usr ! -name lost+found \
-    \( -type d -printf '%p/\n' -o -print \) | sort > "$fs"
-
-  comm -23 "$fs" "$db"
-}
-
-function pacmanallkeys() {
-  curl -sL https://www.archlinux.org/people/{developers,trusted-users}/ | \
-    awk -F\" '(/keyserver.ubuntu.com/) { sub(/.*search=0x/,""); print $1}' | \
-    xargs sudo pacman-key --recv-keys
-}
-
-function pacmansignkeys() {
-  local key
-  for key in $@; do
-    sudo pacman-key --recv-keys $key
-    sudo pacman-key --lsign-key $key
-    printf 'trust\n3\n' | sudo gpg --homedir /etc/pacman.d/gnupg \
-      --no-permission-warning --command-fd 0 --edit-key $key
-  done
-}
-
-if (( $+commands[xdg-open] )); then
-  function pacweb() {
-    local pkg="$1"
-    local infos="$(LANG=C pacman -Si "$pkg")"
-    if [[ -z "$infos" ]]; then
-      return
-    fi
-    local repo="$(grep -m 1 '^Repo' <<< "$infos" | grep -oP '[^ ]+$')"
-    local arch="$(grep -m 1 '^Arch' <<< "$infos" | grep -oP '[^ ]+$')"
-    xdg-open "https://www.archlinux.org/packages/$repo/$arch/$pkg/" &>/dev/null
-  }
 fi

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -2,6 +2,12 @@
 #               Pacman                #
 #######################################
 
+# abs and aur command check
+local abs_aur=''
+(( ! $+commands[abs] )) || abs_aur+=' && sudo abs'
+(( ! $+commands[aur] )) || abs_aur+=' && sudo aur'
+
+
 # Pacman - https://wiki.archlinux.org/index.php/Pacman_Tips
 alias pacupg='sudo pacman -Syu'
 alias pacin='sudo pacman -S'
@@ -20,17 +26,8 @@ alias pacfileupg='sudo pacman -Fy'
 alias pacfiles='pacman -F'
 alias pacls='pacman -Ql'
 alias pacown='pacman -Qo'
+alias pacupd="sudo pacman -Sy$abs_aur"
 alias upgrade='sudo pacman -Syu'
-
-if (( $+commands[abs] && $+commands[aur] )); then
-  alias pacupd='sudo pacman -Sy && sudo abs && sudo aur'
-elif (( $+commands[abs] )); then
-  alias pacupd='sudo pacman -Sy && sudo abs'
-elif (( $+commands[aur] )); then
-  alias pacupd='sudo pacman -Sy && sudo aur'
-else
-  alias pacupd='sudo pacman -Sy'
-fi
 
 function paclist() {
   # Based on https://bbs.archlinux.org/viewtopic.php?id=93683
@@ -109,17 +106,8 @@ if (( $+commands[pacaur] )); then
   alias paorph='pacaur -Qtd'
   alias painsd='pacaur -S --asdeps'
   alias pamir='pacaur -Syy'
+  alias paupd="pacaur -Sy$abs_aur"
   alias upgrade='pacaur -Syu'
-
-  if (( $+commands[abs] && $+commands[aur] )); then
-    alias paupd='pacaur -Sy && sudo abs && sudo aur'
-  elif (( $+commands[abs] )); then
-    alias paupd='pacaur -Sy && sudo abs'
-  elif (( $+commands[aur] )); then
-    alias paupd='pacaur -Sy && sudo aur'
-  else
-    alias paupd='pacaur -Sy'
-  fi
 fi
 
 if (( $+commands[trizen] )); then
@@ -138,17 +126,8 @@ if (( $+commands[trizen] )); then
   alias trorph='trizen -Qtd'
   alias trinsd='trizen -S --asdeps'
   alias trmir='trizen -Syy'
+  alias trupd="trizen -Sy$abs_aur"
   alias upgrade='trizen -Syu'
-
-  if (( $+commands[abs] && $+commands[aur] )); then
-    alias trupd='trizen -Sy && sudo abs && sudo aur'
-  elif (( $+commands[abs] )); then
-    alias trupd='trizen -Sy && sudo abs'
-  elif (( $+commands[aur] )); then
-    alias trupd='trizen -Sy && sudo aur'
-  else
-    alias trupd='trizen -Sy'
-  fi
 fi
 
 if (( $+commands[yaourt] )); then
@@ -167,17 +146,8 @@ if (( $+commands[yaourt] )); then
   alias yaorph='yaourt -Qtd'
   alias yainsd='yaourt -S --asdeps'
   alias yamir='yaourt -Syy'
+  alias yaupd="yaourt -Sy$abs_aur"
   alias upgrade='yaourt -Syu'
-
-  if (( $+commands[abs] && $+commands[aur] )); then
-    alias yaupd='yaourt -Sy && sudo abs && sudo aur'
-  elif (( $+commands[abs] )); then
-    alias yaupd='yaourt -Sy && sudo abs'
-  elif (( $+commands[aur] )); then
-    alias yaupd='yaourt -Sy && sudo aur'
-  else
-    alias yaupd='yaourt -Sy'
-  fi
 fi
 
 if (( $+commands[yay] )); then
@@ -196,15 +166,8 @@ if (( $+commands[yay] )); then
   alias yaorph='yay -Qtd'
   alias yainsd='yay -S --asdeps'
   alias yamir='yay -Syy'
+  alias yaupd="yay -Sy$abs_aur"
   alias upgrade='yay -Syu'
-
-  if (( $+commands[abs] && $+commands[aur] )); then
-    alias yaupd='yay -Sy && sudo abs && sudo aur'
-  elif (( $+commands[abs] )); then
-    alias yaupd='yay -Sy && sudo abs'
-  elif (( $+commands[aur] )); then
-    alias yaupd='yay -Sy && sudo aur'
-  else
-    alias yaupd='yay -Sy'
-  fi
 fi
+
+unset abs_aur


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

* Fix naming.
* Pacman goes first. AUR helpers, sorted alphabetically, follow it.
* Add footnote to explain identically named *upg aliases.
* Convert upgrade function to aliases, put them alongside other aliases.
* Rewrite paclist function: it was unreliable and over-complicated.
* Add --help to pacweb function instead of silently failing.

## Other comments:

This refactoring is a prerequisite for #9467 