### PR TITLE
feat(fzf): look in XDG compliant location

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -7,6 +7,7 @@ function setup_using_base_dir() {
         fzfdirs=(
           "${HOME}/.fzf"
           "${HOME}/.nix-profile/share/fzf"
+          "${XDG_DATA_HOME}/fzf"
           "/usr/local/opt/fzf"
           "/usr/share/fzf"
           "/usr/local/share/examples/fzf"

--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -7,7 +7,7 @@ function setup_using_base_dir() {
         fzfdirs=(
           "${HOME}/.fzf"
           "${HOME}/.nix-profile/share/fzf"
-          "${XDG_DATA_HOME}/fzf"
+          "${XDG_DATA_HOME:-$HOME/.local/share}/fzf"
           "/usr/local/opt/fzf"
           "/usr/share/fzf"
           "/usr/local/share/examples/fzf"


### PR DESCRIPTION
Please see [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added an additional location to search for a preexisting installation of FZF via the `XDG_DATA_HOME` environment variable as specified in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

## Other comments:

...
