### PR TITLE
Updated the condition to search for themes in custom/themes folder

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -124,6 +124,8 @@ if [ ! "$ZSH_THEME" = ""  ]; then
     source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
   elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
     source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
+  elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME/$ZSH_THEME.zsh-theme" ]; then
+    source "$ZSH_CUSTOM/themes/$ZSH_THEME/$ZSH_THEME.zsh-theme"
   else
     source "$ZSH/themes/$ZSH_THEME.zsh-theme"
   fi


### PR DESCRIPTION
Updated the condition which looks for themes in custom folders for those situations where .zsh-theme is available under `$ZSH_CUSTOM/themes/$ZSH_THEME/$ZSH_THEME.zsh-theme`

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added condition to handle those situations where a custom theme file might be available in a theme named folder inside custom/themes directory.