### PR TITLE
refactor(fzf): adopt code style and simplify function naming

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -163,7 +163,7 @@ setup_using_openbsd_package \
     || setup_using_base_dir \
     || indicate_error
 
-unset -f setup_using_opensuse_package setup_using_debian_package setup_using_base_dir indicate_error
+unset -f setup_using_openbsd_package setup_using_opensuse_package setup_using_debian_package setup_using_base_dir indicate_error
 
 if [[ -z "$FZF_DEFAULT_COMMAND" ]]; then
     if (( $+commands[rg] )); then

--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -1,176 +1,176 @@
-function setup_using_base_dir() {
-    local fzf_base fzf_shell fzfdirs dir
+function fzf_setup_using_base_dir() {
+  local fzf_base fzf_shell fzfdirs dir
 
-    test -d "${FZF_BASE}" && fzf_base="${FZF_BASE}"
+  test -d "${FZF_BASE}" && fzf_base="${FZF_BASE}"
+
+  if [[ -z "${fzf_base}" ]]; then
+    fzfdirs=(
+      "${HOME}/.fzf"
+      "${HOME}/.nix-profile/share/fzf"
+      "${XDG_DATA_HOME:-$HOME/.local/share}/fzf"
+      "/usr/local/opt/fzf"
+      "/usr/share/fzf"
+      "/usr/local/share/examples/fzf"
+    )
+    for dir in ${fzfdirs}; do
+      if [[ -d "${dir}" ]]; then
+        fzf_base="${dir}"
+        break
+      fi
+    done
 
     if [[ -z "${fzf_base}" ]]; then
-        fzfdirs=(
-          "${HOME}/.fzf"
-          "${HOME}/.nix-profile/share/fzf"
-          "${XDG_DATA_HOME:-$HOME/.local/share}/fzf"
-          "/usr/local/opt/fzf"
-          "/usr/share/fzf"
-          "/usr/local/share/examples/fzf"
-        )
-        for dir in ${fzfdirs}; do
-            if [[ -d "${dir}" ]]; then
-                fzf_base="${dir}"
-                break
-            fi
-        done
-
-        if [[ -z "${fzf_base}" ]]; then
-            if (( ${+commands[fzf-share]} )) && dir="$(fzf-share)" && [[ -d "${dir}" ]]; then
-                fzf_base="${dir}"
-            elif (( ${+commands[brew]} )) && dir="$(brew --prefix fzf 2>/dev/null)"; then
-                if [[ -d "${dir}" ]]; then
-                    fzf_base="${dir}"
-                fi
-            fi
+      if (( ${+commands[fzf-share]} )) && dir="$(fzf-share)" && [[ -d "${dir}" ]]; then
+        fzf_base="${dir}"
+      elif (( ${+commands[brew]} )) && dir="$(brew --prefix fzf 2>/dev/null)"; then
+        if [[ -d "${dir}" ]]; then
+          fzf_base="${dir}"
         fi
+      fi
     fi
+  fi
 
-    if [[ ! -d "${fzf_base}" ]]; then
-        return 1
-    fi
+  if [[ ! -d "${fzf_base}" ]]; then
+    return 1
+  fi
 
-    # Fix fzf shell directory for Arch Linux, NixOS or Void Linux packages
-    if [[ ! -d "${fzf_base}/shell" ]]; then
-        fzf_shell="${fzf_base}"
-    else
-        fzf_shell="${fzf_base}/shell"
-    fi
+  # Fix fzf shell directory for Arch Linux, NixOS or Void Linux packages
+  if [[ ! -d "${fzf_base}/shell" ]]; then
+    fzf_shell="${fzf_base}"
+  else
+    fzf_shell="${fzf_base}/shell"
+  fi
 
-    # Setup fzf binary path
-    if (( ! ${+commands[fzf]} )) && [[ "$PATH" != *$fzf_base/bin* ]]; then
-        export PATH="$PATH:$fzf_base/bin"
-    fi
+  # Setup fzf binary path
+  if (( ! ${+commands[fzf]} )) && [[ "$PATH" != *$fzf_base/bin* ]]; then
+    export PATH="$PATH:$fzf_base/bin"
+  fi
 
-    # Auto-completion
-    if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
-        source "${fzf_shell}/completion.zsh" 2> /dev/null
-    fi
+  # Auto-completion
+  if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
+    source "${fzf_shell}/completion.zsh" 2> /dev/null
+  fi
 
-    # Key bindings
-    if [[ "$DISABLE_FZF_KEY_BINDINGS" != "true" ]]; then
-        source "${fzf_shell}/key-bindings.zsh"
-    fi
+  # Key bindings
+  if [[ "$DISABLE_FZF_KEY_BINDINGS" != "true" ]]; then
+    source "${fzf_shell}/key-bindings.zsh"
+  fi
 }
 
 
-function setup_using_debian_package() {
-    if (( ! $+commands[dpkg] )) || ! dpkg -s fzf &>/dev/null; then
-        # Either not a debian based distro, or no fzf installed
-        return 1
-    fi
+function fzf_setup_using_debian() {
+  if (( ! $+commands[dpkg] )) || ! dpkg -s fzf &>/dev/null; then
+    # Either not a debian based distro, or no fzf installed
+    return 1
+  fi
 
-    # NOTE: There is no need to configure PATH for debian package, all binaries
-    # are installed to /usr/bin by default
+  # NOTE: There is no need to configure PATH for debian package, all binaries
+  # are installed to /usr/bin by default
 
-    local completions key_bindings
+  local completions key_bindings
 
-    case $PREFIX in
-        *com.termux*)
-            # Support Termux package
-            completions="${PREFIX}/share/fzf/completion.zsh"
-            key_bindings="${PREFIX}/share/fzf/key-bindings.zsh"
-            ;;
-        *)
-            # Determine completion file path: first bullseye/sid, then buster/stretch
-            completions="/usr/share/doc/fzf/examples/completion.zsh"
-            [[ -f "$completions" ]] || completions="/usr/share/zsh/vendor-completions/_fzf"
-            key_bindings="/usr/share/doc/fzf/examples/key-bindings.zsh"
-            ;;
-    esac
+  case $PREFIX in
+    *com.termux*)
+      # Support Termux package
+      completions="${PREFIX}/share/fzf/completion.zsh"
+      key_bindings="${PREFIX}/share/fzf/key-bindings.zsh"
+      ;;
+    *)
+      # Determine completion file path: first bullseye/sid, then buster/stretch
+      completions="/usr/share/doc/fzf/examples/completion.zsh"
+      [[ -f "$completions" ]] || completions="/usr/share/zsh/vendor-completions/_fzf"
+      key_bindings="/usr/share/doc/fzf/examples/key-bindings.zsh"
+      ;;
+  esac
 
