### PR TITLE
feat(sudo): respect `$SUDO_EDITOR` and `$VISUAL`, switch to `sudo -e`

### DIFF
--- a/plugins/sudo/README.md
+++ b/plugins/sudo/README.md
@@ -24,6 +24,20 @@ By pressing the <kbd>esc</kbd> key twice, you will have the same command with `s
 $ sudo apt-get install build-essential
 ```
 
+The same happens for editing files with your default editor (defined in `$SUDO_EDITOR`, `$VISUAL` or `$EDITOR`, in that order):
+
+If the editor defined were `vim`:
+
+```console
+$ vim /etc/hosts
+```
+
+By pressing the <kbd>esc</kbd> key twice, you will have the same command with `sudo -e` instead of the editor, that would open that editor with root privileges:
+
+```console
+$ sudo -e /etc/hosts
+```
+
 ### Previous executed commands
 
 Say you want to delete a system file and denied:
@@ -43,6 +57,8 @@ $ sudo rm some-system-file.txt
 Password:
 $
 ```
+
+The same happens for file editing, as told before.
 
 ## Key binding
 

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -2,7 +2,7 @@
 # Description
 # -----------
 #
-# sudo or sudoedit will be inserted before the command
+# sudo or sudo -e (replacement for sudoedit) will be inserted before the command
 #
 # ------------------------------------------------------------------------------
 # Authors
@@ -11,6 +11,7 @@
 # * Dongweiming <ciici123@gmail.com>
 # * Subhaditya Nath <github.com/subnut>
 # * Marc Cornellà <github.com/mcornella>
+# * Carlo Sala <carlosalag@protonmail.com>
 #
 # ------------------------------------------------------------------------------
 
@@ -35,10 +36,14 @@ sudo-command-line() {
     LBUFFER="${LBUFFER:1}"
   fi
 
+  # If $SUDO_EDITOR or $VISUAL are defined, then use that as $EDITOR
+  # Else use the default $EDITOR
+  local EDITOR=${SUDO_EDITOR:-${VISUAL:-$EDITOR}}
+
   # If $EDITOR is not set, just toggle the sudo prefix on and off
   if [[ -z "$EDITOR" ]]; then
     case "$BUFFER" in
-      sudoedit\ *) __sudo-replace-buffer "sudoedit" "" ;;
+      sudo\ -e\ *) __sudo-replace-buffer "sudo -e" "" ;;
       sudo\ *) __sudo-replace-buffer "sudo" "" ;;
       *) LBUFFER="sudo $LBUFFER" ;;
     esac
@@ -72,9 +77,9 @@ sudo-command-line() {
 
     # Check for editor commands in the typed command and replace accordingly
     case "$BUFFER" in
-      $editorcmd\ *) __sudo-replace-buffer "$editorcmd" "sudoedit" ;;
-      \$EDITOR\ *) __sudo-replace-buffer '$EDITOR' "sudoedit" ;;
-      sudoedit\ *) __sudo-replace-buffer "sudoedit" "$EDITOR" ;;
+      $editorcmd\ *) __sudo-replace-buffer "$editorcmd" "sudo -e" ;;
+      \$EDITOR\ *) __sudo-replace-buffer '$EDITOR' "sudo -e" ;;
+      sudo\ -e\ *) __sudo-replace-buffer "sudo -e" "$EDITOR" ;;
       sudo\ *) __sudo-replace-buffer "sudo" "" ;;
       *) LBUFFER="sudo $LBUFFER" ;;
     esac


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Switches from `sudoedit` to `sudo -e` when editing files, to give compatibility with MacOS (closes #10509). In `sudo`'s manpage is told that `sudoedit` is just an alias for `sudo -e`, so there's no problem with that :)
- Now the plugin respects the `$SUDO_EDITOR` and `$VISUAL` variables, instead of always using `$EDITOR`, with the priorities stated in `sudo`'s manpage.