### PR TITLE
zshrc: Include `export GPG_TTY=$TTY`

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -99,3 +99,7 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+
+# To enable signed commits on GitHub
+# export GPG_TTY=$TTY
+


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open. As best as I could. Searched for different GPG related terms, but found nothing close. Sorry if I missed any. 
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
Include `export GPG_TTY=$TTY` to zshrc

When setting up GPG commit signing on Github ([example walkthrough article](https://sabbour.me/setting-up-signed-git-commits-on-macos/)), can get this error
`gpg: signing failed: Inappropriate ioctl for device`
https://github.com/keybase/keybase-issues/issues/2798

a fix is proposed to be to `export GPG_TTY=$(tty)` and put that into `~/.bash_profile`. 
but according to this post 
https://unix.stackexchange.com/a/608921
`export GPG_TTY=$TTY` is better. 

The change has been tested, here's the test commit
https://github.com/alanmynah/cheat-sheets/commit/8ff6913f4928e55cd6cfc6a511ae5d34684a9161
