### PR TITLE
style: use `-n` flag in `head` and `tail` commands

### DIFF
--- a/lib/diagnostics.zsh
+++ b/lib/diagnostics.zsh
@@ -335,7 +335,7 @@ function _omz_diag_dump_os_specific_version() {
       builtin echo "OS Version: $osname $osver build $(sw_vers -buildVersion)"
       ;;
     cygwin)
-      command systeminfo | command head -4 | command tail -2
+      command systeminfo | command head -n 4 | command tail -n 2
       ;;
   esac
 

--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -26,7 +26,7 @@ function d () {
   if [[ -n $1 ]]; then
     dirs "$@"
   else
-    dirs -v | head -10
+    dirs -v | head -n 10
   fi
 }
 compdef _dirs d

--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -1,7 +1,7 @@
 function zsh_stats() {
   fc -l 1 \
     | awk '{ CMD[$2]++; count++; } END { for (a in CMD) print CMD[a] " " CMD[a]*100/count "% " a }' \
-    | grep -v "./" | sort -nr | head -20 | column -c3 -s " " -t | nl
+    | grep -v "./" | sort -nr | head -n 20 | column -c3 -s " " -t | nl
 }
 
 function uninstall_oh_my_zsh() {
@@ -45,7 +45,7 @@ function takeurl() {
   data="$(mktemp)"
   curl -L "$1" > "$data"
   tar xf "$data"
-  thedir="$(tar tf "$data" | head -1)"
+  thedir="$(tar tf "$data" | head -n 1)"
   rm "$data"
   cd "$thedir"
 }

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -51,7 +51,7 @@ function parse_git_dirty() {
         FLAGS+="--ignore-submodules=${GIT_STATUS_IGNORE_SUBMODULES:-dirty}"
         ;;
     esac
-    STATUS=$(__git_prompt_git status ${FLAGS} 2> /dev/null | tail -1)
+    STATUS=$(__git_prompt_git status ${FLAGS} 2> /dev/null | tail -n 1)
   fi
   if [[ -n $STATUS ]]; then
     echo "$ZSH_THEME_GIT_PROMPT_DIRTY"

--- a/plugins/scd/scd
+++ b/plugins/scd/scd
@@ -270,7 +270,7 @@ fi
 
 # Determine the last recorded directory
 if [[ -s ${SCD_HISTFILE} ]]; then
-    last_directory=${"$(tail -1 ${SCD_HISTFILE})"#*;}
+    last_directory=${"$(tail -n 1 ${SCD_HISTFILE})"#*;}
 fi
 
 # The "record" function adds its arguments to the directory index.

--- a/plugins/systemadmin/README.md
+++ b/plugins/systemadmin/README.md
@@ -17,9 +17,9 @@ plugins=(... systemadmin)
 | path    | `print -l $path`                                                           | Displays PATH with each entry on a separate line                   |
 | mkdir   | `mkdir -pv`                                                                | Automatically create parent directories and display verbose output |
 | psmem   | `ps -e -orss=,args= \| sort -b -k1 -nr`                                    | Display the processes using the most memory                        |
-| psmem10 | `ps -e -orss=,args= \| sort -b -k1 -nr \| head -10`                        | Display the top 10 processes using the most memory                 |
+| psmem10 | `ps -e -orss=,args= \| sort -b -k1 -nr \| head -n 10`                      | Display the top 10 processes using the most memory                 |
 | pscpu   | `ps -e -o pcpu,cpu,nice,state,cputime,args \|sort -k1 -nr`                 | Display the top processes using the most CPU                       |
-| pscpu10 | `ps -e -o pcpu,cpu,nice,state,cputime,args \|sort -k1 -nr \| head -10`     | Display the top 10 processes using the most CPU                    |
+| pscpu10 | `ps -e -o pcpu,cpu,nice,state,cputime,args \|sort -k1 -nr \| head -n 10`   | Display the top 10 processes using the most CPU                    |
 | hist10  | `print -l ${(o)history%% *} \| uniq -c \| sort -nr \| head -n 10`          | Display the top 10 most used commands in the history               |
 
 ## Functions

--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -26,10 +26,10 @@ alias path='print -l $path'
 alias mkdir='mkdir -pv'
 # get top process eating memory
 alias psmem='ps -e -orss=,args= | sort -b -k1 -nr'
-alias psmem10='ps -e -orss=,args= | sort -b -k1 -nr | head -10'
+alias psmem10='ps -e -orss=,args= | sort -b -k1 -nr | head -n 10'
 # get top process eating cpu if not work try excute : export LC_ALL='C'
 alias pscpu='ps -e -o pcpu,cpu,nice,state,cputime,args|sort -k1,1n -nr'
-alias pscpu10='ps -e -o pcpu,cpu,nice,state,cputime,args|sort -k1,1n -nr | head -10'
+alias pscpu10='ps -e -o pcpu,cpu,nice,state,cputime,args|sort -k1,1n -nr | head -n 10'
 # top10 of the history
 alias hist10='print -l ${(o)history%% *} | uniq -c | sort -nr | head -n 10'
 
@@ -74,7 +74,7 @@ req20() {
 
 # top20 of Using tcpdump port 80 access to view
 http20() {
-    sudo tcpdump -i eth0 -tnn dst port 80 -c 1000 | awk -F"." '{print $1"."$2"."$3"."$4}' | sort | uniq -c | sort -nr |head -20
+    sudo tcpdump -i eth0 -tnn dst port 80 -c 1000 | awk -F"." '{print $1"."$2"."$3"."$4}' | sort | uniq -c | sort -nr |head -n 20
 }
 
 # top20 of Find time_wait connection
@@ -99,14 +99,14 @@ accessip10() {
 
 # top20 of Most Visited file or page
 visitpage20() {
-    awk '{print $11}' "$(retlog)"|sort|uniq -c|sort -nr|head -20
+    awk '{print $11}' "$(retlog)"|sort|uniq -c|sort -nr|head -n 20
 }
 
 # top100 of Page lists the most time-consuming (more than 60 seconds) as well as the corresponding page number of occurrences
 consume100() {
-    awk '($NF > 60 && $7~/\.php/){print $7}' "$(retlog)" |sort -n|uniq -c|sort -nr|head -100
+    awk '($NF > 60 && $7~/\.php/){print $7}' "$(retlog)" |sort -n|uniq -c|sort -nr|head -n 100
     # if django website or other webiste make by no suffix language
-    # awk '{print $7}' "$(retlog)" |sort -n|uniq -c|sort -nr|head -100
+    # awk '{print $7}' "$(retlog)" |sort -n|uniq -c|sort -nr|head -n 100
 }
 
 # Website traffic statistics (G)

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -311,7 +311,7 @@ EOF
     # 1. Use the most preceding one based on $PATH, then check that it's in the shells file
     # 2. If that fails, get a zsh path from the shells file, then check it actually exists
     if ! zsh=$(command -v zsh) || ! grep -qx "$zsh" "$shells_file"; then
-      if ! zsh=$(grep '^/.*/zsh$' "$shells_file" | tail -1) || [ ! -f "$zsh" ]; then
+      if ! zsh=$(grep '^/.*/zsh$' "$shells_file" | tail -n 1) || [ ! -f "$zsh" ]; then
         fmt_error "no zsh binary found or not present in '$shells_file'"
         fmt_error "change your default shell manually."
         return


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

The `tail` manpage says:

> For compatibility tail also supports an obsolete usage ‘tail
> -[num][bcl][f] [file]’, which is recognized only if it does not
> conflict with the usage described above. This obsolete form uses
> exactly one option and at most one file. In the option, num is
> an optional decimal number optionally followed by a size letter
> (‘b’, ‘c’, ‘l’) to mean count by 512-byte blocks, bytes,
> or lines, optionally followed by ‘f’ which has the same meaning
> as -f.

This usage is not supported with newer coreutils implementations
(for example github.com/uutils/coreutils), so let's just use the
non-deprecated flag option.