### PR TITLE
Fix gccd invocation without destination folder

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -100,7 +100,7 @@ alias gcf='git config --list'
 
 function gccd() {
   command git clone --recurse-submodules "$@"
-  [[ -d "$_" ]] && cd "$_" || cd "${${_:h}%.git}"
+  [[ -d "$_" ]] && cd "$_" || cd "${${_:t}%.git}"
 }
 compdef _git gccd=git-clone
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- instead of taking `head` of the parameter (github username), take the `tail` (repo name)