### PR TITLE
Add support for alternative completions directories

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -86,17 +86,17 @@ is_plugin() {
 # Add all defined plugins to fpath. This must be done
 # before running compinit.
 for plugin ($plugins); do
-  for dir ($ZSH_CUSTOM $ZSH); do
-    if is_plugin $dir $plugin; then
-      if [ -f $dir/plugins/$plugin/completions-dir.txt ]; then
-        fpath=($dir/plugins/$plugin/$(cat $dir/plugins/$plugin/completions-dir.txt) $fpath)
-      else
-        fpath=($dir/plugins/$plugin $fpath)
-      fi
+  if is_plugin $ZSH_CUSTOM $plugin; then
+    if [ -f $ZSH_CUSTOM/plugins/$plugin/completions-dir.txt ]; then
+      fpath=($ZSH_CUSTOM/plugins/$plugin/$(cat $ZSH_CUSTOM/plugins/$plugin/completions-dir.txt) $fpath)
     else
-      echo "[oh-my-zsh] plugin '$plugin' not found"
+      fpath=($ZSH_CUSTOM/plugins/$plugin $fpath)
     fi
-  done
+  elif is_plugin $ZSH $plugin; then
+    fpath=($ZSH/plugins/$plugin $fpath)
+  else
+    echo "[oh-my-zsh] plugin '$plugin' not found"
+  fi
 done
 
 # Figure out the SHORT hostname

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -86,13 +86,17 @@ is_plugin() {
 # Add all defined plugins to fpath. This must be done
 # before running compinit.
 for plugin ($plugins); do
-  if is_plugin $ZSH_CUSTOM $plugin; then
-    fpath=($ZSH_CUSTOM/plugins/$plugin $fpath)
-  elif is_plugin $ZSH $plugin; then
-    fpath=($ZSH/plugins/$plugin $fpath)
-  else
-    echo "[oh-my-zsh] plugin '$plugin' not found"
-  fi
+  for dir ($ZSH_CUSTOM $ZSH); do
+    if is_plugin $dir $plugin; then
+      if [ -f $dir/plugins/$plugin/completions-dir.txt ]; then
+        fpath=($dir/plugins/$plugin/$(cat $dir/plugins/$plugin/completions-dir.txt) $fpath)
+      else
+        fpath=($dir/plugins/$plugin $fpath)
+      fi
+    else
+      echo "[oh-my-zsh] plugin '$plugin' not found"
+    fi
+  done
 done
 
 # Figure out the SHORT hostname


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Description

This will check if a `completions-dir.txt` is present in the root of the custom plugin before adding the plugin's root to `fpath`. If the file is there, the `fpath` will be filled with `$plugin_dir/<contents of completions-dir.txt>` instead of `$plugin_dir`.

This should not cause any breaking change, as no custom plugins would already have such a file.

It will be taken into account for custom plugins. This will decrease the amount of times we check for the file, and I think it's very reasonable that the plugins in this repo (not custom ones) needs to follow the rule of having completions in their root directories.

Also, regarding my concern at duplications in `fpath` (https://github.com/ohmyzsh/ohmyzsh/issues/10412#issuecomment-967214321), there isn't much we can do about it in Oh My ZSH itself. My suggestion is that this should be handled in the plugins, like how I did in https://github.com/zsh-users/zsh-completions/pull/835.

Fixes https://github.com/ohmyzsh/ohmyzsh/issues/10412

The PR which implements this at zsh-completions is https://github.com/zsh-users/zsh-completions/pull/835.

I'm testing this at https://github.com/felipecrs/dotfiles/pull/59.