### PR TITLE
feat(rvm): add latest `rb*` utility functions

### DIFF
--- a/plugins/rvm/README.md
+++ b/plugins/rvm/README.md
@@ -16,5 +16,9 @@ plugins=(... rvm)
 | `rb19`         | `rvm use ruby-1.9.3` |
 | `rb20`         | `rvm use ruby-2.0.0` |
 | `rb21`         | `rvm use ruby-2.1.2` |
+| `rb25`         | `rvm use ruby-2.5.9` |
+| `rb26`         | `rvm use ruby-2.6.7` |
+| `rb27`         | `rvm use ruby-2.7.3` |
+| `rb30`         | `rvm use ruby-3.0.1` |
 | `rvm-update`   | `rvm get head`       |
 | `gems`         | `gem list`           |

--- a/plugins/rvm/rvm.plugin.zsh
+++ b/plugins/rvm/rvm.plugin.zsh
@@ -7,6 +7,10 @@ local ruby18='ruby-1.8.7'
 local ruby19='ruby-1.9.3'
 local ruby20='ruby-2.0.0'
 local ruby21='ruby-2.1.2'
+local ruby25='ruby-2.5.9'
+local ruby26='ruby-2.6.7'
+local ruby27='ruby-2.7.3'
+local ruby30='ruby-3.0.1'
 
 function rb18 {
 	if [ -z "$1" ]; then
@@ -51,6 +55,50 @@ function rb21 {
 
 _rb21() {compadd `ls -1 $rvm_path/gems | grep "^$ruby21@" | sed -e "s/^$ruby21@//" | awk '{print $1}'`}
 compdef _rb21 rb21
+
+function rb25 {
+	if [ -z "$1" ]; then
+		rvm use "$ruby25"
+	else
+		rvm use "$ruby25@$1"
+	fi
+}
+
+_rb25() {compadd `ls -1 $rvm_path/gems | grep "^$ruby25@" | sed -e "s/^$ruby25@//" | awk '{print $1}'`}
+compdef _rb25 rb25
+
+function rb26 {
+	if [ -z "$1" ]; then
+		rvm use "$ruby26"
+	else
+		rvm use "$ruby26@$1"
+	fi
+}
+
+_rb26() {compadd `ls -1 $rvm_path/gems | grep "^$ruby26@" | sed -e "s/^$ruby26@//" | awk '{print $1}'`}
+compdef _rb26 rb26
+
+function rb27 {
+	if [ -z "$1" ]; then
+		rvm use "$ruby27"
+	else
+		rvm use "$ruby27@$1"
+	fi
+}
+
+_rb27() {compadd `ls -1 $rvm_path/gems | grep "^$ruby27@" | sed -e "s/^$ruby27@//" | awk '{print $1}'`}
+compdef _rb27 rb27
+
+function rb30 {
+	if [ -z "$1" ]; then
+		rvm use "$ruby30"
+	else
+		rvm use "$ruby30@$1"
+	fi
+}
+
+_rb30() {compadd `ls -1 $rvm_path/gems | grep "^$ruby30@" | sed -e "s/^$ruby30@//" | awk '{print $1}'`}
+compdef _rb30 rb30
 
 function rvm-update {
 	rvm get head


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

It's been a while and Ruby grew up to 3.0.1 version, but rvm plugin does not have any up-to-date aliases. I've took current stable minor versions from [this](https://www.ruby-lang.org/en/downloads/releases) link and add those version to rvm too. Most of gems currently support 2.5 and above versions, up to 3.x.
Hope it fits well!
