### PR TITLE
feat(git): improve primary branch detection (`gcm`)

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -29,16 +29,27 @@ function work_in_progress() {
   fi
 }
 
-# Check if main exists and use instead of master
+# Detect name of the primary branch
+# (Use master as a fallback.)
 function git_main_branch() {
+  # Abort if not inside git repository
   command git rev-parse --git-dir &>/dev/null || return
-  local branch
+
+  # Resolve primary branch from the remote reference
+  local reference=$(command git rev-parse --symbolic-full-name --remotes='*/HEAD')
+  if [[ -n $reference ]]; then
+    echo ${reference#refs/remotes/*/}
+    return
+  fi
+
+  # Look up list of local branches and return the first one that exists
   for branch in main trunk; do
     if command git show-ref -q --verify refs/heads/$branch; then
       echo $branch
       return
     fi
   done
+
   echo master
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Support resolving the main branch from the remote reference.

## Other comments:

This is an improved version of #9879 in the sense that it is remote agnostic - doesn't assume the existence of `origin` remote. (closes #9879)

@mcornella wrote [there](https://github.com/ohmyzsh/ohmyzsh/pull/9879#issuecomment-831295623):
> A version of this was released some time ago but removed after complaints that now `gcd` (`git checkout develop`) and `gcm` (`git checkout main`) did the same thing.

That is true if the _primary_ branch is named dev/develop but as @AnatoleLucet said there are also more exotic _primary_ branch names out there. 🙃 