### PR TITLE
fix(bgnotify): avoid permission prompts by checking frontmost app ID

### DIFF
--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -20,9 +20,15 @@ if ! (type bgnotify_formatted | grep -q 'function'); then ## allow custom functi
   }
 fi
 
+currentAppId () {
+  if (( $+commands[osascript] )); then
+    osascript -e 'tell application (path to frontmost application as text) to id' 2>/dev/null
+  fi
+}
+
 currentWindowId () {
   if hash osascript 2>/dev/null; then #osx
-    osascript -e 'tell application "System Events" to get unix id of application processes whose frontmost is true' 2&> /dev/null || echo "0"
+    osascript -e 'tell application (path to frontmost application as text) to id of front window' 2&> /dev/null || echo "0"
   elif (hash notify-send 2>/dev/null || hash kdialog 2>/dev/null); then #ubuntu!
     xprop -root 2> /dev/null | awk '/NET_ACTIVE_WINDOW/{print $5;exit} END{exit !$5}' || echo "0"
   else
@@ -32,11 +38,20 @@ currentWindowId () {
 
 bgnotify () { ## args: (title, subtitle)
   if hash terminal-notifier 2>/dev/null; then #osx
-    [[ "$TERM_PROGRAM" == 'iTerm.app' ]] && term_id='com.googlecode.iterm2';
-    [[ "$TERM_PROGRAM" == 'Apple_Terminal' ]] && term_id='com.apple.terminal';
+    local term_id="$bgnotify_appid"
+    if [[ -z "$term_id" ]]; then
+      case "$TERM_PROGRAM" in
+      iTerm.app) term_id='com.googlecode.iterm2' ;;
+      Apple_Terminal) term_id='com.apple.terminal' ;;
+      esac
+    fi
+
     ## now call terminal-notifier, (hopefully with $term_id!)
-    [ -z "$term_id" ] && terminal-notifier -message "$2" -title "$1" >/dev/null ||
-    terminal-notifier -message "$2" -title "$1" -activate "$term_id" -sender "$term_id" >/dev/null
+    if [[ -z "$term_id" ]]; then
+      terminal-notifier -message "$2" -title "$1" >/dev/null
+    else
+      terminal-notifier -message "$2" -title "$1" -activate "$term_id" -sender "$term_id" >/dev/null
+    fi
   elif hash growlnotify 2>/dev/null; then #osx growl
     growlnotify -m "$1" "$2"
   elif hash notify-send 2>/dev/null; then #ubuntu gnome!
@@ -54,6 +69,7 @@ bgnotify () { ## args: (title, subtitle)
 bgnotify_begin() {
   bgnotify_timestamp=$EPOCHSECONDS
   bgnotify_lastcmd="${1:-$2}"
+  bgnotify_appid="$(currentAppId)"
   bgnotify_windowid=$(currentWindowId)
 }
 
@@ -62,7 +78,7 @@ bgnotify_end() {
   elapsed=$(( EPOCHSECONDS - bgnotify_timestamp ))
   past_threshold=$(( elapsed >= bgnotify_threshold ))
   if (( bgnotify_timestamp > 0 )) && (( past_threshold )); then
-    if [ $(currentWindowId) != "$bgnotify_windowid" ]; then
+    if [[ $(currentAppId) != "$bgnotify_appid" || $(currentWindowId) != "$bgnotify_windowid" ]]; then
       print -n "\a"
       bgnotify_formatted "$didexit" "$bgnotify_lastcmd" "$elapsed"
     fi

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -22,7 +22,7 @@ fi
 
 currentWindowId () {
   if hash osascript 2>/dev/null; then #osx
-    osascript -e 'tell application (path to frontmost application as text) to id of front window' 2&> /dev/null || echo "0"
+    osascript -e 'tell application "System Events" to get unix id of application processes whose frontmost is true' 2&> /dev/null || echo "0"
   elif (hash notify-send 2>/dev/null || hash kdialog 2>/dev/null); then #ubuntu!
     xprop -root 2> /dev/null | awk '/NET_ACTIVE_WINDOW/{print $5;exit} END{exit !$5}' || echo "0"
   else


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Replaced the applescript to get the pid of the frontmost app instead of the window id of the active window.

## Other comments:

On recent macOS versions, getting the window id of the active window of the frontmost app using `osascript` and `tell` requires granting permission for controlling said app. This means that if `bgnotify` is active and one puts the terminal in the background, after the terminal process completes it will spawn a permission request window relating to the app currently in the foreground. Obviously this gets annoying really quickly as each new foreground app has to be approved separately. Getting the pid of the frontmost app only requires this permission to be granted once, for the "System Events" app.
