### PR TITLE
Add Python version autodetection for the `salt` plugin

### DIFF
--- a/plugins/salt/README.md
+++ b/plugins/salt/README.md
@@ -1,5 +1,13 @@
 ## Salt autocomplete plugin
 
-A copy of the completion script from the
+Based on the completion script from the
 [salt](https://github.com/saltstack/salt/blob/develop/pkg/zsh_completion.zsh)
 git repo.
+
+
+### Configurable knobs
+
+
+| Env. Var.             | Purpose                                                                                    |
+|-----------------------|--------------------------------------------------------------------------------------------|
+| `SALT_PYTHON_VERSION` | Specifies Python version to use, either `2` or `3`. If not set, then will be autodetected. |

--- a/plugins/salt/_salt
+++ b/plugins/salt/_salt
@@ -15,7 +15,18 @@
 # zstyle ':completion::complete:salt(|-cp|-call):minions:'            cache-ttl 4 days
 
 
-local state line curcontext="$curcontext" salt_dir
+local state line curcontext="$curcontext" salt_dir python
+if [[ -z $SALT_PYTHON_VERSION ]]; then
+    if command -v python3 > /dev/null; then
+        python=python3
+    elif command -v python2 > /dev/null; then
+        python=python2
+    else
+        python=python
+    fi
+else
+    python=python${SALT_PYTHON_VERSION}
+fi
 
 _modules(){
     local _funcs expl curcontext=${curcontext%:*}:modules
@@ -271,7 +282,7 @@ _salt_comp(){
     fi
 
     if _cache_invalid salt/salt_dir || ! _retrieve_cache salt/salt_dir; then
-        salt_dir="${$(python2 -c 'import sys; del sys.path[0]; import salt; print(salt.__file__);')%__init__*}"
+        salt_dir="${$(${python} -c 'import sys; del sys.path[0]; import salt; print(salt.__file__);')%__init__*}"
         _store_cache salt/salt_dir salt_dir
     fi
 }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Perform autodetection of existing Python version, no longer hard-coded to `python2`
- Adds a configurable knob `SALT_PYTHON_VERSION` just in case
