### PR TITLE
refactor(lib): move `setopt auto_cd` to directories.zsh

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -1,3 +1,5 @@
+setopt auto_cd
+
 # Changing/making/removing directory
 setopt auto_pushd
 setopt pushd_ignore_dups

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -44,7 +44,6 @@ if command diff --color . . &>/dev/null; then
   alias diff='diff --color'
 fi
 
-setopt auto_cd
 setopt multios
 setopt prompt_subst
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- extract `setopt auto_cd` from `lib/theme-and-appearance.zsh` and insert it to `lib/directories.zsh`

## Other comments:

fixes https://github.com/ohmyzsh/ohmyzsh/issues/3586
