### PR TITLE
feat(brew): improve `brews` list layout

### DIFF
--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -1,5 +1,4 @@
 alias brewp='brew pin'
-alias brews='brew list -1'
 alias brewsp='brew list --pinned'
 alias bubo='brew update && brew outdated'
 alias bubc='brew upgrade && brew cleanup'
@@ -7,3 +6,16 @@ alias bubu='bubo && bubc'
 alias buf='brew upgrade --formula'
 alias bcubo='brew update && brew outdated --cask'
 alias bcubc='brew upgrade --cask && brew cleanup'
+
+function brews() {
+  local formulae="$(brew leaves | xargs brew deps --installed --for-each)"
+  local casks="$(brew list --cask)"
+
+  local blue="$(tput setaf 4)"
+  local bold="$(tput bold)"
+  local off="$(tput sgr0)"
+
+  echo "${blue}==>${off} ${bold}Formulae${off}"
+  echo "${formulae}" | sed "s/^\(.*\):\(.*\)$/\1${blue}\2${off}/"
+  echo "\n${blue}==>${off} ${bold}Casks${off}\n${casks}"
+}


### PR DESCRIPTION
This is an improvement (in my opinion) to the `brews` command that prints each leaf formula (in white), followed by its dependencies (in blue), on each line. Compared to the existing flat list of formulae, the new layout is both more compact and more informative, by differentiating leaves from dependencies at a glance.

Screenshot:
<img width="530" src="https://user-images.githubusercontent.com/1753319/130641713-b78535c9-e3f5-4dbb-80f8-22bc00e1129d.png">

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.