### PR TITLE
feat(git): Add alias for 'git switch --detach'

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -167,6 +167,7 @@ plugins=(... git)
 | gsu                  | git submodule update                                                                                                             |
 | gsw                  | git switch                                                                                                                       |
 | gswc                 | git switch -c                                                                                                                    |
+| gswd                 | git switch -d                                                                                                                    |
 | gts                  | git tag -s                                                                                                                       |
 | gtv                  | git tag \| sort -V                                                                                                               |
 | gtl                  | gtl(){ git tag --sort=-v:refname -n -l ${1}* }; noglob gtl                                                                       |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -287,6 +287,7 @@ alias gstall='git stash --all'
 alias gsu='git submodule update'
 alias gsw='git switch'
 alias gswc='git switch -c'
+alias gswd='git switch -d'
 
 alias gts='git tag -s'
 alias gtv='git tag | sort -V'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds the alias `gswd` for `git switch --detach`

## Other comments:

This is an alias that I frequently use for trying out changes from other members of my team.

Example usage: 

1. `gswd origin/that-new-feature`
2. Everything looks good on this branch.
3. `gsw -`
4. Now I'm back to where I was before - without having to delete an unused local branch.

there may be reason to make this `gswdt` to prevent confusion with other aliases that reference the `develop` branch.

### Usage note for remote branches
Using this with a remote branch without specifying the name of the remote (e.g., origin) will result in the following fatal error for most configurations:

`fatal: '--detach' cannot be used with '-b/-B/--orphan'`

This is because the standard git configuration includes `checkout.guess=true`, so git attempts to create a new branch
 when the identifier exists on origin but not locally. Confusingly, it references the `-b/-B` options from `git checkout`, rather than the `-c` option from `git switch`.

`git switch -d --no-guess my-remote-branch` gives a less confusing error in this scenario: `fatal: invalid reference: my-remote-branch`, but I wasn't sure if it made sense to include this flag in the alias. Logically, `git switch --detach` should only be usable with `--no-guess`.