### PR TITLE
feat(kubectl): add aliases for replicasets

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -22,7 +22,7 @@ plugins=(... kubectl)
 | kcsc    | `kubectl config set-context`        | Set a context entry in kubeconfig                                                                |
 | kcdc    | `kubectl config delete-context`     | Delete the specified context from the kubeconfig                                                 |
 | kccc    | `kubectl config current-context`    | Display the current-context                                                                      |
-| kcgc    | `kubectl config get-contexts`       | List of contexts available
+| kcgc    | `kubectl config get-contexts`       | List of contexts available                                                                       |
 |         |                                     | **General aliases**                                                                              |
 | kdel    | `kubectl delete`                    | Delete resources by filenames, stdin, resources and names, or by resources and label selector    |
 | kdelf   | `kubectl delete -f`                 | Delete a pod using the type and name specified in -f argument                                    |
@@ -71,9 +71,11 @@ plugins=(... kubectl)
 | kdeld   | `kubectl delete deployment`         | Delete the deployment                                                                            |
 | ksd     | `kubectl scale deployment`          | Scale a deployment                                                                               |
 | krsd    | `kubectl rollout status deployment` | Check the rollout status of a deployment                                                         |
-| kres    | `kubectl set env $@ REFRESHED_AT=...` | Recreate all pods in deployment with zero-downtime                                                         |
+| kres    | `kubectl set env $@ REFRESHED_AT=...` | Recreate all pods in deployment with zero-downtime                                             |
 |         |                                     | **Rollout management**                                                                           |
-| kgrs    | `kubectl get rs`                    | To see the ReplicaSet `rs` created by the deployment                                             |
+| kgrs    | `kubectl get replicaset`            | List all ReplicaSets `rs` created by the deployment                                              |
+| kdrs    | `kubectl describe replicaset`       | Describe ReplicaSet in detail                                                                    |
+| kers    | `kubectl edit replicaset`           | Edit ReplicaSet from the default editor                                                          |
 | krh     | `kubectl rollout history`           | Check the revisions of this deployment                                                           |
 | kru     | `kubectl rollout undo`              | Rollback to the previous revision                                                                |
 |         |                                     | **Port forwarding**                                                                              |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -102,7 +102,8 @@ kres(){
 }
 
 # Rollout management.
-alias kgrs='kubectl get rs'
+alias kgrs='kubectl get replicaset'
+alias kdrs='kubectl describe replicaset'
 alias krh='kubectl rollout history'
 alias kru='kubectl rollout undo'
 

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -104,6 +104,7 @@ kres(){
 # Rollout management.
 alias kgrs='kubectl get replicaset'
 alias kdrs='kubectl describe replicaset'
+alias kers='kubectl edit replicaset'
 alias krh='kubectl rollout history'
 alias kru='kubectl rollout undo'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add `kdrs` alias for describing replicasets
- Update `kgrs` to allow grepping for `replicaset` more easily
