### PR TITLE
fix(dirhistory): make sure to call built-in zle widgets

### DIFF
--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -108,16 +108,16 @@ function dirhistory_forward() {
 # Bind keys to history navigation
 function dirhistory_zle_dirhistory_back() {
   # Erase current line in buffer
-  zle kill-buffer
-  dirhistory_back 
-  zle accept-line
+  zle .kill-buffer
+  dirhistory_back
+  zle .accept-line
 }
 
 function dirhistory_zle_dirhistory_future() {
   # Erase current line in buffer
-  zle kill-buffer
+  zle .kill-buffer
   dirhistory_forward
-  zle accept-line
+  zle .accept-line
 }
 
 zle -N dirhistory_zle_dirhistory_back
@@ -160,15 +160,15 @@ function dirhistory_down() {
 
 # Bind keys to hierarchy navigation
 function dirhistory_zle_dirhistory_up() {
-  zle kill-buffer   # Erase current line in buffer
+  zle .kill-buffer   # Erase current line in buffer
   dirhistory_up
-  zle accept-line
+  zle .accept-line
 }
 
 function dirhistory_zle_dirhistory_down() {
-  zle kill-buffer   # Erase current line in buffer
+  zle .kill-buffer   # Erase current line in buffer
   dirhistory_down
-  zle accept-line
+  zle .accept-line
 }
 
 zle -N dirhistory_zle_dirhistory_up


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Make sure built-in widgets are used for `kill-buffer` and `accept-line`

## Other comments:

Fixes https://github.com/ohmyzsh/ohmyzsh/issues/9770