### PR TITLE
fix(kubectl): fix arguments in `keti` alias to allow completion

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -29,7 +29,7 @@ alias kca='_kca(){ kubectl "$@" --all-namespaces;  unset -f _kca; }; _kca'
 alias kaf='kubectl apply -f'
 
 # Drop into an interactive terminal on a container
-alias keti='kubectl exec -ti'
+alias keti='kubectl exec -t -i'
 
 # Manage configuration quickly to switch contexts between local, dev ad staging.
 alias kcuc='kubectl config use-context'


### PR DESCRIPTION
`keti` is the only `kubectl` command alias that doesn't autocomplete with the pod names when you `TAB` complete. This is because I failed to properly separate the arguments to the source command when I wrote the original aliases for `kubectl` these back in 2017.  This has been occasionally bothering me ever since like a small paper cut thats not important enough to dig into. I finally broke down and dove into the cause this morning. 

This should do NOTHING except fix a very small and subtle bug with no other potential side effects to users. Safe to merge. 

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x] The PR title is descriptive.
- [ x] The PR doesn't replicate another PR which is already open.
- [x ] I have read the contribution guide and followed all the instructions.
- [x ] The code follows the code style guide detailed in the wiki.
- [x ] The code is mine or it's from somewhere with an MIT-compatible license.
- [x ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Minor edit of the alias keti (aliased to: kubectl exec -t -i)
