### PR TITLE
feat(yarn): add setting to disable adding global dir to `$PATH`

### DIFF
--- a/plugins/yarn/README.md
+++ b/plugins/yarn/README.md
@@ -9,6 +9,15 @@ To use it, add `yarn` to the plugins array in your zshrc file:
 plugins=(... yarn)
 ```
 
+## Global scripts directory
+
+It also adds `yarn` global scripts dir (commonly `~/.yarn/bin`) to the `$PATH`.
+To disable this feature, set the following style in your `.zshrc`:
+
+```zsh
+zstyle ':omz:plugins:yarn' global-path false
+```
+
 ## Aliases
 
 | Alias | Command                                   | Description                                                                   |

--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -1,12 +1,14 @@
-# Skip yarn call if default global bin dir exists
-[[ -d "$HOME/.yarn/bin" ]] && bindir="$HOME/.yarn/bin" || bindir="$(yarn global bin 2>/dev/null)"
+if zstyle -T ':omz:plugins:yarn' global-path; then
+  # Skip yarn call if default global bin dir exists
+  [[ -d "$HOME/.yarn/bin" ]] && bindir="$HOME/.yarn/bin" || bindir="$(yarn global bin 2>/dev/null)"
 
-# Add yarn bin directory to $PATH if it exists and not already in $PATH
-[[ $? -eq 0 ]] \
-  && [[ -d "$bindir" ]] \
-  && (( ! ${path[(Ie)$bindir]} )) \
-  && path+=("$bindir")
-unset bindir
+  # Add yarn bin directory to $PATH if it exists and not already in $PATH
+  [[ $? -eq 0 ]] \
+    && [[ -d "$bindir" ]] \
+    && (( ! ${path[(Ie)$bindir]} )) \
+    && path+=("$bindir")
+  unset bindir
+fi
 
 alias y="yarn"
 alias ya="yarn add"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Setting `ZSH_YARN_GLOBAL_DISABLE=true` prevents adding `yarn global bin` to the `$PATH`.
Fixes #10641