### PR TITLE
Add option to have update reminder instead of update prompt

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -78,17 +78,21 @@ function update_ohmyzsh() {
   if [[ "$DISABLE_UPDATE_PROMPT" = true ]]; then
     update_ohmyzsh
   else
-    # input sink to swallow all characters typed before the prompt
-    # and add a newline if there wasn't one after characters typed
-    while read -t -k 1 option; do true; done
-    [[ "$option" != ($'\n'|"") ]] && echo
+    if [[ "$UPDATE_NOTIFICATION" = true ]]; then
+      echo "[oh-my-zsh] There is an update available for oh-my-zsh. You can update using \"omz update\"."
+    else
+      # input sink to swallow all characters typed before the prompt
+      # and add a newline if there wasn't one after characters typed
+      while read -t -k 1 option; do true; done
+      [[ "$option" != ($'\n'|"") ]] && echo
 
-    echo -n "[oh-my-zsh] Would you like to update? [Y/n] "
-    read -r -k 1 option
-    [[ "$option" != $'\n' ]] && echo
-    case "$option" in
-      [yY$'\n']) update_ohmyzsh ;;
-      [nN]) update_last_updated_file ;;
-    esac
+      echo -n "[oh-my-zsh] Would you like to update? [Y/n] "
+      read -r -k 1 option
+      [[ "$option" != $'\n' ]] && echo
+      case "$option" in
+        [yY$'\n']) update_ohmyzsh ;;
+        [nN]) update_last_updated_file ;;
+      esac
+    fi
   fi
 }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds an option to have an update reminder rather than an update prompt upon startup
- Addresses #10187 

## Other comments:
- **I haven't been able to test it yet** because I haven't received any OMZ updates. I would hold off on merging until I or someone else can properly test it.
- My code technically doesn't follow the coding style because line 82 of `check_for_upgrade.sh` is about 100 characters long. I couldn't find a way to reasonably split the line. This may not actually be a violation of the style guidelines, but I thought it's better to be safe than sorry.
