### PR TITLE
feat(autojump): add support for NetBSD

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -8,6 +8,7 @@ autojump_paths=(
   /etc/profile.d/autojump.zsh                        # manual installation
   /etc/profile.d/autojump.sh                         # Gentoo installation
   /usr/local/share/autojump/autojump.zsh             # FreeBSD installation
+  /usr/pkg/share/autojump/autojump.zsh               # NetBSD installation
   /opt/local/etc/profile.d/autojump.sh               # macOS with MacPorts
   /usr/local/etc/profile.d/autojump.sh               # macOS with Homebrew (default)
 )


### PR DESCRIPTION
NetBSD's default path structure is a bit different - everything is put
in /usr/pkg by default. This is tested and working on NetBSD 9.1 for
amd64.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Make the autojump plugin work on NetBSD.

## Other comments:

...
