### PR TITLE
fix(gentoo): fix the color of the prompt symbol

### DIFF
--- a/themes/gentoo.zsh-theme
+++ b/themes/gentoo.zsh-theme
@@ -25,4 +25,4 @@ gentoo_precmd() {
 autoload -U add-zsh-hook
 add-zsh-hook precmd gentoo_precmd
 
-PROMPT='%(!.%B%F{red}.%B%F{green}%n@)%m %F{blue}%(!.%1~.%~) ${vcs_info_msg_0_}%(!.#.$)%k%b%f '
+PROMPT='%(!.%B%F{red}.%B%F{green}%n@)%m %F{blue}%(!.%1~.%~) ${vcs_info_msg_0_}%F{blue}%(!.#.$)%k%b%f '


### PR DESCRIPTION
This commit fixes an issue where the prompt symbol is white when vcs_info is displayed in the gentoo theme.

before:
![image](https://user-images.githubusercontent.com/7548/116957467-de712a00-acd2-11eb-8193-8756ae96c72e.png)

after:
![image](https://user-images.githubusercontent.com/7548/116957403-c26d8880-acd2-11eb-869b-bc88c2000114.png)

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
