### PR TITLE
Add custom resource definition management aliases to kubectl plugin

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -168,6 +168,13 @@ alias kecj='kubectl edit cronjob'
 alias kdcj='kubectl describe cronjob'
 alias kdelcj='kubectl delete cronjob'
 
+# Custom resource definition management
+alias kgcrd='kubectl get crd'
+alias kgcrda='kubectl get crd --all-namespaces'
+alias kecrd='kubectl edit crd'
+alias kdcrd='kubectl describe crd'
+alias kdelcrd='kubectl delete crd'
+
 # Only run if the user actually has kubectl installed
 if (( ${+_comps[kubectl]} )); then
   kj() { kubectl "$@" -o json | jq; }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add aliases for Kubernetes Custom Resource Definitions following the same get, edit, describe, delete pattern as other resources