### PR TITLE
Fix issues with the fastfile plugin

### DIFF
--- a/plugins/fastfile/fastfile.plugin.zsh
+++ b/plugins/fastfile/fastfile.plugin.zsh
@@ -78,9 +78,9 @@ function fastfile_print() {
 #    (=> fastfle_print) for each shortcut
 #
 function fastfile_ls() {
-    for f in "${fastfile_dir}"/*(NF); do
-        file=`basename "$f"` # To enable simpler handeling of spaces in file names
-        varkey=`echo "$file" | tr " " "_"`
+    for f in "${fastfile_dir}"/*; do
+        file=$(basename "$f") # To enable simpler handeling of spaces in file names
+        varkey=$(echo "$file" | tr " " "_")
 
         # Special format for colums
         echo "${fastfile_var_prefix}${varkey}|->|$(fastfile_get "$file")"

--- a/plugins/fastfile/fastfile.plugin.zsh
+++ b/plugins/fastfile/fastfile.plugin.zsh
@@ -6,7 +6,7 @@
 # overwritten with their default values
 
 default fastfile_dir        "${HOME}/.fastfile"
-default fastfile_var_prefix "§"
+default fastfile_var_prefix "@"
 
 ###########################
 # Impl

--- a/plugins/fastfile/fastfile.plugin.zsh
+++ b/plugins/fastfile/fastfile.plugin.zsh
@@ -104,9 +104,9 @@ function fastfile_rm() {
 # Generate the aliases for the shortcuts
 #
 function fastfile_sync() {
-    for f in "${fastfile_dir}"/*(NF); do
-        file=`basename "$f"` # To enable simpler handeling of spaces in file names
-        varkey=`echo "$file" | tr " " "_"`
+    for f in "${fastfile_dir}"/*; do
+        file=$(basename "$f") # To enable simpler handeling of spaces in file names
+        varkey=$(echo "$file" | tr " " "_")
 
         alias -g "${fastfile_var_prefix}${varkey}"="'$(fastfile_get "$file")'"
     done

--- a/plugins/fastfile/fastfile.plugin.zsh
+++ b/plugins/fastfile/fastfile.plugin.zsh
@@ -44,7 +44,7 @@ function fastfile() {
 #   The path to the shortcut file
 #
 function fastfile_resolv() {
-    echo "${fastfile_dir}${1}"
+    echo "${fastfile_dir}/${1}"
 }
 
 #


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fixed `fastfile_resolve` function. It was resolving aliases outside `fastfile_dir` location.
- Fixed `fastfile_sync` and `fastfile_ls` functions. They were not doing any work.
- Changed default alias prefix `§` to `@` because it is a more common symbol and this should not cause any problems 