### PR TITLE
Tilde key switch plugin for Macbooks: tilde-switch plugin

### DIFF
--- a/plugins/tilde-switch/README.md
+++ b/plugins/tilde-switch/README.md
@@ -1,0 +1,9 @@
+# tilde-switch plugin
+
+By default, on some non-US keyboards of Macbooks like Swedish and Turkish, tilde key switched with a plus-minus key. So this plugin switches back the `±` key to `~` without needing any third-party tool or service.
+
+To use it, add `tilde-switch` to the plugins array of your `.zshrc` file:
+```
+plugins=(... tilde-switch)
+```
+

--- a/plugins/tilde-switch/tilde-switch.plugin.zsh
+++ b/plugins/tilde-switch/tilde-switch.plugin.zsh
@@ -1,0 +1,22 @@
+#!/usr/bin/env zsh
+
+#
+# tilde-switch-zsh
+#
+# This key binding plugin gets tilde key back on MacOS 
+# Swithes back ± key to ~ 
+#
+# Copyright(c) 2021 Mevlut Canvar <mevlutcanvar@gmail.com>
+# MIT Licensed
+#
+
+#
+# Mevlüt Canvar
+# GitHub: https://github.com/mcanvar
+# Twitter: https://twitter.com/mevlutcanvar
+#
+
+#
+# This solution taken from here: https://apple.stackexchange.com/a/353941
+#
+hidutil property --set '{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":0x700000035,"HIDKeyboardModifierMappingDst":0x700000064},{"HIDKeyboardModifierMappingSrc":0x700000064,"HIDKeyboardModifierMappingDst":0x700000035}]}' > /dev/null

--- a/plugins/tilde-switch/tilde-switch.plugin.zsh
+++ b/plugins/tilde-switch/tilde-switch.plugin.zsh
@@ -19,4 +19,21 @@
 #
 # This solution taken from here: https://apple.stackexchange.com/a/353941
 #
-hidutil property --set '{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":0x700000035,"HIDKeyboardModifierMappingDst":0x700000064},{"HIDKeyboardModifierMappingSrc":0x700000064,"HIDKeyboardModifierMappingDst":0x700000035}]}' > /dev/null
+
+MAPPING=$(cat <<EOF
+{
+   "UserKeyMapping":[
+      {
+         "HIDKeyboardModifierMappingSrc":0x700000035,
+         "HIDKeyboardModifierMappingDst":0x700000064
+      },
+      {
+         "HIDKeyboardModifierMappingSrc":0x700000064,
+         "HIDKeyboardModifierMappingDst":0x700000035
+      }
+   ]
+}
+EOF
+)
+
+hidutil property --set $MAPPING > /dev/null


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- When enabling this plugin it switches back the `±` key to `~` without needing any third-party tool or service on Macbooks which has non-US native keyboards like Swedish or Turkish etc.

## Other comments:
I am using it in my local oh-my-zsh and it saves my time a lot. As you can see in this question on [stackexchange.com](https://apple.stackexchange.com/questions/329085/tilde-and-plus-minus-%c2%b1-in-wrong-place-on-keyboard) lots of people suffer. I would appreciate if my PR accepted. I think this is a serious need for people to have a non-US keyboard on their Macbooks.

Thank you for your amazing work!
