### PR TITLE
chore(1password): fix typo in `opswd`

### DIFF
--- a/plugins/1password/README.md
+++ b/plugins/1password/README.md
@@ -11,7 +11,7 @@ plugins=(... 1password)
 Then, you can use the command `opswd` to copy passwords for services into your
 clipboard.
 
-## `opwsd`
+## `opswd`
 
 The `opswd` command is a wrapper around the `op` command. It takes a service
 name as an argument and copies the password for that service to the clipboard.


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fix typo in `plugins/1password/README.md`

