### PR TITLE
Fix(nvm): Disable lazy load when auto load nvmrc

### DIFF
--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -1,3 +1,8 @@
+# Disable lazy load when auto load nvmrc
+if (( $+NVM_AUTOLOAD )); then
+  unset NVM_LAZY
+fi
+
 # See https://github.com/nvm-sh/nvm#installation-and-update
 if [[ -z "$NVM_DIR" ]]; then
   if [[ -d "$HOME/.nvm" ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Disable lazy load when auto load nvmrc

## Other comments:

.nvmrc auto load will try to set specific version of node in .nvmrc file and according to code, if there is not any .nvmrc we will try to set default node version.
But if lazy load was enabled it going wrong and generate something like this:
```
Reverting to nvm default version
nvm is not compatible with the npm config "prefix" option: currently set to "Now using node v14.13.1 (npm v6.14.8)
/home/amir/.nvm/versions/node/v14.13.1"
Run `npm config delete prefix` or `nvm use --delete-prefix v14.13.1` to unset it.
```
To fix this problem I have disabled lazy load when .nvmrc auto load was enabled.
