### PR TITLE
Fix svn_dirtry_choose echoing wrong input parameters

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -67,10 +67,10 @@ svn_dirty_choose() {
   root=$(sed -n 's/^Working Copy Root Path: //p' <<< "${1:-$(LANG= svn info 2>/dev/null)}")
   if LANG= svn status "$root" 2>/dev/null | command grep -Eq '^\s*[ACDIM!?L]'; then
     # Grep exits with 0 when "One or more lines were selected", return "dirty".
-    echo $1
+    echo $2
   else
     # Otherwise, no lines were found, or an error occurred. Return clean.
-    echo $2
+    echo $3
   fi
 }
 


### PR DESCRIPTION
svn_dirty_choose had the "return" mixed up, echoing the first input (which is basically svn info) for dirty repositories and $ZSH_THEME_SVN_PROMPT_DIRTY for clean repositories ($1 and $2). The correct behaviour is rechoing $2 and $3, respectively.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x ] The PR title is descriptive.
- [x ] The PR doesn't replicate another PR which is already open.
- [x ] I have read the contribution guide and followed all the instructions.
- x[ ] The code follows the code style guide detailed in the wiki.
- [x ] The code is mine or it's from somewhere with an MIT-compatible license.
- [x ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- 

## Other comments:

...
