### PR TITLE
fix(rails): add bin/dev to _rails_command

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -1,5 +1,7 @@
 function _rails_command () {
-  if [ -e "bin/stubs/rails" ]; then
+  if [ -e "bin/dev" ]; then
+    bin/dev $@
+  elif [ -e "bin/stubs/rails" ]; then
     bin/stubs/rails $@
   elif [ -e "bin/rails" ]; then
     bin/rails $@


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Since version 7.0.0, Rails now adds a `bin/dev` entrypoint for starting Rails and development dependencies with foreman.

## Other comments:
This also solves #9600.
