### PR TITLE
docs(nvm): clarify how to get Homebrew directory

### DIFF
--- a/plugins/nvm/README.md
+++ b/plugins/nvm/README.md
@@ -17,7 +17,9 @@ where you installed nvm.
 These settings should go in your zshrc file, before Oh My Zsh is sourced:
 
 - **`NVM_HOMEBREW`**: if you installed nvm via Homebrew, in a directory other than `/usr/local/opt/nvm`, you
-  can set `NVM_HOMEBREW` to be the directory where you installed it.
+  can set `NVM_HOMEBREW` to be the directory where you installed it. For example, on Apple Silicon-based Macs,
+  [Homebrew is installed in `/opt/homebrew`](https://docs.brew.sh/Installation). To get the directory where
+  nvm has been installed, regardless of chip architecture, use `NVM_HOMEBREW=$(brew --prefix nvm)`.
 
 - **`NVM_LAZY`**: if you want the plugin to defer the load of nvm to speed-up the start of your zsh session,
   set `NVM_LAZY` to `1`. This will use the `--no-use` parameter when loading nvm, and will create a function


### PR DESCRIPTION
`$(brew --prefix nvm)` gets the definitive directory where Homebrew has installed nvm.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Updates the README to provide a helpful hint about how to get the directory Homebrew has installed nvm in.

## Other comments:

Having upgraded to an Apple Silicon-based Mac, I was completely stumped as to why I couldn’t get the autoloading feature to work. Oh My Zsh was working. NVM was working, it didn’t make sense. Only once I discovered that Homebrew installs in a different directory on Apple Silicon-based Macs, was I able to realise what the problem was.

Not sure if this is the best place for this information, but it’s where I came looking for help as I tried to understand why auto loading wasn’t working. I’ve also linked to the relevant page on the Homebrew site.