### PR TITLE
Added support for SUSE-derived operation systems (ZYpp) to CNF plugin

### DIFF
--- a/plugins/command-not-found/README.md
+++ b/plugins/command-not-found/README.md
@@ -29,5 +29,6 @@ It works out of the box with the command-not-found packages for:
 - [Fedora](https://fedoraproject.org/wiki/Features/PackageKitCommandNotFound)
 - [NixOS](https://github.com/NixOS/nixpkgs/tree/master/nixos/modules/programs/command-not-found)
 - [Termux](https://github.com/termux/command-not-found)
+- [SUSE](https://www.unix.com/man-page/suse/1/command-not-found/)
 
 You can add support for other platforms by submitting a Pull Request.

--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -60,3 +60,10 @@ if [[ -x /data/data/com.termux/files/usr/libexec/termux/command-not-found ]]; th
     /data/data/com.termux/files/usr/libexec/termux/command-not-found "$1"
   }
 fi
+
+# SUSE and derivates: https://www.unix.com/man-page/suse/1/command-not-found/
+if [[ -x /usr/bin/command-not-found ]]; then
+  command_not_found_handler() {
+    /usr/bin/command-not-found "$1"
+  }
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Added support for SUSE and its derivatives utilizing the ZYpp package manager to the command-not-found plugin.
 
On openSUSE Tumbleweed:
 
![image](https://user-images.githubusercontent.com/90578104/146115611-1cafb7bd-337b-4418-a578-a29f41626e6e.png)