### PR TITLE
feat(kubectl): add aliases for HPA management

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -120,6 +120,13 @@ plugins=(... kubectl)
 | kecj    | `kubectl edit cronjob`              | Edit CronJob from the default editor                                                             |
 | kdcj    | `kubectl describe cronjob`          | Describe a CronJob in details                                                                    |
 | kdelcj  | `kubectl delete cronjob`            | Delete the CronJob                                                                               |
+|         |                                     | **HorizontalPodAutoscaler management**                                                           |
+| kghpa   | `kubectl get hpa`                   | List all HorizontalPodAutoscalers in ps output format                                            |
+| kghpaw  | `kghpa --watch`                     | After listing all HorizontalPodAutoscalers, watch for changes                                    |
+| kehpa   | `kubectl edit hpa`                  | Edit a HorizontalPodAutoscaler from default editor                                               |
+| kdhpa   | `kubectl describe hpa`              | Describe a HorizontalPodAutoscaler in detail                                                     |
+| kdelhpa | `kubectl delete hpa`                | Delete all HorizontalPodAutoscalers matching passed argument                                     |
+| kas     | `kubectl autoscale`                 | Create a HorizontalPodAutoscaler for a targeted resource                                         |
 
 ## Wrappers
 

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -168,6 +168,15 @@ alias kecj='kubectl edit cronjob'
 alias kdcj='kubectl describe cronjob'
 alias kdelcj='kubectl delete cronjob'
 
+# HorizontalPodAutoScaler management.
+alias kghpa='kubectl get hpa'
+alias kghpaa='kubectl get hpa --all-namespaces'
+alias kghpaw='kghpa --watch'
+alias kehpa='kubectl edit hpa'
+alias kdhpa='kubectl describe hpa'
+alias kdelhpa='kubectl delete hpa'
+alias kas='kubectl autoscale'
+
 # Only run if the user actually has kubectl installed
 if (( ${+_comps[kubectl]} )); then
   kj() { kubectl "$@" -o json | jq; }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds a full set of aliases to manage HorizontalPodAutoscaler objects with kubectl

## Other comments:

- Fixes #10029 