### PR TITLE
fix(half-life): fixes input prompt colour issue in the half-life theme (#10085)

### DIFF
--- a/themes/half-life.zsh-theme
+++ b/themes/half-life.zsh-theme
@@ -93,4 +93,6 @@ function steeef_precmd {
 }
 add-zsh-hook precmd steeef_precmd
 
+zle_highlight=( default:fg=white )
 PROMPT=$'%{$purple%}%n%{$reset_color%} in %{$limegreen%}%~%{$reset_color%}$(ruby_prompt_info " with%{$fg[red]%} " v g "%{$reset_color%}")$vcs_info_msg_0_%{$orange%} λ%{$reset_color%} '
+preexec () { echo -n '\033[0m' }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fixes issue #10085
- With this fix, the colour of the input prompt will not change by pressing [TAB] and the output will be displayed in the appropriate colours. 

## Other comments:

...
