### PR TITLE
feat(lib): add the git tag in the prompt

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -22,6 +22,10 @@ function git_prompt_info() {
   || ref=$(__git_prompt_git rev-parse --short HEAD 2> /dev/null) \
   || return 0
 
+  local tag
+  tag=$(__git_prompt_git describe --tags --exact-match 2> /dev/null) \
+      && tag="(${tag})"
+
   # Use global ZSH_THEME_GIT_SHOW_UPSTREAM=1 for including upstream remote info
   local upstream
   if (( ${+ZSH_THEME_GIT_SHOW_UPSTREAM} )); then
@@ -29,7 +33,7 @@ function git_prompt_info() {
     && upstream=" -> ${upstream}"
   fi
 
-  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref:gs/%/%%}${upstream:gs/%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
+  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref:gs/%/%%}${tag}${upstream:gs/%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
 }
 
 # Checks if working tree is dirty


### PR DESCRIPTION
Signed-off-by: chuang wang <nashuiliang@gmail.com>

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- This change adds a git tag on current `HEAD` in the function `git_prompt_info`

I.e: `osc@ubuntu /linux ‹7d2a07b76933(v5.14)›` instead of `osc@ubuntu /linux ‹7d2a07b76933›`. `v5.14` is a git tag on current `HEAD`.