### PR TITLE
feat(prompt): add git short-hash option to git_prompt_info via env var

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -29,7 +29,13 @@ function git_prompt_info() {
     && upstream=" -> ${upstream}"
   fi
 
-  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref}${upstream}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
+  # Use global ZSH_THEME_GIT_SHOW_COMMITHASH=1 for including current HEAD commit short hash
+  local commitHash
+  if (( ${+ZSH_THEME_GIT_SHOW_COMMITHASH} )); then
+    commitHash="[$(git_prompt_short_sha)]"
+  fi
+
+  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref}${commitHash}${upstream}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
 }
 
 # Checks if working tree is dirty


### PR DESCRIPTION
Utilizing env:`ZSH_THEME_GIT_SHOW_COMMITHASH`, which potentially could greatly help developers, simply from the terminal prompt, to recover latest local HEAD commit after altering or removing commands (like: `commit --ammend` or `rebase`).

It is using the same existing strategy of env:`ZSH_THEME_GIT_SHOW_UPSTREAM`.

---

Example with `jonathan` theme (while the `cwd` is a git repo)

**Before** 

<img width="202" alt="Screenshot 2021-10-10 at 20 14 47" src="https://user-images.githubusercontent.com/17128077/136708259-6718ffe8-3dc6-4feb-aed5-02b467281b9a.png">

**After**

<img width="291" alt="Screenshot 2021-10-10 at 20 15 07" src="https://user-images.githubusercontent.com/17128077/136708269-83e1325f-4b96-43b7-969e-db704d789dca.png">

---

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Updating the `git_prompt_info` function adding short-hash of the HEAD commit, if the env var `ZSH_THEME_GIT_SHOW_COMMITHASH` is set to 1

## Other comments:

N/A
