### PR TITLE
fix(lib): fix `1` alias to `cd` to directory 1 in stack

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -9,7 +9,7 @@ alias -g .....='../../../..'
 alias -g ......='../../../../..'
 
 alias -- -='cd -'
-alias 1='cd -'
+alias 1='cd -1'
 alias 2='cd -2'
 alias 3='cd -3'
 alias 4='cd -4'


### PR DESCRIPTION
alias for 1 needs to specify 1.  '-' is the previous directory, which may not be the same as the 1 directory on the stack if the previous location was just popd.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
