### PR TITLE
fix(gentoo): fix tab completion color bleed

### DIFF
--- a/themes/gentoo.zsh-theme
+++ b/themes/gentoo.zsh-theme
@@ -25,4 +25,4 @@ gentoo_precmd() {
 autoload -U add-zsh-hook
 add-zsh-hook precmd gentoo_precmd
 
-PROMPT='%(!.%B%F{red}.%B%F{green}%n@)%m %F{blue}%(!.%1~.%~) ${vcs_info_msg_0_}%(!.#.$)%{$reset_color%} '
+PROMPT='%(!.%B%F{red}.%B%F{green}%n@)%m %F{blue}%(!.%1~.%~) ${vcs_info_msg_0_}%(!.#.$)%k%b%f '


### PR DESCRIPTION
This commit fixes an issue in the gentoo theme introduced in 3bb5e977.
Due to incorrect line width calculations, colors are incorrectly applied
when using tab.

Fixes #9778

Signed-off-by: Thomas De Backer <mosterdt@debacker.me>

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

The last %{$reset_color%} part of the theme messes up the line width calculation (`%{...%}` tells zsh that the characters inside have zero width.) Replacing this somewhat opaque variable with `%k%b%f` fixes the line width calculation and the tab completion color bleed. (stop background color, stop boldface mode, stop foreground color, see zshmisc(1))

## Other comments:

I've ran this version of the theme for a week or 2, and I didn't see the problem reoccur except once. It might have been a specific vcs state that combined the other snippets into a broken prompt line. I was not able to reproduce however.