### PR TITLE
fix(cli): turn of `commit.gpgsign` compatibly with git v1.7.1

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -573,13 +573,15 @@ function _omz::pr::test {
 
     # Rebase pull request branch against the current master
     _omz::log info "rebasing PR #$1..."
-    command git rebase --no-gpg-sign master ohmyzsh/pull-$1 || {
+    command git config commit.gpgsign false
+    command git rebase master ohmyzsh/pull-$1 || {
       command git rebase --abort &>/dev/null
       _omz::log warn "could not rebase PR #$1 on top of master."
       _omz::log warn "you might not see the latest stable changes."
       _omz::log info "run \`zsh\` to test the changes."
       return 1
     }
+    command git config --unset commit.gpgsign
 
     _omz::log info "fetch of PR #${1} successful."
   )

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -573,15 +573,28 @@ function _omz::pr::test {
 
     # Rebase pull request branch against the current master
     _omz::log info "rebasing PR #$1..."
-    command git config commit.gpgsign false
-    command git rebase master ohmyzsh/pull-$1 || {
-      command git rebase --abort &>/dev/null
-      _omz::log warn "could not rebase PR #$1 on top of master."
-      _omz::log warn "you might not see the latest stable changes."
-      _omz::log info "run \`zsh\` to test the changes."
-      return 1
+    local gpgsign
+    {
+      # Back up commit.gpgsign setting: use --local to get the current repository
+      # setting, not the global one. If --local is not a known option, it will
+      # exit with a 129 status code.
+      gpgsign=$(command git config --local commit.gpgsign 2>/dev/null)
+      [[ $? -ne 129 ]] || gpgsign=$(command git config commit.gpgsign 2>/dev/null)
+      command git config commit.gpgsign false
+
+      command git rebase master ohmyzsh/pull-$1 || {
+        command git rebase --abort &>/dev/null
+        _omz::log warn "could not rebase PR #$1 on top of master."
+        _omz::log warn "you might not see the latest stable changes."
+        _omz::log info "run \`zsh\` to test the changes."
+        return 1
+      }
+    } always {
+      case "$gpgsign" in
+      "") command git config --unset commit.gpgsign ;;
+      *) command git config commit.gpgsign "$gpgsign" ;;
+      esac
     }
-    command git config --unset commit.gpgsign
 
     _omz::log info "fetch of PR #${1} successful."
   )


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

I don't know how we should do this, is how I do it great, or other options are preferred?