### PR TITLE
fix(pyenv): do not warn if PYENV_ROOT is undefined

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -62,14 +62,14 @@ if [[ $FOUND_PYENV -ne 1 ]]; then
 fi
 
 if [[ $FOUND_PYENV -eq 1 ]]; then
-  # Setup $PYENV_ROOT if not already set
   if [[ -z "$PYENV_ROOT" ]]; then
+    # This is only for backwards compatibility with users that previously relied
+    # on this plugin exporting it. pyenv itself does not require it to be exported
     export PYENV_ROOT="$(pyenv root)"
-    pyenv_config_warning 'missing $PYENV_ROOT'
   fi
 
   # Add pyenv shims to $PATH if not already added
-  if [[ -z "${path[(Re)$PYENV_ROOT/shims]}" ]]; then
+  if [[ -z "${path[(Re)$(pyenv root)/shims]}" ]]; then
     eval "$(pyenv init --path)"
     pyenv_config_warning 'missing pyenv shims in $PATH'
   fi
@@ -78,7 +78,7 @@ if [[ $FOUND_PYENV -eq 1 ]]; then
   eval "$(pyenv init - --no-rehash zsh)"
 
   # If pyenv-virtualenv exists, load it
-  if [[ -d "$PYENV_ROOT/plugins/pyenv-virtualenv" && "$ZSH_PYENV_VIRTUALENV" != false ]]; then
+  if [[ -d "$(pyenv root)/plugins/pyenv-virtualenv" && "$ZSH_PYENV_VIRTUALENV" != false ]]; then
     eval "$(pyenv virtualenv-init - zsh)"
   fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- fix(pyenv): do not warn if PYENV_ROOT is undefined

## Other comments:

Fixes #10161 . See issue for details

Unfortunately this plugin has been exporting PYENV_ROOT since b85e1dd5d6b0ee527b313ce8c902bbc4e34e36e0 (18th August 2021), so we continue to export it to avoid breaking users that have since relied on it, but pyenv itself does not need it to be defined.