### PR TITLE
fix(updater): change remote using deprecated `git:` protocol

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -164,6 +164,10 @@ git remote -v | while read remote url extra; do
   git@github.com:robbyrussell/oh-my-zsh(|.git))
     git remote set-url "$remote" "git@github.com:ohmyzsh/ohmyzsh.git"
     break ;;
+  # Update out-of-date "unauthenticated git protocol on port 9418" to https
+  git://github.com/robbyrussell/oh-my-zsh(|.git))
+    git remote set-url "$remote" "https://github.com/ohmyzsh/ohmyzsh.git"
+    break ;;
   esac
 done
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [x] add codes in `upgrade.sh` to avoid using `git` protocol

Fixes #10778