### PR TITLE
feat(git): add `develop` branch name detection

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -47,8 +47,8 @@ plugins=(... git)
 | gcl                  | git clone --recurse-submodules                                                                                                   |
 | gclean               | git clean -id                                                                                                                    |
 | gpristine            | git reset --hard && git clean -dffx                                                                                              |
-| gcm                  | git checkout $(git_main_branch)                                                                                                                |
-| gcd                  | git checkout $(git_develop_branch)                                                                                                             |
+| gcm                  | git checkout $(git_main_branch)                                                                                                  |
+| gcd                  | git checkout $(git_develop_branch)                                                                                               |
 | gcmsg                | git commit -m                                                                                                                    |
 | gco                  | git checkout                                                                                                                     |
 | gcount               | git shortlog -sn                                                                                                                 |
@@ -85,7 +85,7 @@ plugins=(... git)
 | ghh                  | git help                                                                                                                         |
 | gignore              | git update-index --assume-unchanged                                                                                              |
 | gignored             | git ls-files -v \| grep "^[[:lower:]]"                                                                                           |
-| git-svn-dcommit-push | git svn dcommit && git push github $(git_main_branch):svntrunk                                                                                 |
+| git-svn-dcommit-push | git svn dcommit && git push github $(git_main_branch):svntrunk                                                                   |
 | gk                   | gitk --all --branches                                                                                                            |
 | gke                  | gitk --all $(git log -g --pretty=%h)                                                                                             |
 | gl                   | git pull                                                                                                                         |
@@ -104,10 +104,10 @@ plugins=(... git)
 | gloga                | git log --oneline --decorate --graph --all                                                                                       |
 | glp                  | git log --pretty=\<format\>                                                                                                      |
 | gm                   | git merge                                                                                                                        |
-| gmom                 | git merge origin/$(git_main_branch)                                                                                                            |
+| gmom                 | git merge origin/$(git_main_branch)                                                                                              |
 | gmt                  | git mergetool --no-prompt                                                                                                        |
 | gmtvim               | git mergetool --no-prompt --tool=vimdiff                                                                                         |
-| gmum                 | git merge upstream/$(git_main_branch)                                                                                                          |
+| gmum                 | git merge upstream/$(git_main_branch)                                                                                            |
 | gma                  | git merge --abort                                                                                                                |
 | gp                   | git push                                                                                                                         |
 | gpd                  | git push --dry-run                                                                                                               |
@@ -121,10 +121,10 @@ plugins=(... git)
 | grb                  | git rebase                                                                                                                       |
 | grba                 | git rebase --abort                                                                                                               |
 | grbc                 | git rebase --continue                                                                                                            |
-| grbd                 | git rebase $(git_develop_branch)                                                                                                               |
+| grbd                 | git rebase $(git_develop_branch)                                                                                                 |
 | grbi                 | git rebase -i                                                                                                                    |
-| grbm                 | git rebase $(git_main_branch)                                                                                                                  |
-| grbo                 | git rebase --onto                                                                                                             |
+| grbm                 | git rebase $(git_main_branch)                                                                                                    |
+| grbo                 | git rebase --onto                                                                                                                |
 | grbs                 | git rebase --skip                                                                                                                |
 | grev                 | git revert                                                                                                                       |
 | grh                  | git reset                                                                                                                        |
@@ -172,7 +172,7 @@ plugins=(... git)
 | gupv                 | git pull --rebase -v                                                                                                             |
 | gupa                 | git pull --rebase --autostash                                                                                                    |
 | gupav                | git pull --rebase --autostash -v                                                                                                 |
-| glum                 | git pull upstream $(git_main_branch)                                                                                                           |
+| glum                 | git pull upstream $(git_main_branch)                                                                                             |
 | gwch                 | git whatchanged -p --abbrev-commit --pretty=medium                                                                               |
 | gwip                 | git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"           |
 | gam                  | git am                                                                                                                           |
@@ -210,14 +210,14 @@ These are aliases that have been removed, renamed, or otherwise modified in a wa
 
 ### Current
 
-| Command                | Description                                                                  |
-|:-----------------------|:-----------------------------------------------------------------------------|
-| `grename <old> <new>`  | Rename `old` branch to `new`, including in origin remote                     |
-| current_branch         | Return the name of the current branch                                        |
-| git_current_user_name  | Returns the `user.name` config value                                         |
-| git_current_user_email | Returns the `user.email` config value                                        |
-| git_main_branch        | Returns the name of the main branch: `main` if it exists, `master` otherwise |
-| git_develop_branch        | Returns the name of the develop branch: `dev`, `devel`, `development` if they exists, otherwise `develop` by default |
+| Command                | Description                                                                                              |
+|:-----------------------|:---------------------------------------------------------------------------------------------------------|
+| `grename <old> <new>`  | Rename `old` branch to `new`, including in origin remote                                                 |
+| current_branch         | Return the name of the current branch                                                                    |
+| git_current_user_name  | Returns the `user.name` config value                                                                     |
+| git_current_user_email | Returns the `user.email` config value                                                                    |
+| git_main_branch        | Returns the name of the main branch: `main` if it exists, `master` otherwise                             |
+| git_develop_branch     | Returns the name of the develop branch: `dev`, `devel`, `development` if they exist, `develop` otherwise |
 
 ### Work in Progress (WIP)
 

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -23,7 +23,7 @@ plugins=(... git)
 | gb                   | git branch                                                                                                                       |
 | gba                  | git branch -a                                                                                                                    |
 | gbd                  | git branch -d                                                                                                                    |
