### PR TITLE
feat(tig): add `tdo` alias to show current branch and its upstream branch

### DIFF
--- a/plugins/tig/README.md
+++ b/plugins/tig/README.md
@@ -9,8 +9,9 @@ plugins=(... tig)
 
 ## Features
 
-| Alias | Command        | Description                                     |
-|-------|----------------|-------------------------------------------------|
-| `tis` | `tig status`   | Show git status                                 |
-| `til` | `tig log`      | Show git log                                    |
-| `tib` | `tig blame -C` | `git-blame` a file detecting copies and renames |
+| Alias | Command             | Description                                                |
+|-------|---------------------|------------------------------------------------------------|
+| `tis` | `tig status`        | Show git status                                            |
+| `til` | `tig log`           | Show git log                                               |
+| `tib` | `tig blame -C`      | `git-blame` a file detecting copies and renames            |
+| `tdo` | `tig HEAD@{u} HEAD` | tig show(or diff) current branch and its origin(upsteam)   |

--- a/plugins/tig/tig.plugin.zsh
+++ b/plugins/tig/tig.plugin.zsh
@@ -1,3 +1,4 @@
 alias tis='tig status'
 alias til='tig log'
 alias tib='tig blame -C'
+alias tdo='tig HEAD@{u} HEAD'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added alias for tig, showing current branch and its origin branch in one tig view

## Other comments:

N/A
