### PR TITLE
feat(git): add `gupom` and `gupomi` aliases

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -177,6 +177,7 @@ plugins=(... git)
 | gupv                 | git pull --rebase -v                                                                                                             |
 | gupa                 | git pull --rebase --autostash                                                                                                    |
 | gupav                | git pull --rebase --autostash -v                                                                                                 |
+| gupom                | git pull --rebase origin $(git_main_branch)                                                                                      |
 | glum                 | git pull upstream $(git_main_branch)                                                                                             |
 | gwch                 | git whatchanged -p --abbrev-commit --pretty=medium                                                                               |
 | gwip                 | git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"           |

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -178,6 +178,7 @@ plugins=(... git)
 | gupa                 | git pull --rebase --autostash                                                                                                    |
 | gupav                | git pull --rebase --autostash -v                                                                                                 |
 | gupom                | git pull --rebase origin $(git_main_branch)                                                                                      |
+| gupomi               | git pull --rebase=interactive origin $(git_main_branch)                                                                          |
 | glum                 | git pull upstream $(git_main_branch)                                                                                             |
 | gwch                 | git whatchanged -p --abbrev-commit --pretty=medium                                                                               |
 | gwip                 | git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"           |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -299,6 +299,7 @@ alias gup='git pull --rebase'
 alias gupv='git pull --rebase -v'
 alias gupa='git pull --rebase --autostash'
 alias gupav='git pull --rebase --autostash -v'
+alias gupom='git pull --rebase origin $(git_main_branch)'
 alias glum='git pull upstream $(git_main_branch)'
 
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -300,6 +300,7 @@ alias gupv='git pull --rebase -v'
 alias gupa='git pull --rebase --autostash'
 alias gupav='git pull --rebase --autostash -v'
 alias gupom='git pull --rebase origin $(git_main_branch)'
+alias gupomi='git pull --rebase=interactive origin $(git_main_branch)'
 alias glum='git pull upstream $(git_main_branch)'
 
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'


### PR DESCRIPTION
Alias `gupom` to `git pull --rebase origin $(git_main_branch)`.
It is a very common practice for me to rebase off latest remote origin/main once I am finished with a PR, so that the commit history is clean.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Alias `gupom` to `git pull --rebase origin $(git_main_branch)`
- Update README to reflect the new alias

## Other comments:

*Note in this section that I am using `master`/`main`/`$(git_main_branch)` interchangibly in some places, as the PR I am referencing was created before using `git_main_branch` was common practice.*

Also see @hikaru-shindo's PR https://github.com/ohmyzsh/ohmyzsh/pull/8988, which introduces `alias grbom='git rebase origin/master'`.
This is a good suggestion, but it does not cover the full scope of my desires, mainly because it rebases off local origin/master (the version last fetched), not remote origin/master.
I could achieve similar behavior with `gfa && grbom`, but I feel that rebasing off the latest remote master is a common enough practice that a convenient single alias is justified.

CC @hikaru-shindo, @SimenB, @mcornella
