### PR TITLE
feat(updater): show command to update when update skipped

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -160,7 +160,8 @@ function update_ohmyzsh() {
     [[ "$option" != $'\n' ]] && echo
     case "$option" in
       [yY$'\n']) update_ohmyzsh ;;
-      [nN]) update_last_updated_file ;;
+      [nN]) update_last_updated_file ;&
+      *) echo "[oh-my-zsh] You can update manually by running \`omz update\`" ;;
     esac
   fi
 }


### PR DESCRIPTION
It's great that oh-my-zsh supports a "reminder" mode for updating.  I personally prefer the (default) prompting behavior.  However, I occasionally inadvertently dismiss it (usually as part of a "new tab -> start typing first command" workflow).  When I do so, I usually want to do the update as soon as possible afterwards.  I have a terrible memory, so it's a nice QOL change to emit the command to manually update, so that I can know what to run right away to trigger the update (rather than waiting for the next time I open a new shell).  This is kind of the best of both worlds of the prompt + reminder behavior.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
    - as far as I can tell (it's hard to search for "update" and get any relevant results 😃  )
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
    - I didn't see anything in the code style guide covering case statements 😬 
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Echo the command (`omz update`) to update oh-my-zsh if the prompt is declined
    - preserves the current behavior of only updating the timestamp if `n` was explicitly passed

## Other comments:


