### PR TITLE
feat(bundler): add completion for `info` argument

### DIFF
--- a/plugins/bundler/_bundler
+++ b/plugins/bundler/_bundler
@@ -18,6 +18,7 @@ case $state in
 			"check[Determine whether the requirements for your application are installed]" \
 			"list[Show all of the gems in the current bundle]" \
 			"show[Show the source location of a particular gem in the bundle]" \
+			"info[Show details of a particular gem in the bundle]" \
 			"outdated[Show all of the outdated gems in the current bundle]" \
 			"console[Start an IRB session in the context of the current bundle]" \
 			"open[Open an installed gem in the editor]" \
@@ -84,7 +85,7 @@ case $state in
 					'(--verbose)--verbose[Enable verbose output mode]'
 				ret=0
 				;;
-			(open|show)
+			(open|show|info)
 				_gems=( $(bundle show 2> /dev/null | sed -e '/^  \*/!d; s/^  \* \([^ ]*\) .*/\1/') )
 				if [[ $_gems != "" ]]; then
 					_values 'gems' $_gems && ret=0


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [x] Add "info" argument.
- [x] Completion for gem names using "info".

## Other comments:

Bundler 2.2.5 shows deprecation warning using "show":
```
[DEPRECATED] use `bundle info gem_name` instead of `bundle show gem_name`
```
