### PR TITLE
feat(sudo): allow running aliases and functions with `sudo`

### DIFF
--- a/plugins/sudo/README.md
+++ b/plugins/sudo/README.md
@@ -1,8 +1,8 @@
 # sudo
 
 This plugin adds a shortcut to easily add or remove `sudo` from the command line
-when pressing <kbd>Esc</kbd> twice. It also adds a function to be able to run
-zsh functions with sudo.
+when pressing <kbd>Esc</kbd> twice. It also adds an alias and a function to be
+able to run aliases and functions with sudo.
 
 To use it, add `sudo` to the plugins array in your zshrc file:
 
@@ -15,6 +15,14 @@ plugins=(... sudo)
 - **Key binding**: press <kbd>Esc</kbd> twice to add or remove `sudo` from the command line.
   It has support for `sudoedit`. See the [key binding examples](#examples) section for more
   information.
+
+- **Aliases**: to make sudo work with aliases, the plugin adds an alias to sudo that makes
+  it so aliases are expanded when prepended with `sudo`. This is achieved by adding an
+  extra space to the alias:
+
+  ```zsh
+  alias sudo='sudo '
+  ```
 
 - **Functions**: to run a function with `sudo`, use `sudofn`. This function allows you
   to run a function in a new zsh process, so the whole function has admin privileges.

--- a/plugins/sudo/README.md
+++ b/plugins/sudo/README.md
@@ -1,6 +1,8 @@
 # sudo
 
-Easily prefix your current or previous commands with `sudo` by pressing <kbd>esc</kbd> twice
+This plugin adds a shortcut to easily add or remove `sudo` from the command line
+when pressing <kbd>Esc</kbd> twice. It also adds a function to be able to run
+zsh functions with sudo.
 
 To use it, add `sudo` to the plugins array in your zshrc file:
 
@@ -10,36 +12,63 @@ plugins=(... sudo)
 
 ## Usage
 
-### Current typed commands
+- **Key binding**: press <kbd>Esc</kbd> twice to add or remove `sudo` from the command line.
+  It has support for `sudoedit`. See the [key binding examples](#examples) section for more
+  information.
 
-Say you have typed a long command and forgot to add `sudo` in front:
+- **Functions**: to run a function with `sudo`, use `sudofn`. This function allows you
+  to run a function in a new zsh process, so the whole function has admin privileges.
+  This can be helpful when using functions from an Oh My Zsh plugin, like `systemadmin`.
+  Be careful when using this; all effects of the function will be run as root.
+  Examples:
 
-```console
-$ apt-get install build-essential
-```
+  ```zsh
+  # This runs the sudo-me function with arguments "one", "two" and "three"
+  sudofn sudo-me one two three
 
-By pressing the <kbd>esc</kbd> key twice, you will have the same command with `sudo` prefixed without typing:
+  # You might want to use this if omz is installed in a directory owned by root
+  sudofn omz update
 
-```console
-$ sudo apt-get install build-essential
-```
+  # This runs the sudo-me function while passing options to the zsh
+  # process (you might want to do this for testing purposes)
+  # -f: don't read rc files, -x: run zsh in debug mode
+  sudofn -f -x sudo-me one two three
+  ```
 
-### Previous executed commands
+  The key binding will automatically prepend `sudofn` when you want to call a function.
 
-Say you want to delete a system file and denied:
+## Examples
 
-```console
-$ rm some-system-file.txt
--su: some-system-file.txt: Permission denied
-$
-```
+- Typed commands:
 
-By pressing the <kbd>esc</kbd> key twice, you will have the same command with `sudo` prefixed without typing:
+  Say you have typed a long command and forgot to add `sudo` in front:
 
-```console
-$ rm some-system-file.txt
--su: some-system-file.txt: Permission denied
-$ sudo rm some-system-file.txt
-Password:
-$
-```
+  ```console
+  $ apt-get install build-essential
+  ```
+
+  By pressing the <kbd>Esc</kbd> key twice, you will have the same command with `sudo` prefixed without typing:
+
+  ```console
+  $ sudo apt-get install build-essential
+  ```
+
+- Previously executed commands:
+
+  Say you want to delete a system file and get permission denied:
+
+  ```console
+  $ rm some-system-file.txt
+  -su: some-system-file.txt: Permission denied
+  $
+  ```
+
+  By pressing the <kbd>Esc</kbd> key twice, you will have the same command with `sudo` prefixed without typing:
+
+  ```console
+  $ rm some-system-file.txt
+  -su: some-system-file.txt: Permission denied
+  $ sudo rm some-system-file.txt
+  Password:
+  $
+  ```

--- a/plugins/sudo/_sudofn
+++ b/plugins/sudo/_sudofn
@@ -1,0 +1,20 @@
+#compdef sudofn
+
+_sudofn() {
+  local -a fns excl
+
+  # Get functions that don't start with _
+  fns=(${(ok)functions:#_*})
+  # Ignore sudofn and functions that haven't been loaded
+  excl=(sudofn ${${(k)functions[(R)builtin autoload *]}:#_*})
+  fns=(${fns:|excl})
+
+  # 1. Suggest function names as the first argument
+  # 2. Use function's own completion logic to complete the rest of the arguments:
+  #    `*:: :` makes it so the argument position is reset and the typed command is ignored
+  #    `${_comps[${words[2]}]}` tries to find the completion function (stored in $_comps) for the
+  #    passed function name (${words[2]}). If none found, use `_files` which suggests filenames.
+  _arguments "1:shell function:($fns)" "*:: :${_comps[${words[2]}]:-_files}"
+}
+
+_sudofn "$@"

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -96,46 +96,6 @@ bindkey -M viins '\e\e' sudo-command-line
 # Add alias to allow calling aliases with sudo
 alias sudo='sudo '
 
-# Add function for calling zsh functions with sudo
-sudofn() {
-  # Optionally allow specifying zsh options when running it. The
-  # zsh arguments need to be specified before the fn name, e.g.:
-  # $ sudofn -f -x funcname arg1 arg2
-  local -a opts
-  while [[ "$1" = [-+]* ]]; do
-    opts+=($1)
-    shift
-  done
-
-  # Return error if function not provided or undefined
-  if [[ -z "$1" ]]; then
-    echo "$0: you need to specify a function" >&2
-    return 1
-  elif (( ! ${+functions[$1]} )); then
-    echo "$0: function is not defined: $1" >&2
-    return 1
-  fi
-
-  # Define the function and run it in a new shell
-  local fn="$1"; shift
-  # Force non-interactive session but load .zshrc
-  command sudo -E -s -- zsh $opts +i -s <<EOF
-source ${ZDOTDIR:-$HOME}/.zshrc
-function $fn {
-${functions[$fn]}
-}
-$fn ${(j: :)${(q)@}}
-EOF
-}
-
-_sudofn() {
-  local -a fns excl
-  # Get functions that don't start with _
-  fns=(${(ok)functions:#_*})
-  # Ignore sudofn and functions that haven't been loaded
-  excl=(sudofn ${${(k)functions[(R)builtin autoload *]}:#_*})
-  fns=(${fns:|excl})
-  _arguments "1:shell function:($fns)" "*:: :${_comps[${words[2]}]:-_files}"
-}
-
-compdef _sudofn sudofn
+# Add function for calling zsh functions with sudo and make it expand aliases
+autoload -Uz sudofn
+alias sudofn='sudofn '

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -93,6 +93,9 @@ bindkey -M emacs '\e\e' sudo-command-line
 bindkey -M vicmd '\e\e' sudo-command-line
 bindkey -M viins '\e\e' sudo-command-line
 
+# Add alias to allow calling aliases with sudo
+alias sudo='sudo '
+
 # Add function for calling zsh functions with sudo
 sudofn() {
   # Optionally allow specifying zsh options when running it. The

--- a/plugins/sudo/sudofn
+++ b/plugins/sudo/sudofn
@@ -1,0 +1,30 @@
+#autoload
+
+# Optionally allow specifying zsh options when running it. The
+# zsh arguments need to be specified before the fn name, e.g.:
+# $ sudofn -f -x funcname arg1 arg2
+local -a opts
+while [[ "$1" = [-+]* ]]; do
+  opts+=($1)
+  shift
+done
+
+# Return error if function not provided or undefined
+if [[ -z "$1" ]]; then
+  echo "$0: you need to specify a function" >&2
+  return 1
+elif (( ! ${+functions[$1]} )); then
+  echo "$0: function is not defined: $1" >&2
+  return 1
+fi
+
+# Define the function and run it in a new shell
+local fn="$1"; shift
+# Force non-interactive session but load .zshrc
+command sudo -E -s -- zsh $opts +i -s <<EOF
+source ${ZDOTDIR:-$HOME}/.zshrc
+function $fn {
+${functions[$fn]}
+}
+$fn ${(j: :)${(q)@}}
+EOF


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds `sudofn` function to run functions with sudo in a new zsh process
- Add alias for `sudo` so that aliases are expanded when run with `sudo`

## Other comments:

To merge, use rebase and merge strategy to pull in all commits separately, for the changelog.