### PR TITLE
fix(cli): exit `omz update` with correct error code

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -751,7 +751,6 @@ function _omz::theme::use {
 }
 
 function _omz::update {
-  local ret=0
   local last_commit=$(cd "$ZSH"; git rev-parse HEAD)
 
   # Run update script
@@ -774,6 +773,4 @@ function _omz::update {
     # Check whether to run a login shell
     [[ "$zsh" = -* || -o login ]] && exec -l "${zsh#-}" || exec "$zsh"
   fi
-
-  return $ret
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- `omz update` exits with 0 while there is an error (see the attached screenshot). With this change, `_omz::update` function return the `$ZSH/tools/upgrade.sh` exit code instead of the last command exit code.

<img width="841" alt="Screen Shot 2021-10-24 at 5 07 53 PM" src="https://user-images.githubusercontent.com/39435912/138597097-66352a73-6fa3-47fe-8373-3c041bcfde9b.png">

