### PR TITLE
[lib/git.zsh] Prefer `branch --show-current` for `git_current_branch`

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -94,8 +94,9 @@ function git_remote_status() {
 # Using '--quiet' with 'symbolic-ref' will not cause a fatal error (128) if
 # it's not a symbolic ref, but in a Git repo.
 function git_current_branch() {
-  local ref=$(__git_prompt_git branch --show-current 2> /dev/null)
-  local ret=$?
+  local ref ret
+  ref=$(__git_prompt_git branch --show-current 2> /dev/null)
+  ret=$?
   [[ $ret == 128 ]] && return  # no git repo.
   if [[ $ret != 0 ]]; then  # Git versions before 2.22.0
     ref=$(__git_prompt_git symbolic-ref --quiet HEAD 2> /dev/null)

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -94,11 +94,13 @@ function git_remote_status() {
 # Using '--quiet' with 'symbolic-ref' will not cause a fatal error (128) if
 # it's not a symbolic ref, but in a Git repo.
 function git_current_branch() {
-  local ref
-  ref=$(__git_prompt_git symbolic-ref --quiet HEAD 2> /dev/null)
+  local ref=$(__git_prompt_git branch --show-current 2> /dev/null)
   local ret=$?
-  if [[ $ret != 0 ]]; then
-    [[ $ret == 128 ]] && return  # no git repo.
+  [[ $ret == 128 ]] && return  # no git repo.
+  if [[ $ret != 0 ]]; then  # Git versions before 2.22.0
+    ref=$(__git_prompt_git symbolic-ref --quiet HEAD 2> /dev/null)
+  fi
+  if [[ -z "${ref}" ]]; then  # No symbolic ref, return short sha
     ref=$(__git_prompt_git rev-parse --short HEAD 2> /dev/null) || return
   fi
   echo ${ref#refs/heads/}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Try to get current branch using `git branch --show-current`

## Other comments:

Git release 2.22.0[1] introduced `git branch --show-current` to return the current branch.[2] This change implements the current primary approach for determining the branch name natively.

[1] https://github.com/git/git/blob/master/Documentation/RelNotes/2.22.0.txt#L32
[2] https://github.com/git/git/commit/0ecb1fc7269e15be890870937b8b639c987abd08