### PR TITLE
Handle dollar zero ($0) according to the zsh plugin standard

### DIFF
--- a/plugins/cargo/cargo.plugin.zsh
+++ b/plugins/cargo/cargo.plugin.zsh
@@ -1,4 +1,9 @@
 if (( $+commands[rustup] && $+commands[cargo] )); then
+  # Handle $0 according to the standard:
+  # https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+  0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+  0="${${(M)0:#/*}:-$PWD/$0}"
+
   # remove old generated completion file
   command rm -f "${0:A:h}/_cargo"
 

--- a/plugins/colemak/colemak.plugin.zsh
+++ b/plugins/colemak/colemak.plugin.zsh
@@ -19,6 +19,11 @@ bindkey -a 'N' vi-join
 bindkey -a 'j' vi-forward-word-end
 bindkey -a 'J' vi-forward-blank-word-end
 
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 # New less versions will read this file directly
 export LESSKEYIN="${0:h:A}/colemak-less"
 

--- a/plugins/colored-man-pages/colored-man-pages.plugin.zsh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.zsh
@@ -16,6 +16,11 @@ less_termcap[se]="${reset_color}"
 less_termcap[us]="${fg_bold[green]}"
 less_termcap[ue]="${reset_color}"
 
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 # Absolute path to this file's directory.
 typeset __colored_man_pages_dir="${0:A:h}"
 

--- a/plugins/deno/deno.plugin.zsh
+++ b/plugins/deno/deno.plugin.zsh
@@ -13,6 +13,11 @@ alias dup='deno upgrade'
 
 # COMPLETION FUNCTION
 if (( $+commands[deno] )); then
+  # Handle $0 according to the standard:
+  # https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+  0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+  0="${${(M)0:#/*}:-$PWD/$0}"
+
   # remove old generated completion file
   command rm -f "${0:A:h}/_deno"
 

--- a/plugins/emacs/emacs.plugin.zsh
+++ b/plugins/emacs/emacs.plugin.zsh
@@ -13,6 +13,11 @@
 autoload -Uz is-at-least
 is-at-least 24 "${${(Az)"$(emacsclient --version 2>/dev/null)"}[2]}" || return 0
 
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 # Path to custom emacsclient launcher
 export EMACS_PLUGIN_LAUNCHER="${0:A:h}/emacsclient.sh"
 

