### PR TITLE
Fixing the path to homebrew installation of `asdf`

### DIFF
--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -4,7 +4,7 @@ ASDF_COMPLETIONS="$ASDF_DIR/completions"
 
 # If not found, check for Homebrew package
 if [[ ! -f "$ASDF_DIR/asdf.sh" || ! -f "$ASDF_COMPLETIONS/asdf.bash" ]] && (( $+commands[brew] )); then
-   ASDF_DIR="$(brew --prefix asdf)"
+   ASDF_DIR="$(brew --prefix asdf)/libexec"
    ASDF_COMPLETIONS="$ASDF_DIR/etc/bash_completion.d"
 fi
 

--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -5,7 +5,7 @@ ASDF_COMPLETIONS="$ASDF_DIR/completions"
 # If not found, check for Homebrew package
 if [[ ! -f "$ASDF_DIR/asdf.sh" || ! -f "$ASDF_COMPLETIONS/asdf.bash" ]] && (( $+commands[brew] )); then
    ASDF_DIR="$(brew --prefix asdf)/libexec"
-   ASDF_COMPLETIONS="$ASDF_DIR/etc/bash_completion.d"
+   ASDF_COMPLETIONS="$(brew --prefix asdf)/etc/bash_completion.d"
 fi
 
 # Load command


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

As the. code has been moved to `libexec` it seems, the path should be updated accordingly

## Other comments:

...
