### PR TITLE
Make the root shell distinguishable by changing the $PS1 color and prompt for it in strug.zsh-theme

### DIFF
--- a/themes/strug.zsh-theme
+++ b/themes/strug.zsh-theme
@@ -4,8 +4,8 @@ export LSCOLORS=dxFxCxDxBxegedabagacad
 
 local git_branch='$(git_prompt_info)%{$reset_color%}$(git_remote_status)'
 
-PROMPT="%{$fg[green]%}╭─%n@%m %{$reset_color%}%{$fg[yellow]%}in %~ %{$reset_color%}${git_branch}
-%{$fg[green]%}╰\$ %{$reset_color%}"
+PROMPT="%{%(#~$fg[red]~$fg[green])%}╭─%n@%m %{$reset_color%}%{$fg[yellow]%}in %~ %{$reset_color%}${git_branch}
+%{%(#~$fg[red]~$fg[green])%}╰%(#~#~\$) %{$reset_color%}"
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[yellow]%}on "
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x] The PR title is descriptive.
- [ x] The PR doesn't replicate another PR which is already open.
- [ x] I have read the contribution guide and followed all the instructions.
- [ x] The code follows the code style guide detailed in the wiki.
- [ x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Turned $PS1 color from green to red in root shell
- Changed root prompt from Dollar to Hashtag in root shell

## Other comments:
@ncanceill 