### PR TITLE
feat(gnu-utils): include ggrep in gcmds

### DIFF
--- a/plugins/gnu-utils/gnu-utils.plugin.zsh
+++ b/plugins/gnu-utils/gnu-utils.plugin.zsh
@@ -36,7 +36,7 @@ __gnu_utils() {
   gcmds+=('gfind' 'gxargs' 'glocate')
 
   # Not part of either coreutils or findutils, installed separately.
-  gcmds+=('gsed' 'gtar' 'gtime' 'gmake')
+  gcmds+=('gsed' 'gtar' 'gtime' 'gmake' 'ggrep')
 
   for gcmd in "${gcmds[@]}"; do
     # Do nothing if the command isn't found


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Include `ggrep` in `gcmds` array for gnu-utils plugin. This allows ggrep to be aliased if you have GNU grep installed.

## Other comments:

...
