### PR TITLE
Respect `$ZDOTDIR` in installer and uninstaller

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -16,6 +16,9 @@
 #   ZSH=~/.zsh sh install.sh
 #
 # Respects the following environment variables:
+#   ZDOTDIR - path to Zsh dotfiles directory (default: unset). See [1][2]
+#             [1] https://zsh.sourceforge.io/Doc/Release/Parameters.html#index-ZDOTDIR
+#             [2] https://zsh.sourceforge.io/Doc/Release/Files.html#index-ZDOTDIR_002c-use-of
 #   ZSH     - path to the Oh My Zsh repository folder (default: $HOME/.oh-my-zsh)
 #   REPO    - name of the GitHub repo to install from (default: ohmyzsh/ohmyzsh)
 #   REMOTE  - full remote URL of the git repo to install (default: GitHub via HTTPS)
@@ -53,8 +56,17 @@ HOME="${HOME:-$(eval echo ~$USER)}"
 # Track if $ZSH was provided
 custom_zsh=${ZSH:+yes}
 
-# Default settings
+# Use $zdot to keep track of where the directory is for zsh dotfiles
+# To check if $ZDOTDIR was provided, explicitly check for $ZDOTDIR
+zdot="${ZDOTDIR:-$HOME}"
+
+# Default value for $ZSH
+# a) if $ZDOTDIR is supplied: $ZDOTDIR/ohmyzsh
+# b) otherwise, $HOME/.oh-my-zsh
+ZSH="${ZSH:-${ZDOTDIR:+$ZDOTDIR/ohmyzsh}}"
 ZSH="${ZSH:-$HOME/.oh-my-zsh}"
+
+# Default settings
 REPO=${REPO:-ohmyzsh/ohmyzsh}
 REMOTE=${REMOTE:-https://github.com/${REPO}.git}
 BRANCH=${BRANCH:-master}
@@ -311,11 +323,11 @@ setup_zshrc() {
   echo "${FMT_BLUE}Looking for an existing zsh config...${FMT_RESET}"
 
   # Must use this exact name so uninstall.sh can find it
-  OLD_ZSHRC=~/.zshrc.pre-oh-my-zsh
-  if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
+  OLD_ZSHRC="$zdot/.zshrc.pre-oh-my-zsh"
+  if [ -f "$zdot/.zshrc" ] || [ -h "$zdot/.zshrc" ]; then
     # Skip this if the user doesn't want to replace an existing .zshrc
     if [ "$KEEP_ZSHRC" = yes ]; then
-      echo "${FMT_YELLOW}Found ~/.zshrc.${FMT_RESET} ${FMT_GREEN}Keeping...${FMT_RESET}"
+      echo "${FMT_YELLOW}Found ${zdot}/.zshrc.${FMT_RESET} ${FMT_GREEN}Keeping...${FMT_RESET}"
       return
     fi
     if [ -e "$OLD_ZSHRC" ]; then
@@ -327,19 +339,22 @@ setup_zshrc() {
       fi
       mv "$OLD_ZSHRC" "${OLD_OLD_ZSHRC}"
 
-      echo "${FMT_YELLOW}Found old ~/.zshrc.pre-oh-my-zsh." \
+      echo "${FMT_YELLOW}Found old .zshrc.pre-oh-my-zsh." \
         "${FMT_GREEN}Backing up to ${OLD_OLD_ZSHRC}${FMT_RESET}"
     fi
-    echo "${FMT_YELLOW}Found ~/.zshrc.${FMT_RESET} ${FMT_GREEN}Backing up to ${OLD_ZSHRC}${FMT_RESET}"
-    mv ~/.zshrc "$OLD_ZSHRC"
+    echo "${FMT_YELLOW}Found ${zdot}/.zshrc.${FMT_RESET} ${FMT_GREEN}Backing up to ${OLD_ZSHRC}${FMT_RESET}"
+    mv "$zdot/.zshrc" "$OLD_ZSHRC"
   fi
 
-  echo "${FMT_GREEN}Using the Oh My Zsh template file and adding it to ~/.zshrc.${FMT_RESET}"
+  echo "${FMT_GREEN}Using the Oh My Zsh template file and adding it to $zdot/.zshrc.${FMT_RESET}"
 
-  # Replace $HOME path with '$HOME' in $ZSH variable in .zshrc file
-  omz=$(echo "$ZSH" | sed "s|^$HOME/|\$HOME/|")
-  sed "s|^export ZSH=.*$|export ZSH=\"${omz}\"|" "$ZSH/templates/zshrc.zsh-template" > ~/.zshrc-omztemp
-  mv -f ~/.zshrc-omztemp ~/.zshrc
+  # Modify $ZSH variable in .zshrc directory to use the literal $ZDOTDIR or $HOME
+  omz="$ZSH"
+  [ -z "$ZDOTDIR" ] || omz=$(echo "$omz" | sed "s|^$ZDOTDIR/|\$ZDOTDIR/|")
+  omz=$(echo "$omz" | sed "s|^$HOME/|\$HOME/|")
+
+  sed "s|^export ZSH=.*$|export ZSH=\"${omz}\"|" "$ZSH/templates/zshrc.zsh-template" > "$zdot/.zshrc-omztemp"
+  mv -f "$zdot/.zshrc-omztemp" "$zdot/.zshrc"
 
   echo
 }
@@ -407,9 +422,9 @@ EOF
 
   # We're going to change the default shell, so back up the current one
   if [ -n "$SHELL" ]; then
-    echo "$SHELL" > ~/.shell.pre-oh-my-zsh
+    echo "$SHELL" > "$zdot/.shell.pre-oh-my-zsh"
   else
-    grep "^$USER:" /etc/passwd | awk -F: '{print $7}' > ~/.shell.pre-oh-my-zsh
+    grep "^$USER:" /etc/passwd | awk -F: '{print $7}' > "$zdot/.shell.pre-oh-my-zsh"
   fi
 
   echo "Changing your shell to $zsh..."
@@ -451,7 +466,7 @@ print_success() {
   printf '\n'
   printf '\n'
   printf "%s %s %s\n" "Before you scream ${FMT_BOLD}${FMT_YELLOW}Oh My Zsh!${FMT_RESET} look over the" \
-    "$(fmt_code "$(fmt_link ".zshrc" "file://$HOME/.zshrc" --text)")" \
+    "$(fmt_code "$(fmt_link ".zshrc" "file://$zdot/.zshrc" --text)")" \
     "file to select plugins, themes, and options."
   printf '\n'
   printf '%s\n' "• Follow us on Twitter: $(fmt_link @ohmyzsh https://twitter.com/ohmyzsh)"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- feat(installer): respect and install in `$ZDOTDIR` if set (#9376)
  Fixes #9001, fixes #10479

## Other comments:

- [x] Installer support
- [ ] Uninstaller support
- [ ] Figure out other places where it might need to be taken into consideration