### PR TITLE
fix(pip): don't overwrite `requirements.txt` in internal commands

### DIFF
--- a/plugins/pip/pip.plugin.zsh
+++ b/plugins/pip/pip.plugin.zsh
@@ -88,10 +88,9 @@ alias pip="noglob pip" # allows square brackets for pip command invocation
 alias pipreq="pip freeze > requirements.txt"
 
 # Update all installed packages
-alias pipupall="pipreq && sed -i 's/==/>=/g' requirements.txt && pip install -r requirements.txt --upgrade && rm -rf requirements.txt"
-
+alias pipupall="pip list --outdated --format freeze | cut --delimiter '=' --fields 1 | xargs --no-run-if-empty pip install --upgrade"
 # Install packages from requirements file
-alias pipir="pip install -r requirements.txt"
+alias pipir="pip install --requirement requirements.txt"
 
 # Uninstalled all installed packages
-alias pipunall="pipreq && pip uninstall -r requirements.txt -y && rm -rf requirements.txt"
+alias pipunall="pip list --format freeze | cut --delimiter '=' --fields 1 | xargs --no-run-if-empty pip uninstall"

--- a/plugins/pip/pip.plugin.zsh
+++ b/plugins/pip/pip.plugin.zsh
@@ -87,10 +87,21 @@ alias pip="noglob pip" # allows square brackets for pip command invocation
 # Create requirements file
 alias pipreq="pip freeze > requirements.txt"
 
-# Update all installed packages
-alias pipupall="pip list --outdated --format freeze | cut --delimiter '=' --fields 1 | xargs --no-run-if-empty pip install --upgrade"
 # Install packages from requirements file
-alias pipir="pip install --requirement requirements.txt"
+alias pipir="pip install -r requirements.txt"
+
+# Update all installed packages
+function pipupall {
+  # non-GNU xargs does not support nor need `--no-run-if-empty`
+  local xargs="xargs --no-run-if-empty"
+  xargs --version 2>/dev/null | grep -q GNU || xargs="xargs"
+  pip list --outdated --format freeze | cut -d= -f1 | ${=xargs} pip install --upgrade
+}
 
 # Uninstalled all installed packages
-alias pipunall="pip list --format freeze | cut --delimiter '=' --fields 1 | xargs --no-run-if-empty pip uninstall"
+function pipunall {
+  # non-GNU xargs does not support nor need `--no-run-if-empty`
+  local xargs="xargs --no-run-if-empty"
+  xargs --version 2>/dev/null | grep -q GNU || xargs="xargs"
+  pip list --format freeze | cut -d= -f1 | ${=xargs} pip uninstall
+}


### PR DESCRIPTION


## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
1. Change to a long style parameter.
2. Use pipeline processing to replace temporary files. 

## Other comments:
The original way of using "requirements.txt" as a temporary file name risked overwriting the original file.
And if the action of deleting a file is not performed correctly, the temporary files left behind can easily mislead the user.
...
