### PR TITLE
fix(shell-proxy): make ssh-proxy compatible with macOS

### DIFF
--- a/plugins/shell-proxy/.editorconfig
+++ b/plugins/shell-proxy/.editorconfig
@@ -1,0 +1,3 @@
+[*.py]
+indent_size = 4
+indent_style = space

--- a/plugins/shell-proxy/ssh-proxy.py
+++ b/plugins/shell-proxy/ssh-proxy.py
@@ -21,7 +21,7 @@ if parsed.scheme not in proxy_protocols:
     raise TypeError('unsupported proxy protocol: "{}"'.format(parsed.scheme))
 
 def make_argv():
-    yield os.environ.get("SHELLPROXY_NETCAT_PROGRAM", "nc")
+    yield "nc"
     if sys.platform == 'linux':
         # caveats: macOS built-in netcat command not supported proxy-type
         yield "-X" # --proxy-type

--- a/plugins/shell-proxy/ssh-proxy.py
+++ b/plugins/shell-proxy/ssh-proxy.py
@@ -20,14 +20,17 @@ proxy_protocols = {
 if parsed.scheme not in proxy_protocols:
     raise TypeError('unsupported proxy protocol: "{}"'.format(parsed.scheme))
 
-argv = [
-    "nc",
-    "-X",
-    proxy_protocols[parsed.scheme], # Supported protocols are 4 (SOCKS v4), 5 (SOCKS v5) and connect (HTTP proxy). Default SOCKS v5 is used.
-    "-x",
-    parsed.netloc,  # proxy-host:proxy-port
-    sys.argv[1],  # host
-    sys.argv[2],  # port
-]
+def make_argv():
+    yield os.environ.get("SHELLPROXY_NETCAT_PROGRAM", "nc")
+    if sys.platform == 'linux':
+        # caveats: macOS built-in netcat command not supported proxy-type
+        yield "-X" # --proxy-type
+        # Supported protocols are 4 (SOCKS v4), 5 (SOCKS v5) and connect (HTTP proxy).
+        # Default SOCKS v5 is used.
+        yield proxy_protocols[parsed.scheme]
+    yield "-x" # --proxy
+    yield parsed.netloc # proxy-host:proxy-port
+    yield sys.argv[1] # host
+    yield sys.argv[2] # port
 
-subprocess.call(argv)
+subprocess.call(make_argv())


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Allow customize netcat program

## Other comments:

macOS built-in netcat program not supported `-X` parameter