### PR TITLE
fix plugin command-not-found on M1 macbooks

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -40,11 +40,11 @@ fi
 
 # macOS command-not-found support
 # https://github.com/Homebrew/homebrew-command-not-found
-if (( $+commands[brew] )); then
-    HB_CNF_HANDLER="$(brew --repository)/Library/Taps/homebrew/homebrew-command-not-found/handler.sh"
-    if [ -f "$HB_CNF_HANDLER" ]; then
-        source "$HB_CNF_HANDLER";
-    fi
+HB_CNF_HANDLER_SUFFIX="Library/Taps/homebrew/homebrew-command-not-found/handler.sh"
+if [[ -s "/opt/homebrew/$HB_CNF_HANDLER_SUFFIX" ]]; then
+      source "/opt/homebrew/$HB_CNF_HANDLER_SUFFIX"
+elif [[ -s "/usr/local/Homebrew/$HB_CNF_HANDLER_SUFFIX" ]]; then
+      source "/usr/local/Homebrew/$HB_CNF_HANDLER_SUFFIX"
 fi
 
 # NixOS command-not-found support

--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -38,10 +38,13 @@ if [ -f /usr/libexec/pk-command-not-found ]; then
     }
 fi
 
-# OSX command-not-found support
+# macOS command-not-found support
 # https://github.com/Homebrew/homebrew-command-not-found
-if [[ -s '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh' ]]; then
-    source '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh'
+if (( $+commands[brew] )); then
+    HB_CNF_HANDLER="$(brew --repository)/Library/Taps/homebrew/homebrew-command-not-found/handler.sh"
+    if [ -f "$HB_CNF_HANDLER" ]; then
+        source "$HB_CNF_HANDLER";
+    fi
 fi
 
 # NixOS command-not-found support


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- the `command-not-found` plugin does not work on the M1 macbooks, because homebrew repository on M1 macbook is not `/usr/local/Homebrew` but `/opt/homebrew`. this patch fixes it.

