### PR TITLE
fix(michelebologna): use `$HOST` variable instead of running `hostname`

### DIFF
--- a/themes/michelebologna.zsh-theme
+++ b/themes/michelebologna.zsh-theme
@@ -40,7 +40,7 @@ local username_root_color=$red
 local hostname_root_color=$red
 
 # calculating hostname color with hostname characters
-for i in `hostname`; local hostname_normal_color=$color_array[$[((#i))%7+1]]
+for i in $HOST; local hostname_normal_color=$color_array[$[((#i))%7+1]]
 local -a hostname_color
 hostname_color=%(!.$hostname_root_color.$hostname_normal_color)
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Fixes #10715.

## Other comments

I think that this theme has a really low code quality for `omz` standards. It's not a priority, but maybe we should reorganize its logic.