### PR TITLE
fix(mvn): fix listing modules in completion

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -117,7 +117,7 @@ function listMavenCompletions {
   done
 
   # List modules
-  modules=($(find **/pom.xml -type f | grep -v '/target/classes/META-INF/' | grep '/pom.xml' |sed 's|\(.*\)/pom\.xml|\1|'))
+  modules=($(print -l **/pom.xml(-.N:h) | grep -v '/target/classes/META-INF/'))
 
   reply=(
     # common lifecycle


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Remove usage of `find` and use glob expansion instead.

Fixes #10580