### PR TITLE
feat(systemadmin): add IPv6 info to `geteip` command

### DIFF
--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -131,7 +131,8 @@ d0() {
 
 # gather external ip address
 geteip() {
-    curl -s -S -6 https://icanhazip.com ; curl -s -S -4 https://icanhazip.com
+    curl -s -S -4 https://icanhazip.com
+    curl -s -S -6 https://icanhazip.com
 }
 
 # determine local IP address(es)

--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -131,7 +131,7 @@ d0() {
 
 # gather external ip address
 geteip() {
-    curl -s -S https://icanhazip.com
+    curl -s -S -6 https://icanhazip.com ; curl -s -S -4 https://icanhazip.com
 }
 
 # determine local IP address(es)


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- modified the first curl command to get the dedicated external ipv6 address
- added a curl command to get the dedicated external ipv4 address

## Other comments:

This is needed for dual stack setups. Feedback is wanted on how to test it for resiliency.
