### PR TITLE
fix aliasing to "diff --color" from hanging the script

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -40,7 +40,7 @@ if [[ "$DISABLE_LS_COLORS" != "true" ]]; then
 fi
 
 # enable diff color if possible.
-if command diff --color . . &>/dev/null; then
+if command diff --color "$0" "$0" &>/dev/null; then
   alias diff='diff --color'
 fi
 


### PR DESCRIPTION
The current implementation to check if diff should alias to "diff --color" is
to try if "diff --color . ." works. However when "." cannot diff fast enough,
say if it's a huge, deep directory or if it's a remotely mounted directory, it 
could hang and wait until `diff` completely scans the current directory.

Since all we need is to see if `diff --color` works this commit simply replace
"." with "$0", which is the path to this script and therefore the existence is
guaranteed and can be processed rather quickly.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ *] The PR title is descriptive.
- [* ] The PR doesn't replicate another PR which is already open.
- [ *] I have read the contribution guide and followed all the instructions.
- [ *] The code follows the code style guide detailed in the wiki.
- [ *] The code is mine or it's from somewhere with an MIT-compatible license.
- [ *] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ *] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
