### PR TITLE
Fix virtualenvwrapper plugin's activate virtualenv from a git subtree working firectory

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -38,7 +38,7 @@ if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
       # Get absolute path, resolving symlinks
       local PROJECT_ROOT="${PWD:A}"
       while [[ "$PROJECT_ROOT" != "/" && ! -e "$PROJECT_ROOT/.venv" \
-          && ! -d "$PROJECT_ROOT/.git" ]]; do
+          && ! -e "$PROJECT_ROOT/.git" ]]; do
         PROJECT_ROOT="${PROJECT_ROOT:h}"
       done
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

In a `git subtree` working directory, `.git` is a file containing a path
to the parent git working direcotry. This change attempts to find a
virtualenv for a subtree.