### PR TITLE
Fix: abort uninstall when unable to change shell

### DIFF
--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -1,3 +1,15 @@
+if hash chsh >/dev/null 2>&1 && [ -f ~/.shell.pre-oh-my-zsh ]; then
+  old_shell=$(cat ~/.shell.pre-oh-my-zsh)
+  echo "Switching your shell back to '$old_shell':"
+  if chsh -s "$old_shell"; then
+    rm -f ~/.shell.pre-oh-my-zsh
+  else
+    echo "Could not change default shell. Change it manually by running chsh"
+    echo "or editing the /etc/passwd file."
+    exit
+  fi
+fi
+
 read -r -p "Are you sure you want to remove Oh My Zsh? [y/N] " confirmation
 if [ "$confirmation" != y ] && [ "$confirmation" != Y ]; then
   echo "Uninstall cancelled"
@@ -23,17 +35,6 @@ if [ -e "$ZSHRC_ORIG" ]; then
   echo "Your original zsh config was restored."
 else
   echo "No original zsh config found"
-fi
-
-if hash chsh >/dev/null 2>&1 && [ -f ~/.shell.pre-oh-my-zsh ]; then
-  old_shell=$(cat ~/.shell.pre-oh-my-zsh)
-  echo "Switching your shell back to '$old_shell':"
-  if chsh -s "$old_shell"; then
-    rm -f ~/.shell.pre-oh-my-zsh
-  else
-    echo "Could not change default shell. Change it manually by running chsh"
-    echo "or editing the /etc/passwd file."
-  fi
 fi
 
 echo "Thanks for trying out Oh My Zsh. It's been uninstalled."


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Fixes https://github.com/ohmyzsh/ohmyzsh/issues/6581: when the system is unable to revert back to the previous shell, the uninstaller aborts the uninstall process.

