### PR TITLE
feat(init): add options to disable Oh My Zsh aliases

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -143,6 +143,12 @@ fi
 
 unset zcompdump_revision zcompdump_fpath zcompdump_refresh
 
+# Store current aliases if should not enable the default ones from Oh My Zsh 
+local aliases_backup="/tmp/aliases_backup.sh"
+
+if [[ "$DISABLE_OMZ_ALIASES" == "true" ]]; then
+  alias > $aliases_backup
+fi
 
 # Load all of the config files in ~/oh-my-zsh that end in .zsh
 # TIP: Add files you don't want in git to .gitignore
@@ -152,6 +158,11 @@ for config_file ($ZSH/lib/*.zsh); do
   source $config_file
 done
 
+# Store current aliases if should not enable the ones from plugins
+if [[ "$DISABLE_OMZ_PLUGIN_ALIASES" == "true" ]] && [[ "$DISABLE_OMZ_ALIASES" != "true" ]]; then
+  alias > $aliases_backup
+fi
+
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do
   if [ -f $ZSH_CUSTOM/plugins/$plugin/$plugin.plugin.zsh ]; then
@@ -160,6 +171,15 @@ for plugin ($plugins); do
     source $ZSH/plugins/$plugin/$plugin.plugin.zsh
   fi
 done
+
+# Restore saved aliases
+if [[ "$DISABLE_OMZ_ALIASES" == "true" ]] || [[ "$DISABLE_OMZ_PLUGIN_ALIASES" == "true" ]]; then
+  if [ -f "$aliases_backup" ]; then
+    unalias -a
+    sed -i -e 's/^/alias /' $aliases_backup
+    source $aliases_backup
+  fi
+fi
 
 # Load all of your custom configurations from custom/
 for config_file ($ZSH_CUSTOM/*.zsh(N)); do

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -43,6 +43,12 @@ ZSH_THEME="robbyrussell"
 # Uncomment the following line to enable command auto-correction.
 # ENABLE_CORRECTION="true"
 
+# Uncomment the following line to disable all Oh My Zsh aliases.
+# DISABLE_OMZ_ALIASES="true"
+
+# Uncomment the following line to disable only plugin related aliases.
+# DISABLE_OMZ_PLUGIN_ALIASES="true"
+
 # Uncomment the following line to display red dots whilst waiting for completion.
 # You can also set it to another string to have that shown instead of the default red dots.
 # e.g. COMPLETION_WAITING_DOTS="%F{yellow}waiting...%f"


### PR DESCRIPTION
Closes #9414, resolves #8344, closes #7328, closes #6630, resolves #8933, resolves #8015, closes #9621

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added option to not enable any alias from Oh My Zsh: DISABLE_OMZ_ALIASES
- Added option to not enable Oh My Zsh plugins aliases: DISABLE_OMZ_PLUGIN_ALIASES

## Other comments:
Long time requested feature.
...
