### PR TITLE
fix(git plugin): check for origin head

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -33,6 +33,11 @@ function work_in_progress() {
 function git_main_branch() {
   command git rev-parse --git-dir &>/dev/null || return
   local branch
+  branch=$(command git symbolic-ref refs/remotes/origin/HEAD &>/dev/null | sed "s@^refs/remotes/origin/@@")
+  if ! [ -z "${branch// }" ]; then
+    echo $branch
+    return
+  fi
   for branch in main trunk; do
     if command git show-ref -q --verify refs/heads/$branch; then
       echo $branch


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Adds a condition in `git_main_branch` to check for the origin remote's HEAD.
Not all repos use `master`, `main`, or `trunk` as their default branch. Some might choose `develop`, `release`, etc... This change makes this a bit more dynamic while still keeping the fallbacks for (e.g.) local repos with no origin remote.

## Other comments:

I'm not a pro in bash / zsh scripting, so there might be room for improvement here.