### PR TITLE
fix(helm): support completion for snap installs

### DIFF
--- a/plugins/helm/helm.plugin.zsh
+++ b/plugins/helm/helm.plugin.zsh
@@ -14,9 +14,9 @@ command mkdir -p "$ZSH_CACHE_DIR/completions"
 # If the completion file does not exist, generate it and then source it
 # Otherwise, source it and regenerate in the background
 if [[ ! -f "$ZSH_CACHE_DIR/completions/_helm" ]]; then
-  helm completion zsh >| "$ZSH_CACHE_DIR/completions/_helm"
+  helm completion zsh | tee "$ZSH_CACHE_DIR/completions/_helm" >/dev/null
   source "$ZSH_CACHE_DIR/completions/_helm"
 else
   source "$ZSH_CACHE_DIR/completions/_helm"
-  helm completion zsh >| "$ZSH_CACHE_DIR/completions/_helm" &|
+  helm completion zsh | tee "$ZSH_CACHE_DIR/completions/_helm" >/dev/null &|
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Redirecting output from `helm` CLI caused `--classic` snap installs to throw an error if the file where it was trying to redirect its output was in a hidden folder. This workaround fixes this.

Fixes #10722