### PR TITLE
feat(zbell): add option not to use notify-send

### DIFF
--- a/plugins/zbell/README.md
+++ b/plugins/zbell/README.md
@@ -24,6 +24,9 @@ These settings need to be set in your zshrc file, before Oh My Zsh is sourced.
   zbell_ignore=($EDITOR $PAGER)
   ```
 
+- `zbell_use_notify_send`: If set to `true`, `notify-send` tool is used -- if
+  available -- to display a popup on the screen. Default: `true` (enabled).
+
 ## Author
 
 Adapted from an original version by [Jean-Philippe Ouellet](https://github.com/jpouellet).

--- a/plugins/zbell/zbell.plugin.zsh
+++ b/plugins/zbell/zbell.plugin.zsh
@@ -29,18 +29,31 @@ autoload -Uz regexp-replace || return
 # initialize zbell_ignore if not set
 (( ${+zbell_ignore} )) || zbell_ignore=($EDITOR $PAGER)
 
+# initialize zbell_use_notify_send if not set
+(( ${+zbell_use_notify_send} )) || zbell_use_notify_send=true
+
 # initialize it because otherwise we compare a date and an empty string
 # the first time we see the prompt. it's fine to have lastcmd empty on the
 # initial run because it evaluates to an empty string, and splitting an
 # empty string just results in an empty array.
 zbell_timestamp=$EPOCHSECONDS
 
+# UI notification function
+# $1: command
+# $2: duration in seconds
+zbell_ui_notify() {
+	[[ $zbell_use_notify_send != "true" ]] && return
+
+	if type notify-send > /dev/null; then
+		notify-send -i terminal "Command completed in ${2}s:" $1
+	fi
+}
+
 # default notification function
 # $1: command
 # $2: duration in seconds
 zbell_notify() {
-	type notify-send > /dev/null && \
-		notify-send -i terminal "Command completed in ${2}s:" $1
+	zbell_ui_notify "${@}"
 	print -n "\a"
 }
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki. (But it also follows in priority the design that was already applied in the modified file)
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

When using a workstation remotely with something like SSH, we might not want to send pop-up's on the screen.

In my case, when I connect to the UI session, I can see heaps of missed notifications. All I want with this zbell plugin is the 'bell' sent in the terminal and displayed in Tmux.

Now we have a simple option not to use 'notify-send' even if it is available.

## Other comments:

Please note that the code follows in priority the design that was already applied in the modified file.
