### PR TITLE
fix(systemd): fix the restart command

### DIFF
--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -45,6 +45,7 @@ sudo_commands=(
   reload-or-restart
   reset-failed
   rescue
+  restart
   revert
   set-default
   set-environment
@@ -63,7 +64,6 @@ power_commands=(
   hybrid-sleep
   poweroff
   reboot
-  restart
   suspend
 )
 


### PR DESCRIPTION
`restart` is a unit-related command, not power-related, so it should appear as `sc-restart=sudo systemctl restart` and `scu-restart=systemctl --user restart`

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- In #9441 I introduced a bad commit which falsely deleted the `scu-restart=systemctl --user restart` command. I moved away from oh my zsh soon after that PR so never found the issue myself. However, after it was merged, someone else notified us about the mistake. This intends PR intends to fix the issue.

