### PR TITLE
refactor(vim-interaction): clean up code and open gvim instance if none open

### DIFF
--- a/plugins/vim-interaction/vim-interaction.plugin.zsh
+++ b/plugins/vim-interaction/vim-interaction.plugin.zsh
@@ -4,8 +4,7 @@
 # Derek Wyatt (derek@{myfirstnamemylastname}.org
 # 
 
-function callvim
-{
+function callvim {
   if [[ $# == 0 ]]; then
     cat <<EOH
 usage: callvim [-b cmd] [-a cmd] [-n name] [file ... fileN]
@@ -19,11 +18,20 @@ EOH
     return 0
   fi
 
-  local cmd=""
-  local before="<esc>"
-  local after=""
-  # Look up the newest instance
+  # Look up the newest instance or start one
   local name="$(gvim --serverlist | tail -n 1)"
+  [[ -n "$name" ]] || {
+    # run gvim or exit if it fails
+    gvim || return $?
+
+    # wait for gvim instance to fully load
+    while name=$(gvim --serverlist) && [[ -z "$name" ]]; do
+      sleep 0.1
+    done
+  }
+
+  local before="<esc>" files after cmd
+
   while getopts ":b:a:n:" option
   do
     case $option in
@@ -36,22 +44,20 @@ EOH
     esac
   done
   shift $((OPTIND-1))
-  if [[ ${after#:} != $after && ${after%<cr>} == $after ]]; then
-    after="$after<cr>"
-  fi
-  if [[ ${before#:} != $before && ${before%<cr>} == $before ]]; then
-    before="$before<cr>"
-  fi
-  local files
-  if [[ $# -gt 0 ]]; then
-    # absolute path of files resolving symlinks (:A) and quoting special chars (:q)
-    files=':args! '"${@:A:q}<cr>"
-  fi
+
+  # If before or after commands begin with : and don't end with <cr>, append it
+  [[ ${after}  = :* && ${after}  != *\<cr\> ]] && after+="<cr>"
+  [[ ${before} = :* && ${before} != *\<cr\> ]] && before+="<cr>"
+  # Open files passed (:A means abs path resolving symlinks, :q means quoting special chars)
+  [[ $# -gt 0 ]] && files=':args! '"${@:A:q}<cr>"
+  # Pass the built vim command to gvim
   cmd="$before$files$after"
-  gvim --servername "$name" --remote-send "$cmd"
-  if typeset -f postCallVim > /dev/null; then
-    postCallVim
-  fi
+
+  # Run the gvim command
+  gvim --servername "$name" --remote-send "$cmd" || return $?
+
+  # Run postCallVim if defined (maybe to bring focus to gvim, see README)
+  (( ! $+functions[postCallVim] )) || postCallVim
 }
 
 alias v=callvim


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Simplified `$before` and `$after` command building.
- Open a gvim instance if none found.
- Clean up syntax to be more idiomatic zsh.
