### PR TITLE
Refactor and fix various issues in emacs plugin

### DIFF
--- a/plugins/emacs/emacs.plugin.zsh
+++ b/plugins/emacs/emacs.plugin.zsh
@@ -9,57 +9,55 @@
 # - You can share opened buffered across opened frames.
 # - Configuration changes made at runtime are applied to all frames.
 
+# Require emacs version to be minimum 24
+autoload -Uz is-at-least
+is-at-least 24 "${${(Az)"$(emacsclient --version 2>/dev/null)"}[2]}" || return 0
 
-if "$ZSH/tools/require_tool.sh" emacsclient 24 2>/dev/null ; then
-    export EMACS_PLUGIN_LAUNCHER="$ZSH/plugins/emacs/emacsclient.sh"
+# Path to custom emacsclient launcher
+export EMACS_PLUGIN_LAUNCHER="${0:A:h}/emacsclient.sh"
 
-    # set EDITOR if not already defined.
-    export EDITOR="${EDITOR:-${EMACS_PLUGIN_LAUNCHER}}"
+# set EDITOR if not already defined.
+export EDITOR="${EDITOR:-${EMACS_PLUGIN_LAUNCHER}}"
 
-    alias emacs="$EMACS_PLUGIN_LAUNCHER --no-wait"
-    alias e=emacs
-    # open terminal emacsclient
-    alias te="$EMACS_PLUGIN_LAUNCHER -nw"
+alias emacs="$EMACS_PLUGIN_LAUNCHER --no-wait"
+alias e=emacs
+# open terminal emacsclient
+alias te="$EMACS_PLUGIN_LAUNCHER -nw"
 
-    # same than M-x eval but from outside Emacs.
-    alias eeval="$EMACS_PLUGIN_LAUNCHER --eval"
-    # create a new X frame
-    alias eframe='emacsclient --alternate-editor "" --create-frame'
+# same than M-x eval but from outside Emacs.
+alias eeval="$EMACS_PLUGIN_LAUNCHER --eval"
+# create a new X frame
+alias eframe='emacsclient --alternate-editor "" --create-frame'
 
-    # Emacs ANSI Term tracking
-    if [[ -n "$INSIDE_EMACS" ]]; then
-        chpwd_emacs() { print -P "\033AnSiTc %d"; }
-        print -P "\033AnSiTc %d"    # Track current working directory
-        print -P "\033AnSiTu %n"    # Track username        
+# Emacs ANSI Term tracking
+if [[ -n "$INSIDE_EMACS" ]]; then
+  chpwd_emacs() { print -P "\033AnSiTc %d"; }
+  print -P "\033AnSiTc %d"    # Track current working directory
+  print -P "\033AnSiTu %n"    # Track username
 
-        # add chpwd hook
-        autoload -Uz add-zsh-hook
-        add-zsh-hook chpwd chpwd_emacs
-    fi    
-
-    # Write to standard output the path to the file
-    # opened in the current buffer.
-    function efile {
-        local cmd="(buffer-file-name (window-buffer))"
-        "$EMACS_PLUGIN_LAUNCHER" --eval "$cmd" | tr -d \"
-    }
-
-    # Write to standard output the directory of the file
-    # opened in the the current buffer
-    function ecd {
-        local cmd="(let ((buf-name (buffer-file-name (window-buffer))))
-                     (if buf-name (file-name-directory buf-name)))"
-
-        local dir="$($EMACS_PLUGIN_LAUNCHER --eval $cmd | tr -d \")"
-        if [ -n "$dir" ] ;then
-            echo "$dir"
-        else
-            echo "can not deduce current buffer filename." >/dev/stderr
-            return 1
-        fi
-    }
+  # add chpwd hook
+  autoload -Uz add-zsh-hook
+  add-zsh-hook chpwd chpwd_emacs
 fi
 
-## Local Variables:
-## mode: sh
-## End:
+# Write to standard output the path to the file
+# opened in the current buffer.
+function efile {
+  local cmd="(buffer-file-name (window-buffer))"
+  local file="$("$EMACS_PLUGIN_LAUNCHER" --eval "$cmd" | tr -d \")"
+
+  if [[ -z "$file" ]]; then
+    echo "Can't deduce current buffer filename." >&2
+    return 1
+  fi
+
+  echo "$file"
+}
+
+# Write to standard output the directory of the file
+# opened in the the current buffer
+function ecd {
+  local file
+  file="$(efile)" || return $?
+  echo "${file:h}"
+}

