### PR TITLE
Add avd (Android Virtual Device) plugin

### DIFF
--- a/plugins/avd/README.md
+++ b/plugins/avd/README.md
@@ -1,7 +1,8 @@
 # avd plugin
 
-The avd plugin provides aliases for Android Virtual Device / Android
-Emulator commands.
+The avd plugin provides a few functions for Android Virtual Device /
+Android Emulator commands to list all the available AVDs and launch them
+more easily.
 
 To use it, add avd to the plugins array of your zshrc file:
 

--- a/plugins/avd/README.md
+++ b/plugins/avd/README.md
@@ -36,9 +36,9 @@ not work as expected.
 ```
 ~/
 > avds
-Pixel_2_API_30
-Samsung_Tab_A_2019_API_25
-Samsung_Tab_A_2019_API_29
+1:Pixel_2_API_30
+2:Samsung_Tab_A_2019_API_25
+3:Samsung_Tab_A_2019_API_29
 
 ~/
 > avd 2

--- a/plugins/avd/README.md
+++ b/plugins/avd/README.md
@@ -1,0 +1,46 @@
+# avd plugin
+
+The avd plugin provides aliases for Android Virtual Device / Android
+Emulator commands.
+
+To use it, add avd to the plugins array of your zshrc file:
+
+```zsh
+plugins=(... avd)
+```
+
+## Requirements
+
+In order to make this work, you will need to have the Android `emulator`
+tool set up in your path. This plugin will try to find that tool in
+`$ANDROID_HOME` as a last resort, however it will make it slower and may
+not work as expected.
+
+## Functions
+
+- `avds` - Lists all the AVDs
+- `avd [-v] <n>` - Launches n-th AVD from the AVDs list printed by
+  `avds`
+  - `-v` will let stdout and stderr print to the console which is
+    disabled by default to avoid the clutter
+- `find_emulator` - Tries to find the `emulator` tool either in your
+  path or `$ANDROID_HOME` directory
+
+## Aliases
+
+- `emus` - Same as `avds`
+- `emu [-v] <n>` - Same as `avd [-v] <n>`
+
+## Exemplary usage:
+```
+~/
+> avds
+Pixel_2_API_30
+Samsung_Tab_A_2019_API_25
+Samsung_Tab_A_2019_API_29
+
+~/
+> avd 2
+Starting emulator: Samsung_Tab_A_2019_API_25
+[3] 33463
+```

--- a/plugins/avd/README.md
+++ b/plugins/avd/README.md
@@ -43,5 +43,4 @@ not work as expected.
 ~/
 > avd 2
 Starting emulator: Samsung_Tab_A_2019_API_25
-[3] 33463
 ```

--- a/plugins/avd/README.md
+++ b/plugins/avd/README.md
@@ -20,6 +20,7 @@ not work as expected.
 ## Functions
 
 - `avds` - Lists all the AVDs
+  - `-s` will skip the AVD numbers at the beginning of each output line
 - `avd [-v] <n>` - Launches n-th AVD from the AVDs list printed by
   `avds`
   - `-v` will let stdout and stderr print to the console which is
@@ -29,7 +30,7 @@ not work as expected.
 
 ## Aliases
 
-- `emus` - Same as `avds`
+- `emus [-s]` - Same as `avds [-s]`
 - `emu [-v] <n>` - Same as `avd [-v] <n>`
 
 ## Exemplary usage:

