### PR TITLE
feat(git): add `gswm` and `gswd` aliases (#8989)

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -165,6 +165,8 @@ plugins=(... git)
 | gsu                  | git submodule update                                                                                                             |
 | gsw                  | git switch                                                                                                                       |
 | gswc                 | git switch -c                                                                                                                    |
+| gswm                 | git switch $(git_main_branch)                                                                                                    |
+| gswd                 | git switch develop                                                                                                               |
 | gts                  | git tag -s                                                                                                                       |
 | gtv                  | git tag \| sort -V                                                                                                               |
 | gtl                  | gtl(){ git tag --sort=-v:refname -n -l ${1}* }; noglob gtl                                                                       |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -270,6 +270,8 @@ alias gstall='git stash --all'
 alias gsu='git submodule update'
 alias gsw='git switch'
 alias gswc='git switch -c'
+alias gswm='git switch $(git_main_branch)'
+alias gswd='git switch develop'
 
 alias gts='git tag -s'
 alias gtv='git tag | sort -V'


### PR DESCRIPTION
## Standards checklist:

- [X]  The PR title is descriptive.
- [X]  The PR doesn't replicate another PR which is already open.
- [X]  I have read the contribution guide and followed all the instructions.
- [X]  The code follows the code style guide detailed in the wiki.
- [X]  The code is mine or it's from somewhere with an MIT-compatible license.
- [X]  The code is efficient, to the best of my ability, and does not waste computer resources.
- [X]  The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
- Adds `gswm` as an alias for `git switch $(git_main_branch)` to the git plugin
- Adds `gswd` as an alias for `git switch develop` to the git plugin
- Updates git plugin README

## Other comments:
- [Git 2.23](https://github.blog/2019-08-16-highlights-from-git-2-23/) introduced `git switch` and `git restore` to divvy up the responsibilities of `git checkout`.
- #8089 added aliases for `git switch` and `git switch -c` to the Oh My Zsh git plugin.
- #8989 (@hikaru-shindo) proposes adding aliases for `git switch master` and `git switch develop` to mirror the aliases that existed at the time for `git checkout master` and `git checkout develop`.
- #9049 changed `gcm` to be an alias for `git checkout $(git_main_branch)`. 
- This would allow closing #8989.
- Thanks for all your work as a maintainer, @mcornella!