### PR TITLE
Improve Pacman Plugin

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -12,39 +12,37 @@ plugins=(... archlinux)
 
 ### Pacman
 
-| Alias        | Command                                | Description                                                      |
-|--------------|----------------------------------------|------------------------------------------------------------------|
-| pacin        | `sudo pacman -S`                       | Install packages from the repositories                           |
-| pacins       | `sudo pacman -U`                       | Install a package from a local file                              |
-| pacinsd      | `sudo pacman -S --asdeps`              | Install packages as dependencies of another package              |
-| pacloc       | `pacman -Qi`                           | Display information about a package in the local database        |
-| paclocs      | `pacman -Qs`                           | Search for packages in the local database                        |
-| paclsorphans | `sudo pacman -Qdt`                     | List all orphaned packages                                       |
-| pacmir       | `sudo pacman -Syy`                     | Force refresh of all package lists after updating mirrorlist     |
-| pacre        | `sudo pacman -R`                       | Remove packages, keeping its settings and dependencies           |
-| pacrem       | `sudo pacman -Rns`                     | Remove packages, including its settings and dependencies         |
-| pacrep       | `pacman -Si`                           | Display information about a package in the repositories          |
-| pacreps      | `pacman -Ss`                           | Search for packages in the repositories                          |
-| pacrmorphans | `sudo pacman -Rs $(pacman -Qtdq)`      | Delete all orphaned packages                                     |
-| pacupd       | `sudo pacman -Sy`                      | Update and refresh local package, ABS and AUR databases          |
-| pacupg       | `sudo pacman -Syu`                     | Sync with repositories before upgrading packages                 |
-| pacfileupg   | `sudo pacman -Fy`                      | Download fresh package databases from the server                 |
-| pacfiles     | `pacman -F`                            | Search package file names for matching strings                   |
-| pacls        | `pacman -Ql`                           | List files in a package                                          |
-| pacown       | `pacman -Qo`                           | Show which package owns a file                                   |
-| upgrade[¹](#f1) | `sudo pacman -Syu`                  | Sync with repositories before upgrading packages                 |
+| Alias        | Command                                | Description                                                                    |
+|--------------|----------------------------------------|--------------------------------------------------------------------------------|
+| pacin        | `sudo pacman -S`                       | Install packages from the repositories                                         |
+| pacins       | `sudo pacman -U`                       | Install a package from a local file                                            |
+| pacinsd      | `sudo pacman -S --asdeps`              | Install packages as dependencies of another package                            |
+| pacmir       | `sudo pacman -Syy`                     | Force refresh of all package lists after updating mirrorlist                   |
+| pacre        | `sudo pacman -R`                       | Remove packages, keeping its settings and dependencies                         |
+| pacrem       | `sudo pacman -Rns`                     | Remove packages, including its settings and dependencies                       |
+| pacgr        | `pacman -Sg`                           | Display packages belong to a group                                             | 
+| pacrep       | `pacman -Si`                           | Display information about a package in the repositories                        |
+| pacreps      | `pacman -Ss`                           | Search for packages in the repositories                                        |
+| pacorphans   | `pacman -Qet`                          | List all packages explicitly installed and not required as dependencies        |
+| pacupd       | `sudo pacman -Sy`                      | Update and refresh local package, ABS and AUR databases                        |
+| pacupg       | `sudo pacman -Syu`                     | Sync with repositories before upgrading packages                               |
+| pacfileupg   | `sudo pacman -Fy`                      | Download fresh package databases from the server                               |
+| pacfiles     | `pacman -F`                            | Search package file names for matching strings                                 |
+| paclist      | `pacman -Qe`                           | List all explicitly installed packages with version number                     |
+| pacloc       | `pacman -Qi`                           | Display information about a package in the local database                      |
+| paclocs      | `pacman -Qs`                           | Search for packages in the local database                                      |
+| pacls        | `pacman -Ql`                           | List files in a package                                                        |
+| paclsorphans | `pacman -Qdt`                          | List all orphaned packages                                                     |
+| pacown       | `pacman -Qo`                           | Show which package owns a file                                                 |
+| upgrade[¹](#f1) | `sudo pacman -Syu`                  | Sync with repositories before upgrading packages                               |
 
 | Function       | Description                                               |
 |----------------|-----------------------------------------------------------|
 | pacdisowned    | List all disowned files in your system                    |
-| paclist        | List all explicitly installed packages with a description |
 | pacmanallkeys  | Get all keys for developers and trusted users             |
 | pacmansignkeys | Locally trust all keys passed as parameters               |
 | pacweb         | Open the website of an ArchLinux package                  |
 
-Note: paclist used to print packages with a description which are (1) explicitly installed
-and (2) available for upgrade. Due to flawed scripting, it also printed all packages if no
-upgrades were available. Use `pacman -Que` instead.
 
 ### AUR helpers
 

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -2,33 +2,28 @@
 #               Pacman                #
 #######################################
 
-# Pacman - https://wiki.archlinux.org/index.php/Pacman_Tips
-alias pacupg='sudo pacman -Syu'
+# Pacman - https://wiki.archlinux.org/title/pacman
 alias pacin='sudo pacman -S'
 alias pacins='sudo pacman -U'
+alias pacinsd='sudo pacman -S --asdeps'
 alias pacre='sudo pacman -R'
 alias pacrem='sudo pacman -Rns'
+alias pacgr='pacman -Sg'
 alias pacrep='pacman -Si'
 alias pacreps='pacman -Ss'
+alias pacmir='sudo pacman -Syy'
+alias pacorphans='pacman -Qet'
+alias pacfiles='pacman -F'
+alias pacfileupg='sudo pacman -Fy'
 alias pacloc='pacman -Qi'
 alias paclocs='pacman -Qs'
-alias pacinsd='sudo pacman -S --asdeps'
-alias pacmir='sudo pacman -Syy'
-alias paclsorphans='sudo pacman -Qdt'
-alias pacrmorphans='sudo pacman -Rs $(pacman -Qtdq)'
-alias pacfileupg='sudo pacman -Fy'
-alias pacfiles='pacman -F'
+alias paclist='pacman -Qe'
 alias pacls='pacman -Ql'
+alias paclsorphans='pacman -Qdt'
 alias pacown='pacman -Qo'
 alias pacupd="sudo pacman -Sy"
+alias pacupg='sudo pacman -Syu'
 alias upgrade='sudo pacman -Syu'
-
-function paclist() {
-  # Based on https://bbs.archlinux.org/viewtopic.php?id=93683
-  pacman -Qqe | \
-    xargs -I '{}' \
-      expac "${bold_color}% 20n ${fg_no_bold[white]}%d${reset_color}" '{}'
-}
 
 function pacdisowned() {
   local tmp db fs


### PR DESCRIPTION
Since version 6, some Pacman functions have been changed. Most of them
were addressed here and root previleges were removed from some commands
that is not required anymore.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
1. Added `pacgr` which can be used to show packages in a group.
2. Removed `pacrmorphans`, as it can break the system now.
3. Removed `paclist`, as it doesn't work anymore.
4. Reorganized the list a bit.