### PR TITLE
Fix for Bureau theme GIT_PROMPT_CLEAN display

### DIFF
--- a/themes/bureau.zsh-theme
+++ b/themes/bureau.zsh-theme
@@ -27,7 +27,7 @@ bureau_git_status() {
   local result gitstatus
 
   # check status of files
-  gitstatus=$(command git status --porcelain -b 2> /dev/null)
+  gitstatus=$(command git status --porcelain 2> /dev/null)
   if [[ -n "$gitstatus" ]]; then
     if $(echo "$gitstatus" | command grep -q '^[AMRD]. '); then
       result+="$ZSH_THEME_GIT_PROMPT_STAGED"
@@ -46,6 +46,7 @@ bureau_git_status() {
   fi
 
   # check status of local repository
+  gitstatus=$(command git status --porcelain -b 2> /dev/null)
   if $(echo "$gitstatus" | command grep -q '^## .*ahead'); then
     result+="$ZSH_THEME_GIT_PROMPT_AHEAD"
   fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Recent changes from [this PR](https://github.com/ohmyzsh/ohmyzsh/commit/8e973d42bd3bc5028d88ce731113b03ac8a5590c) broke `$ZSH_THEME_GIT_PROMPT_CLEAN`

Before that change was made, `git status --porcelain` was used to determine file status and `git status --porcelain -b` was used for branch status. That was changed to be `git status --porcelain -b` for both.

This meant that the `if [[ -n "$gitstatus" ]]; then` check was always true, so `result+="$ZSH_THEME_GIT_PROMPT_CLEAN"` was never happening

This MR just changes it back to having to `git status` checks, one for files and one for branches

## Other comments:

...
