### PR TITLE
Add git log aliases with the '--no-decorate' option.

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -199,6 +199,10 @@ alias glods="git log --graph --pretty='%Cred%h%Creset -%C(auto)%d%Creset %s %Cgr
 alias glola="git log --graph --pretty='%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --all"
 alias glog='git log --oneline --decorate --graph'
 alias gloga='git log --oneline --decorate --graph --all'
+alias glon='git log --oneline --no-decorate'
+alias glona='git log --oneline --no-decorate --all'
+alias glong='git log --oneline --no-decorate --graph'
+alias glonga='git log --oneline --no-decorate --graph --all'
 alias glp="_git_log_prettily"
 
 alias gm='git merge'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [n/a] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added alias for `git log` to the git plugin.

## Other comments:

- I tried to follow the prevailing naming convention for abbreviating the commands to aliases.
- I hope that people who use `--decorate` as a default option for `git log` find these useful. I found myself needing it today.
