### PR TITLE
fix(heroku): fix XDG cache directory name and code style

### DIFF
--- a/plugins/heroku/heroku.plugin.zsh
+++ b/plugins/heroku/heroku.plugin.zsh
@@ -2,7 +2,7 @@ HEROKU_AC_CACHE_DIR="$HOME/.cache"
 if [ "$(uname -s)" = "Darwin" ]; then
   HEROKU_AC_CACHE_DIR="$HOME/Library/Caches"
 fi
-if [ ! -z "$XDG_CACHE_HOME" ]; then
+if [ -n "$XDG_CACHE_HOME" ]; then
   HEROKU_AC_CACHE_DIR="$XDG_CACHE_HOME"
 fi
 HEROKU_AC_ZSH_SETUP_PATH=$HEROKU_AC_CACHE_DIR/heroku/autocomplete/zsh_setup

--- a/plugins/heroku/heroku.plugin.zsh
+++ b/plugins/heroku/heroku.plugin.zsh
@@ -3,7 +3,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
   HEROKU_AC_CACHE_DIR="$HOME/Library/Caches"
 fi
 if [ ! -z "$XDG_CACHE_HOME" ]; then
-  HEROKU_AC_CACHE_DIR="$XDG_CACHE_DIR"
+  HEROKU_AC_CACHE_DIR="$XDG_CACHE_HOME"
 fi
 HEROKU_AC_ZSH_SETUP_PATH=$HEROKU_AC_CACHE_DIR/heroku/autocomplete/zsh_setup
 [ -f $HEROKU_AC_ZSH_SETUP_PATH ] && source $HEROKU_AC_ZSH_SETUP_PATH

--- a/plugins/heroku/heroku.plugin.zsh
+++ b/plugins/heroku/heroku.plugin.zsh
@@ -1,9 +1,9 @@
-HEROKU_AC_CACHE_DIR="$HOME/.cache"
-if [ "$(uname -s)" = "Darwin" ]; then
-  HEROKU_AC_CACHE_DIR="$HOME/Library/Caches"
+if [[ "$OSTYPE" = darwin* ]]; then
+  cache_dir="${HOME}/Library/Caches"
+else
+  cache_dir="${XDG_CACHE_HOME:-"${HOME}/.cache"}"
 fi
-if [ -n "$XDG_CACHE_HOME" ]; then
-  HEROKU_AC_CACHE_DIR="$XDG_CACHE_HOME"
-fi
-HEROKU_AC_ZSH_SETUP_PATH=$HEROKU_AC_CACHE_DIR/heroku/autocomplete/zsh_setup
-[ -f $HEROKU_AC_ZSH_SETUP_PATH ] && source $HEROKU_AC_ZSH_SETUP_PATH
+
+setup_path="${cache_dir}/heroku/autocomplete/zsh_setup"
+[[ -f "$setup_path" ]] && source $setup_path
+unset cache_dir setup_path


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fix name used to reference XDG_CACHE_HOME

## Other comments:

@jdxcode 
