### PR TITLE
fix(gpg-agent): suppress errors from `gpgconf`

### DIFF
--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -9,7 +9,7 @@ autoload -U add-zsh-hook
 add-zsh-hook preexec _gpg-agent_update-tty_preexec
 
 # If enable-ssh-support is set, fix ssh agent integration
-if [[ $(gpgconf --list-options gpg-agent | awk -F: '$1=="enable-ssh-support" {print $10}') = 1 ]]; then
+if [[ $(gpgconf --list-options gpg-agent 2>/dev/null | awk -F: '$1=="enable-ssh-support" {print $10}') = 1 ]]; then
   unset SSH_AGENT_PID
   if [[ "${gnupg_SSH_AUTH_SOCK_by:-0}" -ne $$ ]]; then
     export SSH_AUTH_SOCK="$(gpgconf --list-dirs agent-ssh-socket)"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

From the latest update to gpg-suite 2022.1 (MacGPG 2.2.34) I get the following errors every time I open a new session with enable-ssh-support enabled

This fix suppresses the annoying errors without affecting operation.

```bash
Note: no default option file '/usr/local/MacGPG2/etc/gnupg/gpg-agent.conf'
reading options from '/Users/wayne/.gnupg/gpg-agent.conf'
```

## Other comments:

cc @fwalch

Fixes #10783