### PR TITLE
chore(compfix): adding zstyle config

### DIFF
--- a/lib/compfix.zsh
+++ b/lib/compfix.zsh
@@ -37,8 +37,8 @@ function handle_completion_insecurities() {
 [oh-my-zsh]     compaudit | xargs chmod g-w,o-w
 
 [oh-my-zsh] If the above didn't help or you want to skip the verification of
-[oh-my-zsh] insecure directories you can set the variable ZSH_DISABLE_COMPFIX to
-[oh-my-zsh] "true" before oh-my-zsh is sourced in your zshrc file.
+[oh-my-zsh] insecure directories you can set "zstyle ':omz:compfix' enabled false"
+[oh-my-zsh] before oh-my-zsh is sourced in your zshrc file.
 
 EOD
 }

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -118,7 +118,8 @@ if ! command grep -q -Fx "$zcompdump_revision" "$ZSH_COMPDUMP" 2>/dev/null \
   zcompdump_refresh=1
 fi
 
-if [[ "$ZSH_DISABLE_COMPFIX" != true ]]; then
+if zstyle -T ':omz:compfix' enabled \
+  && [[ "$ZSH_DISABLE_COMPFIX" != true ]]; then
   source "$ZSH/lib/compfix.zsh"
   # If completion insecurities exist, warn the user
   handle_completion_insecurities


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Following the `zstyle` way of customizing omz instead of using variables, I added the option for disabling compfix without setting the `ZSH_DISABLE_COMPFIX` variable.