### PR TITLE
fix(jake-node): support all Jakefile filenames in `jake` completion

### DIFF
--- a/plugins/jake-node/jake-node.plugin.zsh
+++ b/plugins/jake-node/jake-node.plugin.zsh
@@ -6,7 +6,7 @@
 # Inspiration : https://weblog.rubyonrails.org/2006/3/9/fast-rake-task-completion-for-zsh
 
 function _jake () {
-  if [ -f Jakefile ]||[ -f jakefile ]; then
+  if [ -f Jakefile ] || [ -f jakefile ] || [ -f Jakefile.js ] || [ -f jakefile.js ]; then
     compadd `jake -T | cut -d " " -f 2 | sed -E "s/.\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"`
   fi
 }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Extend checks filenames for Jakefiles.
- Add Jakefile, Jakefile.js, jakefile and jakefile.js

## Other comments:

https://jakejs.com/docs-page.html#item-advanced-usage-modularizing
↓
When you run Jake, it will look for a Jakefile in the current diretory. Jake will recognize Jakefile, Jakefile.js, jakefile, or jakefile.js as a vaild name for a Jakefile.