### PR TITLE
feat(toolbox): add plugin to show `toolbox` prompt info

### DIFF
--- a/plugins/toolbox/README.md
+++ b/plugins/toolbox/README.md
@@ -1,0 +1,19 @@
+# toolbox plugin
+
+Plugin for [toolbox](https://containertoolbx.org), a tool to use containerized CLI environments.
+
+To use it, add `toolbox` to your plugins array in your `.zshrc` file:
+
+```zsh
+plugins=(... toolbox)
+```
+
+## Prompt function
+
+This plugins adds `toolbox_prompt_info()` function. Using it in your prompt, it will show the toolbox indicator ⬢ (if you are running in a toolbox container), and nothing if not.
+
+You can use it by adding `$(toolbox_prompt_info)` to your `PROMPT` or `RPROMPT` variable:
+
+```zsh
+RPROMPT='$(toolbox_prompt_info)'
+```

--- a/plugins/toolbox/kubectx.plugin.zsh
+++ b/plugins/toolbox/kubectx.plugin.zsh
@@ -1,0 +1,3 @@
+function toolbox_prompt_info() {
+  [[ -f /run/.toolboxenv ]] && echo "⬢"
+}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Adds `toolbox_prompt_info` function.
Closes #10446 