### PR TITLE
fix(ys): use default color instead of gray for improved readability

### DIFF
--- a/themes/ys.zsh-theme
+++ b/themes/ys.zsh-theme
@@ -5,10 +5,8 @@
 #
 # Mar 2013 Yad Smood
 
-typeset +H my_gray="$FG[247]"
-
 # VCS
-YS_VCS_PROMPT_PREFIX1=" %{$my_gray%}on%{$reset_color%} "
+YS_VCS_PROMPT_PREFIX1=" %{$reset_color%}on%{$fg[blue]%} "
 YS_VCS_PROMPT_PREFIX2=":%{$fg[cyan]%}"
 YS_VCS_PROMPT_SUFFIX="%{$reset_color%}"
 YS_VCS_PROMPT_DIRTY=" %{$fg[red]%}x"
@@ -62,13 +60,13 @@ local exit_code="%(?,,C:%{$fg[red]%}%?%{$reset_color%})"
 PROMPT="
 %{$terminfo[bold]$fg[blue]%}#%{$reset_color%} \
 %(#,%{$bg[yellow]%}%{$fg[black]%}%n%{$reset_color%},%{$fg[cyan]%}%n) \
-%{$my_gray%}@ \
+%{$reset_color%}@ \
 %{$fg[green]%}%m \
-%{$my_gray%}in \
+%{$reset_color%}in \
 %{$terminfo[bold]$fg[yellow]%}%~%{$reset_color%}\
 ${hg_info}\
 ${git_info}\
 ${venv_info}\
  \
-%{$my_gray%}[%*] $exit_code
+[%*] $exit_code
 %{$terminfo[bold]$fg[red]%}$ %{$reset_color%}"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Changes part of the prompt which were changed from white to grey to the terminal default color, providing a better experience across more terminal themes.

On my normal Konsole Breeze:
![image](https://user-images.githubusercontent.com/616215/145695183-2276aec0-e064-4082-bce8-0ffed35abef5.png)

On Konsole Solarized Light:
![image](https://user-images.githubusercontent.com/616215/145695326-86146c62-cf47-4907-9e01-240c7625d354.png)

## Other comments:

Replaces this PR: https://github.com/ohmyzsh/ohmyzsh/pull/10295
