### PR TITLE
add toolbox plugin

### DIFF
--- a/plugins/toolbox/README.md
+++ b/plugins/toolbox/README.md
@@ -1,8 +1,8 @@
-# toolbox plugin
+# Toolbox plugin
 
 Plugin for [toolbox](https://containertoolbx.org), a tool to use containerized CLI environments.
 
-To use it, add `toolbox` to your plugins array in your `.zshrc` file:
+To use it, add `toolbox` to the plugins array in your `zshrc` file:
 
 ```zsh
 plugins=(... toolbox)
@@ -23,3 +23,78 @@ RPROMPT='$(toolbox_prompt_info)'
 | Alias | Command              | Description                            |
 |-------|----------------------|----------------------------------------|
 | tb    | `toolbox enter`      | Enters the toolbox environment         |
+=======
+## Usage
+
+The plugin allows to automatically enter toolboxes on `cd` into git
+repositories. It will use the default container defined in
+`TOOLBOX_DEFAULT_CONTAINER`. It will set the hostname of the container to the
+container name and set a ⬢ in front of the prompt to indicated that you
+are in a toolbox.
+
+```
+➜  github $ cd ansible
+⬢ (default) ➜  ansible git:(devel) $ cd docs
+⬢ (default) ➜  docs git:(devel) $ cd ..
+⬢ (default) ➜  ansible git:(devel) $ cd ..
+➜  github $
+```
+
+We can override this by having a `.toolbox` file in the directory containing a differently named container:
+
+```
+➜  github $ cat ansible/.toolbox
+my-toolbox
+➜  github $ cd ansible
+⬢ (my-toolbox) ➜  ansible git:(devel) $ cd ..
+➜  github $
+```
+
+You can disable this behavior by setting `DISABLE_TOOLBOX_ENTER=1` before Oh My ZSH is sourced:
+```zsh
+DISABLE_TOOLBOX_ENTER=1
+plugins=(... toolbox)
+source $ZSH/oh-my-zsh.sh
+```
+
+Toolboxes are exited when leaving a git repository. You can disable this behavior by setting `DISABLE_TOOLBOX_EXIT=1`.
+
+You can specify which image should be used as a default by setting `TOOLBOX_DEFAULT_IMAGE=ghcr.io/mikebarkmin/fedora-toolbox:35`.
+
+For this plugin to work your container must have `zsh` installed. You can used this image `ghcr.io/mikebarkmin/fedora-toolbox:35` which comes preinstalled with `zsh` and `neovim`.
+
+## Aliases
+
+There are some convenient aliases which make for example use of the `TOOLBOX_DEFAULT_IMAGE` when set.
+
+| alias | command | comment |
+| ----- | ------- | ------- |
+| tb | toolbox | |
+| tbi | echo $TOOLBOX_DEFAULT_CONTAINER > .toolbox && toolbox_cwd | |
+| tbc | toolbox create --image $TOOLBOX_DEFAULT_IMAGE | |
+| tbe | toolbox enter | This is context aware |
+| tbrm | toolbox rm | |
+| tbrmi | toolbox rmi | |
+| tbl | toolbox list | |
+| tbr | toolbox run | This is context aware |
+
+
+## Theme Integration
+In most themes you can see the hostname (`user_host`), which is set by this plugin for each container, so there is no additional setup needed.
+
+Additionally, the plugin provides a prompt function with can be used in a theme to display a hexagon to indicated that you are in a toolbox.
+
+Here is an example of a modified `bira` theme:
+
+```zsh
+...
+local toolbox_prompt='$(toolbox_prompt_info)'
+
+PROMPT="╭─${toolbox_prompt}${user_host}${current_dir}${rvm_ruby}${git_branch}${venv_prompt}
+╰─%B${user_symbol}%b "
+...
+```
+
+## Advanced Setup
+
+This plugin works great with vscode, if you use this [toolbox-vscode](https://github.com/owtaylor/toolbox-vscode).

--- a/plugins/toolbox/README.md
+++ b/plugins/toolbox/README.md
@@ -10,7 +10,7 @@ plugins=(... toolbox)
 
 ## Prompt function
 
-This plugins adds `toolbox_prompt_info()` function. Using it in your prompt, it will show the toolbox indicator ⬢ (if you are running in a toolbox container), and nothing if not.
+This plugins adds `toolbox_prompt_info` function. Using it in your prompt, it will show the toolbox indicator ⬢ (if you are running in a toolbox container), and nothing if not.
 
 You can use it by adding `$(toolbox_prompt_info)` to your `PROMPT` or `RPROMPT` variable:
 
@@ -18,19 +18,12 @@ You can use it by adding `$(toolbox_prompt_info)` to your `PROMPT` or `RPROMPT` 
 RPROMPT='$(toolbox_prompt_info)'
 ```
 
-## Aliases
-
-| Alias | Command              | Description                            |
-|-------|----------------------|----------------------------------------|
-| tb    | `toolbox enter`      | Enters the toolbox environment         |
-=======
 ## Usage
 
-The plugin allows to automatically enter toolboxes on `cd` into git
-repositories. It will use the default container defined in
-`TOOLBOX_DEFAULT_CONTAINER`. It will set the hostname of the container to the
-container name and set a ⬢ in front of the prompt to indicated that you
-are in a toolbox.
+The plugin allows to automatically enter toolboxes on `cd` into git repositories.
+It will use the default container defined in `TOOLBOX_DEFAULT_CONTAINER`. It will
+set the hostname of the container to the container name and set a `⬢` in front of
+the prompt to indicated that you are in a toolbox.
 
 ```
 ➜  github $ cd ansible
@@ -59,27 +52,34 @@ source $ZSH/oh-my-zsh.sh
 
 Toolboxes are exited when leaving a git repository. You can disable this behavior by setting `DISABLE_TOOLBOX_EXIT=1`.
 
-You can specify which image should be used as a default by setting `TOOLBOX_DEFAULT_IMAGE=ghcr.io/mikebarkmin/fedora-toolbox:35`.
+You can specify which image should be used as a default by setting the `TOOLBOX_DEFAULT_IMAGE` variable:
 
-For this plugin to work your container must have `zsh` installed. You can used this image `ghcr.io/mikebarkmin/fedora-toolbox:35` which comes preinstalled with `zsh` and `neovim`.
+```zsh
+TOOLBOX_DEFAULT_IMAGE=ghcr.io/mikebarkmin/fedora-toolbox:35
+```
+
+For this plugin to work your container must have `zsh` installed.
 
 ## Aliases
 
 There are some convenient aliases which make for example use of the `TOOLBOX_DEFAULT_IMAGE` when set.
 
-| alias | command | comment |
-| ----- | ------- | ------- |
-| tb | toolbox | |
-| tbi | echo $TOOLBOX_DEFAULT_CONTAINER > .toolbox && toolbox_cwd | |
-| tbc | toolbox create --image $TOOLBOX_DEFAULT_IMAGE | |
-| tbe | toolbox enter | This is context aware |
-| tbrm | toolbox rm | |
-| tbrmi | toolbox rmi | |
-| tbl | toolbox list | |
-| tbr | toolbox run | This is context aware |
+| Alias | Command                                                     |
+| ----- | ----------------------------------------------------------- |
+| tb    | `toolbox`                                                   |
+| tbi   | `echo $TOOLBOX_DEFAULT_CONTAINER > .toolbox && toolbox_cwd` |
+| tbrm  | `toolbox rm`                                                |
+| tbrmi | `toolbox rmi`                                               |
+| tbl   | `toolbox list`                                              |
 
+## Functions
+
+- `tbc`: creates a toolbox environment from a specified image in `$TOOLBOX_DEFAULT_IMAGE` or the default image.
+- `tbe`: enters the toolbox environment. This is context aware and will create it if it does not exist.
+- `tbr`: runs commands in the toolbox container. This is context aware.
 
 ## Theme Integration
+
 In most themes you can see the hostname (`user_host`), which is set by this plugin for each container, so there is no additional setup needed.
 
 Additionally, the plugin provides a prompt function with can be used in a theme to display a hexagon to indicated that you are in a toolbox.

--- a/plugins/toolbox/toolbox.plugin.zsh
+++ b/plugins/toolbox/toolbox.plugin.zsh
@@ -1,5 +1,112 @@
-function toolbox_prompt_info() {
-  [[ -f /run/.toolboxenv ]] && echo "⬢"
+if [[ $? -eq 0 ]] && ! type toolbox &>/dev/null; then
+  print "[oh-my-zsh] toolbox plugin: shell function 'toolbox' not defined.\n" \
+    "Please check toolbox" >&2
+  return
+fi
+
+function is_in_toolbox() {
+  if [[ -f /run/.containerenv && -f /run/.toolboxenv ]]; then
+    return 0
+  else
+    return 1
+  fi
 }
 
-alias tb="toolbox enter"
+function toolbox_prompt_info() {
+  if is_in_toolbox; then
+    echo "⬢ "
+  else
+    return 0
+  fi
+}
+
+function toolbox_name {
+  # Get absolute path, resolving symlinks
+  local PROJECT_ROOT="${PWD:A}"
+  while [[ "$PROJECT_ROOT" != "/" && ! -e "$PROJECT_ROOT/.toolbox" &&
+    ! -d "$PROJECT_ROOT/.git" ]]; do
+    PROJECT_ROOT="${PROJECT_ROOT:h}"
+  done
+
+  # Check for toolbox name override
+  if [[ -f "$PROJECT_ROOT/.toolbox" ]]; then
+    echo "$(cat "$PROJECT_ROOT/.toolbox")"
+  elif [[ -d "$PROJECT_ROOT/.git" && -n $TOOLBOX_DEFAULT_CONTAINER ]]; then
+    echo "$TOOLBOX_DEFAULT_CONTAINER"
+  fi
+}
+
+# Automatically enter Git projects in the default toolbox container. Toolbox
+# container can be overridden by placing a .toolbox file in the project root
+# with a container name in it.
+#
+function toolbox_cwd {
+  if [[ -z "$TOOLBOX_CWD" ]]; then
+    local TOOLBOX_CWD=1
+    local TOOLBOX_NAME=$(toolbox_name)
+
+    if [[ -n $TOOLBOX_NAME ]]; then
+      if ! is_in_toolbox; then
+        if ! $(podman container exists $TOOLBOX_NAME); then
+          tbc $TOOLBOX_NAME
+        fi
+        toolbox --container $TOOLBOX_NAME run sudo hostname $TOOLBOX_NAME
+        toolbox enter $TOOLBOX_NAME
+      fi
+    elif [[ "$(hostname)" != "toolbox" && ! $DISABLE_TOOLBOX_EXIT -eq 1 ]]; then
+      if is_in_toolbox; then
+        exit
+      fi
+    fi
+  fi
+}
+
+if [[ ! $DISABLE_TOOLBOX_ENTER -eq 1 ]]; then
+
+  # Append workon_cwd to the chpwd_functions array, so it will be called on cd
+  # http://zsh.sourceforge.net/Doc/Release/Functions.html
+  autoload -Uz add-zsh-hook
+  add-zsh-hook chpwd toolbox_cwd
+fi
+
+if [[ -n "$TOOLBOX_DEFAULT_IMAGE" ]]; then
+  alias tbc="toolbox create --image $TOOLBOX_DEFAULT_IMAGE"
+else
+  alias tbc="toolbox create"
+fi
+alias tbi="echo $TOOLBOX_DEFAULT_CONTAINER > .toolbox && toolbox_cwd"
+alias tb="toolbox"
+alias tbrm="toolbox rm"
+alias tbrmi="toolbox rmi"
+alias tbl="toolbox list"
+
+function tbe {
+  local TOOLBOX_NAME=$(toolbox_name)
+
+  if [[ -n "$1" ]]; then
+    TOOLBOX_NAME=$1
+  elif [[ -z $TOOLBOX_NAME ]]; then
+    TOOLBOX_NAME=$TOOLBOX_DEFAULT_CONTAINER
+  fi
+
+  if ! $(podman container exists $TOOLBOX_NAME); then
+    tbc $TOOLBOX_NAME
+  fi
+
+  toolbox --container $TOOLBOX_NAME run sudo hostname $TOOLBOX_NAME
+  toolbox enter $TOOLBOX_NAME
+}
+
+function tbr {
+  local TOOLBOX_NAME=$(toolbox_name)
+
+  if $(podman container exists $1); then
+    TOOLBOX_NAME=$1
+    shift
+  elif [[ -z $TOOLBOX_NAME ]]; then
+    TOOLBOX_NAME=$TOOLBOX_DEFAULT_CONTAINER
+  fi
+
+  toolbox --container $TOOLBOX_NAME run sudo hostname $TOOLBOX_NAME
+  toolbox --container $TOOLBOX_NAME run "$@"
+}

--- a/plugins/toolbox/toolbox.plugin.zsh
+++ b/plugins/toolbox/toolbox.plugin.zsh
@@ -5,18 +5,12 @@ if [[ $? -eq 0 ]] && ! type toolbox &>/dev/null; then
 fi
 
 function is_in_toolbox() {
-  if [[ -f /run/.containerenv && -f /run/.toolboxenv ]]; then
-    return 0
-  else
-    return 1
-  fi
+  [[ -f /run/.containerenv && -f /run/.toolboxenv ]]
 }
 
 function toolbox_prompt_info() {
   if is_in_toolbox; then
     echo "⬢ "
-  else
-    return 0
   fi
 }
 
@@ -30,11 +24,12 @@ function toolbox_name {
 
   # Check for toolbox name override
   if [[ -f "$PROJECT_ROOT/.toolbox" ]]; then
-    echo "$(cat "$PROJECT_ROOT/.toolbox")"
-  elif [[ -d "$PROJECT_ROOT/.git" && -n $TOOLBOX_DEFAULT_CONTAINER ]]; then
+    echo "$(<"$PROJECT_ROOT/.toolbox")"
+  elif [[ -d "$PROJECT_ROOT/.git" && -n "$TOOLBOX_DEFAULT_CONTAINER" ]]; then
     echo "$TOOLBOX_DEFAULT_CONTAINER"
   fi
 }
+
 
 # Automatically enter Git projects in the default toolbox container. Toolbox
 # container can be overridden by placing a .toolbox file in the project root
@@ -45,15 +40,15 @@ function toolbox_cwd {
     local TOOLBOX_CWD=1
     local TOOLBOX_NAME=$(toolbox_name)
 
-    if [[ -n $TOOLBOX_NAME ]]; then
+    if [[ -n "$TOOLBOX_NAME" ]]; then
       if ! is_in_toolbox; then
-        if ! $(podman container exists $TOOLBOX_NAME); then
-          tbc $TOOLBOX_NAME
+        if ! $(podman container exists "$TOOLBOX_NAME"); then
+          tbc "$TOOLBOX_NAME"
         fi
-        toolbox --container $TOOLBOX_NAME run sudo hostname $TOOLBOX_NAME
-        toolbox enter $TOOLBOX_NAME
+        toolbox --container "$TOOLBOX_NAME" run sudo hostname "$TOOLBOX_NAME"
+        toolbox enter "$TOOLBOX_NAME"
       fi
-    elif [[ "$(hostname)" != "toolbox" && ! $DISABLE_TOOLBOX_EXIT -eq 1 ]]; then
+    elif [[ "$(hostname)" != "toolbox" && $DISABLE_TOOLBOX_EXIT -ne 1 ]]; then
       if is_in_toolbox; then
         exit
       fi
@@ -61,52 +56,55 @@ function toolbox_cwd {
   fi
 }
 
-if [[ ! $DISABLE_TOOLBOX_ENTER -eq 1 ]]; then
-
-  # Append workon_cwd to the chpwd_functions array, so it will be called on cd
+if [[ $DISABLE_TOOLBOX_ENTER -ne 1 ]]; then
+  # Append toolbox_cwd to the chpwd_functions array, so it will be called on cd
   # http://zsh.sourceforge.net/Doc/Release/Functions.html
   autoload -Uz add-zsh-hook
   add-zsh-hook chpwd toolbox_cwd
 fi
 
-if [[ -n "$TOOLBOX_DEFAULT_IMAGE" ]]; then
-  alias tbc="toolbox create --image $TOOLBOX_DEFAULT_IMAGE"
-else
-  alias tbc="toolbox create"
-fi
-alias tbi="echo $TOOLBOX_DEFAULT_CONTAINER > .toolbox && toolbox_cwd"
+
 alias tb="toolbox"
+alias tbi="echo $TOOLBOX_DEFAULT_CONTAINER > .toolbox && toolbox_cwd"
 alias tbrm="toolbox rm"
 alias tbrmi="toolbox rmi"
 alias tbl="toolbox list"
+
+function tbc {
+  if [[ -n "$TOOLBOX_DEFAULT_IMAGE" ]]; then
+    toolbox create --image $TOOLBOX_DEFAULT_IMAGE "$@"
+  else
+    toolbox create "$@"
+  fi
+}
 
 function tbe {
   local TOOLBOX_NAME=$(toolbox_name)
 
   if [[ -n "$1" ]]; then
     TOOLBOX_NAME=$1
-  elif [[ -z $TOOLBOX_NAME ]]; then
-    TOOLBOX_NAME=$TOOLBOX_DEFAULT_CONTAINER
+  elif [[ -z "$TOOLBOX_NAME" ]]; then
+    TOOLBOX_NAME="$TOOLBOX_DEFAULT_CONTAINER"
   fi
 
-  if ! $(podman container exists $TOOLBOX_NAME); then
-    tbc $TOOLBOX_NAME
+  if ! podman container exists "$TOOLBOX_NAME"; then
+    tbc "$TOOLBOX_NAME"
   fi
 
-  toolbox --container $TOOLBOX_NAME run sudo hostname $TOOLBOX_NAME
-  toolbox enter $TOOLBOX_NAME
+  toolbox --container "$TOOLBOX_NAME" run sudo hostname "$TOOLBOX_NAME"
+  toolbox enter "$TOOLBOX_NAME"
 }
 
 function tbr {
   local TOOLBOX_NAME=$(toolbox_name)
 
-  if $(podman container exists $1); then
+  if podman container exists "$1"; then
     TOOLBOX_NAME=$1
     shift
-  elif [[ -z $TOOLBOX_NAME ]]; then
+  elif [[ -z "$TOOLBOX_NAME" ]]; then
     TOOLBOX_NAME=$TOOLBOX_DEFAULT_CONTAINER
   fi
 
-  toolbox --container $TOOLBOX_NAME run sudo hostname $TOOLBOX_NAME
-  toolbox --container $TOOLBOX_NAME run "$@"
+  toolbox --container "$TOOLBOX_NAME" run sudo hostname "$TOOLBOX_NAME"
+  toolbox --container "$TOOLBOX_NAME" run "$@"
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Description

[Toolbox](https://github.com/containers/toolbox) is a tool for containerized command line environments on Linux. It is shipped for example with Fedora Silverblue. Since toolbox should be used for isolated developer enviroments similiar to virtualenv but with containers, I wrote this plugin to ease the use of toolbox.

The plugin acts in similar fashin to the virtualenvwrapper plugin. If a git directory is found it will enter the default toolbox, or it will read a container name from a `.toolbox` file. If the git directory is exited, the toolbox is also exited. This behavior can be customized with env variables.

Additionally, some convenient aliases are set.

All of this is also documented in the README.