### PR TITLE
fix(bundler): use BUNDLE_JOBS in `bi` to avoid config file change

### DIFF
--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -40,7 +40,7 @@ bundle_install() {
   else
     local cores_num="$(nproc)"
   fi
-  bundle install --jobs="$cores_num" "$@"
+  BUNDLE_JOBS="$cores_num" bundle install "$@"
 }
 
 ## Gem wrapper

--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -81,14 +81,12 @@ bundled_commands=(
 )
 
 # Remove $UNBUNDLED_COMMANDS from the bundled_commands list
-for cmd in $UNBUNDLED_COMMANDS; do
-  bundled_commands=(${bundled_commands#$cmd});
-done
+bundled_commands=(${bundled_commands:|UNBUNDLED_COMMANDS})
+unset UNBUNDLED_COMMANDS
 
 # Add $BUNDLED_COMMANDS to the bundled_commands list
-for cmd in $BUNDLED_COMMANDS; do
-  bundled_commands+=($cmd);
-done
+bundled_commands+=($BUNDLED_COMMANDS)
+unset BUNDLED_COMMANDS
 
 # Check if in the root or a subdirectory of a bundled project
 _within-bundled-project() {
@@ -126,5 +124,4 @@ for cmd in $bundled_commands; do
     compdef "_$cmd" "bundled_$cmd"="$cmd"
   fi
 done
-
 unset cmd bundled_commands


### PR DESCRIPTION
When calling `bundle install` with `--jobs=<n>`, bundle persists this argument in `.bundle/config`. If we run `BUNDLE_JOBS=<n> bundle install` instead, this is not persisted.

Fixes #10425

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Other comments:

Reference: https://bundler.io/v1.14/man/bundle-config.1.html#LIST-OF-AVAILABLE-KEYS
