### PR TITLE
Add alias for kubectls dry-run flag

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -35,6 +35,10 @@ alias kcgc='kubectl config get-contexts'
 alias kdel='kubectl delete'
 alias kdelf='kubectl delete -f'
 
+# Dry runs
+alias kdr='kubectl --dry-run=client'
+alias kdrs='kubectl --dry-run=server'
+
 # Pod management.
 alias kgp='kubectl get pods'
 alias kgpa='kubectl get pods --all-namespaces'


### PR DESCRIPTION
## Changes:

I added two more aliases in order to support kubectls client and server-side dry run. 

## Other comments:
The try run flag is extremely useful to quickly generate template / boilerplate code for new Kubernetes resources.  https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands