### PR TITLE
fix(rust): Fix cargo completion when Rust sysroot contains spaces

### DIFF
--- a/plugins/rust/rust.plugin.zsh
+++ b/plugins/rust/rust.plugin.zsh
@@ -27,5 +27,5 @@ fi
 rustup completions zsh >| "$ZSH_CACHE_DIR/completions/_rustup" &|
 cat >| "$ZSH_CACHE_DIR/completions/_cargo" <<'EOF'
 #compdef cargo
-source $(rustc +${${(z)$(rustup default)}[1]} --print sysroot)/share/zsh/site-functions/_cargo
+source "$(rustc +${${(z)$(rustup default)}[1]} --print sysroot)"/share/zsh/site-functions/_cargo
 EOF


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- The Rust plugin does not escape spaces in the Rust sysroot (obtained with `rustc +${${(z)$(rustup default)}[1]} --print sysroot`) when generating the completion script for Cargo, so Cargo completions fail when the sysroot contains spaces. Added double quotes around the invocation of rustc to escape spaces.

## Other comments:

I'm not sure who maintains the Rust plugin to mention, but this change is simple enough anyways that I don't think the maintainer(s) of the Rust plugin specifically need to look at this.
