### PR TITLE
fix(archlinux): update URL and key server in `pacmanallkeys`

### DIFF
--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -188,8 +188,8 @@ function pacdisowned() {
 }
 
 function pacmanallkeys() {
-  curl -s https://www.archlinux.org/people/{developers,trustedusers}/ | \
-    awk -F\" '(/pgp.mit.edu/) { sub(/.*search=0x/,""); print $1}' | \
+  curl -sL https://www.archlinux.org/people/{developers,trusted-users}/ | \
+    awk -F\" '(/keyserver.ubuntu.com/) { sub(/.*search=0x/,""); print $1}' | \
     xargs sudo pacman-key --recv-keys
 }
 


### PR DESCRIPTION
Error and investigation:

```
❯ pacmanallkeys                                                                                                                                 ─╯
[sudo] password for lagbrie: 
==> ERROR: No targets specified
❯ which pacmanallkeys                                                                                                                           ─╯
pacmanallkeys () {
	curl -s https://www.archlinux.org/people/{developers,trustedusers}/ | awk -F\" '(/pgp.mit.edu/) { sub(/.*search=0x/,""); print $1}' | xargs sudo pacman-key --recv-keys
}
❯ curl -s https://www.archlinux.org/people/{developers,trustedusers}/ | awk -F\" '(/pgp.mit.edu/) { sub(/.*search=0x/,""); print $1}'
❯ curl -svo /dev/null https://www.archlinux.org/people/\{developers,trustedusers\}/ |& grep -i "< HTTP"
< HTTP/2 301 
< HTTP/2 301 
❯ curl -Lsvo /dev/null https://www.archlinux.org/people/\{developers,trustedusers\}/ |& grep -i "< HTTP\|location:"
< HTTP/2 301 
< location: https://archlinux.org/people/developers/
< HTTP/2 200 
< HTTP/2 301 
< location: https://archlinux.org/people/trustedusers/
< HTTP/2 404 

```

After the above investigation, I've updated the command to function as originally intended.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added follow redirects curl flag to fix the 301 response.
- Updated trusted users URL format.
- Changed from `pgp.mit.edu` keyserver, since the archlinux page has moved to `keyserver.ubuntu.com` keyservers.