### PR TITLE
feat(fzf): add support for Termux package

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -64,11 +64,21 @@ function setup_using_debian_package() {
     # NOTE: There is no need to configure PATH for debian package, all binaries
     # are installed to /usr/bin by default
 
-    # Determine completion file path: first bullseye/sid, then buster/stretch
-    local completions="/usr/share/doc/fzf/examples/completion.zsh"
-    [[ -f "$completions" ]] || completions="/usr/share/zsh/vendor-completions/_fzf"
+    local completions key_bindings
 
-    local key_bindings="/usr/share/doc/fzf/examples/key-bindings.zsh"
+    case $PREFIX in
+        *com.termux*)
+            # Support Termux package
+            completions="${PREFIX}/share/fzf/completion.zsh"
+            key_bindings="${PREFIX}/share/fzf/key-bindings.zsh"
+            ;;
+        *)
+            # Determine completion file path: first bullseye/sid, then buster/stretch
+            completions="/usr/share/doc/fzf/examples/completion.zsh"
+            [[ -f "$completions" ]] || completions="/usr/share/zsh/vendor-completions/_fzf"
+            key_bindings="/usr/share/doc/fzf/examples/key-bindings.zsh"
+            ;;
+    esac
 
     # Auto-completion
     if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added support for Termux debian package