### PR TITLE
remove duplicated alias for kubectl plugin `kgsa`

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -107,7 +107,6 @@ plugins=(... kubectl)
 | ksss    | `kubectl scale statefulset`         | Scale a statefulset                                                                              |
 | krsss   | `kubectl rollout status statefulset`| Check the rollout status of a deployment                                                         |
 |         |                                     | **Service Accounts management**                                                                  |
-| kgsa    | `kubectl get sa`                    | List all service accounts                                                                        |
 | kdsa    | `kubectl describe sa`               | Describe a service account in details                                                            |
 | kdelsa  | `kubectl delete sa`                 | Delete the service account                                                                       |
 |         |                                     | **DaemonSet management**                                                                         |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -151,7 +151,6 @@ alias kdpvc='kubectl describe pvc'
 alias kdelpvc='kubectl delete pvc'
 
 # Service account management.
-alias kgsa="kubectl get sa"
 alias kdsa="kubectl describe sa"
 alias kdelsa="kubectl delete sa"
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

A fix to https://github.com/ohmyzsh/ohmyzsh/issues/9842.

Remove alias `kgsa` from kubectl plugin, because it is conflicting with another alias. To get service accounts, command `k get sa` is short enough. Therefore, surrender this alias for a longer command.

## Other comments:

N.A.