### PR TITLE
fix: this fix the installation in windows WSL to create ohmyzsh folder

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -272,7 +272,7 @@ setup_ohmyzsh() {
   fi
 
   # Manual clone with git config options to support git < v1.7.2
-  git init --quiet "$ZSH" && cd "$ZSH" \
+  mkdir "$ZSH" && cd "$ZSH" && git init --quiet \
   && git config core.eol lf \
   && git config core.autocrlf false \
   && git config fsck.zeroPaddedFilemode ignore \


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- This is just fixing the creation of the folder in windows subsystem

## Other comments:

- I had the issue, and I just edit install.sh file with this change, and it solved the problem
...
