### PR TITLE
fix(init): check for unsafe directories in `fpath`

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -120,17 +120,18 @@ fi
 
 if [[ "$ZSH_DISABLE_COMPFIX" != true ]]; then
   source "$ZSH/lib/compfix.zsh"
-  # If completion insecurities exist, warn the user
-  handle_completion_insecurities
   # Load only from secure directories
-  compinit -i -C -d "$ZSH_COMPDUMP"
+  compinit -i -d "$ZSH_COMPDUMP"
+  # If completion insecurities exist, warn the user
+  handle_completion_insecurities &|
 else
   # If the user wants it, load from all found directories
-  compinit -u -C -d "$ZSH_COMPDUMP"
+  compinit -u -d "$ZSH_COMPDUMP"
 fi
 
 # Append zcompdump metadata if missing
-if (( $zcompdump_refresh )); then
+if (( $zcompdump_refresh )) \
+  || ! command grep -q -Fx "$zcompdump_revision" "$ZSH_COMPDUMP" 2>/dev/null; then
   # Use `tee` in case the $ZSH_COMPDUMP filename is invalid, to silence the error
   # See https://github.com/ohmyzsh/ohmyzsh/commit/dd1a7269#commitcomment-39003489
   tee -a "$ZSH_COMPDUMP" &>/dev/null <<EOF


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Actual `compinit`'s approach was loading completion functions from _insecure_ directories (those categorized as insecure by `compaudit`) even though not having `$ZSH_DISABLE_COMPFIX` set to `true`. This PR's approach should take into account those insecure directories.

Without the `-C` flag in `compinit` call, `.zcompdump` file could potentially change if there are changes in completion functions, so I also added a test to see if this happened and append `omz` metadata to `.zcompdump` file.

Now the function `handle_completion_insecurities` will run in background to speed up a little bit the init time.