### PR TITLE
fix(chruby): fix typo in test for Homebrew path

### DIFF
--- a/plugins/chruby/chruby.plugin.zsh
+++ b/plugins/chruby/chruby.plugin.zsh
@@ -37,7 +37,7 @@ _homebrew-installed() {
 }
 
 _chruby-from-homebrew-installed() {
-  [ -r _brew_prefix ] &> /dev/null
+  [ -r $_brew_prefix ] &> /dev/null
 }
 
 _ruby-build_installed() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- a missing $ made finding homebrew's chruby in an alternate path fail.

## Other comments:

homebrew for OSX on ARM is installed in /opt/homebrew by default, so we might want to add a check for that path the same way we check /usr/local instead of having to shell out to homebrew on every M1 mac.

