### PR TITLE
Removing Yaourt and Pacaur from Archlinux Plugin

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -55,55 +55,6 @@ plugins=(... archlinux)
 | trsu    | trizen -Syua --no-confirm          | Same as `trupg`, but without confirmation                           |
 | upgrade | trizen -Syu                        | Sync with repositories before upgrading packages                    |
 
-#### YAOURT
-
-| Alias   | Command                            | Description                                                         |
-|---------|------------------------------------|---------------------------------------------------------------------|
-| yaconf  | yaourt -C                          | Fix all configuration files with vimdiff                            |
-| yain    | yaourt -S                          | Install packages from the repositories                              |
-| yains   | yaourt -U                          | Install a package from a local file                                 |
-| yainsd  | yaourt -S --asdeps                 | Install packages as dependencies of another package                 |
-| yaloc   | yaourt -Qi                         | Display information about a package in the local database           |
-| yalocs  | yaourt -Qs                         | Search for packages in the local database                           |
-| yalst   | yaourt -Qe                         | List installed packages including from AUR (tagged as "local")      |
-| yamir   | yaourt -Syy                        | Force refresh of all package lists after updating mirrorlist        |
-| yaorph  | yaourt -Qtd                        | Remove orphans using yaourt                                         |
-| yare    | yaourt -R                          | Remove packages, keeping its settings and dependencies              |
-| yarem   | yaourt -Rns                        | Remove packages, including its settings and unneeded dependencies   |
-| yarep   | yaourt -Si                         | Display information about a package in the repositories             |
-| yareps  | yaourt -Ss                         | Search for packages in the repositories                             |
-| yaupd   | yaourt -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases             |
-| yaupd   | yaourt -Sy && sudo abs             | Update and refresh the local package and ABS databases              |
-| yaupd   | yaourt -Sy && sudo aur             | Update and refresh the local package and AUR databases              |
-| yaupd   | yaourt -Sy                         | Update and refresh the local package database                       |
-| yaupg   | yaourt -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
-| yasu    | yaourt -Syua --no-confirm          | Same as `yaupg`, but without confirmation                           |
-| upgrade | yaourt -Syu                        | Sync with repositories before upgrading packages                    |
-
-#### PACAUR
-
-| Alias   | Command                            | Description                                                         |
-|---------|------------------------------------|---------------------------------------------------------------------|
-| pain    | pacaur -S                          | Install packages from the repositories                              |
-| pains   | pacaur -U                          | Install a package from a local file                                 |
-| painsd  | pacaur -S --asdeps                 | Install packages as dependencies of another package                 |
-| paloc   | pacaur -Qi                         | Display information about a package in the local database           |
-| palocs  | pacaur -Qs                         | Search for packages in the local database                           |
-| palst   | pacaur -Qe                         | List installed packages including from AUR (tagged as "local")      |
-| pamir   | pacaur -Syy                        | Force refresh of all package lists after updating mirrorlist        |
-| paorph  | pacaur -Qtd                        | Remove orphans using pacaur                                         |
-| pare    | pacaur -R                          | Remove packages, keeping its settings and dependencies              |
-| parem   | pacaur -Rns                        | Remove packages, including its settings and unneeded dependencies   |
-| parep   | pacaur -Si                         | Display information about a package in the repositories             |
-| pareps  | pacaur -Ss                         | Search for packages in the repositories                             |
-| paupd   | pacaur -Sy && sudo abs && sudo aur | Update and refresh local package, ABS and AUR databases             |
-| paupd   | pacaur -Sy && sudo abs             | Update and refresh the local package and ABS databases              |
-| paupd   | pacaur -Sy && sudo aur             | Update and refresh the local package and AUR databases              |
-| paupd   | pacaur -Sy                         | Update and refresh the local package database                       |
-| paupg   | pacaur -Syua                       | Sync with repositories before upgrading all packages (from AUR too) |
-| pasu    | pacaur -Syua --no-confirm          | Same as `paupg`, but without confirmation                           |
-| upgrade | pacaur -Syu                        | Sync with repositories before upgrading packages                    |
-
 #### PACMAN
 
 | Alias        | Command                                 | Description                                                  |
