### PR TITLE
Rails Plugin: check for bundle if no other 'rails' context is found

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -1,26 +1,26 @@
 function _rails_command () {
-  if [ -e "bin/stubs/rails" ]; then
+  if type bundle &> /dev/null && { [ -e "Gemfile" ] || [ -e "gems.rb" ]; }; then
+    bundle exec rails $@
+  elif [ -e "bin/stubs/rails" ]; then
     bin/stubs/rails $@
   elif [ -e "bin/rails" ]; then
     bin/rails $@
   elif [ -e "script/rails" ]; then
     ruby script/rails $@
   elif [ -e "script/server" ]; then
-    ruby script/$@
-  elif type bundle &> /dev/null && ([ -e "Gemfile" ] || [ -e "gems.rb" ]); then
-    bundle exec rails $@
+    ruby script/server $@
   else
     command rails $@
   fi
 }
 
 function _rake_command () {
-  if [ -e "bin/stubs/rake" ]; then
+  if type bundle &> /dev/null && ([ -e "Gemfile" ] || [ -e "gems.rb" ]); then
+    bundle exec rake $@
+  elif [ -e "bin/stubs/rake" ]; then
     bin/stubs/rake $@
   elif [ -e "bin/rake" ]; then
     bin/rake $@
-  elif type bundle &> /dev/null && ([ -e "Gemfile" ] || [ -e "gems.rb" ]); then
-    bundle exec rake $@
   else
     command rake $@
   fi

--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -7,6 +7,8 @@ function _rails_command () {
     ruby script/rails $@
   elif [ -e "script/server" ]; then
     ruby script/$@
+  elif type bundle &> /dev/null && ([ -e "Gemfile" ] || [ -e "gems.rb" ]); then
+    bundle exec rails $@
   else
     command rails $@
   fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- added check for `bundle` if no other rails context is found, and runs as `bundle exec rails $@`. This duplicates the format used by the `rake` section of this plugin.
