### PR TITLE
feat(shell-proxy): enable unexported `DEFAULT_PROXY` setting

### DIFF
--- a/plugins/shell-proxy/proxy.py
+++ b/plugins/shell-proxy/proxy.py
@@ -9,8 +9,9 @@ user_proxy = os.environ.get("CONFIG_PROXY", os.path.expandvars("$HOME/.config/pr
 
 
 def get_http_proxy():
-    if "DEFAULT_PROXY" in os.environ:
-        return os.environ["DEFAULT_PROXY"]
+    default_proxy = os.environ.get("DEFAULT_PROXY")
+    if default_proxy:
+        return default_proxy
     if os.path.isfile(user_proxy):
         return check_output(user_proxy).decode("utf-8").strip()
     raise Exception("Not found, Proxy configuration")

--- a/plugins/shell-proxy/shell-proxy.plugin.zsh
+++ b/plugins/shell-proxy/shell-proxy.plugin.zsh
@@ -4,7 +4,7 @@
 __PROXY__="${0:A:h}/proxy.py"
 
 proxy() {
-	source <("$__PROXY__" "$1")
+	source <(env "DEFAULT_PROXY=$DEFAULT_PROXY" "$__PROXY__" "$1")
 }
 
 _proxy() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- improve ux

```bash
# before
export DEFAULT_PROXY="your proxy server"
source "$ZSH/oh-my-zsh.sh"

# after (no need to `export`)
DEFAULT_PROXY="your proxy server"
source "$ZSH/oh-my-zsh.sh"
```

## Other comments:

...
