### PR TITLE
wd: Support alternate GNU getopt binary on OpenBSD

### DIFF
--- a/plugins/wd/wd.sh
+++ b/plugins/wd/wd.sh
@@ -402,7 +402,8 @@ do
 done < "$WD_CONFIG"
 
 # get opts
-args=$(getopt -o a:r:c:lhs -l add:,rm:,clean,list,ls:,path:,help,show -- $*)
+GETOPT=$(command -v gnugetopt 2> /dev/null || command getopt || echo getopt)
+args=$($GETOPT -o a:r:c:lhs -l add:,rm:,clean,list,ls:,path:,help,show -- $*)
 
 # check if no arguments were given, and that version is not set
 if [[ ($? -ne 0 || $#* -eq 0) && -z $wd_print_version ]]

--- a/plugins/wd/wd.sh
+++ b/plugins/wd/wd.sh
@@ -402,7 +402,7 @@ do
 done < "$WD_CONFIG"
 
 # get opts
-GETOPT=$(command -v gnugetopt 2> /dev/null || command getopt || echo getopt)
+GETOPT=$(command -v gnugetopt 2> /dev/null || command -v getopt || echo getopt)
 args=$($GETOPT -o a:r:c:lhs -l add:,rm:,clean,list,ls:,path:,help,show -- $*)
 
 # check if no arguments were given, and that version is not set


### PR DESCRIPTION
OpenBSD `getopt(1)` does not support `-l`.  There's a `gnugetopt` port/package that is the GNU implementation (the one on Linux) that supports `-l`.  So if `gnugetopt` is present in the PATH use that, otherwise `getopt`.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Change the wd plugin's invocation of `getopt(1)` to try an alternate binary if present in the PATH, specifically for OpenBSD where the base `getopt(1)` does not support `-l` like GNU getopt.

## Other comments:

None.

`@` mentioning wd plugin maintainers per guidelines:

@alpha-tango-kilo 
@MattLewin