### PR TITLE
fix(vi-mode): hide cursor-change logic behind opt-in setting

### DIFF
--- a/plugins/vi-mode/README.md
+++ b/plugins/vi-mode/README.md
@@ -22,6 +22,13 @@ plugins=(... vi-mode)
   The default value is unset, unless `vi_mode_prompt_info` is used, in which case it'll
   automatically be set to `true`.
 
+- `VI_MODE_SET_CURSOR`: controls whether the cursor style is changed when switching
+  to a different input mode. Set it to `true` to enable it (default: unset):
+
+  ```zsh
+  VI_MODE_SET_CURSOR=true
+  ```
+
 - `MODE_INDICATOR`: controls the string displayed when the shell is in normal mode.
   See [Mode indicator](#mode-indicator) for details.
 

--- a/plugins/vi-mode/README.md
+++ b/plugins/vi-mode/README.md
@@ -1,34 +1,59 @@
-vi-mode
-=======
+# vi-mode plugin
+
 This plugin increase `vi-like` zsh functionality.
+
+To use it, add `vi-mode` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... vi-mode)
+```
+
+## Settings
+
+- `VI_MODE_RESET_PROMPT_ON_MODE_CHANGE`: controls whether the prompt is redrawn when
+  switching to a different input mode. If this is unset, the mode indicator will not
+  be updated when changing to a different mode.
+  Set it to `true` to enable it. For example:
+
+  ```zsh
+  VI_MODE_RESET_PROMPT_ON_MODE_CHANGE=true
+  ```
+
+  The default value is unset, unless `vi_mode_prompt_info` is used, in which case it'll
+  automatically be set to `true`.
+
+- `MODE_INDICATOR`: controls the string displayed when the shell is in normal mode.
+  See [Mode indicator](#mode-indicator) for details.
+
+## Mode indicator
+
+*Normal mode* is indicated with a red `<<<` mark at the right prompt, when it
+hasn't been defined by theme.
+
+You can change this indicator by setting the `MODE_INDICATOR` variable. This setting
+supports Prompt Expansion sequences. For example:
+
+```zsh
+MODE_INDICATOR="%F{yellow}+%f"
+```
+
+You can also use the `vi_mode_prompt_info` function in your prompt, which will display
+this mode indicator.
+
+## Key bindings
 
 Use `ESC` or `CTRL-[` to enter `Normal mode`.
 
+NOTE: some of these key bindings are set by zsh by default when using a vi-mode keymap.
 
-History
--------
+### History
 
 - `ctrl-p` : Previous command in history
 - `ctrl-n` : Next command in history
 - `/`      : Search backward in history
 - `n`      : Repeat the last `/`
 
-
-Mode indicators
----------------
-
-*Normal mode* is indicated with red `<<<` mark at the right prompt, when it
-wasn't defined by theme.
-
-
-Vim edition
------------
-
-- `v`   : Edit current command line in Vim
-
-
-Movement
---------
+### Movement
 
 - `$`   : To the end of the line
 - `^`   : To the first non-blank character of the line
@@ -46,9 +71,7 @@ Movement
 - `;`   : Repeat latest f, t, F or T [count] times
 - `,`   : Repeat latest f, t, F or T in opposite direction
 
-
-Insertion
----------
+### Insertion
 
 - `i`   : Insert text before the cursor
 - `I`   : Insert text before the first character in the line
@@ -57,9 +80,7 @@ Insertion
 - `o`   : Insert new command line below the current one
 - `O`   : Insert new command line above the current one
 
-
-Delete and Insert
------------------
+### Delete and Insert
 
 - `ctrl-h`      : While in *Insert mode*: delete character before the cursor
 - `ctrl-w`      : While in *Insert mode*: delete word before the cursor
@@ -73,3 +94,7 @@ Delete and Insert
 - `R`           : Enter replace mode: Each character replaces existing one
 - `x`           : Delete [count] characters under and after the cursor
 - `X`           : Delete [count] characters before the cursor
+
+### Removed key bindings
+
+- `v`   : Edit current command line in Vim

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -4,13 +4,21 @@
 # This is especially true if the prompt does things like checking git status.
 #
 # Set to "true" to force the prompt to reset on each mode change.
-# Set to "false" to force the prompt *not* to reset on each mode change.
+# Unset or set to any other value to do the opposite.
 #
-# (The default is not to reset, unless we're showing the mode in RPS1).
+# The default is not to reset, unless we're showing the mode in RPS1.
 typeset -g VI_MODE_RESET_PROMPT_ON_MODE_CHANGE
+# Control whether to change the cursor style on mode change.
+#
+# Set to "true" to change the cursor on each mode change.
+# Unset or set to any other value to do the opposite.
+typeset -g VI_MODE_SET_CURSOR
+
 typeset -g VI_KEYMAP=main
 
 function _vi-mode-set-cursor-shape-for-keymap() {
+  [[ "$VI_MODE_SET_CURSOR" = true ]] || return
+
   # https://vt100.net/docs/vt510-rm/DECSCUSR
   local _shape=0
   case "${1:-${VI_KEYMAP:-main}}" in


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- docs(vi-mode): revamp README and document settings
- fix(vi-mode): hide cursor-change logic behind `VI_MODE_SET_CURSOR` setting

Fixes #9570