--- a/plugins/avd/avd.plugin.zsh
+++ b/plugins/avd/avd.plugin.zsh
@@ -23,7 +23,9 @@ function find_emulator() {
 function avds() {
   local emulator_path
   emulator_path=$(find_emulator)
-  eval "$emulator_path -list-avds"
+
+  # Print all AVDs and prepend each output line with a number, starting at 1.
+  eval "$emulator_path -list-avds" | grep -n '^'
 }
 
 function avd() {

--- a/plugins/avd/avd.plugin.zsh
+++ b/plugins/avd/avd.plugin.zsh
@@ -1,0 +1,81 @@
+function find_emulator() {
+  local emulator_found
+
+  if [[ -n $(command -v emulator) ]]; then
+    emulator_found="emulator"
+  elif [[ -d "$ANDROID_HOME" ]]; then
+    # If there is no emulator in the path, try to find it in $ANDROID_HOME if it
+    # is defined.
+    emulator_found=$(find "$ANDROID_HOME" -name emulator -type f | head -1)
+  fi
+
+  if [[ -n $emulator_found ]]; then
+    echo "$emulator_found"
+  else
+    cat <<< "Emulator not found" 1>&2
+
+    # Use "emulator" even if it's not found just to let the other functions fail
+    # later.
+    echo "emulator"
+  fi
+}
+
+function avds() {
+  local emulator_path
+  emulator_path=$(find_emulator)
+  eval "$emulator_path -list-avds"
+}
+
+function avd() {
+  help() {
+    echo "Usage: avd [-v] [AVD position on the list]"
+    avds
+  }
+
+  local OPTIND o verbose avd_number avd_name avds_count emulator_path
+  while getopts ":v" o; do
+    case "$o" in
+      v)
+        verbose=1;;
+      *)
+        help; return;;
+    esac
+  done
+
+  shift $((OPTIND-1))
+
+  avd_number="$1"
+
+  if [[ -z $avd_number ]]; then
+    help
+    return
+  fi
+
+  avds_count=$(avds | wc -l | grep -Eo '[0-9]+') || return
+
+  if [[ $avds_count -le 0 ]]; then
+    echo "No AVDs found"
+    return
+  fi
+
+  if [[ ($avd_number -lt 1 || $avd_number -gt $avds_count) ]]; then
+    echo "The number must be in 1..${avds_count}"
+    return
+  fi
+
+  avd_name=$(avds | head -"$avd_number" | tail -1)
+  echo "Starting emulator: $avd_name"
+
+  emulator_path=$(find_emulator)
+  cmd_to_execute="$emulator_path -avd $avd_name"
+
+  if [[ $verbose -eq 1 ]]; then
+    eval "$cmd_to_execute"
+  else
+    eval "$cmd_to_execute" > /dev/null 2>&1
+  fi
+}
+
+alias emus="avds"
+alias emu="avd"
+

--- a/plugins/avd/avd.plugin.zsh
+++ b/plugins/avd/avd.plugin.zsh
@@ -34,7 +34,7 @@ function avd() {
     avds
   }
 
-  local OPTIND o verbose avd_number avd_name avds_count emulator_path
+  local OPTIND o verbose avd_number avd_name avds_count emulator_path cmd_to_execute
   while getopts ":v" o; do
     case "$o" in
       v)

--- a/plugins/avd/avd.plugin.zsh
+++ b/plugins/avd/avd.plugin.zsh
@@ -89,7 +89,7 @@ function avd() {
     return
   fi
 
-  # Print only the n-th AVD and remove the number prefix added by 'grep -n'
+  # Print only the n-th AVD name.
   avd_name=$(avds -s | head -"$avd_number" | tail -1)
   echo "Starting emulator: $avd_name"
 

--- a/plugins/avd/avd.plugin.zsh
+++ b/plugins/avd/avd.plugin.zsh
@@ -65,7 +65,8 @@ function avd() {
     return
   fi
 
-  avd_name=$(avds | head -"$avd_number" | tail -1)
+  # Print only the n-th AVD and remove the number prefix added by 'grep -n'
+  avd_name=$(avds | head -"$avd_number" | tail -1 | sed -E 's/^[0-9]+://')
   echo "Starting emulator: $avd_name"
 
   emulator_path=$(find_emulator)


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added avd plugin

## Other comments:

- I tested it locally in different conditions (`emulator` tool in path, not in path but available and not available at all) and it seemed to work well in all circumstances.
- I'm open to improvements and suggestions.
- Of course, there are more things a plugin for Android Virtual Devices could do so there are a lot of features that can be added here. The features I'm adding right now are simply the ones I wanted myself while developing Android apps because I found it really tedious to launch an emulator which, normally, requires copy-pasting the AVD name.
- I suggest squashing all my commits with the following commit message: "feat(avd): add avd plugin" (haven't done that myself to keep the history readable in case someone is in the middle of reading this)