### PR TITLE
fix essembeh theme to show ssh host ip correctly

### DIFF
--- a/themes/essembeh.zsh-theme
+++ b/themes/essembeh.zsh-theme
@@ -32,7 +32,7 @@ local ZSH_ESSEMBEH_COLOR="green"
 local ZSH_ESSEMBEH_PREFIX=""
 if [[ -n "$SSH_CONNECTION" ]]; then
 	# display the source address if connected via ssh
-	ZSH_ESSEMBEH_PREFIX="%{$fg[yellow]%}[$(echo $SSH_CONNECTION | awk '{print $1}')]%{$reset_color%} "
+	ZSH_ESSEMBEH_PREFIX="%{$fg[yellow]%}[$(echo $SSH_CONNECTION | awk '{print $(NF-1)}')]%{$reset_color%} "
 	# use red color to highlight a remote connection
 	ZSH_ESSEMBEH_COLOR="red"
 elif [[ -r /etc/debian_chroot ]]; then 


### PR DESCRIPTION
when I ssh to 192.168.1.35 from 192.168.1.3(my pc), SSH_CONNECTION env is:

$ echo $SSH_CONNECTION
192.168.1.3 49966 192.168.1.35 22
$ echo $SSH_CONNECTION | awk '{print $(NF-1)}'
192.168.1.35

I think, It is better prompt 192.168.1.35 , no 192.168.1.3. 

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

OK because NR >= 2 when SSH_CONNECTION is set in env
