### PR TITLE
fix(emotty): fix `bad assignment` error

### DIFF
--- a/plugins/emotty/emotty.plugin.zsh
+++ b/plugins/emotty/emotty.plugin.zsh
@@ -29,7 +29,7 @@ function emotty() {
   # Parse tty number via prompt expansion. %l equals:
   # - N      if tty = /dev/ttyN
   # - pts/N  if tty = /dev/pts/N
-  local tty = ${${(%):-%l}##pts/}
+  local tty=${${(%):-%l}##pts/}
   # Normalize it to an emotty set index
   (( tty = (tty % ${#${=emotty}}) + 1 ))
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Removed redundant spaces to prevent:
```
$ emotty
emotty:7: bad assignment
```