### PR TITLE
Add bebyx (classic bash) theme

### DIFF
--- a/themes/bebyx.zsh-theme
+++ b/themes/bebyx.zsh-theme
@@ -1,0 +1,12 @@
+# bebyx.zsh-theme (classic bash improved)
+
+local user_host="%{$fg_bold[green]%}%n@%m:%{$reset_color%}"
+local path_p="%{$fg_bold[blue]%}%~%{$reset_color%}"
+local cmd_sign="%{$reset_color%}%{$fg[magenta]%}$%{$reset_color%}"
+PROMPT='${user_host}${path_p}${cmd_sign} '
+RPROMPT='%{$fg_bold[cyan]%}$(git_prompt_info)%{$fg_bold[cyan]%}%{$reset_color%}'
+
+ZSH_THEME_GIT_PROMPT_PREFIX="±(%{$fg[yellow]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[cyan]%}) %{$fg[red]%}✗%{$reset_color%} "
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[cyan]%}) "


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add classic bash theme, improved with zsh git plugin possibilities

## Other comments:

Tested on my various machines (Debian, Gentoo, Arch, macOS). I think it would be nice if people can just choose a theme they are used to in bash, but empowered with zsh goodies.

Source: [bebyx.zsh-theme gist](https://gist.github.com/bebyx/38ce753760f4f3a71e56dc081e64aa8e)