### PR TITLE
Silence "starting ssh-agent..." message with ZSH_SSH_AGENT_QUIET=true

### DIFF
--- a/plugins/ssh-agent/README.md
+++ b/plugins/ssh-agent/README.md
@@ -33,6 +33,10 @@ The lifetime may be specified in seconds or as described in sshd_config(5)
 zstyle :omz:plugins:ssh-agent lifetime 4h
 ```
 
+To **silence the plugin**, such as the `starting ssh agent...` message,
+simply set `ZSH_SSH_AGENT_QUIET=true` somewhere in your zsh profile
+_before_ you source your `oh-my-zsh.sh` file.
+
 ## Credits
 
 Based on code from Joseph M. Reagle: https://www.cygwin.com/ml/cygwin/2001-06/msg00537.html

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -5,7 +5,9 @@ function _start_agent() {
 	zstyle -s :omz:plugins:ssh-agent lifetime lifetime
 
 	# start ssh-agent and setup environment
-	echo Starting ssh-agent...
+	if [[ -z "$ZSH_SSH_AGENT_QUIET" ]]; then
+	    echo Starting ssh-agent...
+	fi
 	ssh-agent -s ${lifetime:+-t} ${lifetime} | sed 's/^echo/#echo/' >! $_ssh_env_cache
 	chmod 600 $_ssh_env_cache
 	. $_ssh_env_cache > /dev/null


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds a check for `$ZSH_SSH_AGENT_QUIET != true` before echoing

## Other comments:

[#4639](https://github.com/ohmyzsh/ohmyzsh/pull/4639) covers similar material but was closed by its author without discussion or integration.
