### PR TITLE
Fix iterm2 detection

### DIFF
--- a/plugins/iterm2/iterm2.plugin.zsh
+++ b/plugins/iterm2/iterm2.plugin.zsh
@@ -4,8 +4,8 @@
 #####################################################
 
 ###
-# This plugin is only relevant if the terminal is iTerm2 on OSX.
-if [[ "$OSTYPE" == darwin* ]] && [[ -n "$ITERM_SESSION_ID" ]] ; then
+# This plugin is only relevant if the original terminal is iTerm2, which can be detected through its installed zsh integration
+if { type iterm2_set_user_var &>/dev/null ; };  then
 
   ###
   # Executes an arbitrary iTerm2 command via an escape code sequce.


### PR DESCRIPTION
https://github.com/ohmyzsh/ohmyzsh/blob/fb12e4135311b9c4189a7e4556be619922052f6b/plugins/iterm2/iterm2.plugin.zsh#L8

One might be running iterm2 locally, but in a remote shell (possibly nested) that's not on OSX, and possibly pretending to be a different terminal (eg xterm-256color).

A better test is to directly check for iterm2's zsh integration, which will create the function `iterm2_set_user_var`.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
