### PR TITLE
fix: typo error in ubuntu plugin

### DIFF
--- a/plugins/ubuntu/README.md
+++ b/plugins/ubuntu/README.md
@@ -19,7 +19,7 @@ Commands that use `$APT` will use `apt` if installed or defer to `apt-get` other
 | acp     | `apt-cache policy`                                                       | Display the package source priorities                                                             |
 | afs     | `apt-file search --regexp`                                               | Perform a regular expression apt-file search                                                      |
 | afu     | `sudo apt-file update`                                                   | Generates or updates the apt-file package database                                                |
-| aga     | `sudo $APT autoclean`                                                    | Clears out the local reposityory of retrieved package files that can no longer be downloaded      |
+| aga     | `sudo $APT autoclean`                                                    | Clears out the local repository of retrieved package files that can no longer be downloaded      |
 | agb     | `sudo $APT build-dep <source_pkg>`                                       | Installs/Removes packages to satisfy the dependencies of a specified build pkg                    |
 | agc     | `sudo $APT clean`                                                        | Clears out the local repository of retrieved package files leaving everything from the lock files |
 | agd     | `sudo $APT dselect-upgrade`                                              | Follows dselect choices for package installation                                                  |


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- I only fixed a small typo error 😅

## Other comments:

...
