### PR TITLE
fix(virtualenvwrapper): only deactivate if virtual env is still present

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -56,7 +56,13 @@ if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
       if [[ -n $CD_VIRTUAL_ENV && "$ENV_NAME" != "$CD_VIRTUAL_ENV" ]]; then
         # We've just left the repo, deactivate the environment
         # Note: this only happens if the virtualenv was activated automatically
-        deactivate && unset CD_VIRTUAL_ENV
+        if [[ -n "$VIRTUAL_ENV" ]]; then
+          # Only deactivate if VIRTUAL_ENV was set
+          # User may have deactivated manually or via another mechanism
+          deactivate
+        fi
+        # clean up regardless
+        unset CD_VIRTUAL_ENV
       fi
       if [[ "$ENV_NAME" != "" ]]; then
         # Activate the environment only if it is not already active


### PR DESCRIPTION
- Only call `deactivate` if `$VIRTUAL_ENV` is set
- Unset `$CD_VIRTUAL_ENV` regardless

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Only call `deactivate` if `$VIRTUAL_ENV` is set
- Unset `$CD_VIRTUAL_ENV` regardless

Closes #10670 