### PR TITLE
Fix completion loading mechanism in helm and kubectl plugins

### DIFF
--- a/plugins/helm/helm.plugin.zsh
+++ b/plugins/helm/helm.plugin.zsh
@@ -11,12 +11,12 @@ command rm -f "${ZSH_CACHE_DIR}/helm_completion"
 command mkdir -p "$ZSH_CACHE_DIR/completions"
 (( ${fpath[(Ie)"$ZSH_CACHE_DIR/completions"]} )) || fpath=("$ZSH_CACHE_DIR/completions" $fpath)
 
-# If the completion file doesn't exist yet, we need to autoload it and
-# bind it to `helm`. Otherwise, compinit will have already done that.
+# If the completion file does not exist, generate it and then source it
+# Otherwise, source it and regenerate in the background
 if [[ ! -f "$ZSH_CACHE_DIR/completions/_helm" ]]; then
-  typeset -g -A _comps
-  autoload -Uz _helm
-  _comps[helm]=_helm
+  helm completion zsh >| "$ZSH_CACHE_DIR/completions/_helm"
+  source "$ZSH_CACHE_DIR/completions/_helm"
+else
+  source "$ZSH_CACHE_DIR/completions/_helm"
+  helm completion zsh >| "$ZSH_CACHE_DIR/completions/_helm" &|
 fi
-
-helm completion zsh >| "$ZSH_CACHE_DIR/completions/_helm" &|

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -8,15 +8,15 @@ if (( $+commands[kubectl] )); then
   command mkdir -p "$ZSH_CACHE_DIR/completions"
   (( ${fpath[(Ie)"$ZSH_CACHE_DIR/completions"]} )) || fpath=("$ZSH_CACHE_DIR/completions" $fpath)
 
-  # If the completion file doesn't exist yet, we need to autoload it and
-  # bind it to `kubectl`. Otherwise, compinit will have already done that.
+  # If the completion file does not exist, generate it and then source it
+  # Otherwise, source it and regenerate in the background
   if [[ ! -f "$ZSH_CACHE_DIR/completions/_kubectl" ]]; then
-    typeset -g -A _comps
-    autoload -Uz _kubectl
-    _comps[kubectl]=_kubectl
+    kubectl completion zsh >| "$ZSH_CACHE_DIR/completions/_kubectl"
+    source "$ZSH_CACHE_DIR/completions/_kubectl"
+  else
+    source "$ZSH_CACHE_DIR/completions/_kubectl"
+    kubectl completion zsh >| "$ZSH_CACHE_DIR/completions/_kubectl" &|
   fi
-
-  kubectl completion zsh >! "$ZSH_CACHE_DIR/completions/_kubectl" &|
 fi
 
 # This command is used a LOT both below and in daily life


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Change kubectl and helm plugins to `source`-ing their completion functions, instead of relying on `compinit` and `autoload`.

Fixes #10581 