### PR TITLE
fix(pass): update `pass` completion to ff5ac38

### DIFF
--- a/plugins/pass/_pass
+++ b/plugins/pass/_pass
@@ -133,7 +133,7 @@ _pass_complete_entries_helper () {
 	local IFS=$'\n'
 	local prefix
 	zstyle -s ":completion:${curcontext}:" prefix prefix || prefix="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
-	_values -C 'passwords' ${$(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print 2>/dev/null | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' -e 's#\\#\\\\#' | sort):-""}
+	_values -C 'passwords' ${$(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o "$@" -print 2>/dev/null | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' -e 's#\\#\\\\#' | sort):-""}
 }
 
 _pass_complete_entries_with_subdirs () {

--- a/plugins/pass/_pass
+++ b/plugins/pass/_pass
@@ -6,17 +6,8 @@
 #    Brian Mattern <rephorm@rephorm.com>
 #    Jason A. Donenfeld <Jason@zx2c4.com>.
 # All Rights Reserved.
-# This file is licensed under the GPLv2+.
-# Please visit https://git.zx2c4.com/password-store/tree/COPYING for more information.
+# This file is licensed under the GPLv2+. Please see COPYING for more information.
 
-
-# If you use multiple repositories, you can configure completion like this:
-#
-# compdef _pass workpass
-# zstyle ':completion::complete:workpass::' prefix "$HOME/work/pass"
-# workpass() {
-#   PASSWORD_STORE_DIR=$HOME/work/pass pass $@
-# }
 
 # If you use multiple repositories, you can configure completion like this:
 #
@@ -133,7 +124,7 @@ _pass_complete_entries_helper () {
 	local IFS=$'\n'
 	local prefix
 	zstyle -s ":completion:${curcontext}:" prefix prefix || prefix="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
-	_values -C 'passwords' ${$(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o "$@" -print 2>/dev/null | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' -e 's#\\#\\\\#' | sort):-""}
+	_values -C 'passwords' ${$(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print 2>/dev/null | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' -e 's#\\#\\\\#g' -e 's#:#\\:#g' | sort):-""}
 }
 
 _pass_complete_entries_with_subdirs () {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Quote $@ in completion.

## Other comments:

I started using zsh yesterday, and my command completion broke. 

It happens at least with filenames containing colons. The details of the breakage are: "the completion suggestions are all weird so they are useless". (I haven't looked at further details.)

The completion command contains a $@, and I my first guess was maybe trying to quote it would help. Lo and behold, it did! So I stopped trying to understand much about zsh completion after that. 