### PR TITLE
fix(colorize): bypass less aliases in `colorize_less`

### DIFF
--- a/plugins/colorize/colorize.plugin.zsh
+++ b/plugins/colorize/colorize.plugin.zsh
@@ -96,7 +96,7 @@ colorize_less() {
         # which assumes that his LESSOPEN has been executed.
         local LESSCLOSE=""
 
-        LESS="$LESS" LESSOPEN="$LESSOPEN" LESSCLOSE="$LESSCLOSE" less "$@"
+        LESS="$LESS" LESSOPEN="$LESSOPEN" LESSCLOSE="$LESSCLOSE" command less "$@"
     }
 
     if [ -t 0 ]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

I want to set `alias less="colorize_less"` to have fancy `less`.
But in current state it will expand alias recursively basically in infinite loop causing the whole terminal to crash. Prevent this by prepending it with `command` which will use default `less` instead.
