### PR TITLE
Complete cargo --target=

### DIFF
--- a/plugins/cargo/_cargo
+++ b/plugins/cargo/_cargo
@@ -56,7 +56,7 @@ _cargo() {
     )
 
     msgfmt='--message-format=[specify error format]:error format [human]:(human json short)'
-    triple='--target=[specify target triple]:target triple'
+    triple='--target=[specify target triple]:target triple:_cargo_target_triples'
     target='--target-dir=[specify directory for all generated artifacts]:directory:_directories'
     manifest='--manifest-path=[specify path to manifest]:path:_directories'
     registry='--registry=[specify registry to use]:registry'
@@ -402,6 +402,12 @@ _cargo_test_names() {
 #Gets the bench names from the manifest file
 _cargo_benchmark_names() {
     _cargo_names_from_array "bench"
+}
+
+_cargo_target_triples() {
+    local -a triples
+    triples=( $(rustc --print target-list) )
+    _describe "target triple" triples
 }
 
 _cargo


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Use `rustc --print target-list` to complete `cargo x --target=<|>`