### PR TITLE
add: git alias - git status with no untracked files displayed

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -279,6 +279,7 @@ alias gsps='git show --pretty=short --show-signature'
 alias gsr='git svn rebase'
 alias gss='git status -s'
 alias gst='git status'
+alias gstnu='git status --untracked-files=no'
 
 # use the default stash push on git 2.13 and newer
 is-at-least 2.13 "$git_version" \


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

-  add an alias for git, to easily hide untracked files.

Name of the alias: `gstnu`:

- `gst` as basis for the  `git status` command
- `nu` as a short mnemo tips for 'no untracked' 


## Other comments:

Hiding untracked files is especially conveneinent when working in a repo with lots of autogenerated files you don't want to add in your .gitignore.