### PR TITLE
fix(symfony2): silence debug lines in command completion

### DIFF
--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -5,7 +5,7 @@ _symfony_console () {
 }
 
 _symfony2_get_command_list () {
-   `_symfony_console` --no-ansi | sed "1,/Available commands/d" | awk '/^  ?[^ ]+ / { print $1 }'
+   `_symfony_console` --no-ansi --no-debug | sed "1,/Available commands/d" | awk '/^  ?[^ ]+ / { print $1 }'
 }
 
 _symfony2 () {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

The "php bin/console" command can write "info/warn" logs and breaks the "sed/awk" command. it makes the Deprecated code visible
````
$ php $(find . -maxdepth 2 -mindepth 1 -name 'console' -type f | head -n 1) --no-ansi | sed "1,/Available commands/d" | awk '/^  ?[^ ]+ / { print $1 }'
[....]
2021-12-23T13:51:13+00:00 [info] User Deprecated: Method "Countable::count()" might add "int" as a native return type declaration in the future. Do the same in implementation "Aws\HandlerList" now to avoid errors or add an explicit @return annotation
security:encode-password 
security:hash-password
workflow:dump
````

Adding the option "--no-debug" in the "php bin/console" command deactivates debug mode
````
$ php $(find . -maxdepth 2 -mindepth 1 -name 'console' -type f | head -n 1) --no-ansi --no-debug | sed "1,/Available commands/d" | awk '/^  ?[^ ]+ / { print $1 }'
[....]
security:encode-password 
security:hash-password
workflow:dump
````
