### PR TITLE
fix(pyenv): `pyenv init --path` before `pyenv init -`

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -29,6 +29,8 @@ if [[ $FOUND_PYENV -ne 1 ]]; then
 fi
 
 if [[ $FOUND_PYENV -eq 1 ]]; then
+    PYENV_VERSION="$(pyenv --version | cut -d ' ' -f 2)"
+    is-at-least 1.2.27-21 "$PYENV_VERSION" && eval "$(pyenv init --path)"
     eval "$(pyenv init - --no-rehash zsh)"
     if (( $+commands[pyenv-virtualenv-init] )); then
         eval "$(pyenv virtualenv-init - zsh)"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- In line with [recent changes](https://github.com/pyenv/pyenv/pull/1920) to pyenv, `pyenv init --path` must be run before `pyenv init -`.

## Other comments:

Without this, I get the following warning when using the latest pyenv version:
```bash
WARNING: `pyenv init -` no longer sets PATH.
Run `pyenv init` to see the necessary changes to make to your configuration.
```
