### PR TITLE
fix(command-not-found): pass arguments correctly in Termux

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -57,6 +57,6 @@ fi
 # Termux: https://github.com/termux/command-not-found
 if [[ -x /data/data/com.termux/files/usr/libexec/termux/command-not-found ]]; then
   command_not_found_handler() {
-    /data/data/com.termux/files/usr/libexec/termux/command-not-found -- "$1"
+    /data/data/com.termux/files/usr/libexec/termux/command-not-found "$1"
   }
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fix passing arguments to command-not-found in Termux

## Other comments:

[command-not-found in Termux](https://github.com/termux/command-not-found/blob/master/command-not-found.cpp#L188) uses the first arg.

<details><summary>screenshot of the problem with fix</summary>
<img src="https://user-images.githubusercontent.com/3288444/141003022-35cbf699-97e4-4981-a43a-c56a937f9fc1.jpg" height="500" />
</details>

latest Termux 0.117
refs: https://github.com/ohmyzsh/ohmyzsh/pull/10381