### PR TITLE
feat(fzf)!: default to using `fd` before `rg`

### DIFF
--- a/plugins/fzf/README.md
+++ b/plugins/fzf/README.md
@@ -31,8 +31,8 @@ export FZF_DEFAULT_COMMAND='<your fzf default command>'
 
 If not set, the plugin will try to set it to these, in the order in which they're found:
 
-- [`rg`](https://github.com/BurntSushi/ripgrep)
 - [`fd`](https://github.com/sharkdp/fd)
+- [`rg`](https://github.com/BurntSushi/ripgrep)
 - [`ag`](https://github.com/ggreer/the_silver_searcher)
 
 ### `DISABLE_FZF_AUTO_COMPLETION`

--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -191,10 +191,10 @@ fzf_setup_using_openbsd \
 unset -f -m 'fzf_setup_*'
 
 if [[ -z "$FZF_DEFAULT_COMMAND" ]]; then
-  if (( $+commands[rg] )); then
-    export FZF_DEFAULT_COMMAND='rg --files --hidden --glob "!.git/*"'
-  elif (( $+commands[fd] )); then
+  if (( $+commands[fd] )); then
     export FZF_DEFAULT_COMMAND='fd --type f --hidden --exclude .git'
+  elif (( $+commands[rg] )); then
+    export FZF_DEFAULT_COMMAND='rg --files --hidden --glob "!.git/*"'
   elif (( $+commands[ag] )); then
     export FZF_DEFAULT_COMMAND='ag -l --hidden -g "" --ignore .git'
   fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

As `fd` is faster than `rg` when searching files, it should have priority when defining `$FZF_DEFAULT_COMMAND`. In my `hyperfine` tests, it's a 10-25% faster (not much, but something).