--- a/plugins/emoji/emoji.plugin.zsh
+++ b/plugins/emoji/emoji.plugin.zsh
@@ -4,6 +4,11 @@
 #
 # See the README for documentation.
 
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 _omz_emoji_plugin_dir="${0:h}"
 
 () {

--- a/plugins/emotty/emotty.plugin.zsh
+++ b/plugins/emotty/emotty.plugin.zsh
@@ -10,6 +10,11 @@
 # % export emotty_set=nature
 # ------------------------------------------------------------------------------
 
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 typeset -gAH _emotty_sets
 local _emotty_plugin_dir="${0:h}"
 source "$_emotty_plugin_dir/emotty_stellar_set.zsh"

--- a/plugins/fnm/fnm.plugin.zsh
+++ b/plugins/fnm/fnm.plugin.zsh
@@ -1,4 +1,9 @@
 if (( $+commands[fnm] )); then
+  # Handle $0 according to the standard:
+  # https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+  0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+  0="${${(M)0:#/*}:-$PWD/$0}"
+
   # remove old generated completion file
   command rm -f "${0:A:h}/_fnm"
 

--- a/plugins/gh/gh.plugin.zsh
+++ b/plugins/gh/gh.plugin.zsh
@@ -1,5 +1,10 @@
 # Autocompletion for the GitHub CLI (gh).
 if (( $+commands[gh] )); then
+  # Handle $0 according to the standard:
+  # https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+  0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+  0="${${(M)0:#/*}:-$PWD/$0}"
+
   # remove old generated completion file
   command rm -f "${0:A:h}/_gh"
 

--- a/plugins/git-prompt/git-prompt.plugin.zsh
+++ b/plugins/git-prompt/git-prompt.plugin.zsh
@@ -1,3 +1,8 @@
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 __GIT_PROMPT_DIR="${0:A:h}"
 
 ## Hook function definitions

--- a/plugins/gitfast/gitfast.plugin.zsh
+++ b/plugins/gitfast/gitfast.plugin.zsh
@@ -1,3 +1,8 @@
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 source "${0:A:h}/git-prompt.sh"
 
 function git_prompt_info() {

--- a/plugins/history-substring-search/history-substring-search.plugin.zsh
+++ b/plugins/history-substring-search/history-substring-search.plugin.zsh
@@ -1,4 +1,8 @@
-0=${(%):-%N}
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 source ${0:A:h}/history-substring-search.zsh
 
 

--- a/plugins/hitchhiker/hitchhiker.plugin.zsh
+++ b/plugins/hitchhiker/hitchhiker.plugin.zsh
@@ -1,3 +1,8 @@
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 HITCHHIKER_DIR="${0:h}/fortunes"
 
 # Aliases

--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -1,3 +1,8 @@
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 # Open the current directory in a Finder window
 alias ofd='open_command $PWD'
 

--- a/plugins/rustup/rustup.plugin.zsh
+++ b/plugins/rustup/rustup.plugin.zsh
@@ -1,4 +1,9 @@
 if (( $+commands[rustup] )); then
+  # Handle $0 according to the standard:
+  # https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+  0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+  0="${${(M)0:#/*}:-$PWD/$0}"
+
   # remove old generated completion file
   command rm -f "${0:A:h}/_rustup"
 

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -46,6 +46,11 @@ else
   export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITHOUT_256COLOR
 fi
 
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 # Set the correct local config file to use.
 if [[ "$ZSH_TMUX_ITERM2" == "false" && -e "$ZSH_TMUX_CONFIG" ]]; then
   export ZSH_TMUX_CONFIG

--- a/plugins/wd/wd.plugin.zsh
+++ b/plugins/wd/wd.plugin.zsh
@@ -7,4 +7,9 @@
 #
 # @github.com/mfaerevaag/wd
 
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 eval "wd() { source '${0:A:h}/wd.sh' }"

--- a/plugins/z/z.plugin.zsh
+++ b/plugins/z/z.plugin.zsh
@@ -1,1 +1,6 @@
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
 source "${0:h}/z.sh"

--- a/plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh
+++ b/plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh
@@ -7,10 +7,11 @@
 # to ~/.zshrc.
 #
 
-# According to the standard:
-# http://zdharma.org/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
+# Handle $0 according to the standard:
+# https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard#zero-handling
 0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
+
 export ZNT_REPO_DIR="${0:h}"
 export ZNT_CONFIG_DIR="$HOME/.config/znt"
 


### PR DESCRIPTION
## Problem

While setting up [zpm](https://github.com/zpm-zsh/zpm), I discovered that some oh-my-zsh plugins don't work correctly with it. In my case, `macos` and `z`:

```
(anon):source:261: no such file or directory: /home/curtis/code/ctrueden/dotfiles/music
(anon):source:264: no such file or directory: /home/curtis/code/ctrueden/dotfiles/spotify
(anon):source:2: no such file or directory: ./z.sh
```

## Diagnosis

The problem is caused by the usage of the `$0` environment variable. The author of zpm, @grigorii-horos, writes in zpm-zsh/zpm#39 that a declaration `0=${(%):-%N}` needs to be present for expressions involving `$0`, but the affected plugins do not have such a declaration. There is also another issue zpm-zsh/zpm#36 specifically discussing this issue with respect to the `macos` plugin.

## Workaround

In the case of `zpm`, you can work around the problem by adding a `,source:my.plugin.zsh` suffix to the `zpm load` command. For example, for `z`, change:
```zsh
zpm load @omz/z
```
to:
```
zpm load @omz/z,source:z.plugin.zsh
```
But if I understand correctly, this makes `zpm` re-source the plugin every time, rather than caching it for performance?

Edit: I have now tested on both macOS and Linux, and the above workaround only works on my Linux system, not my macOS system. So YMMV. But the solution implemented in this PR addresses the problem on both platforms.

## Proposed solution

I decided I would try my hand at a PR for the `macos` plugin. But while grep for `${0...}` usages within ohmyzsh codebase, I discovered quite a few. So this PR then became an attempt to fix all the instances of this issue that I found. I am a long-time *nix shell user, but not a zsh expert, so please consider it an attempt to start a dialogue about this issue, so that we can have better behavior between oh-my-zsh, zpm, and potentially other plugin managers as well.

## Points to consider

* As part of this work, I wanted to put a comment next to every `0=` declaration pointing to the Zsh Plugin Standard document, which is apparently where this whole thing got started. Unfortunately, the commonly shared URL for that standard, `http://zdharma.org/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html`, is now defunct. (One plugin in this repository, `zsh-navigation-tools`, [references that broken link](https://github.com/ohmyzsh/ohmyzsh/blob/904f8685f75ff5dd3f544f8c6f2cabb8e5952e9a/plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh#L10-L11), so I updated it as part of this PR.) I found a newer functional URL for the standard at https://z-shell.github.io/zsh-plugin-assessor/Zsh-Plugin-Standard, although it appears that the `zsh-plugin-assessor` repository was recently renamed from `Zsh-100-Commits-Club`, so another URL `http://z-shell.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard` is also floating around and unfortunately does not redirect to the current location.

* The Zsh Plugin Standard's recommended `$0` block is more complex than the one given by @grigorii-horos; I opted for the one given in the standard. If people think the more concise expression `0=${(%):-%N}` is better/sufficient, I can update the PR to use that expression instead—just let me know.

* I tried to put the `$0` handling code near where the `$0` gets referenced in each plugin, and nested inside the corresponding `if` statement where applicable. If people think it would be better to have these declarations always at the top of each file, I can update the PR to do that instead—just let me know.

* I don't like that the same 2-4 lines of code are repeated in many places across the codebase. I'm hopeful that the oh-my-zsh experts here can suggest a [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)er way of organizing this—perhaps some common function that can be used as a one-liner where needed? But regardless, I think this PR is a step forward compared to the currently broken behavior of various plugins.

* I confess that I did not test this change for every affected plugin, since I don't use them all. However, I did update my zpm installation to use this PR's branch, and the errors cited above go away, and everything appears to work correctly. If more thorough testing is needed, please just let me know what is needed and I will try to do it.

Finally, apologies if this topic has already been covered in a previous issue or PR. I tried searching for it, but could not find anything—as you can imagine, expressions like `0=${(%):-%N}` do not exactly make search engines happy. 😅

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open (as far as I can tell!).
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
