### PR TITLE
fix(lib): fix comment typo

### DIFF
--- a/lib/compfix.zsh
+++ b/lib/compfix.zsh
@@ -38,7 +38,7 @@ function handle_completion_insecurities() {
 
 [oh-my-zsh] If the above didn't help or you want to skip the verification of
 [oh-my-zsh] insecure directories you can set the variable ZSH_DISABLE_COMPFIX to
-[oh-my-zsh] "true" before oh-my-zsh is sourced in your zshrc file.
+[oh-my-zsh] true before oh-my-zsh is sourced in your zshrc file.
 
 EOD
 }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

I removed two quotes. To disable the compfix, the value of `ZSH_DISABLE_COMPFIX` must be `true`, not `"true"`, as you can see [here](https://github.com/ohmyzsh/ohmyzsh/blob/04c96e235ff522704a6f1482e7fd06a05467cbb7/oh-my-zsh.sh#L122).