### PR TITLE
fix(updater): various update check fixes

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -65,11 +65,11 @@ function is_update_available() {
   local remote_head
   remote_head=$(
     if (( ${+commands[curl]} )); then
-      curl -fsSL -H 'Accept: application/vnd.github.v3.sha' $api_url 2>/dev/null
+      curl -m 2 -fsSL -H 'Accept: application/vnd.github.v3.sha' $api_url 2>/dev/null
     elif (( ${+commands[wget]} )); then
-      wget -O- --header='Accept: application/vnd.github.v3.sha' $api_url 2>/dev/null
+      wget -T 2 -O- --header='Accept: application/vnd.github.v3.sha' $api_url 2>/dev/null
     elif (( ${+commands[fetch]} )); then
-      HTTP_ACCEPT='Accept: application/vnd.github.v3.sha' fetch -o - $api_url 2>/dev/null
+      HTTP_ACCEPT='Accept: application/vnd.github.v3.sha' fetch -T 2 -o - $api_url 2>/dev/null
     else
       exit 0
     fi

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -75,8 +75,17 @@ function is_update_available() {
     fi
   ) || return 1
 
-  # Compare local and remote HEADs
-  [[ "$local_head" != "$remote_head" ]]
+  # Compare local and remote HEADs (if they're equal there are no updates)
+  [[ "$local_head" != "$remote_head" ]] || return 1
+
+  # If local and remote HEADs don't match, check if there's a common ancestor
+  # If the merge-base call fails, $remote_head might not be downloaded so assume there are updates
+  local base
+  base=$(cd -q "$ZSH"; git merge-base $local_head $remote_head 2>/dev/null) || return 0
+
+  # If the common ancestor ($base) is not $remote_head,
+  # the local HEAD is older than the remote HEAD
+  [[ $base != $remote_head ]]
 }
 
 function update_last_updated_file() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add a timeout of 2 seconds on latest commit check. This helps when not having a stable connection, in which case the update check will assume no updates are available.

- Properly check whether the latest commit is present in the local repository. Previously, only the local HEAD was compared to the remote HEAD, and if it didn't match it was assumed that the remote HEAD was newer, so there were updates. This is not true if the local repository has newer commits on top of the remote HEAD, so this change checks for that using `git merge-base`.

## Other comments:

If merged, this PR should use the rebase strategy as both commits should appear separately in the changelog.
