### PR TITLE
feat(battery plugin): Add support for Android

### DIFF
--- a/plugins/battery/README.md
+++ b/plugins/battery/README.md
@@ -20,3 +20,9 @@ Here's an example of how to install with apt:
 ```
 sudo apt-get install acpi
 ```
+On Android (via Termux), you must have:
+1. The `Termux:API` addon app installed ( [Google Play](https://play.google.com/store/apps/details?id=com.termux.api)  | [F-Droid](https://f-droid.org/packages/com.termux.api/) ), and
+2. `termux-api` package installed within termux:
+    ```
+    pkg install termux-api
+    ```

--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -10,6 +10,9 @@
 # Author: J (927589452)                   #
 # Modified to add support for FreeBSD     #
 ###########################################
+# Author: Avneet Singh (kalsi-avneet)     #
+# Modified to add support for Android     #
+###########################################
 
 if [[ "$OSTYPE" = darwin* ]]; then
 
@@ -89,6 +92,45 @@ elif [[ "$OSTYPE" = freebsd* ]]; then
       printf %02d:%02d $hour $minute
     fi
   }
+
+  function battery_pct_prompt() {
+    local battery_pct color
+    battery_pct=$(battery_pct_remaining)
+    if battery_is_charging; then
+      echo "∞"
+    else
+      if [[ $battery_pct -gt 50 ]]; then
+        color='green'
+      elif [[ $battery_pct -gt 20 ]]; then
+        color='yellow'
+      else
+        color='red'
+      fi
+      echo "%{$fg[$color]%}${battery_pct}%%%{$reset_color%}"
+    fi
+  }
+
+elif [[ "$OSTYPE" = linux-android  ]]; then
+
+  function battery_is_charging() {
+    [[ $(termux-battery-status | awk '/status/ { gsub(/[,"]/,""); print $2}') = "CHARGING" ]]
+
+  }
+
+  function battery_pct() {
+    termux-battery-status | awk '/percentage/ { gsub(/[,]/,""); print $2}'
+  }
+
+  function battery_pct_remaining() {
+    if ! battery_is_charging; then
+      battery_pct
+    else
+      echo "External Power"
+    fi
+  }
+
+  # Not available on android
+  function battery_time_remaining() { }
 
   function battery_pct_prompt() {
     local battery_pct color


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds support for the battery plugin on Android via Termux 

## Other comments:
1. If using a battery prompt and accessing Termux via ssh, the prompt may hang. This is due to a known issue with `termux-api` ( https://github.com/termux/termux-api/issues/301 )
2. Making many calls to the battery plugin may slow the prompt on some devices. This is due to another known issue ( https://github.com/termux/termux-api/issues/63 )