### PR TITLE
feat(pyenv): fix `pyenv init` call so it sets PATH properly

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -57,7 +57,7 @@ if [[ $FOUND_PYENV -eq 1 ]]; then
     export PYENV_ROOT="$(pyenv root)"
   fi
 
-  eval "$(pyenv init - --no-rehash zsh)"
+  eval "$(pyenv init - --no-rehash --path zsh)"
 
   if [[ -d "$PYENV_ROOT/plugins/pyenv-virtualenv" ]]; then
     eval "$(pyenv virtualenv-init - zsh)"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- When using pyenv without pyenv-virtualenv, make pyenv behave consistently with the other methods by passing the `--path` option to `pyenv init -`. Without this option, pyenv is initialized but does not get added to `$PATH` and this causes issues with the principle of least surprise.