### PR TITLE
fix(perms)!: function name change from fixperms to normalizeperms

### DIFF
--- a/plugins/perms/README.md
+++ b/plugins/perms/README.md
@@ -10,6 +10,10 @@ plugins=(... perms)
 
 ## Usage
 
-* `set755` recursively sets all given directories (default to .) to octal 755.
-* `set644` recursively sets all given files (default to .) to octal 644.
-* `fixperms` is a wrapper around `set755` and `set644` applied to a specified directory or the current directory otherwise. It also prompts prior to execution unlike the other two aliases.
+First of all, **CAUTION!**. The following functions are really harmful if you don't know what they exactly do. All three functions are going to change RECURSIVELY the permissions in files and/or directories.
+
+Taking this into account, this plugin defines three different functions:
+
+- `set755` recursively sets all given directories (default to .) to octal 755. It only affects directories.
+- `set644` recursively sets all given files (default to .) to octal 644. It only affects regular files.
+- `normalizeperms` is a wrapper around `set755` and `set644` applied to a specified directory or the current directory otherwise. It also prompts prior to execution unlike the other two aliases.

--- a/plugins/perms/perms.plugin.zsh
+++ b/plugins/perms/perms.plugin.zsh
@@ -6,25 +6,25 @@
 ### Aliases
 
 # Set all files' permissions to 644 recursively in a directory
-set644() {
+function set644 {
 	find "${@:-.}" -type f ! -perm 644 -print0 | xargs -0 chmod 644
 }
 
 # Set all directories' permissions to 755 recursively in a directory
-set755() {
+function set755 {
 	find "${@:-.}" -type d ! -perm 755 -print0 | xargs -0 chmod 755
 }
 
 ### Functions
 
-# fixperms - fix permissions on files and directories, with confirmation
+# normalizeperms - fix permissions on files and directories, with confirmation
 # Returns 0 on success, nonzero if any errors occurred
-fixperms () {
+function normalizeperms {
   local opts confirm target exit_status chmod_opts use_slow_mode
   zparseopts -E -D -a opts -help -slow v+=chmod_opts
   if [[ $# > 1 || -n "${opts[(r)--help]}" ]]; then
     cat <<EOF
-Usage: fixperms [-v] [--help] [--slow] [target]
+Usage: normalizeperms [-v] [--help] [--slow] [target]
 
   target  is the file or directory to change permissions on. If omitted,
           the current directory is taken to be the target.
@@ -40,7 +40,7 @@ EOF
     return $exit_status
   fi
 
-  if [[ $# == 0 ]]; then
+  if [[ $# -eq 0 ]]; then
     target="."
   else
     target="$1"
@@ -49,7 +49,7 @@ EOF
 
   # Because this requires confirmation, bail in noninteractive shells
   if [[ ! -o interactive ]]; then
-    echo "fixperms: cannot run in noninteractive shell"
+    echo "normalizeperms: cannot run in noninteractive shell"
     return 1
   fi
 
@@ -68,15 +68,20 @@ EOF
   if [[ $use_slow == true ]]; then
     # Process directories first so non-traversable ones are fixed as we go
     find "$target" -type d ! -perm 755 -exec chmod $chmod_opts 755 {} \;
-    if [[ $? != 0 ]]; then exit_status=$?; fi
+    if [[ $? -ne 0 ]]; then exit_status=$?; fi
     find "$target" -type f ! -perm 644 -exec chmod $chmod_opts 644 {} \;
-    if [[ $? != 0 ]]; then exit_status=$?; fi
+    if [[ $? -ne 0 ]]; then exit_status=$?; fi
   else
     find "$target" -type d ! -perm 755 -print0 | xargs -0 chmod $chmod_opts 755
-    if [[ $? != 0 ]]; then exit_status=$?; fi
+    if [[ $? -ne 0 ]]; then exit_status=$?; fi
     find "$target" -type f ! -perm 644 -print0 | xargs -0 chmod $chmod_opts 644
-    if [[ $? != 0 ]]; then exit_status=$?; fi
+    if [[ $? -ne 0 ]]; then exit_status=$?; fi
   fi
   echo "Complete"
   return $exit_status
+}
+
+function fixperms {
+  echo "fixperms has been deprecated. Use normalizeperms instead"
+  return 1
 }


### PR DESCRIPTION
BREAKING CHANGES: function name has been changed to avoid
misunderstandings related to what is exactly normalizeperms doing (#10648)

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

See #10648 to see the reason of this change. I chose `normalizeperms` as the name of the function, but this can be changed. Any ideas?
Closes #10648