### PR TITLE
fix(svn): change sed to read from here-string

### DIFF
--- a/plugins/svn/svn.plugin.zsh
+++ b/plugins/svn/svn.plugin.zsh
@@ -55,7 +55,7 @@ svn_get_branch_name() {
 }
 
 svn_get_rev_nr() {
-  sed -n 's/Revision:\ //p' "${1:-$(LANG= svn info 2>/dev/null)}"
+  sed -n 's/Revision:\ //p' <<<"${1:-$(LANG= svn info 2>/dev/null)}"
 }
 
 svn_dirty() {


### PR DESCRIPTION
Fixes #10589

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- sed read from here-string
