### PR TITLE
fix(wezm): fix dirty git repo glyph width

### DIFF
--- a/themes/wezm.zsh-theme
+++ b/themes/wezm.zsh-theme
@@ -3,5 +3,5 @@ RPROMPT='%{$fg[green]%}%~%{$reset_color%}'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[blue]%}("
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
-ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%})%{$fg[red]%}⚡%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%})%{$fg[red]%}%{%G⚡%}%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%})"


### PR DESCRIPTION
Some terminal emulators rendered this glyph as a wide character, causing a duplicate character glitch with tab autocompletion.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added `%{%G<glyph>%}` around the gliph.

## Other comments:

I found the solution in this comment by @romkatv 
https://github.com/ohmyzsh/ohmyzsh/issues/7945#issuecomment-508724741
