### PR TITLE
feat(git): Add difftool alias (gdtl)

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -66,6 +66,7 @@ plugins=(... git)
 | gdct                 | git describe --tags $(git rev-list --tags --max-count=1)                                                                         |
 | gds                  | git diff --staged                                                                                                                |
 | gdt                  | git diff-tree --no-commit-id --name-only -r                                                                                      |
+| gdtl                 | git difftool --no-prompt                                                                                                         |
 | gdnolock             | git diff $@ ":(exclude)package-lock.json" ":(exclude)&ast;.lock"                                                                 |
 | gdup                 | git diff @{upstream}                                                                                                             |
 | gdv                  | git diff -w $@ \| view -                                                                                                         |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -126,6 +126,7 @@ alias gdcw='git diff --cached --word-diff'
 alias gdct='git describe --tags $(git rev-list --tags --max-count=1)'
 alias gds='git diff --staged'
 alias gdt='git diff-tree --no-commit-id --name-only -r'
+alias gdtl='git difftool --no-prompt'
 alias gdup='git diff @{upstream}'
 alias gdw='git diff --word-diff'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds the alias `gdtl` alias to call the `git difftool --no-prompt` command
- Documents the new alias in the git plugin documentation

## Other comments:

This command was removed a few years ago in favor of `git diff-tree --no-commit-id --name-only -r` because of the duplicate alias, `gdt`. This addition will add back the command `git difftool --no-prompt` without overwriting any already existing aliases.

Resolves #10298 given that the other alias in that feature request already exists.