### PR TITLE
fix(fossil): PROMPT, and RPROMPT are not meant to be exported

### DIFF
--- a/plugins/fossil/fossil.plugin.zsh
+++ b/plugins/fossil/fossil.plugin.zsh
@@ -73,9 +73,9 @@ function _fossil_prompt () {
     local is_prompt=`echo $PROMPT | grep git`
 
     if [ "$is_prompt" = "" ]; then
-      export RPROMPT="$_rprompt"'$(fossil_prompt_info)'
+      RPROMPT="$_rprompt"'$(fossil_prompt_info)'
     else
-      export PROMPT="$_prompt"'$(fossil_prompt_info) '
+      PROMPT="$_prompt"'$(fossil_prompt_info) '
     fi
 
     _FOSSIL_PROMPT="1"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

Fixes #9654

HTH