### PR TITLE
fix(gitfast): update to git-completion 1.3.6

### DIFF
--- a/plugins/gitfast/_git
+++ b/plugins/gitfast/_git
@@ -33,8 +33,9 @@ if [ -z "$script" ]; then
 		bash_completion='/usr/share/bash-completion/completions/'
 
 	locations=(
-		"$(dirname ${funcsourcetrace[1]%:*})"/git-completion.bash
+		"${${funcsourcetrace[1]%:*}:A:h}"/git-completion.bash
 		"$HOME/.local/share/bash-completion/completions/git"
+		'/usr/local/share/bash-completion/completions/git'
 		"$bash_completion/git"
 		'/etc/bash_completion.d/git' # old debian
 		)
@@ -51,10 +52,17 @@ functions[complete]="$old_complete"
 
 __gitcompadd ()
 {
-	compadd -Q -p "${2-}" -S "${3- }" ${@[4,-1]} -- ${=1} && _ret=0
+	compadd -p "${2-}" -S "${3- }" -q -- ${=1} && _ret=0
 }
 
 __gitcomp ()
+{
+	emulate -L zsh
+
+	IFS=$' \t\n' __gitcompadd "$1" "${2-}" "${4- }"
+}
+
+__gitcomp_opts ()
 {
 	emulate -L zsh
 
@@ -70,7 +78,7 @@ __gitcomp ()
 			break
 		fi
 
-		if [[ -z "${4-}" ]]; then
+		if [[ -z "${4+set}" ]]; then
 			case $c in
 			*=) c="${c%=}"; sfx="=" ;;
 			*.) sfx="" ;;
@@ -79,7 +87,7 @@ __gitcomp ()
 		else
 			sfx="$4"
 		fi
-		__gitcompadd "$c" "${2-}" "$sfx" -q
+		__gitcompadd "$c" "${2-}" "$sfx"
 	done
 }
 
@@ -87,7 +95,10 @@ __gitcomp_nl ()
 {
 	emulate -L zsh
 
-	IFS=$'\n' __gitcompadd "$1" "${2-}" "${4- }"
+	# words that don't end up in space
+	compadd -p "${2-}" -S "${4- }" -q -- ${${(f)1}:#*\ } && _ret=0
+	# words that end in space
+	compadd -p "${2-}" -S " ${4- }" -q -- ${${(M)${(f)1}:#*\ }% } && _ret=0
 }
 
 __gitcomp_file ()
@@ -105,21 +116,6 @@ __gitcomp_direct ()
 __gitcomp_file_direct ()
 {
 	__gitcomp_file "$1" ""
-}
-
-__gitcomp_nl_append ()
-{
-	__gitcomp_nl "$@"
-}
-
-__gitcomp_direct_append ()
-{
-	__gitcomp_direct "$@"
-}
-
-_git_zsh ()
-{
-	__gitcomp "v1.2"
 }
 
 __git_complete_command ()
@@ -206,9 +202,7 @@ __git_zsh_main ()
 {
 	local curcontext="$curcontext" state state_descr line
 	typeset -A opt_args
-	local -a orig_words __git_C_args
-
-	orig_words=( ${words[@]} )
+	local -a __git_C_args
 
 	_arguments -C \
 		'(-p --paginate -P --no-pager)'{-p,--paginate}'[pipe all output into ''less'']' \
@@ -245,7 +239,7 @@ __git_zsh_main ()
 		emulate ksh -c __git_complete_config_variable_name_and_value
 		;;
 	(arg)
-		local command="${words[1]}" __git_dir
+		local command="${words[1]}" __git_dir __git_cmd_idx=1
 
 		if (( $+opt_args[--bare] )); then
 			__git_dir='.'
@@ -259,7 +253,7 @@ __git_zsh_main ()
 
 		(( $+opt_args[--help] )) && command='help'
 
-		words=( ${orig_words[@]} )
+		words=( git ${words[@]} )
 
 		__git_zsh_bash_func $command
 		;;
@@ -269,7 +263,7 @@ __git_zsh_main ()
 _git ()
 {
 	local _ret=1
-	local cur cword prev
+	local cur cword prev __git_cmd_idx=0
 
 	cur=${words[CURRENT]}
 	prev=${words[CURRENT-1]}

--- a/plugins/gitfast/git-prompt.sh
+++ b/plugins/gitfast/git-prompt.sh
@@ -138,6 +138,7 @@ __git_ps1_show_upstream ()
 	done <<< "$output"
 
 	# parse configuration values
+	local option
 	for option in ${GIT_PS1_SHOWUPSTREAM}; do
 		case "$option" in
 		git|svn) upstream="$option" ;;
@@ -432,8 +433,8 @@ __git_ps1 ()
 	fi
 
 	local sparse=""
-	if [ -z "${GIT_PS1_COMPRESSSPARSESTATE}" ] &&
-	   [ -z "${GIT_PS1_OMITSPARSESTATE}" ] &&
+	if [ -z "${GIT_PS1_COMPRESSSPARSESTATE-}" ] &&
+	   [ -z "${GIT_PS1_OMITSPARSESTATE-}" ] &&
 	   [ "$(git config --bool core.sparseCheckout)" = "true" ]; then
 		sparse="|SPARSE"
 	fi
@@ -542,7 +543,7 @@ __git_ps1 ()
 			u="%${ZSH_VERSION+%}"
 		fi
 
-		if [ -n "${GIT_PS1_COMPRESSSPARSESTATE}" ] &&
+		if [ -n "${GIT_PS1_COMPRESSSPARSESTATE-}" ] &&
 		   [ "$(git config --bool core.sparseCheckout)" = "true" ]; then
 			h="?"
 		fi

--- a/plugins/gitfast/update
+++ b/plugins/gitfast/update
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 url="https://raw.githubusercontent.com/felipec/git-completion"
-version="1.2"
+version="1.3.6"
 
 curl -s -o _git "${url}/v${version}/git-completion.zsh" &&
 curl -s -o git-completion.bash "${url}/v${version}/git-completion.bash" &&


### PR DESCRIPTION
It's been a while since I synchronized gitfast with git-completion, that's why the changes are big, but they have been thoroughly tested.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Fix to make it loadable through zinit
- Better handling of completion sufixxes
- More completions for `git send-email`
- Update to standardized upstream `__git_complete`
- Many small fixes

This corresponds with upstream's 2.35.0 release.