### PR TITLE
feat(muse): add color showing return code

### DIFF
--- a/themes/muse.zsh-theme
+++ b/themes/muse.zsh-theme
@@ -1,4 +1,4 @@
-PROMPT="${FG[117]}%~%{$reset_color%}\$(git_prompt_info)\$(virtualenv_prompt_info)${FG[133]}\$(git_prompt_status) ${FG[077]}ᐅ%{$reset_color%} "
+PROMPT="${FG[117]}%~%{$reset_color%}\$(git_prompt_info)\$(virtualenv_prompt_info)${FG[133]}\$(git_prompt_status) ${FG[077]}%(?..${FG[160]}[%?] )ᐅ%{$reset_color%} "
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" ${FG[012]}("
 ZSH_THEME_GIT_PROMPT_SUFFIX="${FG[012]})%{$reset_color%}"


### PR DESCRIPTION
This MR injects in red the return code of the previous command if it differs from 0.

- [x ] The PR title is descriptive.
- [ x] The PR doesn't replicate another PR which is already open.
- [ x] I have read the contribution guide and followed all the instructions.
- [ x] The code follows the code style guide detailed in the wiki.
- [ x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

![2021-12-10-205441_935x82_scrot](https://user-images.githubusercontent.com/1290450/145633805-acda5ba1-7ce3-44cc-a70f-03fe06dcf1d5.png)

@mattsacks