### PR TITLE
fix(cargo): complete flags for default cargo aliases

### DIFF
--- a/plugins/cargo/_cargo
+++ b/plugins/cargo/_cargo
@@ -77,7 +77,7 @@ _cargo() {
                         '*:args:_default'
                         ;;
 
-                build)
+                build|b)
                     _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
                         '--all-targets[equivalent to specifying --lib --bins --tests --benches --examples]' \
                         "${command_scope_spec[@]}" \
@@ -86,7 +86,7 @@ _cargo() {
                         '--build-plan[output the build plan in JSON]' \
                         ;;
 
-                check)
+                check|c)
                     _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
                         '--all-targets[equivalent to specifying --lib --bins --tests --benches --examples]' \
                         "${command_scope_spec[@]}" \
@@ -224,7 +224,7 @@ _cargo() {
                     _arguments -s -S $common $manifest
                         ;;
 
-                run)
+                run|r)
                     _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
                         '--example=[name of the bin target]:name' \
                         '--bin=[name of the bin target]:name' \
@@ -259,7 +259,7 @@ _cargo() {
                         '*: :_guard "^-*" "query"'
                         ;;
 
-                test)
+                test|t)
                     _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
                         '--test=[test name]: :_cargo_test_names' \
                         '--no-fail-fast[run all tests regardless of failure]' \


### PR DESCRIPTION
By default, cargo provides alias for some commonly used functions. This patch
makes it that those alias will complete the same as their full commands.

Default alias:
b -> build
c -> check
t -> test
r -> run

Since cargo allows users to define custom alias it would be nice if
oh-my-zsh automatically detected those and preformed completions as such
but that would be a much more complex patch.

Reference documentation: https://doc.rust-lang.org/cargo/reference/config.html#alias

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- The case statement matching the cargo sub-command now also the commands default aliases as described above.
