### PR TITLE
fix(installer): avoid `git clone -c` to support git v1.7.1

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -273,8 +273,8 @@ setup_ohmyzsh() {
   && git config oh-my-zsh.remote origin \
   && git config oh-my-zsh.branch "$BRANCH" \
   && git remote add origin "$REMOTE" \
-  && git fetch --depth=1 origin "$BRANCH" \
-  && git checkout -q "$BRANCH" || {
+  && git fetch --depth=1 origin \
+  && git checkout -b "$BRANCH" "origin/$BRANCH" || {
     rm -rf "$ZSH"
     fmt_error "git clone of oh-my-zsh repo failed"
     exit 1

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -263,13 +263,19 @@ setup_ohmyzsh() {
     exit 1
   fi
 
-  git clone -c core.eol=lf -c core.autocrlf=false \
-    -c fsck.zeroPaddedFilemode=ignore \
-    -c fetch.fsck.zeroPaddedFilemode=ignore \
-    -c receive.fsck.zeroPaddedFilemode=ignore \
-    -c oh-my-zsh.remote=origin \
-    -c oh-my-zsh.branch="$BRANCH" \
-    --depth=1 --branch "$BRANCH" "$REMOTE" "$ZSH" || {
+  # Manual clone with git config options to support git < v1.7.2
+  git init "$ZSH" && cd "$ZSH" \
+  && git config core.eol lf \
+  && git config core.autocrlf false \
+  && git config fsck.zeroPaddedFilemode ignore \
+  && git config fetch.fsck.zeroPaddedFilemode ignore \
+  && git config receive.fsck.zeroPaddedFilemode ignore \
+  && git config oh-my-zsh.remote origin \
+  && git config oh-my-zsh.branch "$BRANCH" \
+  && git remote add origin "$REMOTE" \
+  && git fetch --depth=1 origin "$BRANCH" \
+  && git checkout -q "$BRANCH" || {
+    rm -rf "$ZSH"
     fmt_error "git clone of oh-my-zsh repo failed"
     exit 1
   }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Avoid's using [`git clone -c`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt--cltkeygtltvaluegt) (which specifies git-config options when cloning) to support git versions older than v1.7.7. This parameter was introduced in https://github.com/git/git/commit/84054f79de35015fc92f73ec4780102dd820e452, so using an older git (as in centos 6) will break the installer.

## Other comments:

Fixes #8533