### PR TITLE
feat(nvm): customizable list of command that triggers lazy loading

### DIFF
--- a/plugins/nvm/README.md
+++ b/plugins/nvm/README.md
@@ -21,7 +21,11 @@ These settings should go in your zshrc file, before Oh My Zsh is sourced:
 
 - **`NVM_LAZY`**: if you want the plugin to defer the load of nvm to speed-up the start of your zsh session,
   set `NVM_LAZY` to `1`. This will use the `--no-use` parameter when loading nvm, and will create a function
-  for `node`, `npm` and `yarn`, so when you call either of these three, nvm will load with `nvm use default`.
+  for `node`, `npm`, `yarn`, and the command(s) specified by `NVM_LAZY_CMD`, so when you call either of them,
+  nvm will load with `nvm use default`.
+
+- **`NVM_LAZY_CMD`**: if you want additional command(s) to trigger lazy loading of nvm, set `NVM_LAZY_CMD` to
+  the command or an array of the commands.
 
 - **`NVM_AUTOLOAD`**: if `NVM_AUTOLOAD` is set to `1`, the plugin will automatically load a node version when
   if finds a [`.nvmrc` file](https://github.com/nvm-sh/nvm#nvmrc) in the current working directory indicating

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -28,8 +28,8 @@ fi
 
 # Call nvm when first using node, npm or yarn
 if (( $+NVM_LAZY )); then
-  function node npm yarn {
-    unfunction node npm yarn
+  function node npm yarn $NVM_LAZY_CMD {
+    unfunction node npm yarn $NVM_LAZY_CMD
     nvm use default
     command "$0" "$@"
   }


### PR DESCRIPTION
Add `$NVM_LAZY_CMD` such to customize a list of command that triggers lazy loading.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

-  add parameter `NVM_LAZY_CMD` and expand it in lazy loading 
-  add instruction in `README.md`

## Other comments:

...
