### PR TITLE
Add alias for "git stash push --patch" (git 2.35+)

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -283,6 +283,11 @@ is-at-least 2.13 "$git_version" \
   && alias gsta='git stash push' \
   || alias gsta='git stash save'
 
+# enable "git stash --patch" on git 2.35 or newer
+is-at-least 2.35 "$git_version" \
+  && alias gstapa='git stash push --patch' \
+  || alias gstapa=gsta
+
 alias gstaa='git stash apply'
 alias gstc='git stash clear'
 alias gstd='git stash drop'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add a new alias, `gstapa`, for `git stash push --patch` (new in git 2.35)

## Other comments:

For older version of git (below 2.35) the new alias acts as the already defined alias: `gsta`
