### PR TITLE
feat(xcode): support `.swiftpm` as project file in `xc`

### DIFF
--- a/plugins/xcode/README.md
+++ b/plugins/xcode/README.md
@@ -26,7 +26,7 @@ plugins=(... xcode)
 
 ###  `xc`
 
-Opens the current directory in Xcode as an Xcode project or a Swift package. This will open one of the `.xcworkspace`, `.xcodeproj` and `Package.swift` files that it can find in the current working directory. You can also specify a directory to look in for the Xcode files.
+Opens the current directory in Xcode as an Xcode project or a Swift package. This will open one of the `.xcworkspace`, `.xcodeproj`, `.swiftpm` and `Package.swift` files that it can find in the current working directory. You can also specify a directory to look in for the Xcode files.
 Returns 1 if it didn't find any relevant files.
 
 ###  `xx`

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -7,7 +7,7 @@ alias xcsel='sudo xcode-select --switch'
 # source: https://gist.github.com/subdigital/5420709
 function xc {
   local xcode_files
-  xcode_files=(${1:-.}/{*.{xcworkspace,xcodeproj},Package.swift}(N))
+  xcode_files=(${1:-.}/{*.{xcworkspace,xcodeproj,swiftpm},Package.swift}(N))
 
   if [[ ${#xcode_files} -eq 0 ]]; then
     echo "No Xcode files found in ${1:-the current directory}." >&2


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Allows to open the Swift Playgrounds App introduced by Xcode 13.2 directly with xc.

## Other comments:

N/A
