### PR TITLE
feat(autoenv): add path for Apple Silicon Homebrew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cache/
 log/
 *.swp
 .DS_Store
+
+# ide
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@ cache/
 log/
 *.swp
 .DS_Store
-
-# ide
-.vscode

--- a/plugins/autoenv/autoenv.plugin.zsh
+++ b/plugins/autoenv/autoenv.plugin.zsh
@@ -13,6 +13,7 @@ if ! type autoenv_init >/dev/null; then
       ~/.autoenv
       ~/.local/bin
       /usr/local/opt/autoenv
+      /opt/homebrew/opt/autoenv
       /usr/local/bin
       /usr/share/autoenv-git
       ~/Library/Python/bin


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [x] look for the plugin in /opt/homebrew/opt - Apple silicon default path for homebrew

## Other comments:

Based the path on my local testing and from Homebrew's own installation page [here](https://docs.brew.sh/Installation)

```
This script installs Homebrew to its preferred prefix 
(/usr/local for macOS Intel, 
/opt/homebrew for Apple Silicon and 
/home/linuxbrew/.linuxbrew for Linux)
```
