### PR TITLE
feat(virtualenvwrapper): disable lazy script and force full script wi…

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -8,10 +8,14 @@ function {
       /usr/share/bash-completion/completions/virtualenvwrapper \
       $HOME/.local/bin/virtualenvwrapper.sh
     do
-        if [[ -f "$virtualenvwrapper" ]]; then
-            source "$virtualenvwrapper"
-            return
+      if [[ -f "$virtualenvwrapper" ]]; then
+        if [[ $VIRTUALENVWRAPPER_NO_LAZY -eq 1 ]] && [[ $(echo $virtualenvwrapper | grep lazy) ]]; then
+          true
+        else
+          source "$virtualenvwrapper"
+          return
         fi
+      fi
     done
     print "[oh-my-zsh] virtualenvwrapper plugin: Cannot find virtualenvwrapper.sh.\n"\
           "Please install with \`pip install virtualenvwrapper\`" >&2


### PR DESCRIPTION
…th environment variable

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Allows the user to set an environment variable `VIRTUALENVWRAPPER_NO_LAZY` in their `.zshrc`. If set to one, this forces the loading of the full virtualenvwrapper script. If set to zero or the variable not defined, the lazy script is loaded by default.

## Other comments:

- @mcornella @lbolla  #6842 introduced loading `virtualenvwrapper_lazy.sh` by default if available. Some users (including myself) prefer the full script because the additional loading time is minimal, yet all the functionality is immediately available without first running `workon`. Further justification and explanation provided in feature request #10110.
- This PR allows configuring the behavior with a new environment variable. If this variable is not set, the behavior is exactly the same as the previous default behavior.
