### PR TITLE
fix(git)!: rename `gdu` alias to `gdup`

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -67,7 +67,7 @@ plugins=(... git)
 | gds                  | git diff --staged                                                                                                                |
 | gdt                  | git diff-tree --no-commit-id --name-only -r                                                                                      |
 | gdnolock             | git diff $@ ":(exclude)package-lock.json" ":(exclude)&ast;.lock"                                                                 |
-| gdu                  | git diff @{u}                                                                                                                    |
+| gdup                 | git diff @{upstream}                                                                                                             |
 | gdv                  | git diff -w $@ \| view -                                                                                                         |
 | gdw                  | git diff --word-diff                                                                                                             |
 | gf                   | git fetch                                                                                                                        |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -126,7 +126,7 @@ alias gdcw='git diff --cached --word-diff'
 alias gdct='git describe --tags $(git rev-list --tags --max-count=1)'
 alias gds='git diff --staged'
 alias gdt='git diff-tree --no-commit-id --name-only -r'
-alias gduu='git diff @{u}'
+alias gdup='git diff @{upstream}'
 alias gdw='git diff --word-diff'
 
 function gdnolock() {

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -126,7 +126,7 @@ alias gdcw='git diff --cached --word-diff'
 alias gdct='git describe --tags $(git rev-list --tags --max-count=1)'
 alias gds='git diff --staged'
 alias gdt='git diff-tree --no-commit-id --name-only -r'
-alias gdu='git diff @{u}'
+alias gduu='git diff @{u}'
 alias gdw='git diff --word-diff'
 
 function gdnolock() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
Switching the git alias `gdu` to `gduu`, to avoid conflicts with [gdu](https://github.com/dundee/gdu) following `git diff` alias syntax.
This PR closes #10201.

Thanks!