### PR TITLE
fix(nvm): add check for .nvmrc to improve cd performance

### DIFF
--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -39,6 +39,7 @@ fi
 # Adapted from: https://github.com/nvm-sh/nvm#zsh
 if (( $+NVM_AUTOLOAD )); then
   load-nvmrc() {
+    [[ -a .nvmrc ]] || return
     local node_version="$(nvm version)"
     local nvmrc_path="$(nvm_find_nvmrc)"
 


### PR DESCRIPTION
Going off of [this stackoverflow comment](https://stackoverflow.com/questions/23556330/run-nvm-use-automatically-every-time-theres-a-nvmrc-file-on-the-directory#comment104625451_39519460), adding `[[ -a .nvmrc ]] || return` improves the performance of `cd` when running this autoload function.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add `[[ -a .nvmrc ]] || return` to `load-nvmrc` function

