### PR TITLE
fix(lib): update Emacs terminal detection in `title` function

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -10,7 +10,7 @@ function title {
   emulate -L zsh
   setopt prompt_subst
 
-  [[ "$EMACS" == *term* ]] && return
+  [[ "$INSIDE_EMACS" == *term* ]] && return
 
   # if $2 is unset use $1 as default
   # if it is set and empty, leave it as is


### PR DESCRIPTION
Emacs replaced the environment variable that it sets in interactive subshells from `EMACS`  to `INSIDE_EMACS`. See https://www.gnu.org/software/emacs/manual/html_node/emacs/Interactive-Shell.html for details.

I couldn't find exactly when Emacs made this change, but [this post from 2015](https://lists.gnu.org/archive/html/bug-gnu-emacs/2015-03/msg01008.html) shows that `EMACS` was deprecated for 8 years at that point.

Closes #6411. 

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