-    # Auto-completion
-    if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
-        source $completions 2> /dev/null
-    fi
+  # Auto-completion
+  if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
+    source $completions 2> /dev/null
+  fi
 
-    # Key bindings
-    if [[ ! "$DISABLE_FZF_KEY_BINDINGS" == "true" ]]; then
-        source $key_bindings
-    fi
+  # Key bindings
+  if [[ ! "$DISABLE_FZF_KEY_BINDINGS" == "true" ]]; then
+    source $key_bindings
+  fi
 
-    return 0
+  return 0
 }
 
-function setup_using_opensuse_package() {
-    # OpenSUSE installs fzf in /usr/bin/fzf
-    # If the command is not found, the package isn't installed
-    (( $+commands[fzf] )) || return 1
+function fzf_setup_using_opensuse() {
+  # OpenSUSE installs fzf in /usr/bin/fzf
+  # If the command is not found, the package isn't installed
+  (( $+commands[fzf] )) || return 1
 
-    # The fzf-zsh-completion package installs the auto-completion in
-    local completions="/usr/share/zsh/site-functions/_fzf"
-    # The fzf-zsh-completion package installs the key-bindings file in
-    local key_bindings="/etc/zsh_completion.d/fzf-key-bindings"
+  # The fzf-zsh-completion package installs the auto-completion in
+  local completions="/usr/share/zsh/site-functions/_fzf"
+  # The fzf-zsh-completion package installs the key-bindings file in
+  local key_bindings="/etc/zsh_completion.d/fzf-key-bindings"
 
-    # If these are not found: (1) maybe we're not on OpenSUSE, or
-    # (2) maybe the fzf-zsh-completion package isn't installed.
-    if [[ ! -f "$completions" || ! -f "$key_bindings" ]]; then
-        return 1
-    fi
+  # If these are not found: (1) maybe we're not on OpenSUSE, or
+  # (2) maybe the fzf-zsh-completion package isn't installed.
+  if [[ ! -f "$completions" || ! -f "$key_bindings" ]]; then
+    return 1
+  fi
 
-    # Auto-completion
-    if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
-        source "$completions" 2>/dev/null
-    fi
+  # Auto-completion
+  if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
+    source "$completions" 2>/dev/null
+  fi
 
-    # Key bindings
-    if [[ "$DISABLE_FZF_KEY_BINDINGS" != "true" ]]; then
-        source "$key_bindings" 2>/dev/null
-    fi
+  # Key bindings
+  if [[ "$DISABLE_FZF_KEY_BINDINGS" != "true" ]]; then
+    source "$key_bindings" 2>/dev/null
+  fi
 
-    return 0
+  return 0
 }
 
-function setup_using_openbsd_package() {
-    # openBSD installs fzf in /usr/local/bin/fzf
-    if [[ "$OSTYPE" != openbsd* ]] || (( ! $+commands[fzf] )); then
-        return 1
-    fi
+function fzf_setup_using_openbsd() {
+  # openBSD installs fzf in /usr/local/bin/fzf
+  if [[ "$OSTYPE" != openbsd* ]] || (( ! $+commands[fzf] )); then
+    return 1
+  fi
 
-    # The fzf package installs the auto-completion in
-    local completions="/usr/local/share/zsh/site-functions/_fzf_completion"
-    # The fzf package installs the key-bindings file in
-    local key_bindings="/usr/local/share/zsh/site-functions/_fzf_key_bindings"
+  # The fzf package installs the auto-completion in
+  local completions="/usr/local/share/zsh/site-functions/_fzf_completion"
+  # The fzf package installs the key-bindings file in
+  local key_bindings="/usr/local/share/zsh/site-functions/_fzf_key_bindings"
 
-    # Auto-completion
-    if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
-        source "$completions" 2>/dev/null
-    fi
+  # Auto-completion
+  if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
+    source "$completions" 2>/dev/null
+  fi
 
-    # Key bindings
-    if [[ "$DISABLE_FZF_KEY_BINDINGS" != "true" ]]; then
-        source "$key_bindings" 2>/dev/null
-    fi
+  # Key bindings
+  if [[ "$DISABLE_FZF_KEY_BINDINGS" != "true" ]]; then
+    source "$key_bindings" 2>/dev/null
+  fi
 
-    return 0
-}
-
-function indicate_error() {
-    cat >&2 <<EOF
-[oh-my-zsh] fzf plugin: Cannot find fzf installation directory.
-Please add \`export FZF_BASE=/path/to/fzf/install/dir\` to your .zshrc
-EOF
+  return 0
 }
 
 # Indicate to user that fzf installation not found if nothing worked
-setup_using_openbsd_package \
-    || setup_using_debian_package \
-    || setup_using_opensuse_package \
-    || setup_using_base_dir \
-    || indicate_error
+function fzf_setup_error() {
+  cat >&2 <<'EOF'
+[oh-my-zsh] fzf plugin: Cannot find fzf installation directory.
+Please add `export FZF_BASE=/path/to/fzf/install/dir` to your .zshrc
+EOF
+}
 
-unset -f setup_using_openbsd_package setup_using_opensuse_package setup_using_debian_package setup_using_base_dir indicate_error
+fzf_setup_using_openbsd \
+  || fzf_setup_using_debian \
+  || fzf_setup_using_opensuse \
+  || fzf_setup_using_base_dir \
+  || fzf_setup_error
+
+unset -f -m 'fzf_setup_*'
 
 if [[ -z "$FZF_DEFAULT_COMMAND" ]]; then
-    if (( $+commands[rg] )); then
-        export FZF_DEFAULT_COMMAND='rg --files --hidden --glob "!.git/*"'
-    elif (( $+commands[fd] )); then
-        export FZF_DEFAULT_COMMAND='fd --type f --hidden --exclude .git'
-    elif (( $+commands[ag] )); then
-        export FZF_DEFAULT_COMMAND='ag -l --hidden -g "" --ignore .git'
-    fi
+  if (( $+commands[rg] )); then
+    export FZF_DEFAULT_COMMAND='rg --files --hidden --glob "!.git/*"'
+  elif (( $+commands[fd] )); then
+    export FZF_DEFAULT_COMMAND='fd --type f --hidden --exclude .git'
+  elif (( $+commands[ag] )); then
+    export FZF_DEFAULT_COMMAND='ag -l --hidden -g "" --ignore .git'
+  fi
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fixes `setup_using_openbsd_package` function from fzf plugin from leaking into user environment by unset-ing like its counter-parts.

## Other comments:

- #9463 includes this change, but not in isolation.