### PR TITLE
fix(dirhistory): fix ALT+Left/Right key bindings for iTerm2

### DIFF
--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -124,9 +124,13 @@ zle -N dirhistory_zle_dirhistory_back
 # xterm in normal mode
 bindkey "\e[3D" dirhistory_zle_dirhistory_back
 bindkey "\e[1;3D" dirhistory_zle_dirhistory_back
-# Mac teminal (alt+left/right)
-if [[ "$TERM_PROGRAM" == "Apple_Terminal" || "$TERM_PROGRAM" == "iTerm.app" ]]; then
+# Terminal.app
+if [[ "$TERM_PROGRAM" == "Apple_Terminal" ]]; then
   bindkey "^[b" dirhistory_zle_dirhistory_back
+fi
+# iTerm2
+if [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+  bindkey "^[^[[D" dirhistory_zle_dirhistory_back
 fi
 # Putty:
 bindkey "\e\e[D" dirhistory_zle_dirhistory_back
@@ -136,8 +140,13 @@ bindkey "\eO3D" dirhistory_zle_dirhistory_back
 zle -N dirhistory_zle_dirhistory_future
 bindkey "\e[3C" dirhistory_zle_dirhistory_future
 bindkey "\e[1;3C" dirhistory_zle_dirhistory_future
-if [[ "$TERM_PROGRAM" == "Apple_Terminal" || "$TERM_PROGRAM" == "iTerm.app" ]]; then
+# Terminal.app
+if [[ "$TERM_PROGRAM" == "Apple_Terminal" ]]; then
   bindkey "^[f" dirhistory_zle_dirhistory_future
+fi
+# iTerm2
+if [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+  bindkey "^[^[[C" dirhistory_zle_dirhistory_future
 fi
 bindkey "\e\e[C" dirhistory_zle_dirhistory_future
 bindkey "\eO3C" dirhistory_zle_dirhistory_future


### PR DESCRIPTION
Fixes #9938

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Separates <kbd>ALT+Left</kbd> / <kbd>ALT+Right</kbd> key bindings for iTerm2 and Terminal.app and fixes key binding sequences for iTerm2.