### PR TITLE
feat(lando): add support for `php` command

### DIFF
--- a/plugins/lando/lando.plugin.zsh
+++ b/plugins/lando/lando.plugin.zsh
@@ -8,6 +8,7 @@ function artisan \
          drush \
          gulp \
          npm \
+         php \
          wp \
          yarn {
   if checkForLandoFile; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added php command alias support for lando

## Other comments:
Running `php` in a lando repo's cli (a repo with a .lando.yml in it) will run `lando php` instead.
