### PR TITLE
Allow users to load ssh keys from alternate directory in the ssh-agent plugin

### DIFF
--- a/plugins/ssh-agent/README.md
+++ b/plugins/ssh-agent/README.md
@@ -25,6 +25,12 @@ To **load multiple identities** use the `identities` style, For example:
 zstyle :omz:plugins:ssh-agent identities id_rsa id_rsa2 id_github
 ```
 
+To **load identities from a different directory to .ssh** use the `identity_dir` style, For example:
+
+```zsh
+zstyle :omz:plugins:ssh-agent identity_dir .ssh2
+```
+
 To **set the maximum lifetime of the identities**, use the `lifetime` style.
 The lifetime may be specified in seconds or as described in sshd_config(5)
 (see _TIME FORMATS_). If left unspecified, the default lifetime is forever.

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -13,11 +13,16 @@ function _start_agent() {
 
 function _add_identities() {
 	local id line sig lines
-	local -a identities loaded_sigs loaded_ids not_loaded
+	local -a identities identity_dir loaded_sigs loaded_ids not_loaded
 	zstyle -a :omz:plugins:ssh-agent identities identities
+	zstyle -a :omz:plugins:ssh-agent identity_dir identity_dir
+
+	if [[ -z $identity_dir ]]; then
+		identity_dir=".ssh"
+	fi
 
 	# check for .ssh folder presence
-	if [[ ! -d $HOME/.ssh ]]; then
+	if [[ ! -d $HOME/$identity_dir ]]; then
 		return
 	fi
 
@@ -27,7 +32,7 @@ function _add_identities() {
 		# key list found on `ssh-add` man page's DESCRIPTION section
 		for id in id_rsa id_dsa id_ecdsa id_ed25519 identity; do
 			# check if file exists
-			[[ -f "$HOME/.ssh/$id" ]] && identities+=$id
+			[[ -f "$HOME/$identity_dir/$id" ]] && identities+=$id
 		done
 	fi
 
@@ -43,8 +48,8 @@ function _add_identities() {
 	for id in $identities; do
 		# check for filename match, otherwise try for signature match
 		if [[ ${loaded_ids[(I)$HOME/.ssh/$id]} -le 0 ]]; then
-			sig="$(ssh-keygen -lf "$HOME/.ssh/$id" | awk '{print $2}')"
-			[[ ${loaded_sigs[(I)$sig]} -le 0 ]] && not_loaded+="$HOME/.ssh/$id"
+			sig="$(ssh-keygen -lf "$HOME/$identity_dir/$id" | awk '{print $2}')"
+			[[ ${loaded_sigs[(I)$sig]} -le 0 ]] && not_loaded+="$HOME/$identity_dir/$id"
 		fi
 	done
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Rather than forcing users to load their identities from .ssh, allow this directory to be chosen via the style `identity_dir`.

This has to be a directory in `${HOME}` (I considered allowing arbitrary directories to be specified, but limiting to the home directory seems sensible)