-| gbda                 | git branch --no-color --merged \| command grep -vE "^(\+\|\*\|\s*($(git_main_branch)\|development\|develop\|devel\|dev)\s*$)" \| command xargs -n 1 git branch -d |
+| gbda                 | git branch --no-color --merged \| command grep -vE "^(\+\|\*\|\s*($(git_main_branch)\|$(git_develop_branch))\s*$)" \| command xargs -n 1 git branch -d |
 | gbD                  | git branch -D                                                                                                                    |
 | gbl                  | git blame -b -w                                                                                                                  |
 | gbnm                 | git branch --no-merged                                                                                                           |
@@ -48,7 +48,7 @@ plugins=(... git)
 | gclean               | git clean -id                                                                                                                    |
 | gpristine            | git reset --hard && git clean -dffx                                                                                              |
 | gcm                  | git checkout $(git_main_branch)                                                                                                                |
-| gcd                  | git checkout develop                                                                                                             |
+| gcd                  | git checkout $(git_develop_branch)                                                                                                             |
 | gcmsg                | git commit -m                                                                                                                    |
 | gco                  | git checkout                                                                                                                     |
 | gcount               | git shortlog -sn                                                                                                                 |
@@ -121,7 +121,7 @@ plugins=(... git)
 | grb                  | git rebase                                                                                                                       |
 | grba                 | git rebase --abort                                                                                                               |
 | grbc                 | git rebase --continue                                                                                                            |
-| grbd                 | git rebase develop                                                                                                               |
+| grbd                 | git rebase $(git_develop_branch)                                                                                                               |
 | grbi                 | git rebase -i                                                                                                                    |
 | grbm                 | git rebase $(git_main_branch)                                                                                                                  |
 | grbo                 | git rebase --onto                                                                                                             |
@@ -217,6 +217,7 @@ These are aliases that have been removed, renamed, or otherwise modified in a wa
 | git_current_user_name  | Returns the `user.name` config value                                         |
 | git_current_user_email | Returns the `user.email` config value                                        |
 | git_main_branch        | Returns the name of the main branch: `main` if it exists, `master` otherwise |
+| git_develop_branch        | Returns the name of the develop branch: `dev`, `devel`, `development` if they exists, otherwise `develop` by default |
 
 ### Work in Progress (WIP)
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -42,7 +42,7 @@ function git_main_branch() {
   echo master
 }
 
-# Check for develop and similar named branches
+# Check for develop and similarly named branches
 function git_develop_branch() {
   command git rev-parse --git-dir &>/dev/null || return
   local branch

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -42,6 +42,19 @@ function git_main_branch() {
   echo master
 }
 
+# Check for develop and similar named branches
+function git_develop_branch() {
+  command git rev-parse --git-dir &>/dev/null || return
+  local branch
+  for branch in dev devel development; do
+    if command git show-ref -q --verify refs/heads/$branch; then
+      echo $branch
+      return
+    fi
+  done
+  echo develop
+}
+
 #
 # Aliases
 # (sorted alphabetically)
@@ -60,7 +73,7 @@ alias gapt='git apply --3way'
 alias gb='git branch'
 alias gba='git branch -a'
 alias gbd='git branch -d'
-alias gbda='git branch --no-color --merged | command grep -vE "^(\+|\*|\s*($(git_main_branch)|development|develop|devel|dev)\s*$)" | command xargs -n 1 git branch -d'
+alias gbda='git branch --no-color --merged | command grep -vE "^(\+|\*|\s*($(git_main_branch)|$(git_develop_branch))\s*$)" | command xargs -n 1 git branch -d'
 alias gbD='git branch -D'
 alias gbl='git blame -b -w'
 alias gbnm='git branch --no-merged'
@@ -86,7 +99,7 @@ alias gcl='git clone --recurse-submodules'
 alias gclean='git clean -id'
 alias gpristine='git reset --hard && git clean -dffx'
 alias gcm='git checkout $(git_main_branch)'
-alias gcd='git checkout develop'
+alias gcd='git checkout $(git_develop_branch)'
 alias gcmsg='git commit -m'
 alias gco='git checkout'
 alias gcount='git shortlog -sn'
@@ -221,7 +234,7 @@ alias gra='git remote add'
 alias grb='git rebase'
 alias grba='git rebase --abort'
 alias grbc='git rebase --continue'
-alias grbd='git rebase develop'
+alias grbd='git rebase $(git_develop_branch)'
 alias grbi='git rebase -i'
 alias grbm='git rebase $(git_main_branch)'
 alias grbo='git rebase --onto'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Some repositories use branch names other than `develop` for the development branch. This PR adds a `develop` branch name detection inspired by the `main` branch name detection.

Closes #10088