### PR TITLE
feat(laravel): add make:migration for laravel

### DIFF
--- a/plugins/laravel/README.md
+++ b/plugins/laravel/README.md
@@ -29,12 +29,15 @@ plugins=(... laravel)
 | `pamc`  |  `php artisan make:controller` |
 | `pams`  |  `php artisan make:seeder` |
 | `pamt`  |  `php artisan make:test` |
-| `pamfa`  |  `php artisan make:factory` |
+| `pamfa` |  `php artisan make:factory` |
 | `pamp`  |  `php artisan make:policy` |
 | `pame`  |  `php artisan make:event` |
 | `pamj`  |  `php artisan make:job` |
 | `paml`  |  `php artisan make:listener` |
 | `pamn`  |  `php artisan make:notification` |
+| `pampp` |  `php artisan make:provider` |
+| `pammm` |  `php artisan make:migration` |
+
 
 ## Clears
 

--- a/plugins/laravel/laravel.plugin.zsh
+++ b/plugins/laravel/laravel.plugin.zsh
@@ -24,6 +24,7 @@ alias pamj='php artisan make:job'
 alias paml='php artisan make:listener'
 alias pamn='php artisan make:notification'
 alias pampp='php artisan make:provider'
+alias pammm='php artisan make:migration'
 
 
 # Clears


### PR DESCRIPTION
Added php artisan make:migration for laravel( I also edited readme.md filein second commit. (added make:migration command, and I see make:provider command is dont added in readme, I added that too.))

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [Added php artisan make:migration to laravel plugin]