--- a/plugins/emacs/emacsclient.sh
+++ b/plugins/emacs/emacsclient.sh
@@ -1,29 +1,27 @@
 #!/bin/sh
 
-_emacsfun()
-{
-    # get list of emacs frames.
-    frameslist=`emacsclient --alternate-editor '' --eval '(frame-list)' 2>/dev/null | egrep -o '(frame)+'`
+emacsfun() {
+  local frames="$(emacsclient --alternate-editor "" -n -e "(length (frame-list))" 2>/dev/null)"
 
-    if [ "$(echo "$frameslist" | sed -n '$=')" -ge 2 ] ;then
-        # prevent creating another X frame if there is at least one present.
-        emacsclient --alternate-editor "" "$@"
-    else
-        # Create one if there is no X window yet.
-        emacsclient --alternate-editor "" --create-frame "$@"
-    fi
+  # Only create another X frame if there isn't one present
+  if [ -z "$frames" -o "$frames" -lt 2 ]; then
+    emacsclient --alternate-editor "" --create-frame "$@"
+    return $?
+  fi
+
+  emacsclient --alternate-editor "" "$@"
 }
 
 
 # adopted from https://github.com/davidshepherd7/emacs-read-stdin/blob/master/emacs-read-stdin.sh
 # If the second argument is - then write stdin to a tempfile and open the
 # tempfile. (first argument will be `--no-wait` passed in by the plugin.zsh)
-if [ "$#" -ge "2" -a "$2" = "-" ]
-then
-    tempfile="$(mktemp --tmpdir emacs-stdin-$USERNAME.XXXXXXX 2>/dev/null \
-                || mktemp -t emacs-stdin-$USERNAME)" # support BSD mktemp
-    cat - > "$tempfile"
-    _emacsfun --no-wait $tempfile
-else
-    _emacsfun "$@"
+if [ $# -ge 2 -a "$2" = "-" ]; then
+  tempfile="$(mktemp --tmpdir emacs-stdin-$USERNAME.XXXXXXX 2>/dev/null \
+    || mktemp -t emacs-stdin-$USERNAME)" # support BSD mktemp
+  cat - > "$tempfile"
+  emacsfun --no-wait "$tempfile"
+  return $?
 fi
+
+emacsfun "$@"

--- a/plugins/emacs/emacsclient.sh
+++ b/plugins/emacs/emacsclient.sh
@@ -22,16 +22,17 @@ emacsfun() {
   emacsclient --alternate-editor "" "$@"
 }
 
-
-# adopted from https://github.com/davidshepherd7/emacs-read-stdin/blob/master/emacs-read-stdin.sh
+# Adapted from https://github.com/davidshepherd7/emacs-read-stdin/blob/master/emacs-read-stdin.sh
 # If the second argument is - then write stdin to a tempfile and open the
 # tempfile. (first argument will be `--no-wait` passed in by the plugin.zsh)
 if [ $# -ge 2 -a "$2" = "-" ]; then
+  # Create a tempfile to hold stdin
   tempfile="$(mktemp --tmpdir emacs-stdin-$USERNAME.XXXXXXX 2>/dev/null \
     || mktemp -t emacs-stdin-$USERNAME)" # support BSD mktemp
+  # Redirect stdin to the tempfile
   cat - > "$tempfile"
-  emacsfun --no-wait "$tempfile"
-  return $?
+  # Reset $2 to the tempfile so that "$@" works as expected
+  set -- "$1" "$tempfile" "${@:3}"
 fi
 
 emacsfun "$@"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Remove dependency on `require_tool.sh` and use `is-at-least` instead.
- Fix code style in `emacsclient.sh`.
- Fix test for open frames in `emacsclient` wrapper: supports testing for tty and graphical frames.
- Fix passing stdin as arguments to `emacsclient` wrapper.

Fixes #5405
Fixes #5779