### PR TITLE
Allow tmux binary name to be changed for tmux plugin

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -33,6 +33,7 @@ The plugin also supports the following:
 | `ZSH_TMUX_AUTOSTART_ONCE`           | Autostart only if tmux hasn't been started previously (default: `true`)       |
 | `ZSH_TMUX_AUTOCONNECT`              | Automatically connect to a previous session if it exits (default: `true`)     |
 | `ZSH_TMUX_AUTOQUIT`                 | Automatically closes terminal once tmux exits (default: `ZSH_TMUX_AUTOSTART`) |
+| `ZSH_TMUX_BINARY`                   | Sets the name of the tmux binary (default: `tmux`)                            |
 | `ZSH_TMUX_FIXTERM`                  | Sets `$TERM` to 256-color term or not based on current terminal support       |
 | `ZSH_TMUX_ITERM2`                   | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)          |
 | `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `screen`)                |

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -1,18 +1,6 @@
-if ! (( $+commands[tmux] )); then
-  print "zsh tmux plugin: tmux not found. Please install tmux before using this plugin." >&2
-  return 1
-fi
-
-# ALIASES
-
-alias ta='tmux attach -t'
-alias tad='tmux attach -d -t'
-alias ts='tmux new-session -s'
-alias tl='tmux list-sessions'
-alias tksv='tmux kill-server'
-alias tkss='tmux kill-session -t'
-
 # CONFIGURATION VARIABLES
+# Location/name of tmux binary
+: ${ZSH_TMUX_BINARY:=tmux}
 # Automatically start tmux
 : ${ZSH_TMUX_AUTOSTART:=false}
 # Only autostart once. If set to false, tmux will attempt to
@@ -39,6 +27,21 @@ alias tkss='tmux kill-session -t'
 # Set -u option to support unicode
 : ${ZSH_TMUX_UNICODE:=false}
 
+
+if ! (( $+commands[${ZSH_TMUX_BINARY}] )); then
+  print "zsh tmux plugin: ${ZSH_TMUX_BINARY} not found. Please install tmux before using this plugin." >&2
+  return 1
+fi
+
+# ALIASES
+
+alias ta='${ZSH_TMUX_BINARY} attach -t'
+alias tad='${ZSH_TMUX_BINARY} attach -d -t'
+alias ts='${ZSH_TMUX_BINARY} new-session -s'
+alias tl='${ZSH_TMUX_BINARY} list-sessions'
+alias tksv='${ZSH_TMUX_BINARY} kill-server'
+alias tkss='${ZSH_TMUX_BINARY} kill-session -t'
+
 # Determine if the terminal supports 256 colors
 if [[ $terminfo[colors] == 256 ]]; then
   export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITH_256COLOR
@@ -57,12 +60,12 @@ fi
 # Wrapper function for tmux.
 function _zsh_tmux_plugin_run() {
   if [[ -n "$@" ]]; then
-    command tmux "$@"
+    command ${ZSH_TMUX_BINARY} "$@"
     return $?
   fi
 
   local -a tmux_cmd
-  tmux_cmd=(command tmux)
+  tmux_cmd=(command ${ZSH_TMUX_BINARY})
   [[ "$ZSH_TMUX_ITERM2" == "true" ]] && tmux_cmd+=(-CC)
   [[ "$ZSH_TMUX_UNICODE" == "true" ]] && tmux_cmd+=(-u)
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds configuration variable for the name of the tmux binary.

Fixes #9652 