### PR TITLE
feat(init): show error and process tree if OMZ is loaded from non-zsh shells

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -1,8 +1,40 @@
 # Protect against non-zsh execution of Oh My Zsh (use POSIX syntax here)
 [ -n "$ZSH_VERSION" ] || {
-  # ANSI (\033[<code>m): 0: reset, 1: bold, 4: underline, 22: no bold, 24: no underline, 31: red
-  printf "\033[1;31mERROR:\033[22m Oh My Zsh can't be loaded from: \033[1m${0#-}\033[22m. " >&2
-  printf "You need to run \033[1;4mzsh\033[22;24m instead.\033[0m\n" >&2
+  # ANSI formatting function (\033[<code>m)
+  # 0: reset, 1: bold, 4: underline, 22: no bold, 24: no underline, 31: red, 33: yellow
+  f() {
+    [ $# -gt 0 ] || return
+    IFS=";" printf "\033[%sm" $*
+  }
+  # If stdout is not a terminal ignore all formatting
+  [ -t 1 ] || f() { :; }
+
+  ptree() {
+    # Get process tree of the current process
+    pid=$$; pids="$pid"
+    while [ ${pid-0} -ne 1 ] && ppid=$(ps -e -o pid,ppid | awk "\$1 == $pid { print \$2 }"); do
+      pids="$pids $pid"; pid=$ppid
+    done
+
+    # Show process tree
+    case "$(uname)" in
+    Linux) ps -o ppid,pid,command -f -p $pids 2>/dev/null ;;
+    Darwin|*) ps -o ppid,pid,command -p $pids 2>/dev/null ;;
+    esac
+
+    # If ps command failed, try Busybox ps
+    [ $? -eq 0 ] || ps -o ppid,pid,comm | awk "NR == 1 || index(\"$pids\", \$2) != 0"
+  }
+
+  {
+    shell=$(ps -o pid,comm | awk "\$1 == $$ { print \$2 }")
+    printf "$(f 1 31)Error:$(f 22) Oh My Zsh can't be loaded from: $(f 1)${shell}$(f 22). "
+    printf "You need to run $(f 1)zsh$(f 22) instead.$(f 0)\n"
+    printf "$(f 33)Here's the process tree:$(f 22)\n\n"
+    ptree
+    printf "$(f 0)\n"
+  } >&2
+
   return 1
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Removes formatting when output is non-tty
- Adds `ptree` function that gathers information about the process tree of the caller shell
- Correctly gets shell name from `$$` process command

## Other comments:

Related: #10213 