### PR TITLE
feat(cli): add custom plugins and themes auto-updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,17 @@ zstyle ':omz:update' frequency 7
 zstyle ':omz:update' frequency 0
 ```
 
+### Custom Directory Updates
+
+In case you have custom plugins or themes installed and you want to get them updated at the same time than ohmyzsh does you can configure the updater to do so.
+Setting the following snippet in your `.zshrc` every git repository inside `$ZSH_CUSTOM/themes` and `$ZSH_CUSTOM/plugins` directories are going to pull latest changes when ohmyzsh is updated.
+
+```sh
+zstyle ':omz:update' custom yes
+```
+
+NOTE: this feature is disabled by default
+
 ### Manual Updates
 
 If you'd like to update at any point in time (maybe someone just released a new plugin and you don't want to wait a week?) you just need to run:

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -775,12 +775,16 @@ function _omz::theme::use {
 function _omz::update {
   local last_commit=$(builtin cd -q "$ZSH"; git rev-parse HEAD)
 
+  custom=""
+  zstyle -t ':omz:update' custom && custom=true
   # Run update script
   if [[ "$1" != --unattended ]]; then
-    ZSH="$ZSH" command zsh -f "$ZSH/tools/upgrade.sh" --interactive || return $?
+    ZSH="$ZSH" custom=$custom command zsh -f "$ZSH/tools/upgrade.sh" --interactive \
+      || return $?
   else
-    ZSH="$ZSH" command zsh -f "$ZSH/tools/upgrade.sh" || return $?
+    ZSH="$ZSH" custom=$custom command zsh -f "$ZSH/tools/upgrade.sh" || return $?
   fi
+  unset custom_update
 
   # Update last updated file
   zmodload zsh/datetime


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Add option to auto-update custom plugins and themes by setting a `zstyle` option. This feature is disabled by default.
This feature seems to be really wanted by the community.
Closes #9512
Closes #6242
