### PR TITLE
fix(cli): disable GPG signing in `omz pr test` to avoid key prompt

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -573,7 +573,7 @@ function _omz::pr::test {
 
     # Rebase pull request branch against the current master
     _omz::log info "rebasing PR #$1..."
-    command git rebase master ohmyzsh/pull-$1 || {
+    command git rebase --no-gpg-sign master ohmyzsh/pull-$1 || {
       command git rebase --abort &>/dev/null
       _omz::log warn "could not rebase PR #$1 on top of master."
       _omz::log warn "you might not see the latest stable changes."


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

When using `omz pr test #sth` I'm being prompted to enter my GPG key password, and it's really annoying because them are not important commits. I think would be nice to just don't sign it.