### PR TITLE
Adding an alias for npm install --save-exact Install exact version ra…

### DIFF
--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -14,6 +14,7 @@ plugins=(... npm)
 |:------  |:-----------------------------|:----------------------------------------------------------------|
 | `npmg`  | `npm i -g`                   | Install dependencies globally                                   |
 | `npmS`  | `npm i -S`                   | Install and save to dependencies in your package.json           |
+| `npmSE`  | `npm i --save-exact`          | Install exact version rather dependencies than using npm's default semver range operator.
 | `npmD`  | `npm i -D`                   | Install and save to dev-dependencies in your package.json       |
 | `npmF`  | `npm i -f`                   | Force install from remote registries ignoring local cache       |
 | `npmE`  | `PATH="$(npm bin)":"$PATH"`  | Run command from node_modules folder based on current directory |

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -27,6 +27,9 @@ alias npmS="npm i -S "
 # npmd is used by https://github.com/dominictarr/npmd
 alias npmD="npm i -D "
 
+# Install exact version rather dependencies than using npm's default semver range operator. 
+alias npmSE="npm i --save-exact"
+
 # Force npm to fetch remote resources even if a local copy exists on disk.
 alias npmF='npm i -f'
 


### PR DESCRIPTION
…ther dependencies than using npm's default semver range operator.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [x] Adding an alias for `npm install --save-exact` to install exact version rather dependencies than using npm default semver range operator.
