### PR TITLE
feat(mlh): let users configure the official MLH theme

### DIFF
--- a/themes/mlh.zsh-theme
+++ b/themes/mlh.zsh-theme
@@ -12,17 +12,38 @@
 # # # Feel free to customize! # # #
 # # # # # # # # # # # # # # # # # #
 
-# To easily discover colors and their codes, type `spectrum_ls` in the terminal
+# To customize symbols (e.g MLH_AT_SYMBOL), simply set them as environment variables
+# for example in your ~/.zshrc file, like this:
+# export MLH_AT_SYMBOL=" at "
 
-# enable or disable particular elements
-PRINT_EXIT_CODE=true
-PRINT_TIME=true
+# Hint: to easily discover colors and their codes, type `spectrum_ls` in the terminal
 
-# symbols
-AT_SYMBOL=" @ "
-IN_SYMBOL=" in "
-ON_SYMBOL=" on "
-SHELL_SYMBOL="$"
+# right prompt default settings
+if [ -z "$MLH_PRINT_EXIT_CODE" ]; then
+  MLH_PRINT_EXIT_CODE=true
+fi
+
+if [ -z "$MLH_PRINT_TIME" ]; then
+  MLH_PRINT_TIME=false
+fi
+
+# symbols default settings
+
+if [ -z "$MLH_AT_SYMBOL" ]; then
+  MLH_AT_SYMBOL="@"
+fi
+
+if [ -z "$MLH_IN_SYMBOL" ]; then
+  MLH_IN_SYMBOL=" in "
+fi
+
+if [ -z "$MLH_ON_SYMBOL" ]; then
+  MLH_ON_SYMBOL=" on "
+fi
+
+if [ -z "$MLH_SHELL_SYMBOL" ]; then
+  MLH_SHELL_SYMBOL="$ "
+fi
 
 # colors
 USER_COLOR="%F{001}"
@@ -47,24 +68,28 @@ directory() {
 
 # Prints current time
 current_time() {
-  if [ "$PRINT_TIME" = true ]; then
-    echo " $TIME_COLOR%*%f"
+  if [ "$MLH_PRINT_TIME" = true ]; then
+    echo " $MLH_PRINT_TIME%*%f"
   fi
 }
 
 # Prints exit code of the last executed command
 exit_code() {
-  if [ "$PRINT_EXIT_CODE" = true ]; then
+  if [ "$MLH_PRINT_EXIT_CODE" = true ]; then
     echo "%(?..%F{001}exit %?)%f"
   fi
 }
 
+prompt_end() {
+  printf "\n$MLH_SHELL_SYMBOL"
+}
+
 # Set git_prompt_info text
-ZSH_THEME_GIT_PROMPT_PREFIX="${ON_SYMBOL}${BRANCH_COLOR}"
+ZSH_THEME_GIT_PROMPT_PREFIX="${MLH_ON_SYMBOL}${BRANCH_COLOR}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%f"
 ZSH_THEME_GIT_PROMPT_DIRTY=""
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 
 # %B and %b make the text bold
-PROMPT='%b$(username)$AT_SYMBOL$(device)$IN_SYMBOL$(directory)$(git_prompt_info)%b $SHELL_SYMBOL '
+PROMPT='%b$(username)$MLH_AT_SYMBOL$(device)$MLH_IN_SYMBOL$(directory)$(git_prompt_info)%b$(prompt_end)'
 RPROMPT="$(exit_code)$(current_time)"

--- a/themes/mlh.zsh-theme
+++ b/themes/mlh.zsh-theme
@@ -14,9 +14,11 @@
 
 # To customize symbols (e.g MLH_AT_SYMBOL), simply set them as environment variables
 # for example in your ~/.zshrc file, like this:
-# export MLH_AT_SYMBOL=" at "
-
-# Hint: to easily discover colors and their codes, type `spectrum_ls` in the terminal
+# MLH_AT_SYMBOL=" at "
+# 
+# Settings *must* be set before sourcing oh-my-zsh.sh the .zshrc file.
+#
+# To easily discover colors and their codes, type `spectrum_ls` in the terminal
 
 # right prompt default settings
 if [ -z "$MLH_PRINT_EXIT_CODE" ]; then
@@ -27,7 +29,7 @@ if [ -z "$MLH_PRINT_TIME" ]; then
   MLH_PRINT_TIME=false
 fi
 
-# symbols default settings
+# left prompt symbols default settings
 
 if [ -z "$MLH_AT_SYMBOL" ]; then
   MLH_AT_SYMBOL="@"
@@ -69,7 +71,7 @@ directory() {
 # Prints current time
 current_time() {
   if [ "$MLH_PRINT_TIME" = true ]; then
-    echo " $MLH_PRINT_TIME%*%f"
+    echo " $TIME_COLOR%*%f"
   fi
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- let users configure MLH theme using environmental variables. User can set
  them conveniently, for example, in their `~/.zshrc` file, instead of being
  forced to override the whole theme.

- make the theme 2 line. Currently, when the user is working on a branch with a long name, it looks
  really awkward:

<img width="1082" alt="Screenshot 2021-06-21 at 13 09 08" src="https://user-images.githubusercontent.com/40357511/122821551-46102280-d2dd-11eb-9620-293f59372552.png">

Now, it looks just cool.
![Screenshot 2021-06-21 at 22 09 10](https://user-images.githubusercontent.com/40357511/122821570-4f00f400-d2dd-11eb-9fc7-3f1bb3389bab.png)

