### PR TITLE
fix(git-auto-fetch): cancel fetch if we don't have permission over git folder

### DIFF
--- a/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
+++ b/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
@@ -11,8 +11,9 @@ function git-fetch-all {
       return 0
     fi
 
-    # Do nothing if auto-fetch disabled
-    if [[ -z "$gitdir" || -f "$gitdir/NO_AUTO_FETCH" ]]; then
+    # Do nothing if auto-fetch is disabled or don't have permissions
+    if [[ ! -w "$gitdir" || -f "$gitdir/NO_AUTO_FETCH" ]] ||
+       [[ -f "$gitdir/FETCH_LOG" && ! -w "$gitdir/FETCH_LOG" ]]; then
       return 0
     fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Check directory and file permissions before fetching the Git remotes.

## Other comments:

The zsh prompt will display an error message if the user don't own the git directory.

![Screenshot](https://user-images.githubusercontent.com/16078332/123647247-7ebe7780-d85a-11eb-85cb-67424c9c880a.png)

...
