### PR TITLE
feat(kind): add plugin for Kind k8s tool

### DIFF
--- a/plugins/kind/README.md
+++ b/plugins/kind/README.md
@@ -1,0 +1,9 @@
+# Kind plugin
+
+This plugin adds completion for the [Kind](https://kind.sigs.k8s.io/) tool.
+
+To use it, add `kind` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... kind)
+```

--- a/plugins/kind/README.md
+++ b/plugins/kind/README.md
@@ -1,9 +1,22 @@
 # Kind plugin
 
-This plugin adds completion for the [Kind](https://kind.sigs.k8s.io/) tool.
+This plugin adds completion for the [Kind](https://kind.sigs.k8s.io/) tool, as well
+as a few aliases for easier use.
 
 To use it, add `kind` to the plugins array in your zshrc file:
 
 ```zsh
 plugins=(... kind)
 ```
+
+## Aliases
+
+| Alias   | Command                      |
+| ------- | ---------------------------- |
+| `kicc`  | `kind create cluster`        |
+| `kiccn` | `kind create cluster --name` |
+| `kigc`  | `kind get clusters`          |
+| `kidc`  | `kind delete cluster`        |
+| `kidcn` | `kind delete cluster --name` |
+| `kidca` | `kind delete clusters -A`    |
+| `kigk`  | `kind get kubeconfig`        |

--- a/plugins/kind/kind.plugin.zsh
+++ b/plugins/kind/kind.plugin.zsh
@@ -1,0 +1,10 @@
+if (( $+commands[kind] )); then
+  __KIND_COMPLETION_FILE="${ZSH_CACHE_DIR}/kind_completion"
+  if [[ ! -f $__KIND_COMPLETION_FILE || ! -s $__KIND_COMPLETION_FILE ]]; then
+    kind completion zsh >! $__KIND_COMPLETION_FILE
+  fi
+
+  [[ -f $__KIND_COMPLETION_FILE ]] && source $__KIND_COMPLETION_FILE
+
+  unset __KIND_COMPLETION_FILE
+fi

--- a/plugins/kind/kind.plugin.zsh
+++ b/plugins/kind/kind.plugin.zsh
@@ -1,10 +1,14 @@
-if (( $+commands[kind] )); then
-  __KIND_COMPLETION_FILE="${ZSH_CACHE_DIR}/kind_completion"
-  if [[ ! -f $__KIND_COMPLETION_FILE || ! -s $__KIND_COMPLETION_FILE ]]; then
-    kind completion zsh >! $__KIND_COMPLETION_FILE
-  fi
-
-  [[ -f $__KIND_COMPLETION_FILE ]] && source $__KIND_COMPLETION_FILE
-
-  unset __KIND_COMPLETION_FILE
+if (( ! $+commands[kind] )); then
+  return
 fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `kind`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_kind" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _kind
+  _comps[kind]=_kind
+fi
+
+# Generate and load kind completion
+kind completion zsh >! "$ZSH_CACHE_DIR/completions/_kind" &|

--- a/plugins/kind/kind.plugin.zsh
+++ b/plugins/kind/kind.plugin.zsh
@@ -12,3 +12,12 @@ fi
 
 # Generate and load kind completion
 kind completion zsh >! "$ZSH_CACHE_DIR/completions/_kind" &|
+
+# Register aliases
+alias kicc="kind create cluster"
+alias kiccn="kind create cluster --name"
+alias kigc="kind get clusters"
+alias kidc="kind delete cluster"
+alias kidcn="kind delete cluster --name"
+alias kidca="kind delete clusters -A"
+alias kigk="kind get kubeconfig"


### PR DESCRIPTION
This plugin adds completion for the [Kind](https://kind.sigs.k8s.io/) tool.

Signed-off-by: Adam Henley <adam.henley@shuttlerock.com>

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds autocompletion for `kind`

## Other comments:

- Uses the zsh command completion generated by Kind itself like as kubectl does.
- Fixes #9826

Closes #10413 
Closes #11560 