### PR TITLE
Transfer plugin can perform symetric encryption on file/folder before uploading to server 

### DIFF
--- a/plugins/transfer/README.md
+++ b/plugins/transfer/README.md
@@ -22,3 +22,25 @@ transfer file.txt
 ```zsh
 transfer directory/
 ```
+
+### Encryption/Decryption
+
+- encrypt and upload file with symmetric cipher and create ASCII armored output
+```zsh
+transfer file -ca
+```
+
+- encrypt and upload folder with symmetric cipher and gpg output
+```zsh
+transfer folder -ca
+```
+
+- decrypt file
+```zsh
+gpg -d file -ca
+```
+
+- decrypt folder
+```zsh
+gpg -d your_archive.tgz.gpg | tar xz
+```


### PR DESCRIPTION
Transfer plugin can perform symetric cryptography on file/folder before uploading to transfer.sh server 
**Issue #9712**
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [x] Update on README.md according with the new feature
- [x] New argument enabled to perform file/folder encryption

## Other comments:
Encryption is done by [GPG](https://gnupg.org/)
...
