### PR TITLE
chore(kubectl): standard completion loading

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -1,23 +1,16 @@
-if (( $+commands[kubectl] )); then
-  # TODO: 2022-01-05: remove this block
-  # remove old generated files
-  command rm -f "$ZSH_CACHE_DIR/kubectl_completion"
-
-  # TODO: 2022-01-05: remove this bit of code as it exists in oh-my-zsh.sh
-  # Add completions folder in $ZSH_CACHE_DIR
-  command mkdir -p "$ZSH_CACHE_DIR/completions"
-  (( ${fpath[(Ie)"$ZSH_CACHE_DIR/completions"]} )) || fpath=("$ZSH_CACHE_DIR/completions" $fpath)
-
-  # If the completion file does not exist, generate it and then source it
-  # Otherwise, source it and regenerate in the background
-  if [[ ! -f "$ZSH_CACHE_DIR/completions/_kubectl" ]]; then
-    kubectl completion zsh >| "$ZSH_CACHE_DIR/completions/_kubectl"
-    source "$ZSH_CACHE_DIR/completions/_kubectl"
-  else
-    source "$ZSH_CACHE_DIR/completions/_kubectl"
-    kubectl completion zsh >| "$ZSH_CACHE_DIR/completions/_kubectl" &|
-  fi
+if (( ! $+commands[kubectl] )); then
+  return
 fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `kubectl`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_kubectl" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _kubectl
+  _comps[kubectl]=_kubectl
+fi
+
+kubectl completion zsh >| "$ZSH_CACHE_DIR/completions/_kubectl" &|
 
 # This command is used a LOT both below and in daily life
 alias k=kubectl


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Change `kubectl` completion loading to meet the standard now in omz (such as `deno`, `gh` plugins)