### PR TITLE
feat(git-commit-template): add plugin for git commit template

### DIFF
--- a/plugins/git-commit-template/README.md
+++ b/plugins/git-commit-template/README.md
@@ -1,0 +1,29 @@
+# git-commit-template plugin
+
+To better write git commit messages, we can use template to specify the desired description and type of message.
+
+To use it, add `git-commit-template` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... git-commit-template)
+```
+
+## Learn This Articles
+
+- #### [How to Write Better Git Commit Messages](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/)
+
+- #### [Epower Git Template](https://github.com/epowerng/git-template)
+
+## Usage
+
+All you have to do is call the `gct` command and fill in the items that are not optional at each step to prepare the message format.
+
+![gct](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/1.png)
+
+![result](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/2.png)
+
+With the `git log` command, we can see the message that we committed.
+
+![git log](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/3.png)
+
+### Tanks For Supporting [📌 Source](https://github.com/ghasemdev/git-commit-template)

--- a/plugins/git-commit-template/README.md
+++ b/plugins/git-commit-template/README.md
@@ -1,8 +1,10 @@
 # git-commit-template plugin
 
-To better write git commit messages, we can use template to specify the desired description and type of message.
+To better write git commit messages, we can use template to specify the 
+desired description and type of message.
 
-To use it, add `git-commit-template` to the plugins array in your zshrc file:
+To use it, add `git-commit-template` to the plugins array in your zshrc 
+file:
 
 ```zsh
 plugins=(... git-commit-template)
@@ -16,7 +18,8 @@ plugins=(... git-commit-template)
 
 ## Usage
 
-All you have to do is call the `gct` command and fill in the items that are not optional at each step to prepare the message format.
+All you have to do is call the `gct` command and fill in the items that 
+are not optional at each step to prepare the message format.
 
 ![gct](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/1.png)
 

