### PR TITLE
feat(asdf): Add support for archlinux/AUR package

### DIFF
--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -2,6 +2,12 @@
 ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
 ASDF_COMPLETIONS="$ASDF_DIR/completions"
 
+# If not found, check for archlinux/AUR package (/opt/asdf-vm/)
+if [[ ! -f "$ASDF_DIR/asdf.sh" || ! -f "$ASDF_COMPLETIONS/asdf.bash" ]] && [[ -f "/opt/asdf-vm/asdf.sh" ]]; then
+   ASDF_DIR="/opt/asdf-vm/"
+   ASDF_COMPLETIONS="$ASDF_DIR"
+fi
+
 # If not found, check for Homebrew package
 if [[ ! -f "$ASDF_DIR/asdf.sh" || ! -f "$ASDF_COMPLETIONS/asdf.bash" ]] && (( $+commands[brew] )); then
    ASDF_DIR="$(brew --prefix asdf)"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add support for archlinux/AUR package in the asdf plugin, since it is installed in a different directory 

## Other comments:

- [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=asdf-vm#n33) installing asdf in `/opt/asdf-vm/`
- [Pinned comment](https://aur.archlinux.org/packages/asdf-vm/#pinned-728548) on the AUR package page

Tagging original plugin author: @RobLoach 
