### PR TITLE
feat(rbw): add completion for `rbw` Bitwarden client

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -22,8 +22,8 @@ acr
 acroread
 acs
 acsc
-acss
 acsp
+acss
 actionformats
 Adamantium
 adb
@@ -312,6 +312,7 @@ bisd
 bitboxer
 bitbucket
 bitswap
+bitwarden
 blkio
 blockprofile
 blockprofilerate
@@ -3119,6 +3120,7 @@ rbenv
 rbenvdirs
 rbfu
 RBUFFER
+rbw
 rcfile
 Rchive
 rcs
@@ -4442,8 +4444,8 @@ zrr
 zrs
 zscore
 zse
-zsh'ed
 zsh
+zsh'ed
 zshaddhistory
 zshcmd
 zshcommands

--- a/plugins/rbw/README.md
+++ b/plugins/rbw/README.md
@@ -1,0 +1,12 @@
+# Bitwarden (unofficial) CLI plugin
+
+This plugin adds completion for [rbw](https://github.com/doy/rbw), an unofficial
+CLI for [Bitwarden](https://bitwarden.com).
+
+To use it, add `rbw` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... rbw)
+```
+
+This plugin does not add any aliases.

--- a/plugins/rbw/rbw.plugin.zsh
+++ b/plugins/rbw/rbw.plugin.zsh
@@ -1,0 +1,19 @@
+if (( ! $+commands[rbw] )); then
+  return
+fi
+
+# TODO: 2021-12-28: remove this bit of code as it exists in oh-my-zsh.sh
+# Add completions folder in $ZSH_CACHE_DIR
+command mkdir -p "$ZSH_CACHE_DIR/completions"
+(( ${fpath[(Ie)"$ZSH_CACHE_DIR/completions"]} )) || fpath=("$ZSH_CACHE_DIR/completions" $fpath)
+
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `rbw`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_rbw" ]]; then
+  declare -A _comps
+  autoload -Uz _rbw
+  _comps[rbw]=_rbw
+fi
+
+rbw gen-completions zsh >| "$ZSH_CACHE_DIR/completions/_rbw" &|


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adding [`rbw`](https://github.com/doy/rbw) plugin

## Other comments:

[`rbw`](https://github.com/doy/rbw) is nowadays the most used CLI for [Bitwarden](https://bitwarden.com), an Open Source password manager.