### PR TITLE
feat(plugin): Adds alias-printer plugin

### DIFF
--- a/plugins/alias-printer/README.md
+++ b/plugins/alias-printer/README.md
@@ -23,5 +23,5 @@ input. See the options below
 ## Examples
 ```
 $ gl
-alias-printer: git pull
+gl='git pull'
 ```

--- a/plugins/alias-printer/README.md
+++ b/plugins/alias-printer/README.md
@@ -1,0 +1,27 @@
+# alias-printer plugin
+
+This plugin searches the defined aliases and outputs any command that matches 
+the inputted alias. So that when presenting the audience understands the alias 
+being executed.
+
+To use it, add `alias-printer` to the `plugins` array of your zshrc file:
+```
+plugins=(... alias-printer)
+```
+
+## Usage
+To see if there is an alias defined for the command, pass it as an argument to 
+`alias-printer`. This can also run automatically before each command you 
+input. See the options below
+
+## Options
+
+- Use `--on` to start run automatically before each command you input.
+- Use `--off`to stop the automatically running execute before each command you
+- input.
+
+## Examples
+```
+$ gl
+alias-printer: git pull
+```

--- a/plugins/alias-printer/README.md
+++ b/plugins/alias-printer/README.md
@@ -23,5 +23,10 @@ input. See the options below
 ## Examples
 ```
 $ gl
-gl='git pull'
+alias-printer: git pull
+```
+
+```
+$ gl && grbm
+alias-printer: git pull && git rebase $(git_main_branch)
 ```

--- a/plugins/alias-printer/alias-printer.plugin.zsh
+++ b/plugins/alias-printer/alias-printer.plugin.zsh
@@ -12,9 +12,7 @@ alias-printer() {
         echo "alias-printer turned off";
         ;;
       * )
-        if [[ ! -z $1 ]]; then
-          alias $1
-        fi
+        echo "alias-printer: $2"
         break
       ;;
     esac

--- a/plugins/alias-printer/alias-printer.plugin.zsh
+++ b/plugins/alias-printer/alias-printer.plugin.zsh
@@ -1,15 +1,22 @@
 alias-printer() {
-  if [[ "$1" = "--on" ]]; then
-    autoload -U add-zsh-hook;
-    add-zsh-hook preexec alias-printer;
-    echo "alias-printer turned on";
-  fi
-  if [[ "$1" = "--off" ]]; then
-    autoload -U add-zsh-hook;
-    add-zsh-hook -d preexec alias-printer;
-    echo "alias-printer turned off";
-  fi
-  if [[ ! -z $2 ]]; then
-    echo 'alias-printer: '"$2";
-  fi
+  for arg in $@; do
+    case $arg in
+      --on )
+        autoload -U add-zsh-hook;
+        add-zsh-hook preexec alias-printer;
+        echo "alias-printer turned on";
+        ;;
+      --off )
+        autoload -U add-zsh-hook;
+        add-zsh-hook -d preexec alias-printer;
+        echo "alias-printer turned off";
+        ;;
+      * )
+        if [[ ! -z $2 ]]; then
+          echo 'alias-printer: '"$2";
+        fi
+        break
+      ;;
+    esac
+  done
 }

--- a/plugins/alias-printer/alias-printer.plugin.zsh
+++ b/plugins/alias-printer/alias-printer.plugin.zsh
@@ -12,8 +12,8 @@ alias-printer() {
         echo "alias-printer turned off";
         ;;
       * )
-        if [[ ! -z $2 ]]; then
-          echo 'alias-printer: '"$2";
+        if [[ ! -z $1 ]]; then
+          alias $1
         fi
         break
       ;;

--- a/plugins/alias-printer/alias-printer.plugin.zsh
+++ b/plugins/alias-printer/alias-printer.plugin.zsh
@@ -1,0 +1,15 @@
+alias-printer() {
+  if [[ "$1" = "--on" ]]; then
+    autoload -U add-zsh-hook;
+    add-zsh-hook preexec alias-printer;
+    echo "alias-printer turned on";
+  fi
+  if [[ "$1" = "--off" ]]; then
+    autoload -U add-zsh-hook;
+    add-zsh-hook -d preexec alias-printer;
+    echo "alias-printer turned off";
+  fi
+  if [[ ! -z $2 ]]; then
+    echo 'alias-printer: '"$2";
+  fi
+}


### PR DESCRIPTION
This plugin searches the defined aliases and outputs any command that matches the inputted alias. So that when presenting the audience understands the alias being executed.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
