### PR TITLE
Fix Rails plugin documentation to reflect #9662

### DIFF
--- a/plugins/rails/README.md
+++ b/plugins/rails/README.md
@@ -21,6 +21,8 @@ plugins=(... rails)
 | `rgen`| `rails generate`           | Generate boilerplate code                          |
 | `rgm` | `rails generate migration` | Generate a db migration                            |
 | `rp`  | `rails plugin`             | Run a Rails plugin command                         |
+| `rr`  | `rails routes`             | List all defined routes                            |
+| `rrg` | `rails routes \| grep`     | List and filter the defined routes                 |
 | `ru`  | `rails runner`             | Run Ruby code in the context of Rails              |
 | `rs`  | `rails server`             | Launch a web server                                |
 | `rsd` | `rails server --debugger`  | Launch a web server with debugger                  |
@@ -43,8 +45,6 @@ plugins=(... rails)
 | `rdsl`  | `rake db:schema:load`           | Load the database schema                               |
 | `rlc`   | `rake log:clear`                | Clear Rails logs                                       |
 | `rn`    | `rake notes`                    | Search for notes (`FIXME`, `TODO`) in code comments    |
-| `rr`    | `rake routes`                   | List all defined routes                                |
-| `rrg`   | `rake routes \| grep`           | List and filter the defined routes                     |
 | `rt`    | `rake test`                     | Run Rails tests                                        |
 | `rmd`   | `rake middleware`               | Interact with Rails middlewares                        |
 | `rsts`  | `rake stats`                    | Print code statistics                                  |


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

#9662 Fixed the deprecated `rake routes`. However, the documentation in the README was not reflective of this change. This PR corrects the documentation to reflect this change. 

BTW. Thank you for a great product. 
