### PR TITLE
ci(spelling): automatically accept aliased commands

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -22,6 +22,7 @@ acr
 acroread
 acs
 acsc
+acss
 acsp
 actionformats
 Adamantium
@@ -1459,6 +1460,7 @@ gpr
 gpristine
 gpsup
 gpu
+gpus
 gpv
 gradle
 gradlew
@@ -2396,6 +2398,7 @@ mirrorlist
 mixin
 mkcd
 mkdir
+mkdirs
 mktag
 mktemp
 mktree

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -30,6 +30,14 @@ jobs:
     - name: checkout
       if: github.event_name == 'push'
       uses: actions/checkout@v2
+    - name: find aliases
+      run: |
+        for a in $(git ls-files|grep '\.zsh$'); do
+          echo "-- $a"
+          if [ -s "$a" ]; then
+            perl -ne 'next unless s/^alias ([A-Za-z]{3,})=.*/$1/;print' "$a" | tee -a .github/actions/spelling/allow.txt
+          fi
+        done;
     - name: check-spelling
       id: spelling
       uses: check-spelling/check-spelling@prerelease


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- `expect.txt` shrinks a bit as items that are defined as aliases are automatically included in the dictionary

## Other comments:

Addresses https://github.com/ohmyzsh/ohmyzsh/pull/10349#issuecomment-985725019
