### PR TITLE
docs(git-prompt): explain stashed icon (⚑)

### DIFF
--- a/plugins/git-prompt/README.md
+++ b/plugins/git-prompt/README.md
@@ -24,6 +24,7 @@ The prompt may look like the following:
 - `(master|✖2✚3)`: on branch `master`, 2 conflicts, 3 files changed
 - `(experimental↓2↑3|✔)`: on branch `experimental`; your branch has diverged by 3 commits, remote by 2 commits; the repository is otherwise clean
 - `(:70c2952|✔)`: not on any branch; parent commit has hash `70c2952`; the repository is otherwise clean
+- `(master|⚑2)`: on branch `master`, there are 2 stashed changes
 
 ## Prompt Structure
 
@@ -43,6 +44,7 @@ The symbols are as follows:
 | ●n     | there are `n` staged files     |
 | ✖n     | there are `n` unmerged files   |
 | ✚n     | there are `n` unstaged files   |
+| ⚑n     | there are `n` stashed changes  |
 | …      | there are some untracked files |
 
 ### Branch Tracking Symbols


### PR DESCRIPTION
Stashed icon is added in #4880

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- The `stashed` icon is added in #4880 PR. This PR updates the README file to explain the icon.

## Other comments:
