### PR TITLE
feat(git): guess main branch name also from remotes

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -32,12 +32,15 @@ function work_in_progress() {
 # Check if main exists and use instead of master
 function git_main_branch() {
   command git rev-parse --git-dir &>/dev/null || return
+  local ref_prefix
   local branch
-  for branch in main trunk; do
-    if command git show-ref -q --verify refs/heads/$branch; then
-      echo $branch
-      return
-    fi
+  for ref_prefix in heads remotes/origin remotes/upstream; do
+    for branch in main trunk; do
+      if command git show-ref -q --verify refs/$ref_prefix/$branch; then
+        echo $branch
+        return
+      fi
+    done
   done
   echo master
 }

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -32,15 +32,12 @@ function work_in_progress() {
 # Check if main exists and use instead of master
 function git_main_branch() {
   command git rev-parse --git-dir &>/dev/null || return
-  local ref_prefix
-  local branch
-  for ref_prefix in heads remotes/origin remotes/upstream; do
-    for branch in main trunk; do
-      if command git show-ref -q --verify refs/$ref_prefix/$branch; then
-        echo $branch
-        return
-      fi
-    done
+  local ref
+  for ref in refs/{heads,remotes/{origin,upstream}}/{main,trunk}; do
+    if command git show-ref -q --verify $ref; then
+      echo ${ref:t}
+      return
+    fi
   done
   echo master
 }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- When guessing the git main branch name consider remote branches from origin or upstream remotes that weren't checked out locally, this allows shortcuts like `gcm`, `glum`, and `gmom` to work even before the main branch is checked out locally.
