### PR TITLE
Add plugin for ExpressVPN

### DIFF
--- a/plugins/expressvpn/README.md
+++ b/plugins/expressvpn/README.md
@@ -1,0 +1,14 @@
+# ExpressVPN
+
+This plugin provides completion support for [`ExpressVPN`](https://www.expressvpn.com/vpn-software/vpn-linux)
+command line interface on Linux.
+
+To use it, add expressvpn to the plugins array in your zshrc file.
+
+```zsh
+plugins=(... expressvpn)
+```
+
+## INSTALLATION NOTES
+
+Besides oh-my-zsh, `expressvpn` needs to be installed by following these steps: https://www.expressvpn.com/support/vpn-setup/app-for-linux/.

--- a/plugins/expressvpn/_expressvpn
+++ b/plugins/expressvpn/_expressvpn
@@ -1,0 +1,49 @@
+#compdef expressvpn
+
+# bash completion for expressvpn                           -*- shell-script -*-
+
+_expressvpn_bash_autocomplete() {
+    local cur cmd opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    if [ "$COMP_CWORD" -gt 1 ]; then
+        cmd="${COMP_WORDS[1]}"
+        opts=$( ${COMP_WORDS[0]} "$cmd" "${COMP_WORDS[@]:2:$COMP_CWORD-2}" --generate-bash-completion )
+    else
+        opts=$( ${COMP_WORDS[0]} --generate-bash-completion )
+    fi
+
+    local IFS=$'\n'
+    COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+
+    local escaped_single_qoute="\\'"
+    local i=0
+    for entry in ${COMPREPLY[*]}
+    do
+        if [[ "${cur:0:1}" == "'" ]] 
+        then
+            # started with single quote, escaping only other single quotes
+            # [']bla'bla"bla\bla bla --> [']bla'\''bla"bla\bla bla
+            COMPREPLY[$i]="${entry//\'/${escaped_single_qoute}}" 
+        elif [[ "${cur:0:1}" == "\"" ]] 
+        then
+            # started with double quote, escaping all double quotes and all backslashes
+            # ["]bla'bla"bla\bla bla --> ["]bla'bla\"bla\\bla bla
+            entry="${entry//\\/\\\\}" 
+            COMPREPLY[$i]="${entry//\"/\\\"}" 
+        else 
+            # no quotes in front, escaping _everything_
+            # [ ]bla'bla"bla\bla bla --> [ ]bla\'bla\"bla\\bla\ bla
+            entry="${entry//\\/\\\\}" 
+            entry="${entry//\'/\'}" 
+            entry="${entry//\"/\\\"}" 
+            COMPREPLY[$i]="${entry// /\\ }"
+        fi
+        (( i++ ))
+    done
+
+    return 0
+}
+
+complete -F _expressvpn_bash_autocomplete expressvpn


### PR DESCRIPTION
ExpressVPN comes with a completion script for Bash, but none for Zsh. Fortunately, I was able to make it work for both shells pretty easily with only a small modification (see diff below).

This code is not publicly hosted by ExpressVPN, so I figured that here would be a place that makes sense to publish it.

I also submitted the fix via ExpressVPN's support, although I do not know how much faith I should have that it will make it into their codebase someday.

This fix makes the autocompletion script also work on zsh without changing how it works for Bash. The expression "${COMP_WORDS[@]:2:$COMP_CWORD-2}" does not behave the
same on Bash and Zsh when the command has only zero or one arguments,
e.g. typing "expressvpn conne<TAB>" or "expressvpn <TAB>" would print
the error "autocomplete:8: substring expression: 1 < 2". This fixes it
by handling the case of the short command separately in a simpler way
and handling the rest of the cases the same way as before.

With this fix, zsh users just have to use the command "source
/usr/share/bash-completion/completions/expressvpn" to get the same
auto-completion as bash users.

File : /usr/share/bash-completion/completions/expressvpn

Diff to the original file (using the `diff` command) :

```diff
9a10,12
>         opts=$( ${COMP_WORDS[0]} "$cmd" "${COMP_WORDS[@]:2:$COMP_CWORD-2}" --generate-bash-completion )
>     else
>         opts=$( ${COMP_WORDS[0]} --generate-bash-completion )
11d13
<     opts=$( ${COMP_WORDS[0]} "$cmd" "${COMP_WORDS[@]:2:$COMP_CWORD-2}" --generate-bash-completion )
```
**NB:** bash is regularly referenced throughout the file, it is on purpose as I wanted to keep the diff to the original file to a minimum.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
