### PR TITLE
perf(pipenv) - Add lazy-pipenv option

### DIFF
--- a/plugins/pipenv/README.md
+++ b/plugins/pipenv/README.md
@@ -11,6 +11,9 @@ plugins=(... pipenv ...)
 This plugin provides some features to simplify the use of Pipenv while working on ZSH. 
 - Adds completion for pipenv
 - Auto activates and deactivates pipenv shell
+ - If lazy loading is desierd, e.g. in case you use direnv, or just need shortkeys,
+   setting `PIPENV_LAZY_LOAD` to 1 befor activating the plugin in `.zshrc` disables automatic pipenv shell activation.
+
 - Adds short aliases for common pipenv commands
   - `pch` is aliased to `pipenv check`
   - `pcl` is aliased to `pipenv clean`

--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -23,9 +23,14 @@ _togglePipenvShell() {
     fi
   fi
 }
-autoload -U add-zsh-hook
-add-zsh-hook chpwd _togglePipenvShell
-_togglePipenvShell
+
+# If lazy loading selected, disable automatic pipenv shell activation;
+# e.g. in case you using direnv, or just need shortkeys and not the env.
+if [[ "$PIPENV_LAZY_LOAD" != 1 ]]; then
+  autoload -U add-zsh-hook
+  add-zsh-hook chpwd _togglePipenvShell
+  _togglePipenvShell
+fi
 
 # Aliases
 alias pch="pipenv check"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Using `PIPENV_LAZY_LOAD` variable to enable/disable automatic loading of PIPENV environments. 

## Other comments:

Cases that such a behaviour is desired is:
- Those who rely on `direnv` for enabling venv
- The projects that have both `Pipfile` and `poetry.lock` for whatever reason
- In case you don't want slow down navigating folders, and `pipenv` aliases are enough for you.
