### PR TITLE
fixed command duplicate issue when  when using tab

### DIFF
--- a/themes/flazz.zsh-theme
+++ b/themes/flazz.zsh-theme
@@ -3,14 +3,14 @@ then CARETCOLOR="red"
 else CARETCOLOR="blue"
 fi
 
-local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
+local return_code="%(?..%{$fg[red]%}%? %{%G↵%}%{$reset_color%})"
 
 PROMPT='%m%{${fg_bold[magenta]}%} :: %{$reset_color%}%{${fg[green]}%}%3~ $(git_prompt_info)%{${fg_bold[$CARETCOLOR]}%}%#%{${reset_color}%} '
 
 RPS1='$(vi_mode_prompt_info) ${return_code}'
 
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}‹"
-ZSH_THEME_GIT_PROMPT_SUFFIX="› %{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}%{%G‹%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{%G›%} %{$reset_color%}"
 
 MODE_INDICATOR="%{$fg_bold[magenta]%}<%{$reset_color%}%{$fg[magenta]%}<<%{$reset_color%}"
 


### PR DESCRIPTION
bug : 
when user try to use autocomplete in git prompt the characters written before the tab will be part of the prompt and can't be deleted 
because of the special chars used in git prompt I just wrapped them in 
to reproduce the error
- enter any git folder 
- try to autocomplete any command

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [changed flazz theme file ]

## Other comments:
it's a common issue and and the fix is pretty simple 
if you have any suggestion please report them to me 

