### PR TITLE
fix(lib): don't error if `INSIDE_EMACS` is not defined

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -10,7 +10,7 @@ function title {
   setopt localoptions nopromptsubst
 
   # Don't set the title if inside emacs, unless using vterm
-  [[ -n "$INSIDE_EMACS" && "$INSIDE_EMACS" != vterm ]] && return
+  [[ -n "${INSIDE_EMACS:-}" && "$INSIDE_EMACS" != vterm ]] && return
 
   # if $2 is unset use $1 as default
   # if it is set and empty, leave it as is


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- in lib/termsupport.zsh's title function: Use a parameter substitution to avoid erroring if INSIDE_EMACS is not set

## Other comments:

After updating ohmyzsh this morning, I was getting the following error:

```
title:4: INSIDE_EMACS: parameter not set                                        
zsh: vcs_info_msg_0_: parameter not set
~
```

where the final `~` is the start of my prompt, but not the whole thing. I tracked the `title:4` error to this `-n "$INSIDE_EMACS"` condition and have changed it to `-n "${INSIDE_EMACS:-}"`. The problem appears to have been introduced in a263cdac9:

```diff
diff --git a/lib/termsupport.zsh b/lib/termsupport.zsh
index ef0d7889..49f64400 100644
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -7,8 +7,7 @@
 # (In screen, only short_tab_title is used)
 # Limited support for Apple Terminal (Terminal can't set window and tab separately)
 function title {
-  emulate -L zsh
-  setopt prompt_subst
+  setopt localoptions nopromptsubst
 
   # Don't set the title if inside emacs, unless using vterm
   [[ -n "$INSIDE_EMACS" && "$INSIDE_EMACS" != vterm ]] && return
```

If I revert the title function to what it was previously, I no longer get the error. It sounds like there's some important reasons for making that change, though, so I've opted for a parameter substitution instead of changing setopt.