### PR TITLE
feat(archlinux)!: remove deprecated commands `aur` and `abs`

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -26,7 +26,7 @@ plugins=(... archlinux)
 | pacrep       | `pacman -Si`                           | Display information about a package in the repositories          |
 | pacreps      | `pacman -Ss`                           | Search for packages in the repositories                          |
 | pacrmorphans | `sudo pacman -Rs $(pacman -Qtdq)`      | Delete all orphaned packages                                     |
-| pacupd       | `sudo pacman -Sy && <abs/aur refresh>`[¹](#f1) | Update and refresh local package, ABS and AUR databases  |
+| pacupd       | `sudo pacman -Sy`                      | Update and refresh local package, ABS and AUR databases          |
 | pacupg       | `sudo pacman -Syu`                     | Sync with repositories before upgrading packages                 |
 | pacfileupg   | `sudo pacman -Fy`                      | Download fresh package databases from the server                 |
 | pacfiles     | `pacman -F`                            | Search package file names for matching strings                   |
@@ -70,7 +70,7 @@ upgrades were available. Use `pacman -Que` instead.
 | aurrep  | `aura -Ai`                                      | Display information about a package from AUR                            |
 | aureps  | `aura -As --both`                               | Search for packages in the repositories and AUR                         |
 | auras   | `aura -As --both`                               | Same as above                                                           |
-| auupd   | `sudo aura -Sy && <abs/aur refresh>`[¹](#f1)    | Update and refresh local package, ABS and AUR databases                 |
+| auupd   | `sudo aura -Sy`                                 | Update and refresh local package, ABS and AUR databases                 |
 | auupg   | `sudo sh -c "aura -Syu              && aura -Au"` | Sync with repositories before upgrading all packages (from AUR too)   |
 | ausu    | `sudo sh -c "aura -Syu --no-confirm && aura -Au --no-confirm"` | Same as `auupg`, but without confirmation                |
 | upgrade[³](#f3) | `sudo aura -Syu`                        | Sync with repositories before upgrading packages                        |
@@ -96,7 +96,7 @@ upgrades were available. Use `pacman -Que` instead.
 | parem   | `pacaur -Rns`                     | Remove packages, including its settings and unneeded dependencies   |
 | parep   | `pacaur -Si`                      | Display information about a package in the repositories             |
 | pareps  | `pacaur -Ss`                      | Search for packages in the repositories                             |
-| paupd   | `pacaur -Sy && <abs/aur refresh>`[¹](#f1) | Update and refresh local package, ABS and AUR databases     |
+| paupd   | `pacaur -Sy`                      | Update and refresh local package, ABS and AUR databases             |
 | paupg   | `pacaur -Syua`                    | Sync with repositories before upgrading all packages (from AUR too) |
 | pasu    | `pacaur -Syua --no-confirm`       | Same as `paupg`, but without confirmation                           |
 | upgrade[³](#f3) | `pacaur -Syu`             | Sync with repositories before upgrading packages                    |
@@ -118,7 +118,7 @@ upgrades were available. Use `pacman -Que` instead.
 | trrem   | `trizen -Rns`                     | Remove packages, including its settings and unneeded dependencies   |
 | trrep   | `trizen -Si`                      | Display information about a package in the repositories             |
 | trreps  | `trizen -Ss`                      | Search for packages in the repositories                             |
-| trupd   | `trizen -Sy && <abs/aur refresh>`[¹](#f1) | Update and refresh local package, ABS and AUR databases     |
+| trupd   | `trizen -Sy`                      | Update and refresh local package, ABS and AUR databases             |
 | trupg   | `trizen -Syua`                    | Sync with repositories before upgrading all packages (from AUR too) |
 | trsu    | `trizen -Syua --no-confirm`       | Same as `trupg`, but without confirmation                           |
 | upgrade[³](#f3) | `trizen -Syu`             | Sync with repositories before upgrading packages                    |
@@ -140,7 +140,7 @@ upgrades were available. Use `pacman -Que` instead.
 | yarem   | `yaourt -Rns`                     | Remove packages, including its settings and unneeded dependencies   |
 | yarep   | `yaourt -Si`                      | Display information about a package in the repositories             |
 | yareps  | `yaourt -Ss`                      | Search for packages in the repositories                             |
-| yaupd   | `yaourt -Sy && <abs/aur refresh>`[¹](#f1) | Update and refresh local package, ABS and AUR databases     |
+| yaupd   | `yaourt -Sy`                      | Update and refresh local package, ABS and AUR databases             |
 | yaupg   | `yaourt -Syua`                    | Sync with repositories before upgrading all packages (from AUR too) |
 | yasu    | `yaourt -Syua --no-confirm`       | Same as `yaupg`, but without confirmation                           |
 | upgrade[³](#f3) | `yaourt -Syu`             | Sync with repositories before upgrading packages                    |
@@ -162,16 +162,12 @@ upgrades were available. Use `pacman -Que` instead.
 | yarem   | `yay -Rns`                     | Remove packages, including its settings and unneeded dependencies |
 | yarep   | `yay -Si`                      | Display information about a package in the repositories           |
 | yareps  | `yay -Ss`                      | Search for packages in the repositories                           |
-| yaupd   | `yay -Sy && <abs/aur refresh>`[¹](#f1) | Update and refresh local package, ABS and AUR databases   |
+| yaupd   | `yay -Sy`                      | Update and refresh local package, ABS and AUR databases           |
 | yaupg   | `yay -Syu`                     | Sync with repositories before upgrading packages                  |
 | yasu    | `yay -Syu --no-confirm`        | Same as `yaupg`, but without confirmation                         |
 | upgrade[³](#f3) | `yay -Syu`             | Sync with repositories before upgrading packages                  |
 
 ---
-
-<span id="f1">¹</span>
-If the `abs` and/or `aur` commands are present, `sudo abs` and `sudo aur` are also
-called to update the ABS and AUR databases.
 
 <span id="f2">²</span>
 Yay and Yaourt aliases overlap. If both are installed, yay will take precedence.
@@ -199,3 +195,4 @@ whether the package manager is installed, checked in the following order:
 - MatthR3D - matthr3d@gmail.com
 - ornicar - thibault.duplessis@gmail.com
 - Ybalrid (Arthur Brainville) - ybalrid@ybalrid.info
+- Jeff M. Hubbard - jeffmhubbard@gmail.com

--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -32,7 +32,7 @@ plugins=(... archlinux)
 | pacfiles     | `pacman -F`                            | Search package file names for matching strings                   |
 | pacls        | `pacman -Ql`                           | List files in a package                                          |
 | pacown       | `pacman -Qo`                           | Show which package owns a file                                   |
-| upgrade[³](#f3) | `sudo pacman -Syu`                  | Sync with repositories before upgrading packages                 |
+| upgrade[²](#f2) | `sudo pacman -Syu`                  | Sync with repositories before upgrading packages                 |
 
 | Function       | Description                                               |
 |----------------|-----------------------------------------------------------|
@@ -73,7 +73,7 @@ upgrades were available. Use `pacman -Que` instead.
 | auupd   | `sudo aura -Sy`                                 | Update and refresh local package, ABS and AUR databases                 |
 | auupg   | `sudo sh -c "aura -Syu              && aura -Au"` | Sync with repositories before upgrading all packages (from AUR too)   |
 | ausu    | `sudo sh -c "aura -Syu --no-confirm && aura -Au --no-confirm"` | Same as `auupg`, but without confirmation                |
-| upgrade[³](#f3) | `sudo aura -Syu`                        | Sync with repositories before upgrading packages                        |
+| upgrade[²](#f2) | `sudo aura -Syu`                        | Sync with repositories before upgrading packages                        |
 
 | Function        | Description                                                         |
 |-----------------|---------------------------------------------------------------------|
@@ -99,7 +99,7 @@ upgrades were available. Use `pacman -Que` instead.
 | paupd   | `pacaur -Sy`                      | Update and refresh local package, ABS and AUR databases             |
 | paupg   | `pacaur -Syua`                    | Sync with repositories before upgrading all packages (from AUR too) |
 | pasu    | `pacaur -Syua --no-confirm`       | Same as `paupg`, but without confirmation                           |
-| upgrade[³](#f3) | `pacaur -Syu`             | Sync with repositories before upgrading packages                    |
+| upgrade[²](#f2) | `pacaur -Syu`             | Sync with repositories before upgrading packages                    |
 
 #### Trizen
 
@@ -121,9 +121,9 @@ upgrades were available. Use `pacman -Que` instead.
 | trupd   | `trizen -Sy`                      | Update and refresh local package, ABS and AUR databases             |
 | trupg   | `trizen -Syua`                    | Sync with repositories before upgrading all packages (from AUR too) |
 | trsu    | `trizen -Syua --no-confirm`       | Same as `trupg`, but without confirmation                           |
-| upgrade[³](#f3) | `trizen -Syu`             | Sync with repositories before upgrading packages                    |
+| upgrade[²](#f2) | `trizen -Syu`             | Sync with repositories before upgrading packages                    |
 
-#### Yaourt[²](#f2)
+#### Yaourt[¹](#f1)
 
 | Alias   | Command                           | Description                                                         |
 |---------|-----------------------------------|---------------------------------------------------------------------|
@@ -143,9 +143,9 @@ upgrades were available. Use `pacman -Que` instead.
 | yaupd   | `yaourt -Sy`                      | Update and refresh local package, ABS and AUR databases             |
 | yaupg   | `yaourt -Syua`                    | Sync with repositories before upgrading all packages (from AUR too) |
 | yasu    | `yaourt -Syua --no-confirm`       | Same as `yaupg`, but without confirmation                           |
-| upgrade[³](#f3) | `yaourt -Syu`             | Sync with repositories before upgrading packages                    |
+| upgrade[²](#f2) | `yaourt -Syu`             | Sync with repositories before upgrading packages                    |
 
-#### Yay[²](#f2)
+#### Yay[¹](#f1)
 
 | Alias   | Command                        | Description                                                       |
 |---------|--------------------------------|-------------------------------------------------------------------|
@@ -165,14 +165,14 @@ upgrades were available. Use `pacman -Que` instead.
 | yaupd   | `yay -Sy`                      | Update and refresh local package, ABS and AUR databases           |
 | yaupg   | `yay -Syu`                     | Sync with repositories before upgrading packages                  |
 | yasu    | `yay -Syu --no-confirm`        | Same as `yaupg`, but without confirmation                         |
-| upgrade[³](#f3) | `yay -Syu`             | Sync with repositories before upgrading packages                  |
+| upgrade[²](#f2) | `yay -Syu`             | Sync with repositories before upgrading packages                  |
 
 ---
 
-<span id="f2">²</span>
+<span id="f1">¹</span>
 Yay and Yaourt aliases overlap. If both are installed, yay will take precedence.
 
-<span id="f3">³</span>
+<span id="f2">²</span>
 The `upgrade` alias is set for all package managers. Its value will depend on
 whether the package manager is installed, checked in the following order:
 

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -2,12 +2,6 @@
 #               Pacman                #
 #######################################
 
-# abs and aur command check
-local abs_aur=''
-(( ! $+commands[abs] )) || abs_aur+=' && sudo abs'
-(( ! $+commands[aur] )) || abs_aur+=' && sudo aur'
-
-
 # Pacman - https://wiki.archlinux.org/index.php/Pacman_Tips
 alias pacupg='sudo pacman -Syu'
 alias pacin='sudo pacman -S'
@@ -26,7 +20,7 @@ alias pacfileupg='sudo pacman -Fy'
 alias pacfiles='pacman -F'
 alias pacls='pacman -Ql'
 alias pacown='pacman -Qo'
-alias pacupd="sudo pacman -Sy$abs_aur"
+alias pacupd="sudo pacman -Sy"
 alias upgrade='sudo pacman -Syu'
 
 function paclist() {
@@ -108,7 +102,7 @@ if (( $+commands[aura] )); then
   alias aurrep='aura -Ai'
   alias aureps='aura -As --both'
   alias auras='aura -As --both'
-  alias auupd="sudo aura -Sy$abs_aur"
+  alias auupd="sudo aura -Sy"
   alias auupg='sudo sh -c "aura -Syu              && aura -Au"'
   alias ausu='sudo  sh -c "aura -Syu --no-confirm && aura -Au --no-confirm"'
   alias upgrade='sudo aura -Syu'
@@ -135,7 +129,7 @@ if (( $+commands[pacaur] )); then
   alias paorph='pacaur -Qtd'
   alias painsd='pacaur -S --asdeps'
   alias pamir='pacaur -Syy'
-  alias paupd="pacaur -Sy$abs_aur"
+  alias paupd="pacaur -Sy"
   alias upgrade='pacaur -Syu'
 fi
 
@@ -155,7 +149,7 @@ if (( $+commands[trizen] )); then
   alias trorph='trizen -Qtd'
   alias trinsd='trizen -S --asdeps'
   alias trmir='trizen -Syy'
-  alias trupd="trizen -Sy$abs_aur"
+  alias trupd="trizen -Sy"
   alias upgrade='trizen -Syu'
 fi
 
@@ -175,7 +169,7 @@ if (( $+commands[yaourt] )); then
   alias yaorph='yaourt -Qtd'
   alias yainsd='yaourt -S --asdeps'
   alias yamir='yaourt -Syy'
-  alias yaupd="yaourt -Sy$abs_aur"
+  alias yaupd="yaourt -Sy"
   alias upgrade='yaourt -Syu'
 fi
 
@@ -195,8 +189,7 @@ if (( $+commands[yay] )); then
   alias yaorph='yay -Qtd'
   alias yainsd='yay -S --asdeps'
   alias yamir='yay -Syy'
-  alias yaupd="yay -Sy$abs_aur"
+  alias yaupd="yay -Sy"
   alias upgrade='yay -Syu'
 fi
 
-unset abs_aur


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Remove calls to aur and abs commands

## Other comments:

See #8591
