### PR TITLE
speed up asdf plugin startup on mac

### DIFF
--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -4,7 +4,7 @@ ASDF_COMPLETIONS="$ASDF_DIR/completions"
 
 # If not found, check for Homebrew package
 if [[ ! -f "$ASDF_DIR/asdf.sh" || ! -f "$ASDF_COMPLETIONS/asdf.bash" ]] && (( $+commands[brew] )); then
-   ASDF_DIR="$(brew --prefix asdf)"
+   ASDF_DIR="$(brew --prefix)/opt/asdf"
    ASDF_COMPLETIONS="$ASDF_DIR/etc/bash_completion.d"
 fi
 


### PR DESCRIPTION
Hi @RobLoach 

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- instead of using `$(brew --prefix asdf)` use `$(brew --prefix)/opt/asdf`

## Other comments:

Speed up start time on mac:
before:
```
{10:24}~ ➭ time zsh -i -c exit    
zsh -i -c exit  1,26s user 0,91s system 101% cpu 2,139 total
```

after:
```
{10:22}~ ➭ time zsh -i -c exit          
zsh -i -c exit  0,38s user 0,15s system 107% cpu 0,492 total
```
