### PR TITLE
feat(juju): add `jclean` function to destroy all controllers, and other aliases

### DIFF
--- a/plugins/juju/README.md
+++ b/plugins/juju/README.md
@@ -113,5 +113,6 @@ Naming convention:
 
 - `jaddr <app_name> [unit_num]`: display app or unit IP address.
 - `jreld <relation_name> <app_name> <unit_num>`: display app and unit relation data.
+- `jclean`: destroy all controllers
 - `wjst [interval_secs] [args_for_watch]`: watch juju status, with optional interval
   (default: 5s); you may pass additional arguments to `watch`.

--- a/plugins/juju/README.md
+++ b/plugins/juju/README.md
@@ -18,26 +18,36 @@ Naming convention:
 
 ### General
 
-| Alias  | Command                                     | Description                                            |
-|--------|---------------------------------------------|--------------------------------------------------------|
-| `jdl`  | `juju debug-log --ms`                       | Display log, with millisecond resolution               |
-| `jdlr` | `juju debug-log --ms --replay`              | Replay entire log                                      |
-| `jh`   | `juju help`                                 | Show help on a command or other topic                  |
-| `jssl` | `juju juju show-status-log`                 | Output past statuses for the specified entity          |
-| `jstj` | `juju status --format=json`                 | Show status in json format (more detailed)             |
-| `jst`  | `juju status --relations --storage --color` | Show status, including relations and storage, in color |
+| Alias   | Command                                     | Description                                            |
+|---------|---------------------------------------------|--------------------------------------------------------|
+| `j`     | `juju`                                      | The juju command                                       |
+| `jcld`  | `juju clouds`                               | Lists all clouds with registered credentials           |
+| `jclda` | `juju clouds --all`                         | Lists all clouds available to Juju                     |
+| `jdl`   | `juju debug-log --ms`                       | Display log, with millisecond resolution               |
+| `jdlr`  | `juju debug-log --ms --replay`              | Replay entire log                                      |
+| `jh`    | `juju help`                                 | Show help on a command or other topic                  |
+| `jssl`  | `juju show-status-log`                      | Output past statuses for the specified entity          |
+| `jstj`  | `juju status --format=json`                 | Show status in json format (more detailed)             |
+| `jst`   | `juju status --relations --color`           | Show status, including relations, in color             |
+| `jsts`  | `juju status --relations --storage --color` | Show status, including relations and storage, in color |
 
 ### Bootstrap
 
-| Alias | Command                   | Description                               |
-|-------|---------------------------|-------------------------------------------|
-| `jb`  | `juju bootstrap`          | Initializing a Juju cloud environment     |
-| `jbm` | `juju bootstrap microk8s` | Initializing a MicroK8s cloud environment |
+| Alias   | Command                             | Description                                           |
+|---------|-------------------------------------|-------------------------------------------------------|
+| `jb`    | `juju bootstrap`                    | Initializing a Juju cloud environment                 |
+| `jbng`  | `juju bootstrap --no-gui`           | Initializing a Juju cloud environment without GUI     |
+| `jbl`   | `juju bootstrap localhost`          | Initializing an lxd cloud environment                 |
+| `jblng` | `juju bootstrap --no-gui localhost` | Initializing an lxd cloud environment without GUI     |
+| `jbm`   | `juju bootstrap microk8s`           | Initializing a MicroK8s cloud environment             |
+| `jbmng` | `juju bootstrap --no-gui microk8s`  | Initializing a MicroK8s cloud environment without GUI |
 
 ### Controller
 
 | Alias    | Command                                                                               | Description                                                       |
 |----------|---------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| `jctl`   | `juju controllers`                                                                    | List all controllers                                              |
+| `jctlr`  | `juju controllers --refresh`                                                          | List all controllers (download latest details)                    |
 | `jdc`    | `juju destroy-controller --destroy-all-models`                                        | Destroy a controller                                              |
 | `jdc!`   | `juju destroy-controller --destroy-all-models --force --no-wait -y`                   | Destroy a controller                                              |
 | `jdcds`  | `juju destroy-controller --destroy-all-models --destroy-storage`                      | Destroy a controller and associated storage                       |

--- a/plugins/juju/README.md
+++ b/plugins/juju/README.md
@@ -15,6 +15,7 @@ Naming convention:
 
 - `!` suffix: `--force --no-wait -y`.
 - `ds` suffix: `--destroy-storage`.
+- `jsh` prefix means `juju show-*`.
 
 ### General
 
@@ -26,7 +27,7 @@ Naming convention:
 | `jdl`   | `juju debug-log --ms`                       | Display log, with millisecond resolution               |
 | `jdlr`  | `juju debug-log --ms --replay`              | Replay entire log                                      |
 | `jh`    | `juju help`                                 | Show help on a command or other topic                  |
-| `jssl`  | `juju show-status-log`                      | Output past statuses for the specified entity          |
+| `jshsl` | `juju show-status-log`                      | Output past statuses for the specified entity          |
 | `jstj`  | `juju status --format=json`                 | Show status in json format (more detailed)             |
 | `jst`   | `juju status --relations --color`           | Show status, including relations, in color             |
 | `jsts`  | `juju status --relations --storage --color` | Show status, including relations and storage, in color |
