### PR TITLE
refactor(sudo): fix code style and other fixes

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -15,48 +15,48 @@
 # ------------------------------------------------------------------------------
 
 __sudo-replace-buffer() {
-    local old=$1 new=$2 space=${2:+ }
-    if [[ ${#LBUFFER} -le ${#old} ]]; then
-        RBUFFER="${space}${BUFFER#$old }"
-        LBUFFER="${new}"
-    else
-        LBUFFER="${new}${space}${LBUFFER#$old }"
-    fi
+  local old=$1 new=$2 space=${2:+ }
+  if [[ ${#LBUFFER} -le ${#old} ]]; then
+    RBUFFER="${space}${BUFFER#$old }"
+    LBUFFER="${new}"
+  else
+    LBUFFER="${new}${space}${LBUFFER#$old }"
+  fi
 }
 
 sudo-command-line() {
-    [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
+  [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
 
-    # Save beginning space
-    local WHITESPACE=""
-    if [[ ${LBUFFER:0:1} = " " ]]; then
-        WHITESPACE=" "
-        LBUFFER="${LBUFFER:1}"
+  # Save beginning space
+  local WHITESPACE=""
+  if [[ ${LBUFFER:0:1} = " " ]]; then
+    WHITESPACE=" "
+    LBUFFER="${LBUFFER:1}"
+  fi
+
+  # Get the first part of the typed command and check if it's an alias to $EDITOR
+  # If so, locally change $EDITOR to the alias so that it matches below
+  if [[ -n "$EDITOR" ]]; then
+    local cmd="${${(Az)BUFFER}[1]}"
+    if [[ "${aliases[$cmd]} " = (\$EDITOR|$EDITOR)\ * ]]; then
+      local EDITOR="$cmd"
     fi
+  fi
 
-    # Get the first part of the typed command and check if it's an alias to $EDITOR
-    # If so, locally change $EDITOR to the alias so that it matches below
-    if [[ -n "$EDITOR" ]]; then
-        local cmd="${${(Az)BUFFER}[1]}"
-        if [[ "${aliases[$cmd]} " = (\$EDITOR|$EDITOR)\ * ]]; then
-            local EDITOR="$cmd"
-        fi
-    fi
+  if [[ -n $EDITOR && $BUFFER = $EDITOR\ * ]]; then
+    __sudo-replace-buffer "$EDITOR" "sudoedit"
+  elif [[ -n $EDITOR && $BUFFER = \$EDITOR\ * ]]; then
+    __sudo-replace-buffer "\$EDITOR" "sudoedit"
+  elif [[ $BUFFER = sudoedit\ * ]]; then
+    __sudo-replace-buffer "sudoedit" "$EDITOR"
+  elif [[ $BUFFER = sudo\ * ]]; then
+    __sudo-replace-buffer "sudo" ""
+  else
+    LBUFFER="sudo $LBUFFER"
+  fi
 
-    if [[ -n $EDITOR && $BUFFER = $EDITOR\ * ]]; then
-        __sudo-replace-buffer "$EDITOR" "sudoedit"
-    elif [[ -n $EDITOR && $BUFFER = \$EDITOR\ * ]]; then
-        __sudo-replace-buffer "\$EDITOR" "sudoedit"
-    elif [[ $BUFFER = sudoedit\ * ]]; then
-        __sudo-replace-buffer "sudoedit" "$EDITOR"
-    elif [[ $BUFFER = sudo\ * ]]; then
-        __sudo-replace-buffer "sudo" ""
-    else
-        LBUFFER="sudo $LBUFFER"
-    fi
-
-    # Preserve beginning space
-    LBUFFER="${WHITESPACE}${LBUFFER}"
+  # Preserve beginning space
+  LBUFFER="${WHITESPACE}${LBUFFER}"
 }
 
 zle -N sudo-command-line

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -25,6 +25,7 @@ __sudo-replace-buffer() {
 }
 
 sudo-command-line() {
+  # If line is empty, get the last run command from history
   [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
 
   # Save beginning space
@@ -34,29 +35,56 @@ sudo-command-line() {
     LBUFFER="${LBUFFER:1}"
   fi
 
-  # Get the first part of the typed command and check if it's an alias to $EDITOR
-  # If so, locally change $EDITOR to the alias so that it matches below
-  if [[ -n "$EDITOR" ]]; then
-    local cmd="${${(Az)BUFFER}[1]}"
-    if [[ "${aliases[$cmd]} " = (\$EDITOR|$EDITOR)\ * ]]; then
-      local EDITOR="$cmd"
-    fi
-  fi
-
-  if [[ -n $EDITOR && $BUFFER = $EDITOR\ * ]]; then
-    __sudo-replace-buffer "$EDITOR" "sudoedit"
-  elif [[ -n $EDITOR && $BUFFER = \$EDITOR\ * ]]; then
-    __sudo-replace-buffer "\$EDITOR" "sudoedit"
-  elif [[ $BUFFER = sudoedit\ * ]]; then
-    __sudo-replace-buffer "sudoedit" "$EDITOR"
-  elif [[ $BUFFER = sudo\ * ]]; then
-    __sudo-replace-buffer "sudo" ""
+  # If $EDITOR is not set, just toggle the sudo prefix on and off
+  if [[ -z "$EDITOR" ]]; then
+    case "$BUFFER" in
+      sudoedit\ *) __sudo-replace-buffer "sudoedit" "" ;;
+      sudo\ *) __sudo-replace-buffer "sudo" "" ;;
+      *) LBUFFER="sudo $LBUFFER" ;;
+    esac
   else
-    LBUFFER="sudo $LBUFFER"
+    # Check if the typed command is really an alias to $EDITOR
+
+    # Get the first part of the typed command
+    local cmd="${${(Az)BUFFER}[1]}"
+    # Get the first part of the alias of the same name as $cmd, or $cmd if no alias matches
+    local realcmd="${${(Az)aliases[$cmd]}[1]:-$cmd}"
+    # Get the first part of the $EDITOR command ($EDITOR may have arguments after it)
+    local editorcmd="${${(Az)EDITOR}[1]}"
+
+    # Note: ${var:c} makes a $PATH search and expands $var to the full path
+    # The if condition is met when:
+    # - $realcmd is '$EDITOR'
+    # - $realcmd is "cmd" and $EDITOR is "cmd"
+    # - $realcmd is "cmd" and $EDITOR is "cmd --with --arguments"
+    # - $realcmd is "/path/to/cmd" and $EDITOR is "cmd"
+    # - $realcmd is "/path/to/cmd" and $EDITOR is "/path/to/cmd"
+    # or
+    # - $realcmd is "cmd" and $EDITOR is "cmd"
+    # - $realcmd is "cmd" and $EDITOR is "/path/to/cmd"
+    # or
+    # - $realcmd is "cmd" and $EDITOR is /alternative/path/to/cmd that appears in $PATH
+    if [[ "$realcmd" = (\$EDITOR|$editorcmd|${editorcmd:c}) \
+      || "${realcmd:c}" = ($editorcmd|${editorcmd:c}) ]] \
+      || builtin which -a "$realcmd" | command grep -Fx -q "$editorcmd"; then
+      editorcmd="$cmd" # replace $editorcmd with the typed command so it matches below
+    fi
+
+    # Check for editor commands in the typed command and replace accordingly
+    case "$BUFFER" in
+      $editorcmd\ *) __sudo-replace-buffer "$editorcmd" "sudoedit" ;;
+      \$EDITOR\ *) __sudo-replace-buffer '$EDITOR' "sudoedit" ;;
+      sudoedit\ *) __sudo-replace-buffer "sudoedit" "$EDITOR" ;;
+      sudo\ *) __sudo-replace-buffer "sudo" "" ;;
+      *) LBUFFER="sudo $LBUFFER" ;;
+    esac
   fi
 
   # Preserve beginning space
   LBUFFER="${WHITESPACE}${LBUFFER}"
+
+  # Redisplay edit buffer (compatibility with zsh-syntax-highlighting)
+  zle redisplay
 }
 
 zle -N sudo-command-line


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adapt code style guide indentation (2 spaces)
- Smarter algorithm to check if the typed command is using `$EDITOR` (fixes #10106)