--- a/plugins/git-commit-template/README.md
+++ b/plugins/git-commit-template/README.md
@@ -1,14 +1,10 @@
-# git-commit-template plugin
+[![Version](https://shields.io/badge/VERSION-1.2.0-blue?style=for-the-badge)](https://github.com/ghasemdev/git-commit-template/releases/tag/v1.1.0)
+[![License Apache-2.0](https://shields.io/badge/LICENSE-APACHE--2.0-orange?style=for-the-badge)](https://opensource.org/licenses/MIT)
+
+# git-commit-template
 
 To better write git commit messages, we can use template to specify the 
-desired description and type of message.
-
-To use it, add `git-commit-template` to the plugins array in your zshrc 
-file:
-
-```zsh
-plugins=(... git-commit-template)
-```
+desired description and type of message. This file is prepared for use in zsh.
 
 ## Learn This Articles
 
@@ -16,17 +12,49 @@ plugins=(... git-commit-template)
 
 - #### [Epower Git Template](https://github.com/epowerng/git-template)
 
+- #### [چگونه یک پیغام گیت با معنا بنویسیم؟](https://virgool.io/@mmdsharifi/how-to-semantic-git-commit-messages-gvmmqatf6acg)
+
+## Installation
+
+In the first step, in the home directory (zshrc directory) clone git-commit-template.
+
+```bash
+➜  ~ git clone https://github.com/ghasemdev/git-commit-template.git
+```
+
+Then we have to run this command to install.
+
+```bash
+➜  ~ chmod +x git-commit-template/installer.sh
+➜  ~ git-commit-template/installer.sh
+```
+
+In the last command we refresh oh-my-zsh source.
+
+```bash
+➜  ~ source ~/.zshrc
+```
+
 ## Usage
 
 All you have to do is call the `gct` command and fill in the items that 
 are not optional at each step to prepare the message format.
 
-![gct](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/1.png)
+![gct](images/1.png)
 
-![result](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/2.png)
+![result](images/2.png)
 
 With the `git log` command, we can see the message that we committed.
 
-![git log](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/3.png)
+![git log](images/3.png)
 
-### Tanks For Supporting [📌 Source](https://github.com/ghasemdev/git-commit-template)
+### signature
+
+You can use `-s` or `sign` to add a signature to the gct.
+
+```bash
+➜  gct -s
+➜  gct sign
+```
+
+## Tanks For Supporting 🐯

--- a/plugins/git-commit-template/README.md
+++ b/plugins/git-commit-template/README.md
@@ -1,10 +1,12 @@
-[![Version](https://shields.io/badge/VERSION-1.2.0-blue?style=for-the-badge)](https://github.com/ghasemdev/git-commit-template/releases/tag/v1.1.0)
-[![License Apache-2.0](https://shields.io/badge/LICENSE-APACHE--2.0-orange?style=for-the-badge)](https://opensource.org/licenses/MIT)
+# git-commit-template plugin
 
-# git-commit-template
+To better write git commit messages, we can use template to specify the desired description and type of message.
 
-To better write git commit messages, we can use template to specify the 
-desired description and type of message. This file is prepared for use in zsh.
+To use it, add `git-commit-template` to the plugins array in your zshrc file:
+
+```bash
+plugins=(... git-commit-template)
+```
 
 ## Learn This Articles
 
@@ -12,41 +14,18 @@ desired description and type of message. This file is prepared for use in zsh.
 
 - #### [Epower Git Template](https://github.com/epowerng/git-template)
 
-- #### [چگونه یک پیغام گیت با معنا بنویسیم؟](https://virgool.io/@mmdsharifi/how-to-semantic-git-commit-messages-gvmmqatf6acg)
-
-## Installation
-
-In the first step, in the home directory (zshrc directory) clone git-commit-template.
-
-```bash
-➜  ~ git clone https://github.com/ghasemdev/git-commit-template.git
-```
-
-Then we have to run this command to install.
-
-```bash
-➜  ~ chmod +x git-commit-template/installer.sh
-➜  ~ git-commit-template/installer.sh
-```
-
-In the last command we refresh oh-my-zsh source.
-
-```bash
-➜  ~ source ~/.zshrc
-```
-
 ## Usage
 
 All you have to do is call the `gct` command and fill in the items that 
 are not optional at each step to prepare the message format.
 
-![gct](images/1.png)
+![gct](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/1.png)
 
-![result](images/2.png)
+![result](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/2.png)
 
 With the `git log` command, we can see the message that we committed.
 
-![git log](images/3.png)
+![git log](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/3.png)
 
 ### signature
 
@@ -57,4 +36,4 @@ You can use `-s` or `sign` to add a signature to the gct.
 ➜  gct sign
 ```
 
-## Tanks For Supporting 🐯
+## Tanks For Supporting 📌 [Source](https://github.com/ghasemdev/git-commit-template)

--- a/plugins/git-commit-template/git-commit-template.plugin.zsh
+++ b/plugins/git-commit-template/git-commit-template.plugin.zsh
@@ -1,0 +1,113 @@
+function git_commit_template() {
+    # Check in this directory git exist
+    if [ ! -d .git ]; then
+        exit 1
+    fi
+
+    # Color formatting
+    RED="\033[0;31m"
+    GREEN="\033[0;32m"
+    BLUE="\033[1;34m"
+    CYAN="\033[0;36m"
+    RESET="\033[0m"
+
+    # Valid types
+    TYPES=("feat" "fix" "docs" "style" "refactor" "pref" "test" "build" "ci" "chore" "revert")
+    NUMBERS=("1" "2" "3" "4" "5" "6" "7" "8" "9" "10" "11")
+
+    # Type section
+    printf "${BLUE}>>> Type of change (name or number)?${RESET}\n\n"
+
+    printf "${CYAN}1.  feat${RESET} - A new feature.\n"
+    printf "${CYAN}2.  fix${RESET} - A bug fix.\n"
+    printf "${CYAN}3.  docs${RESET} - Documentation only changes.\n"
+    printf "${CYAN}4.  style${RESET} - Changes that do notaffect the meaning of the code (white-space, formatting, missing semi-colons, etc).\n"
+    printf "${CYAN}5.  refactor${RESET} - A Code change that neither fixes a bug nor adds a feature.\n"
+    printf "${CYAN}6.  pref${RESET} - A code change that improves performance.\n"
+    printf "${CYAN}7.  test${RESET} - Adding missing tests or correcting existing tests.\n"
+    printf "${CYAN}8.  build${RESET} - Changes that effect the build system or external dependencies (example scopes: glup, broccoli, npm).\n"
+    printf "${CYAN}9.  ci${RESET} - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs).\n"
+    printf "${CYAN}10. chore${RESET} - Other changes that don't modify src or test files.\n"
+    printf "${CYAN}11. revert${RESET} - Reverts a previous commit.\n\n"
+
+    while :; do
+        read -e TYPE
+        # To lower case
+        TYPE=${TYPE,,}
+        # When input type is valid loop break
+        if [[ " ${NUMBERS[*]} " =~ " ${TYPE} " ]]; then
+            TYPE="${TYPES[TYPE - 1]}"
+            break
+        elif [[ " ${TYPES[*]} " =~ " ${TYPE} " ]]; then
+            break
+        else
+            printf "${RED}❌ Please select a valid type.${RESET}\n"
+        fi
+    done
+
+    # Scppe section
+    printf "\n${BLUE}>>> Scope of this change (optional)?${RESET}\n"
+    printf "The scope could be anything specifying place of the commit change e.g a file name, function name, class name, component name etc.\n\n"
+    read -e SCOPE
+
+    # Subject section
+    printf "\n${BLUE}>>> Short description?${RESET}\n"
+    printf "The short description contains succinct description of the change:\n"
+    printf '  • use the imperative, present tense: "change" not "changed" nor "changes"\n'
+    printf "  • don't capitalize first letter\n"
+    printf "  • no dot (.) at the end\n\n"
+
+    while :; do
+        read -e SHORT_DESC
+        if [ -z "$SHORT_DESC" ]; then
+            printf "${RED}❌ Short description can not be empty.${RESET}\n"
+        else
+            break
+        fi
+    done
+
+    # Description section
+    printf "\n${BLUE}>>> Long description (optional)?${RESET}\n"
+    printf "The body should include the motivation for the change and contrast this with previous behavior.\n\n"
+    read -e LONG_DESC
+
+    # Breaking changes section
+    printf "\n${BLUE}>>> Breaking changes (optional)?${RESET}\n"
+    printf "note the reason for a breaking change within the commit.\n\n"
+    read -e BREAKING_CHANGES
+
+    # Closed issues section
+    printf "\n${BLUE}>>> Closed issues (optional)?${RESET}\n"
+    printf "The syntax for closing keywords depends on whether the issue is in the same repository as the pull request.\n"
+    printf "  • Issue in the same repository -> Closes #10\n"
+    printf "  • Issue in a different repository -> Fixes octo-org/octo-repo#100\n"
+    printf "  • Multiple issues -> Resolves #10, resolves #123, resolves octo-org/octo-repo#100\n\n"
+    read -e CLOSED_ISSUES
+
+    # Result section
+    if [ ! -z "$SCOPE" ]; then
+        SCOPE="(${SCOPE})"
+    fi
+
+    if [ ! -z "$BREAKING_CHANGES" ]; then
+        BREAKING_CHANGES="BREAKING CHANGE: ${BREAKING_CHANGES}"
+    fi
+
+    printf "\n    ${GREEN}${TYPE}${SCOPE}: ${SHORT_DESC}
+    ${LONG_DESC}
+    ${BREAKING_CHANGES}
+    ${CLOSED_ISSUES}${RESET}\n\n"
+
+    # Git commit
+    RESULT_CODE=$?
+    if [ "$RESULT_CODE" = 0 ]; then
+        git commit -m "${TYPE}${SCOPE}: ${SHORT_DESC}
+${LONG_DESC}
+${BREAKING_CHANGES}
+${CLOSED_ISSUES}"
+    else
+        printf "\n${RED}❌ An error occurred. Please try again.${RESET}\n"
+    fi
+}
+
+alias gct='git_commit_template'

--- a/plugins/git-commit-template/git-commit-template.plugin.zsh
+++ b/plugins/git-commit-template/git-commit-template.plugin.zsh
@@ -1,6 +1,7 @@
 git_commit_template() {
     # Check in this directory git exist
     if [ ! -d .git ]; then
+        echo "fatal: not a git repository (or any of the parent directories): .git"
         exit 1
     fi
 
@@ -107,6 +108,7 @@ octo-org/octo-repo#100\n\n"
     fi
 
     printf "\n    ${GREEN}${type_var}${scope}: ${short_desc}
+
     ${long_desc}
     ${breaking_changes}
     ${closed_issues}${RESET}\n\n"
@@ -115,6 +117,7 @@ octo-org/octo-repo#100\n\n"
     result_code=$?
     if [ "$result_code" = 0 ]; then
         git commit -m "${type_var}${scope}: ${short_desc}
+
 ${long_desc}
 ${breaking_changes}
 ${closed_issues}"

--- a/plugins/git-commit-template/git-commit-template.plugin.zsh
+++ b/plugins/git-commit-template/git-commit-template.plugin.zsh
@@ -101,15 +101,25 @@ octo-org/octo-repo#100\n\n"
         scope="(${scope})"
     fi
 
-    if [ ! -z "$breaking_changes" ]; then
-        breaking_changes="BREAKING CHANGE: ${breaking_changes}"
+    massage="\n    ${GREEN}${type_var}${scope}: ${short_desc}\n"
+
+    if [ ! -z "$long_desc" ] || [ ! -z "$breaking_changes" ] || [ ! -z "$closed_issues" ]; then
+        massage="${massage}\n"
     fi
 
-    printf "\n    ${GREEN}${type_var}${scope}: ${short_desc}
+    if [ ! -z "$long_desc" ]; then
+        massage="${massage}    ${long_desc}\n"
+    fi
 
-    ${long_desc}
-    ${breaking_changes}
-    ${closed_issues}${RESET}\n\n"
+    if [ ! -z "$breaking_changes" ]; then
+        massage="${massage}    BREAKING CHANGE: ${breaking_changes}\n"
+    fi
+
+    if [ ! -z "$closed_issues" ]; then
+        massage="${massage}    ${closed_issues}\n"
+    fi
+
+    printf "${massage}\n${RESET}"
 
     # Git commit
     result_code=$?

--- a/plugins/git-commit-template/git-commit-template.plugin.zsh
+++ b/plugins/git-commit-template/git-commit-template.plugin.zsh
@@ -1,9 +1,4 @@
 git_commit_template() {
-    # Check in this directory git exist
-    if [ ! -d .git ]; then
-        echo "fatal: not a git repository (or any of the parent directories): .git"
-        exit 1
-    fi
 
     # Color formatting
     RED="\033[0;31m"
@@ -70,10 +65,9 @@ a file name, function name, class name, component name etc.\n\n"
 
     while :; do
         read -e short_desc
-        limit_counter=${#short_desc}
         if [ -z "$short_desc" ]; then
             printf "${RED}❌ Short description can not be empty.${RESET}\n"
-        elif [[ $limit_counter > 50 ]]; then
+        elif [[ ${#limit_counter} -gt 50 ]]; then
             printf "${RED}❌ The maximum character for header is 50, Please\
  provide details in long descriptions.${RESET}\n"
         else

--- a/plugins/git-commit-template/git-commit-template.plugin.zsh
+++ b/plugins/git-commit-template/git-commit-template.plugin.zsh
@@ -120,6 +120,7 @@ ${breaking_changes}
 ${closed_issues}"
     else
         printf "\n${RED}❌ An error occurred. Please try again.${RESET}\n"
+        exit 1
     fi
 }
 

--- a/plugins/git-commit-template/git-commit-template.plugin.zsh
+++ b/plugins/git-commit-template/git-commit-template.plugin.zsh
@@ -1,3 +1,10 @@
+# Color formatting
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+BLUE="\033[1;34m"
+CYAN="\033[0;36m"
+RESET="\033[0m"
+
 git_commit_template() {
 
     # Check the current folder is a git repository
@@ -5,13 +12,6 @@ git_commit_template() {
     if [[ $? != 0 ]]; then
         exit 1
     fi
-
-    # Color formatting
-    RED="\033[0;31m"
-    GREEN="\033[0;32m"
-    BLUE="\033[1;34m"
-    CYAN="\033[0;36m"
-    RESET="\033[0m"
 
     # Valid types
     TYPES=("feat" "fix" "docs" "style" "refactor"
@@ -118,11 +118,11 @@ octo-org/octo-repo#100\n\n"
     fi
 
     if [ ! -z "$breaking_changes" ]; then
-        massage="${massage}    BREAKING CHANGE: ${breaking_changes}\n"
+        massage="${massage}\n    BREAKING CHANGE: ${breaking_changes}\n"
     fi
 
     if [ ! -z "$closed_issues" ]; then
-        massage="${massage}    ${closed_issues}\n"
+        massage="${massage}\n    ${closed_issues}\n"
     fi
 
     printf "${massage}\n${RESET}"
@@ -133,13 +133,17 @@ octo-org/octo-repo#100\n\n"
             git commit -S -m "${type_var}${scope}: ${short_desc}
 
 ${long_desc}
+
 ${breaking_changes}
+
 ${closed_issues}"
         else
             git commit -m "${type_var}${scope}: ${short_desc}
 
 ${long_desc}
+
 ${breaking_changes}
+
 ${closed_issues}"
         fi
     else

--- a/plugins/git-commit-template/git-commit-template.plugin.zsh
+++ b/plugins/git-commit-template/git-commit-template.plugin.zsh
@@ -1,5 +1,11 @@
 git_commit_template() {
 
+    # Check the current folder is a git repository
+    $(git -C $PWD rev-parse)
+    if [[ $? != 0 ]]; then
+        exit 1
+    fi
+
     # Color formatting
     RED="\033[0;31m"
     GREEN="\033[0;32m"
@@ -122,13 +128,20 @@ octo-org/octo-repo#100\n\n"
     printf "${massage}\n${RESET}"
 
     # Git commit
-    result_code=$?
-    if [ "$result_code" = 0 ]; then
-        git commit -m "${type_var}${scope}: ${short_desc}
+    if [ $? == 0 ]; then
+        if [[ $1 == "-s" ]] || [[ $1 == "sign" ]]; then
+            git commit -S -m "${type_var}${scope}: ${short_desc}
 
 ${long_desc}
 ${breaking_changes}
 ${closed_issues}"
+        else
+            git commit -m "${type_var}${scope}: ${short_desc}
+
+${long_desc}
+${breaking_changes}
+${closed_issues}"
+        fi
     else
         printf "\n${RED}❌ An error occurred. Please try again.${RESET}\n"
         exit 1

--- a/plugins/git-commit-template/git-commit-template.plugin.zsh
+++ b/plugins/git-commit-template/git-commit-template.plugin.zsh
@@ -15,7 +15,7 @@ git_commit_template() {
 
     # Valid types
     TYPES=("feat" "fix" "docs" "style" "refactor"
-        "pref" "test" "build" "ci" "chore" "revert")
+        "perf" "test" "build" "ci" "chore" "revert")
 
     NUMBERS=("1" "2" "3" "4" "5" "6" "7" "8" "9" "10" "11")
 
@@ -29,7 +29,7 @@ git_commit_template() {
 the code (white-space, formatting, missing semi-colons, etc).\n"
     printf "${CYAN}5.  refactor${RESET} - A Code change that neither fixes a bug \
 nor adds a feature.\n"
-    printf "${CYAN}6.  pref${RESET} - A code change that improves performance.\n"
+    printf "${CYAN}6.  perf${RESET} - A code change that improves performance.\n"
     printf "${CYAN}7.  test${RESET} - Adding missing tests or correcting existing \
 tests.\n"
     printf "${CYAN}8.  build${RESET} - Changes that effect the build system or \

--- a/plugins/git-commit-template/git-commit-template.plugin.zsh
+++ b/plugins/git-commit-template/git-commit-template.plugin.zsh
@@ -1,4 +1,4 @@
-function git_commit_template() {
+git_commit_template() {
     # Check in this directory git exist
     if [ ! -d .git ]; then
         exit 1
@@ -12,7 +12,9 @@ function git_commit_template() {
     RESET="\033[0m"
 
     # Valid types
-    TYPES=("feat" "fix" "docs" "style" "refactor" "pref" "test" "build" "ci" "chore" "revert")
+    TYPES=("feat" "fix" "docs" "style" "refactor"
+        "pref" "test" "build" "ci" "chore" "revert")
+
     NUMBERS=("1" "2" "3" "4" "5" "6" "7" "8" "9" "10" "11")
 
     # Type section
@@ -21,24 +23,30 @@ function git_commit_template() {
     printf "${CYAN}1.  feat${RESET} - A new feature.\n"
     printf "${CYAN}2.  fix${RESET} - A bug fix.\n"
     printf "${CYAN}3.  docs${RESET} - Documentation only changes.\n"
-    printf "${CYAN}4.  style${RESET} - Changes that do notaffect the meaning of the code (white-space, formatting, missing semi-colons, etc).\n"
-    printf "${CYAN}5.  refactor${RESET} - A Code change that neither fixes a bug nor adds a feature.\n"
+    printf "${CYAN}4.  style${RESET} - Changes that do notaffect the meaning of \
+the code (white-space, formatting, missing semi-colons, etc).\n"
+    printf "${CYAN}5.  refactor${RESET} - A Code change that neither fixes a bug \
+nor adds a feature.\n"
     printf "${CYAN}6.  pref${RESET} - A code change that improves performance.\n"
-    printf "${CYAN}7.  test${RESET} - Adding missing tests or correcting existing tests.\n"
-    printf "${CYAN}8.  build${RESET} - Changes that effect the build system or external dependencies (example scopes: glup, broccoli, npm).\n"
-    printf "${CYAN}9.  ci${RESET} - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs).\n"
-    printf "${CYAN}10. chore${RESET} - Other changes that don't modify src or test files.\n"
+    printf "${CYAN}7.  test${RESET} - Adding missing tests or correcting existing \
+tests.\n"
+    printf "${CYAN}8.  build${RESET} - Changes that effect the build system or \
+external dependencies (example scopes: glup, broccoli, npm).\n"
+    printf "${CYAN}9.  ci${RESET} - Changes to our CI configuration files and \
+scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs).\n"
+    printf "${CYAN}10. chore${RESET} - Other changes that don't modify src or test \
+files.\n"
     printf "${CYAN}11. revert${RESET} - Reverts a previous commit.\n\n"
 
     while :; do
-        read -e TYPE
+        read -e type_var
         # To lower case
-        TYPE=${TYPE,,}
+        type_var=${type_var,,}
         # When input type is valid loop break
-        if [[ " ${NUMBERS[*]} " =~ " ${TYPE} " ]]; then
-            TYPE="${TYPES[TYPE - 1]}"
+        if [[ " ${NUMBERS[*]} " =~ " ${type_var} " ]]; then
+            type_var="${TYPES[type_var - 1]}"
             break
-        elif [[ " ${TYPES[*]} " =~ " ${TYPE} " ]]; then
+        elif [[ " ${TYPES[*]} " =~ " ${type_var} " ]]; then
             break
         else
             printf "${RED}❌ Please select a valid type.${RESET}\n"
@@ -47,19 +55,21 @@ function git_commit_template() {
 
     # Scppe section
     printf "\n${BLUE}>>> Scope of this change (optional)?${RESET}\n"
-    printf "The scope could be anything specifying place of the commit change e.g a file name, function name, class name, component name etc.\n\n"
-    read -e SCOPE
+    printf "The scope could be anything specifying place of the commit change e.g \
+a file name, function name, class name, component name etc.\n\n"
+    read -e scope
 
     # Subject section
     printf "\n${BLUE}>>> Short description?${RESET}\n"
     printf "The short description contains succinct description of the change:\n"
-    printf '  • use the imperative, present tense: "change" not "changed" nor "changes"\n'
+    printf "  • use the imperative, present tense: 'change' not 'changed' nor \
+'changes'\n"
     printf "  • don't capitalize first letter\n"
     printf "  • no dot (.) at the end\n\n"
 
     while :; do
-        read -e SHORT_DESC
-        if [ -z "$SHORT_DESC" ]; then
+        read -e short_desc
+        if [ -z "$short_desc" ]; then
             printf "${RED}❌ Short description can not be empty.${RESET}\n"
         else
             break
@@ -68,43 +78,46 @@ function git_commit_template() {
 
     # Description section
     printf "\n${BLUE}>>> Long description (optional)?${RESET}\n"
-    printf "The body should include the motivation for the change and contrast this with previous behavior.\n\n"
-    read -e LONG_DESC
+    printf "The body should include the motivation for the change and contrast \
+this with previous behavior.\n\n"
+    read -e long_desc
 
     # Breaking changes section
     printf "\n${BLUE}>>> Breaking changes (optional)?${RESET}\n"
     printf "note the reason for a breaking change within the commit.\n\n"
-    read -e BREAKING_CHANGES
+    read -e breaking_changes
 
     # Closed issues section
     printf "\n${BLUE}>>> Closed issues (optional)?${RESET}\n"
-    printf "The syntax for closing keywords depends on whether the issue is in the same repository as the pull request.\n"
+    printf "The syntax for closing keywords depends on whether the issue is in \
+the same repository as the pull request.\n"
     printf "  • Issue in the same repository -> Closes #10\n"
     printf "  • Issue in a different repository -> Fixes octo-org/octo-repo#100\n"
-    printf "  • Multiple issues -> Resolves #10, resolves #123, resolves octo-org/octo-repo#100\n\n"
-    read -e CLOSED_ISSUES
+    printf "  • Multiple issues -> Resolves #10, resolves #123, resolves \
+octo-org/octo-repo#100\n\n"
+    read -e closed_issues
 
     # Result section
-    if [ ! -z "$SCOPE" ]; then
-        SCOPE="(${SCOPE})"
+    if [ ! -z "$scope" ]; then
+        scope="(${scope})"
     fi
 
-    if [ ! -z "$BREAKING_CHANGES" ]; then
-        BREAKING_CHANGES="BREAKING CHANGE: ${BREAKING_CHANGES}"
+    if [ ! -z "$breaking_changes" ]; then
+        breaking_changes="BREAKING CHANGE: ${breaking_changes}"
     fi
 
-    printf "\n    ${GREEN}${TYPE}${SCOPE}: ${SHORT_DESC}
-    ${LONG_DESC}
-    ${BREAKING_CHANGES}
-    ${CLOSED_ISSUES}${RESET}\n\n"
+    printf "\n    ${GREEN}${type_var}${scope}: ${short_desc}
+    ${long_desc}
+    ${breaking_changes}
+    ${closed_issues}${RESET}\n\n"
 
     # Git commit
-    RESULT_CODE=$?
-    if [ "$RESULT_CODE" = 0 ]; then
-        git commit -m "${TYPE}${SCOPE}: ${SHORT_DESC}
-${LONG_DESC}
-${BREAKING_CHANGES}
-${CLOSED_ISSUES}"
+    result_code=$?
+    if [ "$result_code" = 0 ]; then
+        git commit -m "${type_var}${scope}: ${short_desc}
+${long_desc}
+${breaking_changes}
+${closed_issues}"
     else
         printf "\n${RED}❌ An error occurred. Please try again.${RESET}\n"
     fi

--- a/plugins/git-commit-template/git-commit-template.plugin.zsh
+++ b/plugins/git-commit-template/git-commit-template.plugin.zsh
@@ -70,8 +70,12 @@ a file name, function name, class name, component name etc.\n\n"
 
     while :; do
         read -e short_desc
+        limit_counter=${#short_desc}
         if [ -z "$short_desc" ]; then
             printf "${RED}❌ Short description can not be empty.${RESET}\n"
+        elif [[ $limit_counter > 50 ]]; then
+            printf "${RED}❌ The maximum character for header is 50, Please\
+ provide details in long descriptions.${RESET}\n"
         else
             break
         fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- add git commit template plugin
- add limit counter for short description 
- add sign option for commits
- fix description for non git directory 

## Other comments:

To better write git commit messages, we can use template to specify the 
desired description and type of message.

All you have to do is call the `gct` command and fill in the items that 
are not optional at each step to prepare the message format.

![gct](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/1.png)

![result](https://raw.githubusercontent.com/ghasemdev/git-commit-template/master/images/2.png)

