### PR TITLE
fix(plugins): speed up rustup plugin

### DIFF
--- a/plugins/rustup/rustup.plugin.zsh
+++ b/plugins/rustup/rustup.plugin.zsh
@@ -2,7 +2,7 @@ if (( $+commands[rustup] )); then
   # remove old generated completion file
   command rm -f "${0:A:h}/_rustup"
 
-  ver="$(rustup --version 2>/dev/null)"
+  ver="$(rustup --help | head -n 1)" # `rustup --version` is slow
   ver_file="$ZSH_CACHE_DIR/rustup_version"
   comp_file="$ZSH_CACHE_DIR/completions/_rustup"
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Change `rustup --version` to `rustup --help | head -n 1`, the result is the same but `--version` is much slower for some reason. See https://github.com/ohmyzsh/ohmyzsh/issues/10390

## Other comments:

`cargo --version` is also super slow, but I didn't find a faster alternative.

Fixes #10390