### PR TITLE
Add aliases for kubectl rollout restart

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -70,6 +70,7 @@ plugins=(... kubectl)
 | kdd     | `kubectl describe deployment`       | Describe deployment resource in detail                                                           |
 | kdeld   | `kubectl delete deployment`         | Delete the deployment                                                                            |
 | ksd     | `kubectl scale deployment`          | Scale a deployment                                                                               |
+| krrd    | `kubectl rollout restart deployment` | Rollout restart a deployment                                                                     |
 | krsd    | `kubectl rollout status deployment` | Check the rollout status of a deployment                                                         |
 | kres    | `kubectl set env $@ REFRESHED_AT=...` | Recreate all pods in deployment with zero-downtime                                                         |
 |         |                                     | **Rollout management**                                                                           |
@@ -105,7 +106,8 @@ plugins=(... kubectl)
 | kdss    | `kubectl describe statefulset`      | Describe statefulset resource in detail                                                          |
 | kdelss  | `kubectl delete statefulset`        | Delete the statefulset                                                                           |
 | ksss    | `kubectl scale statefulset`         | Scale a statefulset                                                                              |
-| krsss   | `kubectl rollout status statefulset`| Check the rollout status of a deployment                                                         |
+| krrss   | `kubectl rollout restart statefulset` | Rollout restart a statefulset                                                                    |
+| krsss   | `kubectl rollout status statefulset`| Check the rollout status of a statefulset                                                        |
 |         |                                     | **Service Accounts management**                                                                  |
 | kdsa    | `kubectl describe sa`               | Describe a service account in details                                                            |
 | kdelsa  | `kubectl delete sa`                 | Delete the service account                                                                       |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -96,6 +96,7 @@ alias ked='kubectl edit deployment'
 alias kdd='kubectl describe deployment'
 alias kdeld='kubectl delete deployment'
 alias ksd='kubectl scale deployment'
+alias krrd='kubectl rollout restart deployment'
 alias krsd='kubectl rollout status deployment'
 kres(){
     kubectl set env $@ REFRESHED_AT=$(date +%Y%m%d%H%M%S)
@@ -115,6 +116,7 @@ alias kess='kubectl edit statefulset'
 alias kdss='kubectl describe statefulset'
 alias kdelss='kubectl delete statefulset'
 alias ksss='kubectl scale statefulset'
+alias krrss='kubectl rollout restart statefulset'
 alias krsss='kubectl rollout status statefulset'
 
 # Port forwarding


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add kubectl aliases for rollout restart of deployment and statefulset

## Other comments:

Partially replicates #9674, but adds an alias for rollout restarting statefulset as well.
