### PR TITLE
Update VI_KEYMAP on zle-line-finish.  Fixes next prompt draw after running command from 'normal' mode.

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -50,9 +50,10 @@ zle -N zle-keymap-select
 # These "echoti" statements were originally set in lib/key-bindings.zsh
 # Not sure the best way to extend without overriding.
 function zle-line-init() {
-  LAST_VI_KEYMAP=$VI_KEYMAP
+  local prev_vi_keymap
+  prev_vi_keymap="${VI_KEYMAP:-}"
   typeset -g VI_KEYMAP=main
-  [[ $LAST_VI_KEYMAP != 'main' ]] && [[ "${VI_MODE_RESET_PROMPT_ON_MODE_CHANGE:-}" = true ]] && zle reset-prompt
+  [[ "$prev_vi_keymap" != 'main' ]] && [[ "${VI_MODE_RESET_PROMPT_ON_MODE_CHANGE:-}" = true ]] && zle reset-prompt
   (( ! ${+terminfo[smkx]} )) || echoti smkx
   _vi-mode-set-cursor-shape-for-keymap "${VI_KEYMAP}"
 }

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -52,7 +52,7 @@ zle -N zle-keymap-select
 function zle-line-init() {
   LAST_VI_KEYMAP=$VI_KEYMAP
   typeset -g VI_KEYMAP=main
-  [[ $LAST_VI_KEYMAP != 'main' ]] && zle reset-prompt
+  [[ $LAST_VI_KEYMAP != 'main' ]] && [[ "${VI_MODE_RESET_PROMPT_ON_MODE_CHANGE:-}" = true ]] && zle reset-prompt
   (( ! ${+terminfo[smkx]} )) || echoti smkx
   _vi-mode-set-cursor-shape-for-keymap "${VI_KEYMAP}"
 }

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -57,6 +57,7 @@ function zle-line-init() {
 zle -N zle-line-init
 
 function zle-line-finish() {
+  typeset -g VI_KEYMAP=main
   (( ! ${+terminfo[rmkx]} )) || echoti rmkx
   _vi-mode-set-cursor-shape-for-keymap default
 }

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -50,7 +50,9 @@ zle -N zle-keymap-select
 # These "echoti" statements were originally set in lib/key-bindings.zsh
 # Not sure the best way to extend without overriding.
 function zle-line-init() {
+  LAST_VI_KEYMAP=$VI_KEYMAP
   typeset -g VI_KEYMAP=main
+  [[ $LAST_VI_KEYMAP != 'main' ]] && zle reset-prompt
   (( ! ${+terminfo[smkx]} )) || echoti smkx
   _vi-mode-set-cursor-shape-for-keymap "${VI_KEYMAP}"
 }


### PR DESCRIPTION
In some cases, the prompt was not always being redrawn properly after running a command from vi-mode.  If a command is executed with zle in 'normal' mode, after command completion, the next prompt drawn still indicates 'normal' mode, even though it is a new zle line and is back in 'insert' mode.  This was because the `VI_KEYMAP` var (on which the prompt selection is based) was being updated on zle init, which isn't called until after the prompt draw.  This PR fixes this by setting `VI_KEYMAP` back to 'main' on `zle-line-finish` to mirror what is already being done on `zle-line-init`.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- In `vi-mode` plugin, reset `VI_KEYMAP` to 'main' after zle finishes editing line.

