### PR TITLE
A small improvement of speed of function parse_git_dirty

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -51,7 +51,7 @@ function parse_git_dirty() {
         FLAGS+="--ignore-submodules=${GIT_STATUS_IGNORE_SUBMODULES:-dirty}"
         ;;
     esac
-    STATUS=$(__git_prompt_git status ${FLAGS} 2> /dev/null | tail -1)
+    STATUS=$(__git_prompt_git status ${FLAGS} 2> /dev/null | head -1)
   fi
   if [[ -n $STATUS ]]; then
     echo "$ZSH_THEME_GIT_PROMPT_DIRTY"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Modify the way to check whether a git directory is large by using `head` instead of `tail`, so if there are tons of output from `git status`, it will terminate faster since `head` will terminate after receiving the first line.