### PR TITLE
feat(brew): add new aliases for brew services (`bsl`, `bsr`, `bson`, `bsoff`, `bsrunall`, `bsstartall`, and `bsstopall``

### DIFF
--- a/plugins/brew/README.md
+++ b/plugins/brew/README.md
@@ -17,20 +17,26 @@ defined for convenience.
 
 ## Aliases
 
-| Alias    | Command                               | Description                                                         |
-| -------- | ------------------------------------- | ------------------------------------------------------------------- |
-| `bcubc`  | `brew upgrade --cask && brew cleanup` | Update outdated casks, then run cleanup.                            |
-| `bcubo`  | `brew update && brew outdated --cask` | Update Homebrew data, then list outdated casks.                     |
-| `bcubc`  | `brew upgrade --cask && brew cleanup` | Update outdated casks, then run cleanup.                            |
-| `brewp`  | `brew pin`                            | Pin a specified formula so that it's not upgraded.                  |
-| `brews`  | `brew list -1`                        | List installed formulae or the installed files for a given formula. |
-| `brewsp` | `brew list --pinned`                  | List pinned formulae, or show the version of a given formula.       |
-| `bubc`   | `brew upgrade && brew cleanup`        | Upgrade outdated formulae and casks, then run cleanup.              |
-| `bugbc`  | `brew upgrade --greedy && brew cleanup`  | Upgrade outdated formulae and casks (greedy), then run cleanup.         |
-| `bubo`   | `brew update && brew outdated`        | Update Homebrew data, then list outdated formulae and casks.        |
-| `bubu`   | `bubo && bubc`                        | Do the last two operations above.                                   |
-| `buf`    | `brew upgrade --formula`              | Upgrade only formulas (not casks).                                  |
-| `buz`    | `brew uninstall --zap`                | Remove all files associated with a cask.                            |
+| Alias        | Command                                  | Description                                                                               |
+| ------------ | ---------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `bcubc`      | `brew upgrade --cask && brew cleanup`    | Update outdated casks, then run cleanup.                                                  |
+| `bcubo`      | `brew update && brew outdated --cask`    | Update Homebrew data, then list outdated casks.                                           |
+| `brewp`      | `brew pin`                               | Pin a specified formula so that it's not upgraded.                                        |
+| `brews`      | `brew list -1`                           | List installed formulae or the installed files for a given formula.                       |
+| `brewsp`     | `brew list --pinned`                     | List pinned formulae, or show the version of a given formula.                             |
+| `bsl`        | `brew services list`                     | List all running services for the current user (or root).                                 |
+| `bsoff`      | `brew services stop`                     | Stop the service formula immediately and unregister it from launching at login (or boot). |
+| `bson`       | `brew services start`                    | Start the service formula immediately and register it to launch at login (or boot).       |
+| `bsr`        | `brew services run`                      | Run the service formula without registering to launch at login (or boot).                 |
+| `bsrunall`   | Run `bsr` for each service               | Run all stopped services.                                                                 |       
+| `bsstartall` | Run `bson` for each service              | Start all stopped services.                                                               |
+| `bsstopall`  | Run `bsoff` for each service             | Stop all started services.                                                                |
+| `bubc`       | `brew upgrade && brew cleanup`           | Upgrade outdated formulae and casks, then run cleanup.                                    |
+| `bubo`       | `brew update && brew outdated`           | Update Homebrew data, then list outdated formulae and casks.                              |
+| `bubu`       | `bubo && bubc`                           | Do the last two operations above.                                                         |
+| `buf`        | `brew upgrade --formula`                 | Upgrade only formulas (not casks).                                                        |
+| `bugbc`      | `brew upgrade --greedy && brew cleanup`  | Upgrade outdated formulae and casks (greedy), then run cleanup.                           |
+| `buz`        | `brew uninstall --zap`                   | Remove all files associated with a cask.                                                  |
 
 ## Completion
 

--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -50,3 +50,17 @@ function brews() {
   echo "${formulae}" | sed "s/^\(.*\):\(.*\)$/\1${blue}\2${off}/"
   echo "\n${blue}==>${off} ${bold}Casks${off}\n${casks}"
 }
+
+alias bsl='brew services list'
+alias bsr='brew services run'
+alias bson='brew services start'
+alias bsoff='brew services stop'
+
+# Run all stopped services
+alias bsrunall='for service in $(bsl | grep stopped | cut -d" " -f1); bsr $service'
+
+# Start all stopped services
+alias bsstartall='for service in $(bsl | grep stopped | cut -d" " -f1); bson $service'
+
+# Stop all started services
+alias bsstopall='for service in $(bsl | grep started | cut -d" " -f1); bsoff $service'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Add the following aliases:

- `bsl` - List available services
- `bsr` - Run a service
- `bson` - Start a service
- `bsoff` - Stop a service
- `bsrunall` - Run all stopped services
- `bsstartall` - Start all stopped services
- `bsstopall` - Stop all started services
