### PR TITLE
feat(autojump): add new Homebrew default path on M1 Macs

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -10,6 +10,7 @@ autojump_paths=(
   /usr/local/share/autojump/autojump.zsh             # FreeBSD installation
   /opt/local/etc/profile.d/autojump.sh               # macOS with MacPorts
   /usr/local/etc/profile.d/autojump.sh               # macOS with Homebrew (default)
+  /opt/homebrew/etc/profile.d/autojump.sh            # macOS with Homebrew (default on M1 macs)
 )
 
 for file in $autojump_paths; do


### PR DESCRIPTION
On M1-Macs homebrew uses /opt/homebrew as default location for ARM
packages. This results in the autojump plugin not being able to find
autojump after a clean default installation.
This commit adds the new default location to the autojump plugin.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add autojump path for new homebrew default location
