### PR TITLE
style(init): use consistent code style in init script

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -152,9 +152,9 @@ done
 
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do
-  if is_plugin "$ZSH_CUSTOM" "$plugin"; then
+  if [[ -f "$ZSH_CUSTOM/plugins/$plugin/$plugin.plugin.zsh" ]]; then
     source "$ZSH_CUSTOM/plugins/$plugin/$plugin.plugin.zsh"
-  elif is_plugin "$ZSH" "$plugin"; then
+  elif [[ -f "$ZSH/plugins/$plugin/$plugin.plugin.zsh" ]]; then
     source "$ZSH/plugins/$plugin/$plugin.plugin.zsh"
   fi
 done

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -104,7 +104,7 @@ fi
 
 # Save the location of the current completion dump file.
 if [[ -z "$ZSH_COMPDUMP" ]]; then
-  ZSH_COMPDUMP="${ZDOTDIR:-$HOME}/.zcompdump-$SHORT_HOST-$ZSH_VERSION"
+  ZSH_COMPDUMP="${ZDOTDIR:-$HOME}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
 # Construct zcompdump OMZ metadata
@@ -139,7 +139,6 @@ $zcompdump_revision
 $zcompdump_fpath
 EOF
 fi
-
 unset zcompdump_revision zcompdump_fpath zcompdump_refresh
 
 # Load all of the config files in ~/oh-my-zsh that end in .zsh
@@ -149,6 +148,7 @@ for config_file ("$ZSH"/lib/*.zsh); do
   [[ -f "$custom_config_file" ]] && config_file="$custom_config_file"
   source "$config_file"
 done
+unset custom_config_file
 
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -57,14 +57,14 @@ mkdir -p "$ZSH_CACHE_DIR/completions"
 (( ${fpath[(Ie)"$ZSH_CACHE_DIR/completions"]} )) || fpath=("$ZSH_CACHE_DIR/completions" $fpath)
 
 # Check for updates on initial load...
-if [ "$DISABLE_AUTO_UPDATE" != "true" ]; then
-  source $ZSH/tools/check_for_upgrade.sh
+if [[ "$DISABLE_AUTO_UPDATE" != true ]]; then
+  source "$ZSH/tools/check_for_upgrade.sh"
 fi
 
 # Initializes Oh My Zsh
 
 # add a function path
-fpath=($ZSH/functions $ZSH/completions $fpath)
+fpath=("$ZSH/functions" "$ZSH/completions" $fpath)
 
 # Load all stock functions (from $fpath files) called below.
 autoload -U compaudit compinit
@@ -74,7 +74,6 @@ autoload -U compaudit compinit
 if [[ -z "$ZSH_CUSTOM" ]]; then
     ZSH_CUSTOM="$ZSH/custom"
 fi
-
 
 is_plugin() {
   local base_dir=$1
@@ -86,10 +85,10 @@ is_plugin() {
 # Add all defined plugins to fpath. This must be done
 # before running compinit.
 for plugin ($plugins); do
-  if is_plugin $ZSH_CUSTOM $plugin; then
-    fpath=($ZSH_CUSTOM/plugins/$plugin $fpath)
-  elif is_plugin $ZSH $plugin; then
-    fpath=($ZSH/plugins/$plugin $fpath)
+  if is_plugin "$ZSH_CUSTOM" "$plugin"; then
+    fpath=("$ZSH_CUSTOM/plugins/$plugin" $fpath)
+  elif is_plugin "$ZSH" "$plugin"; then
+    fpath=("$ZSH/plugins/$plugin" $fpath)
   else
     echo "[oh-my-zsh] plugin '$plugin' not found"
   fi
@@ -98,14 +97,14 @@ done
 # Figure out the SHORT hostname
 if [[ "$OSTYPE" = darwin* ]]; then
   # macOS's $HOST changes with dhcp, etc. Use ComputerName if possible.
-  SHORT_HOST=$(scutil --get ComputerName 2>/dev/null) || SHORT_HOST=${HOST/.*/}
+  SHORT_HOST=$(scutil --get ComputerName 2>/dev/null) || SHORT_HOST="${HOST/.*/}"
 else
-  SHORT_HOST=${HOST/.*/}
+  SHORT_HOST="${HOST/.*/}"
 fi
 
 # Save the location of the current completion dump file.
