### PR TITLE
style(installer): use rainbow logo and polish success message

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -72,6 +72,15 @@ fmt_code() {
 setup_color() {
   # Only use colors if connected to a terminal
   if [ -t 1 ]; then
+    RAINBOW="
+      $(printf '\033[38;5;196m')
+      $(printf '\033[38;5;202m')
+      $(printf '\033[38;5;226m')
+      $(printf '\033[38;5;082m')
+      $(printf '\033[38;5;021m')
+      $(printf '\033[38;5;093m')
+      $(printf '\033[38;5;163m')
+    "
     RED=$(printf '\033[31m')
     GREEN=$(printf '\033[32m')
     YELLOW=$(printf '\033[33m')
@@ -79,6 +88,7 @@ setup_color() {
     BOLD=$(printf '\033[1m')
     RESET=$(printf '\033[m')
   else
+    RAINBOW=""
     RED=""
     GREEN=""
     YELLOW=""
@@ -243,6 +253,27 @@ EOF
   echo
 }
 
+setup_success() {
+  printf '%s         %s__      %s           %s        %s       %s     %s__   %s\n' $RAINBOW $RESET
+  printf '%s  ____  %s/ /_    %s ____ ___  %s__  __  %s ____  %s_____%s/ /_  %s\n' $RAINBOW $RESET
+  printf '%s / __ \%s/ __ \  %s / __ `__ \%s/ / / / %s /_  / %s/ ___/%s __ \ %s\n' $RAINBOW $RESET
+  printf '%s/ /_/ /%s / / / %s / / / / / /%s /_/ / %s   / /_%s(__  )%s / / / %s\n' $RAINBOW $RESET
+  printf '%s\____/%s_/ /_/ %s /_/ /_/ /_/%s\__, / %s   /___/%s____/%s_/ /_/  %s\n' $RAINBOW $RESET
+  printf '%s    %s        %s           %s /____/ %s       %s     %s          %s....is now installed!%s\n' $RAINBOW $GREEN $RESET
+  printf %s "$GREEN"
+  cat <<EOF
+
+
+Before you scream Oh My Zsh! please look over the ~/.zshrc file to select plugins, themes, and options.
+
+• Follow us on Twitter: $(fmt_underline https://twitter.com/ohmyzsh)
+• Join our Discord server: $(fmt_underline https://discord.gg/ohmyzsh)
+• Get stickers, shirts, coffee mugs and other swag: $(fmt_underline https://shop.planetargon.com/collections/oh-my-zsh)
+
+EOF
+  printf %s "$RESET"
+}
+
 main() {
   # Run as unattended if stdin is not a tty
   if [ ! -t 0 ]; then
@@ -293,26 +324,7 @@ EOF
   setup_zshrc
   setup_shell
 
-  printf %s "$GREEN"
-  cat <<'EOF'
-         __                                     __
-  ____  / /_     ____ ___  __  __   ____  _____/ /_
- / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \
-/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / /
-\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/
-                        /____/                       ....is now installed!
-
-
-EOF
-  cat <<EOF
-Before you scream Oh My Zsh! please look over the ~/.zshrc file to select plugins, themes, and options.
-
-• Follow us on Twitter: $(fmt_underline https://twitter.com/ohmyzsh)
-• Join our Discord server: $(fmt_underline https://discord.gg/ohmyzsh)
-• Get stickers, shirts, coffee mugs and other swag: $(fmt_underline https://shop.planetargon.com/collections/oh-my-zsh)
-
-EOF
-  printf %s "$RESET"
+  setup_success
 
   if [ $RUNZSH = no ]; then
     echo "${YELLOW}Run zsh to try it out.${RESET}"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -56,22 +56,106 @@ command_exists() {
   command -v "$@" >/dev/null 2>&1
 }
 
+# The [ -t 1 ] check only works when the function is not called from
+# a subshell (like in `$(...)` or `(...)`, so this hack redefines the
+# function at the top level to always return false when stdout is not
+# a tty.
+if [ -t 1 ]; then
+  is_tty() {
+    true
+  }
+else
+  is_tty() {
+    false
+  }
+fi
+
+# This function uses the logic from supports-hyperlinks[1][2], which is
+# made by Kat Marchán (@zkat) and licensed under the Apache License 2.0.
+# [1] https://github.com/zkat/supports-hyperlinks
+# [2] https://crates.io/crates/supports-hyperlinks
+#
+# Copyright (c) 2021 Kat Marchán
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+supports_hyperlinks() {
+  # $FORCE_HYPERLINK must be set and be non-zero (this acts as a logic bypass)
+  if [ -n "$FORCE_HYPERLINK" ]; then
+    [ "$FORCE_HYPERLINK" != 0 ]
+    return $?
+  fi
+
+  # If stdout is not a tty, it doesn't support hyperlinks
+  is_tty || return 1
+
+  # DomTerm terminal emulator (domterm.org)
+  if [ -n "$DOMTERM" ]; then
+    return 0
+  fi
+
+  # VTE-based terminals above v0.50 (Gnome Terminal, Guake, ROXTerm, etc)
+  if [ -n "$VTE_VERSION" ]; then
+    [ $VTE_VERSION -ge 5000 ]
+    return $?
+  fi
+
+  # If $TERM_PROGRAM is set, these terminals support hyperlinks
+  case "$TERM_PROGRAM" in
+  Hyper|iTerm.app|terminology|WezTerm) return 0 ;;
+  esac
+
+  # kitty supports hyperlinks
+  if [ "$TERM" = xterm-kitty ]; then
+    return 0
+  fi
+
+  # Windows Terminal or Konsole also support hyperlinks
+  if [ -n "$WT_SESSION" ] || [ -n "$KONSOLE_VERSION" ]; then
+    return 0
+  fi
+
+  return 1
+}
+
+fmt_link() {
+  # $1: text, $2: url, $3: fallback mode
+  if supports_hyperlinks; then
+    printf '\033]8;;%s\a%s\033]8;;\a\n' "$2" "$1"
+    return
+  fi
+
+  case "$3" in
+  --text) printf '%s\n' "$1" ;;
+  --url|*) fmt_underline "$2" ;;
+  esac
+}
+
+fmt_underline() {
+  is_tty && printf '\033[4m%s\033[24m\n' "$*" || printf '%s\n' "$*"
+}
+
+# shellcheck disable=SC2016 # backtick in single-quote
+fmt_code() {
+  is_tty && printf '`\033[2m%s\033[22m`\n' "$*" || printf '`%s`\n' "$*"
+}
+
 fmt_error() {
   printf '%sError: %s%s\n' "$BOLD$RED" "$*" "$RESET" >&2
 }
 
-fmt_underline() {
-  printf '\033[4m%s\033[24m\n' "$*"
-}
-
-fmt_code() {
-  # shellcheck disable=SC2016 # backtick in single-quote
-  printf '`\033[38;5;247m%s%s`\n' "$*" "$RESET"
-}
-
 setup_color() {
   # Only use colors if connected to a terminal
-  if [ -t 1 ]; then
+  if is_tty; then
     RAINBOW="
       $(printf '\033[38;5;196m')
       $(printf '\033[38;5;202m')
@@ -253,25 +337,24 @@ EOF
   echo
 }
 
-setup_success() {
+# shellcheck disable=SC2183  # printf string has more %s than arguments ($RAINBOW expands to multiple arguments)
+print_success() {
   printf '%s         %s__      %s           %s        %s       %s     %s__   %s\n' $RAINBOW $RESET
   printf '%s  ____  %s/ /_    %s ____ ___  %s__  __  %s ____  %s_____%s/ /_  %s\n' $RAINBOW $RESET
   printf '%s / __ \%s/ __ \  %s / __ `__ \%s/ / / / %s /_  / %s/ ___/%s __ \ %s\n' $RAINBOW $RESET
   printf '%s/ /_/ /%s / / / %s / / / / / /%s /_/ / %s   / /_%s(__  )%s / / / %s\n' $RAINBOW $RESET
   printf '%s\____/%s_/ /_/ %s /_/ /_/ /_/%s\__, / %s   /___/%s____/%s_/ /_/  %s\n' $RAINBOW $RESET
   printf '%s    %s        %s           %s /____/ %s       %s     %s          %s....is now installed!%s\n' $RAINBOW $GREEN $RESET
-  printf %s "$GREEN"
-  cat <<EOF
-
-
-Before you scream Oh My Zsh! please look over the ~/.zshrc file to select plugins, themes, and options.
-
-• Follow us on Twitter: $(fmt_underline https://twitter.com/ohmyzsh)
-• Join our Discord server: $(fmt_underline https://discord.gg/ohmyzsh)
-• Get stickers, shirts, coffee mugs and other swag: $(fmt_underline https://shop.planetargon.com/collections/oh-my-zsh)
-
-EOF
-  printf %s "$RESET"
+  printf '\n'
+  printf '\n'
+  printf "%s %s %s\n" "Before you scream ${BOLD}${YELLOW}Oh My Zsh!${RESET} look over the" \
+    "$(fmt_code "$(fmt_link ".zshrc" "file://$HOME/.zshrc" --text)")" \
+    "file to select plugins, themes, and options."
+  printf '\n'
+  printf '%s\n' "• Follow us on Twitter: $(fmt_link @ohmyzsh https://twitter.com/ohmyzsh)"
+  printf '%s\n' "• Join our Discord community: $(fmt_link "Discord server" https://discord.gg/ohmyzsh)"
+  printf '%s\n' "• Get stickers, t-shirts, coffee mugs and more: $(fmt_link "Planet Argon Shop" https://shop.planetargon.com/collections/oh-my-zsh)"
+  printf '%s\n' $RESET
 }
 
 main() {
@@ -324,7 +407,7 @@ EOF
   setup_zshrc
   setup_shell
 
-  setup_success
+  print_success
 
   if [ $RUNZSH = no ]; then
     echo "${YELLOW}Run zsh to try it out.${RESET}"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- The logo is now displayed in rainbow colors as is done in the update script.
- The success message has improved colors and links are rendered as hyperlinks where it's possible.

## Screenshots:

- installer success screen with hyperlink support:
![installer success screen with hyperlink support](https://user-images.githubusercontent.com/1441704/134493858-69ea9111-1578-464a-8574-314107289634.png)
- installer success screen without hyperlink support:
![installer success screen without hyperlink support](https://user-images.githubusercontent.com/1441704/134493714-772a9f36-acc0-4c85-9788-dedcead0158b.png)
- installer success screen without tty:
![installer success screen without tty](https://user-images.githubusercontent.com/1441704/134494106-0a5319b6-25f5-47bb-a731-348efb2ea49a.png)
