### PR TITLE
fix(terraform): use faster method to get workspace

### DIFF
--- a/lib/prompt_info_functions.zsh
+++ b/lib/prompt_info_functions.zsh
@@ -18,6 +18,7 @@ function chruby_prompt_info \
   vi_mode_prompt_info \
   virtualenv_prompt_info \
   jenv_prompt_info \
+  tf_prompt_info \
 {
   return 1
 }

--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -2,8 +2,8 @@ function tf_prompt_info() {
     # dont show 'default' workspace in home dir
     [[ "$PWD" == ~ ]] && return
     # check if in terraform dir
-    if [ -d .terraform ]; then
-      workspace=$(terraform workspace show 2> /dev/null) || return
+    if [[ -d .terraform && -r .terraform/environment  ]]; then
+      workspace=$(cat .terraform/environment) || return
       echo "[${workspace}]"
     fi
 }


### PR DESCRIPTION


## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

The purpose of this change is to speed up tf_prompt_info() function.   This function relies on 'terraform workspace show' which could be very slow operation.   To speed up I made the following changes

- Check for .terraform/environment directory.  If it doesn't exist we are probably not in the terraform stack or the stack doesn't have custom workspace
- To get the workspace one just needs to look into .terraform/environment file.  It contains the workspace name.  No need to launch the terraform command because it is very slow
- Also, added tf_prompt_info to the list of prompt_info functions in lib/prompt_info.  So that theme writers are aware of it