-if [ -z "$ZSH_COMPDUMP" ]; then
-  ZSH_COMPDUMP="${ZDOTDIR:-${HOME}}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
+if [[ -z "$ZSH_COMPDUMP" ]]; then
+  ZSH_COMPDUMP="${ZDOTDIR:-$HOME}/.zcompdump-$SHORT_HOST-$ZSH_VERSION"
 fi
 
 # Construct zcompdump OMZ metadata
@@ -119,15 +118,15 @@ if ! command grep -q -Fx "$zcompdump_revision" "$ZSH_COMPDUMP" 2>/dev/null \
   zcompdump_refresh=1
 fi
 
-if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
-  source $ZSH/lib/compfix.zsh
+if [[ "$ZSH_DISABLE_COMPFIX" != true ]]; then
+  source "$ZSH/lib/compfix.zsh"
   # If completion insecurities exist, warn the user
   handle_completion_insecurities
   # Load only from secure directories
-  compinit -i -C -d "${ZSH_COMPDUMP}"
+  compinit -i -C -d "$ZSH_COMPDUMP"
 else
   # If the user wants it, load from all found directories
-  compinit -u -C -d "${ZSH_COMPDUMP}"
+  compinit -u -C -d "$ZSH_COMPDUMP"
 fi
 
 # Append zcompdump metadata if missing
@@ -143,37 +142,45 @@ fi
 
 unset zcompdump_revision zcompdump_fpath zcompdump_refresh
 
-
 # Load all of the config files in ~/oh-my-zsh that end in .zsh
 # TIP: Add files you don't want in git to .gitignore
-for config_file ($ZSH/lib/*.zsh); do
-  custom_config_file="${ZSH_CUSTOM}/lib/${config_file:t}"
-  [ -f "${custom_config_file}" ] && config_file=${custom_config_file}
-  source $config_file
+for config_file ("$ZSH"/lib/*.zsh); do
+  custom_config_file="$ZSH_CUSTOM/lib/${config_file:t}"
+  [[ -f "$custom_config_file" ]] && config_file="$custom_config_file"
+  source "$config_file"
 done
 
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do
-  if [ -f $ZSH_CUSTOM/plugins/$plugin/$plugin.plugin.zsh ]; then
-    source $ZSH_CUSTOM/plugins/$plugin/$plugin.plugin.zsh
-  elif [ -f $ZSH/plugins/$plugin/$plugin.plugin.zsh ]; then
-    source $ZSH/plugins/$plugin/$plugin.plugin.zsh
+  if is_plugin "$ZSH_CUSTOM" "$plugin"; then
+    source "$ZSH_CUSTOM/plugins/$plugin/$plugin.plugin.zsh"
+  elif is_plugin "$ZSH" "$plugin"; then
+    source "$ZSH/plugins/$plugin/$plugin.plugin.zsh"
   fi
 done
+unset plugin
 
 # Load all of your custom configurations from custom/
-for config_file ($ZSH_CUSTOM/*.zsh(N)); do
-  source $config_file
+for config_file ("$ZSH_CUSTOM"/*.zsh(N)); do
+  source "$config_file"
 done
 unset config_file
 
 # Load the theme
-if [ ! "$ZSH_THEME" = ""  ]; then
-  if [ -f "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme" ]; then
+is_theme() {
+  local base_dir=$1
+  local name=$2
+  builtin test -f $base_dir/$name.zsh-theme
+}
+
+if [[ -n "$ZSH_THEME" ]]; then
+  if is_theme "$ZSH_CUSTOM" "$ZSH_THEME"; then
     source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
-  elif [ -f "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme" ]; then
+  elif is_theme "$ZSH_CUSTOM/themes" "$ZSH_THEME"; then
     source "$ZSH_CUSTOM/themes/$ZSH_THEME.zsh-theme"
-  else
+  elif is_theme "$ZSH/themes" "$ZSH_THEME"; then
     source "$ZSH/themes/$ZSH_THEME.zsh-theme"
+  else
+    echo "[oh-my-zsh] theme '$ZSH_THEME' not found"
   fi
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Reviewing the `oh-my-zsh.sh` file I noticed that wasn't really consistent. Sometimes quotes for variables, sometimes not, sometimes `[ ]`, others `[[ ]]`, so I tried to unify a little bit the style. By the way, this could also be done for other parts of the repo.
I will open this as a draft PR as this is kinda _breaking_ so we can discuss a little bit about it before deciding whether or not merging it.

## Other changes:

I also modified a little bit the plugins loading and theme loading. Just a refactor to have a consistent code in every plugin or theme loading.