### PR TITLE
fix(osx): only run Preview.app in `man-preview` if man page exists

### DIFF
--- a/plugins/osx/osx.plugin.zsh
+++ b/plugins/osx/osx.plugin.zsh
@@ -219,7 +219,8 @@ function quick-look() {
 }
 
 function man-preview() {
-  man -t "$@" | open -f -a Preview
+  # Don't let Preview.app steal focus if the man page doesn't exist
+  man -w "$@" &>/dev/null && man -t "$@" | open -f -a Preview || man "$@"
 }
 compdef _man man-preview
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- The current `man-preview` function switches to Preview.app from your terminal if you attempt to open a man page with `man-preview` and the man page doesn't exist. This adds a check to see if the man page exists before piping it into Preview, and, if not, passes the errors through.