### PR TITLE
chore(poetry): remove unnecessary unset

### DIFF
--- a/plugins/poetry/poetry.plugin.zsh
+++ b/plugins/poetry/poetry.plugin.zsh
@@ -12,5 +12,3 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_poetry" ]]; then
 fi
 
 poetry completions zsh >| "$ZSH_CACHE_DIR/completions/_poetry" &|
-
-unset comp_file


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Removes an `unset` that became stale after the latest plugin refactor.

## Other comments:

See #10595 

@mcornella 
