### PR TITLE
feat(fzf): support getting fzf from nix-darwin

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -20,7 +20,9 @@ function setup_using_base_dir() {
         done
 
         if [[ -z "${fzf_base}" ]]; then
-            if (( ${+commands[brew]} )) && dir="$(brew --prefix fzf 2>/dev/null)"; then
+            if (( ${+commands[fzf-share]} )) && dir="$(fzf-share)" && [[ -d "${dir}" ]]; then
+                fzf_base="${dir}"
+            elif (( ${+commands[brew]} )) && dir="$(brew --prefix fzf 2>/dev/null)"; then
                 if [[ -d "${dir}" ]]; then
                     fzf_base="${dir}"
                 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Support getting fzf for nix-darwin on macos

## Other comments:

Changes from #8618 did not work in my case. I have installed nix on macos using nix-darwin.

In my configuration `${HOME}/.nix-profile/share/fzf` does not exist. I propose using `fzf-share` to get the right path if available. As initially explained in #8548, `fzf-share` finds the fzf shell folder which directly contains the completion scripts.
