### PR TITLE
fix(aws): allow for profile switch w/o MFA configured

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -62,47 +62,47 @@ function acp() {
       read -r sess_duration
     fi
     mfa_opt=(--serial-number "$mfa_serial" --token-code "$mfa_token" --duration-seconds "${sess_duration:-3600}")
+  fi
 
-    # Now see whether we need to just MFA for the current role, or assume a different one
-    local role_arn="$(aws configure get role_arn --profile $profile)"
-    local sess_name="$(aws configure get role_session_name --profile $profile)"
+  # Now see whether we need to just MFA for the current role, or assume a different one
+  local role_arn="$(aws configure get role_arn --profile $profile)"
+  local sess_name="$(aws configure get role_session_name --profile $profile)"
 
-    if [[ -n "$role_arn" ]]; then
-      # Means we need to assume a specified role
-      aws_command=(aws sts assume-role --role-arn "$role_arn" "${mfa_opt[@]}")
+  if [[ -n "$role_arn" ]]; then
+    # Means we need to assume a specified role
+    aws_command=(aws sts assume-role --role-arn "$role_arn" "${mfa_opt[@]}")
 
-      # Check whether external_id is configured to use while assuming the role
-      local external_id="$(aws configure get external_id --profile $profile)"
-      if [[ -n "$external_id" ]]; then
-        aws_command+=(--external-id "$external_id")
-      fi
-
-      # Get source profile to use to assume role
-      local source_profile="$(aws configure get source_profile --profile $profile)"
-      if [[ -z "$sess_name" ]]; then
-        sess_name="${source_profile:-profile}"
-      fi
-      aws_command+=(--profile="${source_profile:-profile}" --role-session-name "${sess_name}")
-
-      echo "Assuming role $role_arn using profile ${source_profile:-profile}"
-    else
-      # Means we only need to do MFA
-      aws_command=(aws sts get-session-token --profile="$profile" "${mfa_opt[@]}")
-      echo "Obtaining session token for profile $profile"
+    # Check whether external_id is configured to use while assuming the role
+    local external_id="$(aws configure get external_id --profile $profile)"
+    if [[ -n "$external_id" ]]; then
+      aws_command+=(--external-id "$external_id")
     fi
 
-    # Format output of aws command for easier processing
-    aws_command+=(--query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' --output text)
-
-    # Run the aws command to obtain credentials
-    local -a credentials
-    credentials=(${(ps:\t:)"$(${aws_command[@]})"})
-
-    if [[ -n "$credentials" ]]; then
-      aws_access_key_id="${credentials[1]}"
-      aws_secret_access_key="${credentials[2]}"
-      aws_session_token="${credentials[3]}"
+    # Get source profile to use to assume role
+    local source_profile="$(aws configure get source_profile --profile $profile)"
+    if [[ -z "$sess_name" ]]; then
+      sess_name="${source_profile:-profile}"
     fi
+    aws_command+=(--profile="${source_profile:-profile}" --role-session-name "${sess_name}")
+
+    echo "Assuming role $role_arn using profile ${source_profile:-profile}"
+  else
+    # Means we only need to do MFA
+    aws_command=(aws sts get-session-token --profile="$profile" "${mfa_opt[@]}")
+    echo "Obtaining session token for profile $profile"
+  fi
+
+  # Format output of aws command for easier processing
+  aws_command+=(--query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' --output text)
+
+  # Run the aws command to obtain credentials
+  local -a credentials
+  credentials=(${(ps:\t:)"$(${aws_command[@]})"})
+
+  if [[ -n "$credentials" ]]; then
+    aws_access_key_id="${credentials[1]}"
+    aws_secret_access_key="${credentials[2]}"
+    aws_session_token="${credentials[3]}"
   fi
 
   # Switch to AWS profile


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Close if statement after checking for mfa_serial in `acp()`
- Remove extraneous `fi` before profile switching
- Fix indentation

## Other comments:

I think scope of one of the if statements was accidentally expanded in #9426 to include code that was supposed to do profile switching. This fix attempts to correct the scope of if statemnts.

Fixes #9843