@@ -53,7 +54,12 @@ Naming convention:
 | `jdcds`  | `juju destroy-controller --destroy-all-models --destroy-storage`                      | Destroy a controller and associated storage                       |
 | `jdcds!` | `juju destroy-controller --destroy-all-models --destroy-storage --force --no-wait -y` | Destroy a controller and associated storage                       |
 | `jkc`    | `juju kill-controller -y -t 0`                                                        | Forcibly terminate all associated resources for a Juju controller |
+| `jshc`   | `juju show-controller`                                                                | Shows detailed information of a controller                    |
 | `jsw`    | `juju switch`                                                                         | Select or identify the current controller and model               |
+
+
+| `jshu`   | `juju show-unit`                                              | Displays information about a unit                                         |
+
 
 ### Model
 
@@ -84,9 +90,9 @@ Naming convention:
 | `jrmds!` | `juju remove-application --destroy-storage --force --no-wait` | Remove application forcefully, destroying attached storage                |
 | `jrp`    | `juju refresh --path`                                         | Upgrade charm from local charm file                                       |
 | `jsa`    | `juju scale-application`                                      | Set the desired number of application units                               |
-| `jsh`    | `juju ssh`                                                    | Initiate an SSH session or execute a command on a Juju target             |
-| `jshc`   | `juju ssh --container`                                        | Initiate an SSH session or execute a command on a given container         |
-| `jsu`    | `juju show-unit`                                              | Displays information about a unit                                         |
+| `jssh`   | `juju ssh`                                                    | Initiate an SSH session or execute a command on a Juju target             |
+| `jsshc`  | `juju ssh --container`                                        | Initiate an SSH session or execute a command on a given container         |
+| `jshu`   | `juju show-unit`                                              | Displays information about a unit                                         |
 
 ### Storage
 

--- a/plugins/juju/juju.plugin.zsh
+++ b/plugins/juju/juju.plugin.zsh
@@ -17,11 +17,20 @@ unset completion_file
 #   - `!` means --force --no-wait -y                         #
 #   - `ds` suffix means --destroy-storage                    #
 # ---------------------------------------------------------- #
+alias j="juju"
 alias jam="juju add-model --config logging-config=\"<root>=WARNING; unit=DEBUG\"\
  --config update-status-hook-interval=\"60m\""
 alias jb='juju bootstrap'
+alias jbng='juju bootstrap --no-gui'
+alias jbl='juju bootstrap localhost'
+alias jblng='juju bootstrap --no-gui localhost'
 alias jbm='juju bootstrap microk8s'
+alias jbmng='juju bootstrap --no-gui microk8s'
 alias jc='juju config'
+alias jcld='juju clouds'
+alias jclda='juju clouds --all'
+alias jctl='juju controllers'
+alias jctlr='juju controllers --refresh'
 alias jdc='juju destroy-controller --destroy-all-models'
 alias 'jdc!'='juju destroy-controller --destroy-all-models --force --no-wait -y'
 alias jdcds='juju destroy-controller --destroy-all-models --destroy-storage'
@@ -61,7 +70,8 @@ alias jshc='juju ssh --container'
 alias jshm='juju show-model'
 alias jssl='juju show-status-log'
 alias jstj='juju status --format=json'
-alias jst='juju status --relations --storage --color'
+alias jst='juju status --relations --color'
+alias jsts='juju status --relations --storage --color'
 alias jsu='juju show-unit'
 alias jsw='juju switch'
 

--- a/plugins/juju/juju.plugin.zsh
+++ b/plugins/juju/juju.plugin.zsh
@@ -16,6 +16,7 @@ unset completion_file
 # Generally,                                                 #
 #   - `!` means --force --no-wait -y                         #
 #   - `ds` suffix means --destroy-storage                    #
+#   - `jsh` prefix means juju show-*                         #
 # ---------------------------------------------------------- #
 alias j="juju"
 alias jam="juju add-model --config logging-config=\"<root>=WARNING; unit=DEBUG\"\
@@ -65,14 +66,16 @@ alias jrp='juju refresh --path'
 alias jrs='juju remove-storage'
 alias 'jrs!'='juju remove-storage --force'
 alias jsa='juju scale-application'
-alias jsh='juju ssh'
-alias jshc='juju ssh --container'
+alias jssh='juju ssh'
+alias jsha='juju show-application'
+alias jshc='juju show-controller'
 alias jshm='juju show-model'
-alias jssl='juju show-status-log'
+alias jshsl='juju show-status-log'
+alias jshu='juju show-unit'
+alias jsshc='juju ssh --container'
 alias jstj='juju status --format=json'
 alias jst='juju status --relations --color'
 alias jsts='juju status --relations --storage --color'
-alias jsu='juju show-unit'
 alias jsw='juju switch'
 
 # ---------------------------------------------------------- #

--- a/plugins/juju/juju.plugin.zsh
+++ b/plugins/juju/juju.plugin.zsh
@@ -162,6 +162,6 @@ jreld() {
 wjst() {
   local interval="${1:-5}"
   shift $(( $# > 0 ))
-  watch -n "$interval" --color juju status --relations --storage --color "$@"
+  watch -n "$interval" --color juju status --relations --color "$@"
 }
 


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
- add `jclean` function to destroy all controllers
- use the `jsh` prefix for `juju show-*` commands
- drop `--storage` from plain `status`
- introduce additional aliases

## Other comments:
NTA