### PR TITLE
Add kubectl horizontal pod autoscaler alias

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -45,6 +45,9 @@ alias kdp='kubectl describe pods'
 alias kdelp='kubectl delete pods'
 alias kgpall='kubectl get pods --all-namespaces -o wide'
 
+# Horizontal Pod Autoscaler
+alias kghpa='kubectl get hpa'
+
 # get pod by label: kgpl "app=myapp" -n myns
 alias kgpl='kgp -l'
 


### PR DESCRIPTION
Signed-off-by: Arthur Diniz <arthurbdiniz@gmail.com>

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add kubectl horizontal pod autoscaler alias inside kubectl plugin file.

Closes: https://github.com/ohmyzsh/ohmyzsh/issues/10029