### PR TITLE
refactor: define $ZSH_THEME_PATH in oh-my-sh.sh

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -121,10 +121,13 @@ unset config_file
 # Load the theme
 if [ ! "$ZSH_THEME" = ""  ]; then
   if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then
-    source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
+    ZSH_THEME_PATH=$ZSH_CUSTOM
+    source "$ZSH_THEME_PATH/$ZSH_THEME.zsh-theme"
   elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
-    source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
+    ZSH_THEME_PATH=$ZSH_CUSTOM/themes
+    source "$ZSH_THEME_PATH/$ZSH_THEME.zsh-theme"
   else
-    source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+    ZSH_THEME_PATH=$ZSH_CUSTOM/themes
+    source "$ZSH_THEME_PATH/$ZSH_THEME.zsh-theme"
   fi
 fi


### PR DESCRIPTION
When you run oh-my-zsh, you can easily reference the top-level path of the theme by setting the theme path. In this case, when implementing the theme, there is no need to manually enter the path if there are files referenced by the theme.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Defines the path of the theme loaded from oh-my-sh.

## Other comments:

When you run oh-my-zsh, you can easily reference the top-level path of the theme by setting the theme path. In this case, when implementing the theme, there is no need to manually enter the path if there are files referenced by the theme.