### PR TITLE
fix(avit): disable `log.showSignatures` in `_git_time_since_commit`

### DIFF
--- a/themes/avit.zsh-theme
+++ b/themes/avit.zsh-theme
@@ -31,7 +31,7 @@ function _git_time_since_commit() {
   local last_commit now seconds_since_last_commit
   local minutes hours days years commit_age
   # Only proceed if there is actually a commit.
-  if last_commit=$(git log --no-show-signature --pretty=format:'%at' -1 2> /dev/null); then
+  if last_commit=$(command git -c log.showSignatures=false log --format='%at' -1 2>/dev/null); then
     now=$(date +%s)
     seconds_since_last_commit=$((now-last_commit))
 

--- a/themes/avit.zsh-theme
+++ b/themes/avit.zsh-theme
@@ -31,7 +31,7 @@ function _git_time_since_commit() {
   local last_commit now seconds_since_last_commit
   local minutes hours days years commit_age
   # Only proceed if there is actually a commit.
-  if last_commit=$(git log --pretty=format:'%at' -1 2> /dev/null); then
+  if last_commit=$(git log --no-show-signature --pretty=format:'%at' -1 2> /dev/null); then
     now=$(date +%s)
     seconds_since_last_commit=$((now-last_commit))
 


### PR DESCRIPTION
Fixes avit's _git_time_since_commit does not work when git log was configured to show signature by default.