### PR TITLE
feat(rbw): add `rbwpw` function to copy passwords to the clipboard

### DIFF
--- a/plugins/rbw/README.md
+++ b/plugins/rbw/README.md
@@ -9,4 +9,11 @@ To use it, add `rbw` to the plugins array in your zshrc file:
 plugins=(... rbw)
 ```
 
+It also adds the `rbwpw` function, that copies the password in the clipboard
+for the service you ask for and clears the clipboard 20s later. Usage:
+
+```zsh
+rbwpw <service>
+```
+
 This plugin does not add any aliases.

--- a/plugins/rbw/README.md
+++ b/plugins/rbw/README.md
@@ -9,8 +9,11 @@ To use it, add `rbw` to the plugins array in your zshrc file:
 plugins=(... rbw)
 ```
 
-It also adds the `rbwpw` function, that copies the password in the clipboard
-for the service you ask for and clears the clipboard 20s later. Usage:
+## `rbwpw`
+
+The `rbwpw` function is a wrapper around `rbw`. It copies the password in the
+clipboard for the service you ask for and clears the clipboard 20s later.
+The usage is as follows:
 
 ```zsh
 rbwpw <service>

--- a/plugins/rbw/rbw.plugin.zsh
+++ b/plugins/rbw/rbw.plugin.zsh
@@ -17,3 +17,23 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_rbw" ]]; then
 fi
 
 rbw gen-completions zsh >| "$ZSH_CACHE_DIR/completions/_rbw" &|
+
+# rbwpw function copies the password of a service to the clipboard
+# and clears it after 20 seconds
+function rbwpw {
+  [[ $# -ne 1 ]] && echo "usage: rbwg <service>" && return 1
+  local service=$1
+  rbw unlock || (echo "rbw is locked" && return 1)
+  local pw=$(rbw get $service 2>/dev/null)
+  [[ -z $pw ]] && echo "$service not found" && return 1
+  echo -n $pw | clipcopy
+  echo "password for $service copied!"
+  (sleep 20 && clipcopy </dev/null 2>/dev/null) &|
+}
+
+function _rbwpw {
+  local -a services=("${(@f)$(rbw ls 2>/dev/null)}")
+  [[ -n services ]] && compadd -a -- services
+}
+
+compdef _rbwpw rbwpw

--- a/plugins/rbw/rbw.plugin.zsh
+++ b/plugins/rbw/rbw.plugin.zsh
@@ -21,19 +21,29 @@ rbw gen-completions zsh >| "$ZSH_CACHE_DIR/completions/_rbw" &|
 # rbwpw function copies the password of a service to the clipboard
 # and clears it after 20 seconds
 function rbwpw {
-  [[ $# -ne 1 ]] && echo "usage: rbwpw <service>" && return 1
+  if [[ $# -ne 1 ]]; then
+    echo "usage: rbwpw <service>"
+    return 1
+  fi
   local service=$1
-  rbw unlock || (echo "rbw is locked" && return 1)
+  if ! rbw unlock; then
+    echo "rbw is locked"
+    return 1
+  fi
   local pw=$(rbw get $service 2>/dev/null)
-  [[ -z $pw ]] && echo "$service not found" && return 1
+  if [[ -z $pw ]]; then
+    echo "$service not found"
+    return 1
+  fi
   echo -n $pw | clipcopy
   echo "password for $service copied!"
-  (sleep 20 && clipcopy </dev/null 2>/dev/null) &|
+  {sleep 20 && clipcopy </dev/null 2>/dev/null} &|
 }
 
 function _rbwpw {
-  local -a services=("${(@f)$(rbw ls 2>/dev/null)}")
-  [[ -n services ]] && compadd -a -- services
+  local -a services
+  services=("${(@f)$(rbw ls 2>/dev/null)}")
+  [[ -n "$services" ]] && compadd -a -- services
 }
 
 compdef _rbwpw rbwpw

--- a/plugins/rbw/rbw.plugin.zsh
+++ b/plugins/rbw/rbw.plugin.zsh
@@ -21,7 +21,7 @@ rbw gen-completions zsh >| "$ZSH_CACHE_DIR/completions/_rbw" &|
 # rbwpw function copies the password of a service to the clipboard
 # and clears it after 20 seconds
 function rbwpw {
-  [[ $# -ne 1 ]] && echo "usage: rbwg <service>" && return 1
+  [[ $# -ne 1 ]] && echo "usage: rbwpw <service>" && return 1
   local service=$1
   rbw unlock || (echo "rbw is locked" && return 1)
   local pw=$(rbw get $service 2>/dev/null)


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Adding `rbwpw` function, very similar to `opwsd` (or something like that 😅) in `1password` plugin. It copies the password for a service and clears the clipboard after 20s.