### PR TITLE
fix(update): don't error on upgrade no-op

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -401,13 +401,14 @@ function _omz::theme::use {
 }
 
 function _omz::update {
+  local last_commit=$(cd "$ZSH"; git rev-parse HEAD)
+
   # Run update script
   if [[ "$1" != --unattended ]]; then
     ZSH="$ZSH" zsh -f "$ZSH/tools/upgrade.sh" --interactive
   else
     ZSH="$ZSH" zsh -f "$ZSH/tools/upgrade.sh"
   fi
-  local ret=$?
 
   # Update last updated file
   zmodload zsh/datetime
@@ -415,8 +416,8 @@ function _omz::update {
   # Remove update lock if it exists
   command rm -rf "$ZSH/log/update.lock"
 
-  # Restart the zsh session
-  if [[ $ret -eq 0 && "$1" != --unattended ]]; then
+  # Restart the zsh session if there were changes
+  if [[ "$1" != --unattended && "$(cd "$ZSH"; git rev-parse HEAD)" != "$last_commit" ]]; then
     # Old zsh versions don't have ZSH_ARGZERO
     local zsh="${ZSH_ARGZERO:-${functrace[-1]%:*}}"
     # Check whether to run a login shell

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -24,8 +24,7 @@ function update_last_updated_file() {
 }
 
 function update_ohmyzsh() {
-  ZSH="$ZSH" zsh -f "$ZSH/tools/upgrade.sh" --interactive
-  if [[ "$?" = (0|80) ]]; then
+  if ZSH="$ZSH" zsh -f "$ZSH/tools/upgrade.sh" --interactive; then
     update_last_updated_file
   fi
 }

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -66,7 +66,6 @@ if git pull --rebase --stat origin master; then
   # Check if it was really updated or not
   if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]; then
     message="Oh My Zsh is already at the latest version."
-    ret=80 # non-zero exit code to indicate no changes pulled
   else
     message="Hooray! Oh My Zsh has been updated!"
 


### PR DESCRIPTION
No error code is required for a non failure scenario.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Removes the `ret=80` when no upgrade has been performed. If no actions is/was required when performing an upgrade then an error scenario hasn't occurred.
