### PR TITLE
Head branch

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -29,17 +29,10 @@ function work_in_progress() {
   fi
 }
 
-# Check if main exists and use instead of master
+# Return the head branch
 function git_main_branch() {
   command git rev-parse --git-dir &>/dev/null || return
-  local branch
-  for branch in main trunk; do
-    if command git show-ref -q --verify refs/heads/$branch; then
-      echo $branch
-      return
-    fi
-  done
-  echo master
+  git branch -rl "*/HEAD" | rev | cut -d/ -f1 | rev
 }
 
 # Check for develop and similarly named branches


### PR DESCRIPTION
I think this should be more robust since it doesn't rely on a fixed list of potential names.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Use `git branch -rl "*/HEAD" | rev | cut -d/ -f1 | rev` to get the `main` branch instead of trying to guess it.

