### PR TITLE
Add venv helper functions

### DIFF
--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -15,4 +15,6 @@ plugins=(... python)
 | `pyfind`         | Finds .py files recursively in the current directory                            |
 | `pyclean [dirs]` | Deletes byte-code and cache files from a list of directories or the current one |
 | `pygrep <text>`  | Looks for `text` in .py files                                                   |
-| `pyuserpaths`    | Add --user site-packages to PYTHONPATH, for all installed python versions.      |
+| `pyuserpaths`    | Add --user site-packages to PYTHONPATH, for all installed python versions       |
+| `mkv`            | Make a new virtual environment called `venv` (by default) in current directory  |
+| `vrun`           | Activate virtual environment called `venv/` (by default) in current directory   |

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -45,3 +45,36 @@ alias pygrep='grep -nr --include="*.py"'
 
 # Run proper IPython regarding current virtualenv (if any)
 alias ipython="python -c 'import IPython; IPython.terminal.ipapp.launch_new_instance()'"
+
+# Activate a python virtual environment called 'venv'
+# Alternatively, activate a virtual environment with a specific name
+function vrun() {
+    if [[ ${1} == "" ]]; then
+        local name="venv";
+    else
+        local name="${1}";
+    fi
+    local loc=$(realpath "${name}");
+    if [[ -d "${loc}/" ]]; then
+        if [[ -f "${loc}/bin/activate" ]]; then
+            . "${loc}/bin/activate" && echo "Activated virtual environment ${name}";
+        else
+            echo "${loc} is not a proper virtual environment. Aborting" && return 1;
+        fi
+    else
+        echo "No ${name}/ subdirectory in ${PWD}. Aborting" && return 1;
+    fi
+}
+
+# Create a new virtual environment
+# The default name is 'venv'
+# But it can be customized
+function mkv() {
+    if [[ ${1} == "" ]]; then
+        local name="venv";
+    else
+        local name="${1}";
+    fi
+    local loc=$(realpath "${name}");
+    python3 -m venv "${name}" && echo "Created ${loc}" && vrun "${name}";
+}

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -46,35 +46,34 @@ alias pygrep='grep -nr --include="*.py"'
 # Run proper IPython regarding current virtualenv (if any)
 alias ipython="python -c 'import IPython; IPython.terminal.ipapp.launch_new_instance()'"
 
-# Activate a python virtual environment called 'venv'
-# Alternatively, activate a virtual environment with a specific name
+## venv utilities
+
+# Activate a the python virtual environment specified.
+# If none specified, use 'venv'.
 function vrun() {
-    if [[ ${1} == "" ]]; then
-        local name="venv";
-    else
-        local name="${1}";
-    fi
-    local loc=$(realpath "${name}");
-    if [[ -d "${loc}/" ]]; then
-        if [[ -f "${loc}/bin/activate" ]]; then
-            . "${loc}/bin/activate" && echo "Activated virtual environment ${name}";
-        else
-            echo "${loc} is not a proper virtual environment. Aborting" && return 1;
-        fi
-    else
-        echo "No ${name}/ subdirectory in ${PWD}. Aborting" && return 1;
-    fi
+  local name="${1:-venv}"
+  local venvpath="${name:P}"
+
+  if [[ ! -d "$venvpath" ]]; then
+    echo >&2 "Error: no such venv in current directory: $name"
+    return 1
+  fi
+
+  if [[ ! -f "${venvpath}/bin/activate" ]]; then
+    echo >&2 "Error: '${name}' is not a proper virtual environment"
+    return 1
+  fi
+
+  . "${venvpath}/bin/activate" || return $?
+  echo "Activated virtual environment ${name}"
 }
 
-# Create a new virtual environment
-# The default name is 'venv'
-# But it can be customized
+# Create a new virtual environment, with default name 'venv'.
 function mkv() {
-    if [[ ${1} == "" ]]; then
-        local name="venv";
-    else
-        local name="${1}";
-    fi
-    local loc=$(realpath "${name}");
-    python3 -m venv "${name}" && echo "Created ${loc}" && vrun "${name}";
+  local name="${1:-venv}"
+  local venvpath="${name:P}"
+
+  python3 -m venv "${name}" || return
+  echo >&2 "Created venv in '${venvpath}'"
+  vrun "${name}"
 }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add `mkv` function that creates a virtual environment using built-in `venv` module in Python Standard Library. The name of the virtual environment can be specified bit it is `venv` by default.
- Add `vrun` function that automatically activates a virtual environment. The name can be secified, but it is `venv` by default.

## Other comments

none