@@ -152,3 +103,4 @@ plugins=(... archlinux)
 - Juraj Fiala - doctorjellyface@riseup.net
 - Majora320 (Moses Miller) - Majora320@gmail.com
 - Ybalrid (Arthur Brainville) - ybalrid@ybalrid.info
+- Nowshed H. Imran(nowshed-imran) - now.im.627@gmail.com

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -27,35 +27,6 @@ if (( $+commands[trizen] )); then
   fi
 fi
 
-if (( $+commands[yaourt] )); then
-  alias yaconf='yaourt -C'
-  alias yaupg='yaourt -Syua'
-  alias yasu='yaourt -Syua --noconfirm'
-  alias yain='yaourt -S'
-  alias yains='yaourt -U'
-  alias yare='yaourt -R'
-  alias yarem='yaourt -Rns'
-  alias yarep='yaourt -Si'
-  alias yareps='yaourt -Ss'
-  alias yaloc='yaourt -Qi'
-  alias yalocs='yaourt -Qs'
-  alias yalst='yaourt -Qe'
-  alias yaorph='yaourt -Qtd'
-  alias yainsd='yaourt -S --asdeps'
-  alias yamir='yaourt -Syy'
-
-
-  if (( $+commands[abs] && $+commands[aur] )); then
-    alias yaupd='yaourt -Sy && sudo abs && sudo aur'
-  elif (( $+commands[abs] )); then
-    alias yaupd='yaourt -Sy && sudo abs'
-  elif (( $+commands[aur] )); then
-    alias yaupd='yaourt -Sy && sudo aur'
-  else
-    alias yaupd='yaourt -Sy'
-  fi
-fi
-
 if (( $+commands[yay] )); then
   alias yaconf='yay -Pg'
   alias yaupg='yay -Syu'
@@ -85,44 +56,9 @@ if (( $+commands[yay] )); then
   fi
 fi
 
-if (( $+commands[pacaur] )); then
-  alias paupg='pacaur -Syu'
-  alias pasu='pacaur -Syu --noconfirm'
-  alias pain='pacaur -S'
-  alias pains='pacaur -U'
-  alias pare='pacaur -R'
-  alias parem='pacaur -Rns'
-  alias parep='pacaur -Si'
-  alias pareps='pacaur -Ss'
-  alias paloc='pacaur -Qi'
-  alias palocs='pacaur -Qs'
-  alias palst='pacaur -Qe'
-  alias paorph='pacaur -Qtd'
-  alias painsd='pacaur -S --asdeps'
-  alias pamir='pacaur -Syy'
-
-  if (( $+commands[abs] && $+commands[aur] )); then
-    alias paupd='pacaur -Sy && sudo abs && sudo aur'
-  elif (( $+commands[abs] )); then
-    alias paupd='pacaur -Sy && sudo abs'
-  elif (( $+commands[aur] )); then
-    alias paupd='pacaur -Sy && sudo aur'
-  else
-    alias paupd='pacaur -Sy'
-  fi
-fi
-
 if (( $+commands[trizen] )); then
   function upgrade() {
     trizen -Syu
-  }
-elif (( $+commands[pacaur] )); then
-  function upgrade() {
-    pacaur -Syu
-  }
-elif (( $+commands[yaourt] )); then
-  function upgrade() {
-    yaourt -Syu
   }
 elif (( $+commands[yay] )); then
   function upgrade() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
Both Yaourt and Pacaur are unmaintained AUR helper now. No one actually uses them anymore. They don't need to be in Archlinux Plugin anymore.

1. Yaourt: https://archlinux.fr/yaourt-en
2. Pacaur: https://github.com/E5ten/pacaur
