### PR TITLE
feat(aws): accept aws mfa tokencode on `acp` cli call

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -15,10 +15,10 @@ plugins=(... aws)
   It also sets `$AWS_EB_PROFILE` to `<profile>` for the Elastic Beanstalk CLI.
   Run `asp` without arguments to clear the profile.
 
-* `acp [<profile>]`: in addition to `asp` functionality, it actually changes the profile by
-   assuming the role specified in the `<profile>` configuration. It supports MFA and sets
-   `$AWS_ACCESS_KEY_ID`, `$AWS_SECRET_ACCESS_KEY` and `$AWS_SESSION_TOKEN`, if obtained. It
-   requires the roles to be configured as per the
+* `acp [<profile>] [<mfa_token>]`: in addition to `asp` functionality, it actually changes
+   the profile by assuming the role specified in the `<profile>` configuration. It supports
+   MFA and sets `$AWS_ACCESS_KEY_ID`, `$AWS_SECRET_ACCESS_KEY` and `$AWS_SESSION_TOKEN`, if
+   obtained. It requires the roles to be configured as per the
    [official guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html).
    Run `acp` without arguments to clear the profile.
 

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -41,6 +41,7 @@ function acp() {
   fi
 
   local profile="$1"
+  local mfa_token="$2"
 
   # Get fallback credentials for if the aws command fails or no command is run
   local aws_access_key_id="$(aws configure get aws_access_key_id --profile $profile)"
@@ -54,9 +55,10 @@ function acp() {
 
   if [[ -n "$mfa_serial" ]]; then
     local -a mfa_opt
-    local mfa_token
-    echo -n "Please enter your MFA token for $mfa_serial: "
-    read -r mfa_token
+    if [[ -z "$mfa_token" ]]; then
+      echo -n "Please enter your MFA token for $mfa_serial: "
+      read -r mfa_token
+    fi
     if [[ -z "$sess_duration" ]]; then
       echo -n "Please enter the session duration in seconds (900-43200; default: 3600, which is the default maximum for a role): "
       read -r sess_duration


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Accept AWS MFA token code on `acp` command line instead of having to wait for the prompt

## Other comments:

...
