### PR TITLE
fix(command-not-found): pass arguments correctly in NixOS

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -50,7 +50,7 @@ fi
 # NixOS: https://github.com/NixOS/nixpkgs/tree/master/nixos/modules/programs/command-not-found
 if [[ -x /run/current-system/sw/bin/command-not-found ]]; then
   command_not_found_handler() {
-    /run/current-system/sw/bin/command-not-found -- "$@"
+    /run/current-system/sw/bin/command-not-found "$@"
   }
 fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fix passing arguments to command-not-found in NixOS

## Other comments:

The [command-not-found script](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/command-not-found/command-not-found.pl) in NixOS uses the first argument to find programs.
Thus there should be no '--' when passing arguments.
