### PR TITLE
chore(ubuntu): add documentation for `acsp` alias

### DIFF
--- a/plugins/ubuntu/README.md
+++ b/plugins/ubuntu/README.md
@@ -16,6 +16,7 @@ Commands that use `$APT` will use `apt` if installed or defer to `apt-get` other
 |---------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | age     | `sudo $APT`                                                              | Run apt-get with sudo                                                                             |
 | acs     | `apt-cache search`                                                       | Search the apt-cache with the specified criteria                                                  |
+| acsp    | `apt-cache showpkg`                                                      | Shows information about the listed packages                                                       |
 | acp     | `apt-cache policy`                                                       | Display the package source priorities                                                             |
 | afs     | `apt-file search --regexp`                                               | Perform a regular expression apt-file search                                                      |
 | afu     | `sudo apt-file update`                                                   | Generates or updates the apt-file package database                                                |


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Documented the `acsp` alias

## Other comments:

I noticed documentation was missing for this alias, so I decided to add it for any missing aliases in this plugin and it ended up that it was only this alias.