### PR TITLE
Fixed fail to register thefuck alias without $ZSH_CACHE_DIR

### DIFF
--- a/plugins/thefuck/thefuck.plugin.zsh
+++ b/plugins/thefuck/thefuck.plugin.zsh
@@ -5,8 +5,12 @@ if [[ -z $commands[thefuck] ]]; then
 fi
 
 # Register alias
-[[ ! -a $ZSH_CACHE_DIR/thefuck ]] && thefuck --alias > $ZSH_CACHE_DIR/thefuck
-source $ZSH_CACHE_DIR/thefuck
+if [[ -n $ZSH_CACHE_DIR ]]; then
+    [[ ! -a $ZSH_CACHE_DIR/thefuck ]] && thefuck --alias > $ZSH_CACHE_DIR/thefuck
+    source $ZSH_CACHE_DIR/thefuck
+else
+    eval $(thefuck --alias)
+fi
 
 fuck-command-line() {
     local FUCK="$(THEFUCK_REQUIRE_CONFIRMATION=0 thefuck $(fc -ln -1 | tail -n 1) 2> /dev/null)"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
