### PR TITLE
fix(cp): add unique suffix to rsync backup directory for each user

### DIFF
--- a/plugins/cp/README.md
+++ b/plugins/cp/README.md
@@ -25,7 +25,7 @@ The enabled options for rsync are:
 
 * `-hhh`: outputs numbers in human-readable format, in units of 1024 (K, M, G, T).
 
-* `--backup-dir=/tmp/rsync`: move backup copies to "/tmp/rsync".
+* `--backup-dir=/tmp/rsync-$USER`: move backup copies to "/tmp/rsync-$USER".
 
 * `-e /dev/null`: only work on local files (disable remote shells).
 

--- a/plugins/cp/README.md
+++ b/plugins/cp/README.md
@@ -25,7 +25,7 @@ The enabled options for rsync are:
 
 * `-hhh`: outputs numbers in human-readable format, in units of 1024 (K, M, G, T).
 
-* `--backup-dir=/tmp/rsync-$USER`: move backup copies to "/tmp/rsync-$USER".
+* `--backup-dir="/tmp/rsync-$USERNAME"`: move backup copies to "/tmp/rsync-$USERNAME".
 
 * `-e /dev/null`: only work on local files (disable remote shells).
 

--- a/plugins/cp/cp.plugin.zsh
+++ b/plugins/cp/cp.plugin.zsh
@@ -1,4 +1,4 @@
 cpv() {
-    rsync -pogbr -hhh --backup-dir="/tmp/rsync-${USER:-"$(whoami)"}" -e /dev/null --progress "$@"
+    rsync -pogbr -hhh --backup-dir="/tmp/rsync-${USERNAME}" -e /dev/null --progress "$@"
 }
 compdef _files cpv

--- a/plugins/cp/cp.plugin.zsh
+++ b/plugins/cp/cp.plugin.zsh
@@ -1,4 +1,4 @@
 cpv() {
-    rsync -pogbr -hhh --backup-dir=/tmp/rsync -e /dev/null --progress "$@"
+    rsync -pogbr -hhh --backup-dir="/tmp/rsync-${USER:-"$(whoami)"}" -e /dev/null --progress "$@"
 }
 compdef _files cpv


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Add a unique suffix (the user name) to `rsync` backup directory for each user.

## Other comments:

If the path to the backup directory is a fixed location, this may cause permission issues on a multi-user operating system (e.g., on a Linux server).

Suppose USERALICE uses the command `cpv` and that creates the backup folder `/tmp/rsync`. Then this backup folder is owned by USERALICE and anyone else on the system does not have permission to write this folder (to use `cpv` command).