### PR TITLE
fix(docker-compose): support Compose V2 `docker compose` command

### DIFF
--- a/plugins/docker-compose/docker-compose.plugin.zsh
+++ b/plugins/docker-compose/docker-compose.plugin.zsh
@@ -1,28 +1,22 @@
-# Authors:
-# https://github.com/tristola
-#
-# Docker-compose related zsh aliases
+# support Compose v2 as docker CLI plugin
+command docker compose &>/dev/null && dccmd='docker compose' || dccmd='docker-compose'
 
-# Aliases ###################################################################
+alias dco="$dccmd"
+alias dcb="$dccmd build"
+alias dce="$dccmd exec"
+alias dcps="$dccmd ps"
+alias dcrestart="$dccmd restart"
+alias dcrm="$dccmd rm"
+alias dcr="$dccmd run"
+alias dcstop="$dccmd stop"
+alias dcup="$dccmd up"
+alias dcupb="$dccmd up --build"
+alias dcupd="$dccmd up -d"
+alias dcdn="$dccmd down"
+alias dcl="$dccmd logs"
+alias dclf="$dccmd logs -f"
+alias dcpull="$dccmd pull"
+alias dcstart="$dccmd start"
+alias dck="$dccmd kill"
 
-# Use dco as alias for docker-compose, since dc on *nix is 'dc - an arbitrary precision calculator'
-# https://www.gnu.org/software/bc/manual/dc-1.05/html_mono/dc.html
-
-alias dco='docker-compose'
-
-alias dcb='docker-compose build'
-alias dce='docker-compose exec'
-alias dcps='docker-compose ps'
-alias dcrestart='docker-compose restart'
-alias dcrm='docker-compose rm'
-alias dcr='docker-compose run'
-alias dcstop='docker-compose stop'
-alias dcup='docker-compose up'
-alias dcupb='docker-compose up --build'
-alias dcupd='docker-compose up -d'
-alias dcdn='docker-compose down'
-alias dcl='docker-compose logs'
-alias dclf='docker-compose logs -f'
-alias dcpull='docker-compose pull'
-alias dcstart='docker-compose start'
-alias dck='docker-compose kill'
+unset dccmd


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Tests if `docker compose` runs successfully and uses that to decide whether to use `docker-compose` or `docker compose` in the aliases.

## Other comments:

Fixes #10231 #10241
