### PR TITLE
fix(kubectx): show plain context if not mapped

### DIFF
--- a/plugins/kubectx/kubectx.plugin.zsh
+++ b/plugins/kubectx/kubectx.plugin.zsh
@@ -3,12 +3,7 @@ typeset -A kubectx_mapping
 function kubectx_prompt_info() {
   if [ $commands[kubectl] ]; then
     local current_ctx=`kubectl config current-context`
-
-    #if associative array declared
-    if [[ -n $kubectx_mapping ]]; then
-      echo "${kubectx_mapping[$current_ctx]}"
-    else
-      echo $current_ctx
-    fi
+    # use value in associative array if it exists, otherwise fall back to the context name
+    echo "${kubectx_mapping[$current_ctx]:-$current_ctx}"
   fi
 }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- If the associative array is declared but the desired key is not there the plugin will now fall back to the default value.
  Previously this situation would result in the empty string, meaning that if you want to remap some value you would have
  to remap all.