### PR TITLE
feat(lib): don't correct `su` command arguments

### DIFF
--- a/lib/correction.zsh
+++ b/lib/correction.zsh
@@ -9,6 +9,7 @@ if [[ "$ENABLE_CORRECTION" == "true" ]]; then
   alias mv='nocorrect mv'
   alias mysql='nocorrect mysql'
   alias sudo='nocorrect sudo'
+  alias su='nocorrect su'
 
   setopt correct_all
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- no correct alias `su` command

## Other comments:

...
