### PR TITLE
fix(lib): mark changes as MODIFIED on 'MM' in `git_prompt_status`

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -170,7 +170,7 @@ function git_prompt_status() {
     '\?\? '     'UNTRACKED'
     'A  '       'ADDED'
     'M  '       'ADDED'
-    'MM '       'ADDED'
+    'MM '       'MODIFIED'
     ' M '       'MODIFIED'
     'AM '       'MODIFIED'
     ' T '       'MODIFIED'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- modify a status mapping in function `git_prompt_status`.

## Other comments:

The 'MM ' prefix means some file modified after added, so the right status should be `'MODIFIED'`.

Like this:

```shell
$ echo 'foo' >> README.md
$ git add README.md
$ echo 'bar' >> README.md
$ git status --short

MM README.md
```