### PR TITLE
docs(kubectx): fix README sample code syntax

### DIFF
--- a/plugins/kubectx/README.md
+++ b/plugins/kubectx/README.md
@@ -17,7 +17,7 @@ One can rename default context name for better readability.
 
 _Example_. Add to **.zshrc**:
 ```
-kubectx_mapping[minikube] = "mini"
+kubectx_mapping[minikube]="mini"
 kubectx_mapping[context_name_from_kubeconfig]="$emoji[wolf_face]"
 kubectx_mapping[production_cluster]="%{$fg[yellow]%}prod!%{$reset_color%}"
 ```


### PR DESCRIPTION
Remove spaces that cause a syntax error