### PR TITLE
Fix bira theme error when presenting conda info

### DIFF
--- a/lib/prompt_info_functions.zsh
+++ b/lib/prompt_info_functions.zsh
@@ -41,3 +41,13 @@ ZSH_THEME_RVM_PROMPT_OPTIONS="i v g"
 function ruby_prompt_info() {
   echo $(rvm_prompt_info || rbenv_prompt_info || chruby_prompt_info)
 }
+
+# use this to enable users to see their conda env info
+conda_prompt_info() {
+    if [ -n "$CONDA_DEFAULT_ENV" ]; then
+        conda config --set changeps1 false
+        echo -n "%{$terminfo[bold]$fg[yellow]%}($CONDA_DEFAULT_ENV) %{$reset_color%}"
+    else
+        echo -n ''
+    fi
+}

--- a/themes/bira.zsh-theme
+++ b/themes/bira.zsh-theme
@@ -13,10 +13,11 @@ local current_dir='%{$terminfo[bold]$fg[blue]%}%~ %{$reset_color%}'
 local git_branch='$(git_prompt_info)'
 local rvm_ruby='$(ruby_prompt_info)'
 local venv_prompt='$(virtualenv_prompt_info)'
+local conda_prompt='$(conda_prompt_info)'
 
 ZSH_THEME_RVM_PROMPT_OPTIONS="i v g"
 
-PROMPT="╭─${user_host}${current_dir}${rvm_ruby}${git_branch}${venv_prompt}
+PROMPT="╭─${conda_prompt}${user_host}${current_dir}${rvm_ruby}${git_branch}${venv_prompt}
 ╰─%B${user_symbol}%b "
 RPROMPT="%B${return_code}%b"
 


### PR DESCRIPTION
Signed-off-by: elfisworking <zymustb@126.com>

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [x] add a conda_prompt_info function to get conda env info
- [x] edit bria.theme  

## Other comments:
when using bira theme, it would show conda env info incorrecly! For example
...
![Screenshot from 2021-10-09 15-33-19](https://user-images.githubusercontent.com/37609214/136649168-93131b54-33c3-470c-83a4-f4012d6d087c.png)
After fix:
![Screenshot from 2021-10-09 15-40-22](https://user-images.githubusercontent.com/37609214/136649188-6199f404-397d-4eb7-8c61-1aaf5b3447be.png)



