### PR TITLE
fix(cli): allow `omz` commands to be used in a script

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -105,7 +105,10 @@ function _omz {
   return 0
 }
 
-compdef _omz omz
+# If run from a script, do not set the completion function
+if (( ${+functions[compdef]} )); then
+  compdef _omz omz
+fi
 
 ## Utility functions
 
@@ -299,10 +302,8 @@ multi == 1 && length(\$0) > 0 {
   # Restart the zsh session if there were no errors
   _omz::log info "plugins disabled: ${(j:, :)dis_plugins}."
 
-  # Old zsh versions don't have ZSH_ARGZERO
-  local zsh="${ZSH_ARGZERO:-${functrace[-1]%:*}}"
-  # Check whether to run a login shell
-  [[ "$zsh" = -* || -o login ]] && exec -l "${zsh#-}" || exec "$zsh"
+  # Only reload zsh if run in an interactive session
+  [[ ! -o interactive ]] || _omz::reload
 }
 
 function _omz::plugin::enable {
@@ -375,10 +376,8 @@ multi == 1 && /^[^#]*\)/ {
   # Restart the zsh session if there were no errors
   _omz::log info "plugins enabled: ${(j:, :)add_plugins}."
 
-  # Old zsh versions don't have ZSH_ARGZERO
-  local zsh="${ZSH_ARGZERO:-${functrace[-1]%:*}}"
-  # Check whether to run a login shell
-  [[ "$zsh" = -* || -o login ]] && exec -l "${zsh#-}" || exec "$zsh"
+  # Only reload zsh if run in an interactive session
+  [[ ! -o interactive ]] || _omz::reload
 }
 
 function _omz::plugin::info {
@@ -731,10 +730,8 @@ EOF
   # Restart the zsh session if there were no errors
   _omz::log info "'$1' theme set correctly."
 
-  # Old zsh versions don't have ZSH_ARGZERO
-  local zsh="${ZSH_ARGZERO:-${functrace[-1]%:*}}"
-  # Check whether to run a login shell
-  [[ "$zsh" = -* || -o login ]] && exec -l "${zsh#-}" || exec "$zsh"
+  # Only reload zsh if run in an interactive session
+  [[ ! -o interactive ]] || _omz::reload
 }
 
 function _omz::theme::use {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

The commands `omz plugin {enable,disable}` and `omz theme set`
automatically reload the zsh session on success. With this
change, the CLI checks whether the commands are run in an
interactive session before reloading the zsh session.

This change also conditionally sets the completion function
for `omz` so that it's not done in a non-interactive session.

## Other comments:

Fixes #10643