### PR TITLE
fix(git): Makes gcs alias consistent with gcsm

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -57,7 +57,7 @@ plugins=(... git)
 | gcp                  | git cherry-pick                                                                                                                  |
 | gcpa                 | git cherry-pick --abort                                                                                                          |
 | gcpc                 | git cherry-pick --continue                                                                                                       |
-| gcs                  | git commit -S                                                                                                                    |
+| gcs                  | git commit -s                                                                                                                    |
 | gd                   | git diff                                                                                                                         |
 | gdca                 | git diff --cached                                                                                                                |
 | gdcw                 | git diff --cached --word-diff                                                                                                    |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -95,7 +95,7 @@ alias gcount='git shortlog -sn'
 alias gcp='git cherry-pick'
 alias gcpa='git cherry-pick --abort'
 alias gcpc='git cherry-pick --continue'
-alias gcs='git commit -S'
+alias gcs='git commit -s'
 
 alias gd='git diff'
 alias gdca='git diff --cached'


### PR DESCRIPTION
`gcsm` is an alias for `git commit -s -m`, while `gcs` is an alias for
`git commit -S`. One (-S) cryptographically signs commits, while the
other (-s) signs-off on commits

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Changes `alias gcs='git commit -S'` to `alias gcs='git commit -s'`

## Other comments:
If we want to add other aliases with `-S` like we have for `git commit -s` (eg: `alias gcsm='git commit -s -m'`), we could capitalize the `s` (eg: `alias gcSm='git commit -S -m'`).

Related: #7460.

...
