### PR TITLE
fix(kubectx): don't error on missing k8s context

### DIFF
--- a/plugins/kubectx/kubectx.plugin.zsh
+++ b/plugins/kubectx/kubectx.plugin.zsh
@@ -3,7 +3,9 @@ typeset -g -A kubectx_mapping
 function kubectx_prompt_info() {
   (( $+commands[kubectl] )) || return
 
-  local current_ctx=$(kubectl config current-context)
+  local current_ctx=$(kubectl config current-context 2> /dev/null)
+
+  [[ -n "$current_ctx" ]] || return
 
   # use value in associative array if it exists
   # otherwise fall back to the context name


### PR DESCRIPTION
Previously if there isn't a current kubectl context every time the plugin runs (e.g. if in a prompt) it would display `error: current-context is not set`.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add `$KUBECTX_UNSET` variable to configure what's displayed when no kubectl context is set
- Removes previous behaviour of displaying the error.
