### PR TITLE
feat(branch): show mercurial bookmarks if used

### DIFF
--- a/plugins/branch/README.md
+++ b/plugins/branch/README.md
@@ -1,32 +1,47 @@
-# Branch
+# Branch plugin
 
-Displays the current Git or Mercurial branch fast.
-Also shows Mercurial Bookmark via slash, if they are used.
+This plugin displays the current Git or Mercurial branch, fast. If in a Mercurial repository,
+also display the current bookmark, if present.
+
+To use it, add `branch` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... branch)
+```
 
 ## Speed test
 
-### Mercurial
+- `hg branch`:
 
-```shell
-$ time hg branch
-0.11s user 0.14s system 70% cpu 0.355 total
-```
+  ```console
+  $ time hg branch
+  0.11s user 0.14s system 70% cpu 0.355 total
+  ```
 
-### Branch plugin
+- branch plugin:
 
-```shell
-$ time zsh /tmp/branch_prompt_info_test.zsh
-0.00s user 0.01s system 78% cpu 0.014 total
-```
+  ```console
+  $ time zsh /tmp/branch_prompt_info_test.zsh
+  0.00s user 0.01s system 78% cpu 0.014 total
+  ```
 
 ## Usage
 
-Edit your theme file (eg.: `~/.oh-my-zsh/theme/robbyrussell.zsh-theme`)
-adding `$(branch_prompt_info)` in your prompt like this:
+Copy your theme to `$ZSH_CUSTOM/themes/` and modify it to add `$(branch_prompt_info)` in your prompt.
+This example is for the `robbyrussell` theme:
 
 ```diff
-- PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)%{$fg_bold[blue]%} % %{$reset_color%}'
-+ PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)$(branch_prompt_info)%{$fg_bold[blue]%} % %{$reset_color%}'
+diff --git a/themes/robbyrussell.zsh-theme b/themes/robbyrussell.zsh-theme
+index 2fd5f2cd..9d89a464 100644
+--- a/themes/robbyrussell.zsh-theme
++++ b/themes/robbyrussell.zsh-theme
+@@ -1,5 +1,5 @@
+ PROMPT="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ )"
+-PROMPT+=' %{$fg[cyan]%}%c%{$reset_color%} $(git_prompt_info)'
++PROMPT+=' %{$fg[cyan]%}%c%{$reset_color%} $(branch_prompt_info)'
+ 
+ ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}git:(%{$fg[red]%}"
+ ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ```
 
 ## Maintainer

--- a/plugins/branch/README.md
+++ b/plugins/branch/README.md
@@ -1,6 +1,7 @@
 # Branch
 
 Displays the current Git or Mercurial branch fast.
+Also shows Mercurial Bookmark via slash, if they are used.
 
 ## Speed test
 

--- a/plugins/branch/branch.plugin.zsh
+++ b/plugins/branch/branch.plugin.zsh
@@ -3,34 +3,33 @@
 # Oct 2, 2015
 
 function branch_prompt_info() {
-  # Defines path as current directory
-  local current_dir=$PWD
-  # While current path is not root path
-  while [[ $current_dir != '/' ]]
-  do
-    # Git repository
-    if [[ -d "${current_dir}/.git" ]]
-    then
-      echo '±' ${"$(<"$current_dir/.git/HEAD")"##*/}
-      return;
+  # Start checking in current working directory
+  local branch="" dir="$PWD"
+  while [[ "$dir" != '/' ]]; do
+    # Found .git directory
+    if [[ -d "${dir}/.git" ]]; then
+      branch="${"$(<"${dir}/.git/HEAD")"##*/}"
+      echo '±' "${branch:gs/%/%%}"
+      return
     fi
-    # Mercurial repository
-    if [[ -d "${current_dir}/.hg" ]]
-    then
-      if [[ -f "$current_dir/.hg/branch" ]]
-      then
-        if [[ -f "$current_dir/.hg/bookmarks.current" ]]
-        then
-            echo '☿' $(<"$current_dir/.hg/branch")/$(<"$current_dir/.hg/bookmarks.current")
-        else
-            echo '☿' $(<"$current_dir/.hg/branch")
-        fi
+
+    # Found .hg directory
+    if [[ -d "${dir}/.hg" ]]; then
+      if [[ -f "${dir}/.hg/branch" ]]; then
+        branch="$(<"${dir}/.hg/branch")"
       else
-        echo '☿ default'
+        branch="default"
       fi
-      return;
+
+      if [[ -f "${dir}/.hg/bookmarks.current" ]]; then
+        branch="${branch}/$(<"${dir}/.hg/bookmarks.current")"
+      fi
+
+      echo '☿' "${branch:gs/%/%%}"
+      return
     fi
-    # Defines path as parent directory and keeps looking for :)
-    current_dir="${current_dir:h}"
+
+    # Check parent directory
+    dir="${dir:h}"
   done
 }

--- a/plugins/branch/branch.plugin.zsh
+++ b/plugins/branch/branch.plugin.zsh
@@ -19,7 +19,12 @@ function branch_prompt_info() {
     then
       if [[ -f "$current_dir/.hg/branch" ]]
       then
-        echo '☿' $(<"$current_dir/.hg/branch")
+        if [[ -f "$current_dir/.hg/bookmarks.current" ]]
+        then
+            echo '☿' $(<"$current_dir/.hg/branch")/$(<"$current_dir/.hg/bookmarks.current")
+        else
+            echo '☿' $(<"$current_dir/.hg/branch")
+        fi
       else
         echo '☿ default'
       fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- if a bookmark is used, it will be shown via slash. Like {branch}/{bookmark}

## Other comments:

...
