### PR TITLE
feat(shell-proxy): support SOCKS protocol based on URI scheme

### DIFF
--- a/plugins/shell-proxy/ssh-proxy.py
+++ b/plugins/shell-proxy/ssh-proxy.py
@@ -2,15 +2,30 @@
 import os
 import subprocess
 import sys
-import urllib.parse
+from urllib.parse import urlparse
 
 proxy = next(os.environ[_] for _ in ("HTTP_PROXY", "HTTPS_PROXY") if _ in os.environ)
+
+parsed = urlparse(proxy)
+
+proxy_protocols = {
+    "http": "connect",
+    "https": "connect",
+    "socks": "5",
+    "socks5": "5",
+    "socks4": "4",
+    "socks4a": "4",
+}
+
+if parsed.scheme not in proxy_protocols:
+    raise TypeError('unsupported proxy protocol: "{}"'.format(parsed.scheme))
+
 argv = [
     "nc",
     "-X",
-    "connect",
+    proxy_protocols[parsed.scheme], # Supported protocols are 4 (SOCKS v.4), 5 (SOCKS v.5) and connect (HTTP proxy). Default SOCKS v.5 is used.
     "-x",
-    urllib.parse.urlparse(proxy).netloc,  # proxy-host:proxy-port
+    parsed.netloc,  # proxy-host:proxy-port
     sys.argv[1],  # host
     sys.argv[2],  # port
 ]

--- a/plugins/shell-proxy/ssh-proxy.py
+++ b/plugins/shell-proxy/ssh-proxy.py
@@ -23,7 +23,7 @@ if parsed.scheme not in proxy_protocols:
 argv = [
     "nc",
     "-X",
-    proxy_protocols[parsed.scheme], # Supported protocols are 4 (SOCKS v.4), 5 (SOCKS v.5) and connect (HTTP proxy). Default SOCKS v.5 is used.
+    proxy_protocols[parsed.scheme], # Supported protocols are 4 (SOCKS v4), 5 (SOCKS v5) and connect (HTTP proxy). Default SOCKS v5 is used.
     "-x",
     parsed.netloc,  # proxy-host:proxy-port
     sys.argv[1],  # host


### PR DESCRIPTION

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Identify the proxy protocol passed to netcat based on URI schemes

## Other comments:

- No longer pass proxy protocol options uniformly as `connect`