### PR TITLE
git plugin: add view tracking branch alias command

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -33,6 +33,7 @@ plugins=(... git)
 | gbsg                 | git bisect good                                                                                                                  |
 | gbsr                 | git bisect reset                                                                                                                 |
 | gbss                 | git bisect start                                                                                                                 |
+| gbt                  | git for-each-ref --format="%(upstream:short)" $(git symbolic-ref -q HEAD)                                                        |
 | gc                   | git commit -v                                                                                                                    |
 | gc!                  | git commit -v --amend                                                                                                            |
 | gcn!                 | git commit -v --no-edit --amend                                                                                                  |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -70,6 +70,7 @@ alias gbsb='git bisect bad'
 alias gbsg='git bisect good'
 alias gbsr='git bisect reset'
 alias gbss='git bisect start'
+alias gbt='git for-each-ref --format="%(upstream:short)" $(git symbolic-ref -q HEAD)'
 
 alias gc='git commit -v'
 alias gc!='git commit -v --amend'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- add git alias `gbt` to view the current tracking branch

## Other comments:

Refer to this question:
https://stackoverflow.com/a/40630957/7736393
