### PR TITLE
feat(cli): add `plugin load` subcommand

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -46,17 +46,25 @@ function _omz {
     esac
   elif (( CURRENT == 4 )); then
     case "$words[2]::$words[3]" in
-      plugin::info) compadd "$ZSH"/plugins/*/README.md(.N:h:t) \
-        "$ZSH_CUSTOM"/plugins/*/README.md(.N:h:t) ;;
-      plugin::load) compadd "$ZSH"/plugins/*/*.plugin.zsh(.N:h:t) \
-        "$ZSH_CUSTOM"/plugins/*/*.plugin.zsh(.N:h:t) ;;
+      plugin::(info|load))
+        local -aU plugins=("$ZSH"/plugins/*/{_*,*.plugin.zsh}(.N:h:t) "$ZSH_CUSTOM"/plugins/*/{_*,*.plugin.zsh}(.N:h:t))
+        _describe 'plugin' plugins ;;
       theme::use) compadd "$ZSH"/themes/*.zsh-theme(.N:t:r) \
         "$ZSH_CUSTOM"/**/*.zsh-theme(.N:r:gs:"$ZSH_CUSTOM"/themes/:::gs:"$ZSH_CUSTOM"/:::) ;;
     esac
   elif (( CURRENT > 4 )); then
     case "$words[2]::$words[3]" in
-      plugin::load) compadd "$ZSH"/plugins/*/*.plugin.zsh(.N:h:t) \
-        "$ZSH_CUSTOM"/plugins/*/*.plugin.zsh(.N:h:t) ;;
+      plugin::load)
+        local -aU plugins=("$ZSH"/plugins/*/{_*,*.plugin.zsh}(.N:h:t) "$ZSH_CUSTOM"/plugins/*/{_*,*.plugin.zsh}(.N:h:t))
+
+        # Remove plugins already passed as arguments
+        # NOTE: $(( CURRENT - 1 )) is the last plugin argument completely passed, i.e. that which
+        # has a space after them. This is to avoid removing plugins partially passed, which makes
+        # the completion not add a space after the completed plugin.
+        local -a args=(${words[4,$(( CURRENT - 1))]})
+        plugins=(${plugins:|args})
+
+        _describe 'plugin' plugins ;;
     esac
   fi
 
@@ -191,7 +199,7 @@ function _omz::plugin::info {
 
 function _omz::plugin::load {
   if [[ -z "$1" ]]; then
-    echo >&2 "Usage: omz plugin load <plugin>"
+    echo >&2 "Usage: omz plugin load <plugin> [...]"
     return 1
   fi
 

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -265,8 +265,10 @@ function _omz::plugin::load {
   # We pass -D to avoid generating a new dump file, which would overwrite our
   # current one for the next session (and we don't want that because we're not
   # actually enabling the plugins for the next session).
+  # Note that we still have to pass -d "$_comp_dumpfile", so that compinit
+  # doesn't use the default zcompdump location (${ZDOTDIR:-$HOME}/.zcompdump).
   if (( has_completion )); then
-    compinit -D
+    compinit -D -d "$_comp_dumpfile"
   fi
 }
 

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -49,8 +49,9 @@ function _omz {
       plugin::(info|load))
         local -aU plugins=("$ZSH"/plugins/*/{_*,*.plugin.zsh}(.N:h:t) "$ZSH_CUSTOM"/plugins/*/{_*,*.plugin.zsh}(.N:h:t))
         _describe 'plugin' plugins ;;
-      theme::use) compadd "$ZSH"/themes/*.zsh-theme(.N:t:r) \
-        "$ZSH_CUSTOM"/**/*.zsh-theme(.N:r:gs:"$ZSH_CUSTOM"/themes/:::gs:"$ZSH_CUSTOM"/:::) ;;
+      theme::use)
+        local -aU themes=("$ZSH"/themes/*.zsh-theme(.N:t:r) "$ZSH_CUSTOM"/**/*.zsh-theme(.N:r:gs:"$ZSH_CUSTOM"/themes/:::gs:"$ZSH_CUSTOM"/:::))
+        _describe 'theme' themes ;;
     esac
   elif (( CURRENT > 4 )); then
     case "$words[2]::$words[3]" in


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- extends omz cli (#8876, #9087) with a plugin load <plugin> subcommand to support loading plugins manually
- Fixes #9672

## Other comments:

Lines 51-52 are repeated in 58-59 to provide completions for multiple plugin entries and there may be a less redundant way to store the added completions.

Reopened since last one (#9753) was polluted with other commits.

