### PR TITLE
Add git -C support to git_prompt_info.

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -10,34 +10,56 @@ function __git_prompt_git() {
 }
 
 function git_prompt_info() {
+  readonly dir="$1"
+
+  # Decorates git command if a directory is passed to us.
+  function __git_dir_decorator() {
+    if [[ -n $dir ]]; then
+      __git_prompt_git -C "$dir" "$@"
+    else
+      __git_prompt_git "$@"
+    fi
+  }
+
   # If we are on a folder not tracked by git, get out.
   # Otherwise, check for hide-info at global and local repository level
-  if ! __git_prompt_git rev-parse --git-dir &> /dev/null \
-     || [[ "$(__git_prompt_git config --get oh-my-zsh.hide-info 2>/dev/null)" == 1 ]]; then
+  if ! __git_dir_decorator rev-parse --git-dir &> /dev/null \
+     || [[ "$(__git_dir_decorator config --get oh-my-zsh.hide-info 2>/dev/null)" == 1 ]]; then
     return 0
   fi
 
   local ref
-  ref=$(__git_prompt_git symbolic-ref --short HEAD 2> /dev/null) \
-  || ref=$(__git_prompt_git rev-parse --short HEAD 2> /dev/null) \
+  ref=$(__git_dir_decorator symbolic-ref --short HEAD 2> /dev/null) \
+  || ref=$(__git_dir_decorator rev-parse --short HEAD 2> /dev/null) \
   || return 0
 
   # Use global ZSH_THEME_GIT_SHOW_UPSTREAM=1 for including upstream remote info
   local upstream
   if (( ${+ZSH_THEME_GIT_SHOW_UPSTREAM} )); then
-    upstream=$(__git_prompt_git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null) \
+    upstream=$(__git_dir_decorator rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null) \
     && upstream=" -> ${upstream}"
   fi
 
-  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref:gs/%/%%}${upstream:gs/%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
+  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref:gs/%/%%}${upstream:gs/%/%%}$(parse_git_dirty $dir)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
 }
 
 # Checks if working tree is dirty
 function parse_git_dirty() {
+  readonly dir="$1"
+
+  # Decorates git command if a directory is passed to us.
+  function __git_dir_decorator() {
+    if [[ -n $dir ]]; then
+      __git_prompt_git -C "$dir" "$@"
+    else
+      __git_prompt_git "$@"
+    fi
+  }
+
   local STATUS
   local -a FLAGS
   FLAGS=('--porcelain')
-  if [[ "$(__git_prompt_git config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
+  if [[ "$(__git_dir_decorator config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
     if [[ "${DISABLE_UNTRACKED_FILES_DIRTY:-}" == "true" ]]; then
       FLAGS+='--untracked-files=no'
     fi
@@ -51,7 +73,7 @@ function parse_git_dirty() {
         FLAGS+="--ignore-submodules=${GIT_STATUS_IGNORE_SUBMODULES:-dirty}"
         ;;
     esac
-    STATUS=$(__git_prompt_git status ${FLAGS} 2> /dev/null | tail -n 1)
+    STATUS=$(__git_dir_decorator status ${FLAGS} 2> /dev/null | tail -n 1)
   fi
   if [[ -n $STATUS ]]; then
     echo "$ZSH_THEME_GIT_PROMPT_DIRTY"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add git `-C` support to `git_prompt_info` function in `lib/git.zsh`.

## Other comments:
All git commands can be used with the `-C` option that allows working on a repository located in a directory different than the current one. This PR extends `git_prompt_info` function to accept an optional directory parameter.

One example use case for this would be a theme wanting to customise git prompt for a specific directory and display git prompt for a repository in a different location, e.g.:

```my-theme.zsh
function my_git_prompt_info() {
  if [[ $PWD == $HOME ]]; then
    echo $(git_prompt_info ".dotfiles")
  else
    echo $(git_prompt_info)
  fi
}

PROMPT=' %F{white}%2c%F{cyan} [%f '
RPROMPT='$(my_git_prompt_info) %F{cyan}] %F{lightblue}%D{%H:%M}'
```