### PR TITLE
Add command-not-found support for Termux

### DIFF
--- a/plugins/command-not-found/README.md
+++ b/plugins/command-not-found/README.md
@@ -28,5 +28,6 @@ It works out of the box with the command-not-found packages for:
 - [macOS (Homebrew)](https://github.com/Homebrew/homebrew-command-not-found)
 - [Fedora](https://fedoraproject.org/wiki/Features/PackageKitCommandNotFound)
 - [NixOS](https://github.com/NixOS/nixpkgs/tree/master/nixos/modules/programs/command-not-found)
+- [Termux](https://github.com/termux/command-not-found)
 
 You can add support for other platforms by submitting a Pull Request.

--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -50,3 +50,10 @@ if [ -x /run/current-system/sw/bin/command-not-found ]; then
         /run/current-system/sw/bin/command-not-found $@
     }
 fi
+
+# Termux command-not-found support
+if [ -x /data/data/com.termux/files/usr/libexec/termux/command-not-found ]; then
+    command_not_found_handler() {
+        /data/data/com.termux/files/usr/libexec/termux/command-not-found "$1"
+    }
+fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- add command-not-found support for Termux (Android terminal emulator)
