### PR TITLE
Add plugin for Bloop

### DIFF
--- a/plugins/bloop/README.md
+++ b/plugins/bloop/README.md
@@ -1,6 +1,6 @@
 # bloop plugin
 
-The plugin adds several aliases for common [bloop](https://https://scalacenter.github.io/bloop/) commands.
+The plugin adds several aliases for common [bloop](https://scalacenter.github.io/bloop/) commands.
 
 To use it, add `bloop` to the plugins array of your zshrc file:
 

--- a/plugins/bloop/README.md
+++ b/plugins/bloop/README.md
@@ -1,0 +1,18 @@
+# bloop plugin
+
+The plugin adds several aliases for common [bloop](https://https://scalacenter.github.io/bloop/) commands.
+
+To use it, add `bloop` to the plugins array of your zshrc file:
+
+```zsh
+plugins=(... bloop)
+```
+
+## Aliases
+
+| Alias    | Command                               | Description                                                         |
+|----------|---------------------------------------|---------------------------------------------------------------------|
+| `bp`     | `brew projects`                       | List the projects in current repository                             |
+| `bc`     | `brew compile `                       | Compile the project                                                 |
+| `bcl`    | `brew clean `                         | Clean the project                                                   |
+| `br`     | `brew run `                           | Run the project                                                     |

--- a/plugins/bloop/README.md
+++ b/plugins/bloop/README.md
@@ -12,7 +12,7 @@ plugins=(... bloop)
 
 | Alias    | Command                               | Description                                                         |
 |----------|---------------------------------------|---------------------------------------------------------------------|
-| `bp`     | `brew projects`                       | List the projects in current repository                             |
-| `bc`     | `brew compile `                       | Compile the project                                                 |
-| `bcl`    | `brew clean `                         | Clean the project                                                   |
-| `br`     | `brew run `                           | Run the project                                                     |
+| `bp`     | `bloop projects`                      | List the projects in current repository                             |
+| `bc`     | `bloop compile `                      | Compile the project                                                 |
+| `bcl`    | `bloop clean `                        | Clean the project                                                   |
+| `br`     | `bloop run `                          | Run the project                                                     |

--- a/plugins/bloop/bloop.plugin.zsh
+++ b/plugins/bloop/bloop.plugin.zsh
@@ -1,0 +1,4 @@
+alias bp='bloop projects'
+alias bc='bloop compile '
+alias bcl='bloop clean '
+alias br='bloop run '


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Other comments:
This pull request adds plugin `bloop` which is a list of frequent [bloop](https://scalacenter.github.io/bloop/) commands.
