### PR TITLE
fix(docker-compose)!: check for old command instead of calling `docker`

### DIFF
--- a/plugins/docker-compose/docker-compose.plugin.zsh
+++ b/plugins/docker-compose/docker-compose.plugin.zsh
@@ -1,7 +1,5 @@
 # support Compose v2 as docker CLI plugin
-DOCKER_CONTEXT=default command docker compose &>/dev/null \
-  && dccmd='docker compose' \
-  || dccmd='docker-compose'
+(( ${+commands[docker-compose]} )) && dccmd='docker-compose' || dccmd='docker compose'
 
 alias dco="$dccmd"
 alias dcb="$dccmd build"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Look for `docker-compose` command instead of trying `docker compose` to decide whether to use `docker compose` or `docker-compose` in aliases.

Fixes #10409