### PR TITLE
feat(aws): Adds the login option for AWS SSO via asp

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -14,6 +14,7 @@ plugins=(... aws)
 * `asp [<profile>]`: sets `$AWS_PROFILE` and `$AWS_DEFAULT_PROFILE` (legacy) to `<profile>`.
   It also sets `$AWS_EB_PROFILE` to `<profile>` for the Elastic Beanstalk CLI.
   Run `asp` without arguments to clear the profile.
+* `asp [<profile>] login`: If AWS SSO has been configured in your aws profile, it will run the `aws sso login` command following profile selection. 
 
 * `acp [<profile>]`: in addition to `asp` functionality, it actually changes the profile by
    assuming the role specified in the `<profile>` configuration. It supports MFA and sets

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -21,6 +21,10 @@ function asp() {
   export AWS_DEFAULT_PROFILE=$1
   export AWS_PROFILE=$1
   export AWS_EB_PROFILE=$1
+
+  if [[ "$2" == "login" ]]; then
+    aws sso login
+  fi
 }
 
 # AWS profile switch


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Allows users that have already setup their AWS_PROFILE with SSO to append `login` to the command. This subsequently runs `aws sso login` after their profile is set with `asp`.

Example: asp dev login -> Sets their profile and runs `aws sso login` immediately after

## Other comments:

...
