### PR TITLE
fix(pip): use `pip3` in `pip3 uninstall` completion

### DIFF
--- a/plugins/pip/_pip
+++ b/plugins/pip/_pip
@@ -13,7 +13,7 @@ _pip_all() {
 }
 
 _pip_installed() {
-  installed_pkgs=(`pip freeze | cut -d '=' -f 1`)
+  installed_pkgs=(`$aliases[pip] freeze | cut -d '=' -f 1`)
 }
 
 local -a _1st_arguments

--- a/plugins/pip/_pip
+++ b/plugins/pip/_pip
@@ -13,7 +13,7 @@ _pip_all() {
 }
 
 _pip_installed() {
-  installed_pkgs=(`$aliases[pip] freeze | cut -d '=' -f 1`)
+  installed_pkgs=($($service freeze | cut -d '=' -f 1))
 }
 
 local -a _1st_arguments


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

If only `pip3` is present in the shell environment,
pip uninstall tab returns an error like:

    _pip_installed:2: command not found: pip

This change makes it possible to alias `pip` to `pip3` and keep the completions
working as intended.

Whatever command that the `pip` command aliases is used for generating
the uninstall completions.

Fixes #8977

## Other comments:

n.a
