### PR TITLE
Check for INSIDE_EMACS variable definition

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -10,7 +10,7 @@ function title {
   emulate -L zsh
   setopt prompt_subst
 
-  [[ "$INSIDE_EMACS" == *term* ]] && return
+  [[ -v INSIDE_EMACS ]] && return
 
   # if $2 is unset use $1 as default
   # if it is set and empty, leave it as is


### PR DESCRIPTION
In emacs shell mode, the existing code won't trigger
correctly due to the variable not containing term.

This change makes oh-my-zsh play nicer with emacs shell mode.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Check for INSIDE_EMACS variable definition regardless of presence of term.

## Other comments:

...
