### PR TITLE
refactor(1password): update plugin and readme for 1Password CLI 2.0

### DIFF
--- a/plugins/1password/1password.plugin.zsh
+++ b/plugins/1password/1password.plugin.zsh
@@ -27,7 +27,7 @@ function opswd() {
   echo -n "$password" | clipcopy
   echo "✔ password for $service copied to clipboard"
 
-  # If there's a one time password, copy it to the clipboard after 5 seconds
+  # If there's a one time password, copy it to the clipboard after 10 seconds
   local totp
   if totp=$(op item get --otp "$service" 2>/dev/null) && [[ -n "$totp" ]]; then
     sleep 10 && echo -n "$totp" | clipcopy

--- a/plugins/1password/1password.plugin.zsh
+++ b/plugins/1password/1password.plugin.zsh
@@ -15,11 +15,11 @@ function opswd() {
   local service=$1
 
   # If not logged in, print error and return
-  op list users > /dev/null || return
+  op user list > /dev/null || return
 
   local password
   # Copy the password to the clipboard
-  if ! password=$(op get item "$service" --fields password 2>/dev/null); then
+  if ! password=$(op item get "$service" --fields password 2>/dev/null); then
     echo "error: could not obtain password for $service"
     return 1
   fi
@@ -29,7 +29,7 @@ function opswd() {
 
   # If there's a one time password, copy it to the clipboard after 5 seconds
   local totp
-  if totp=$(op get totp "$service" 2>/dev/null) && [[ -n "$totp" ]]; then
+  if totp=$(op item get --otp "$service" 2>/dev/null) && [[ -n "$totp" ]]; then
     sleep 10 && echo -n "$totp" | clipcopy
     echo "✔ TOTP for $service copied to clipboard"
   fi
@@ -39,7 +39,7 @@ function opswd() {
 
 function _opswd() {
   local -a services
-  services=("${(@f)$(op list items --categories Login 2>/dev/null | op get item - --fields title 2>/dev/null)}")
+  services=("${(@f)$(op item list --categories Login 2>/dev/null | op item get - --fields title 2>/dev/null)}")
   [[ -z "$services" ]] || compadd -a -- services
 }
 

--- a/plugins/1password/1password.plugin.zsh
+++ b/plugins/1password/1password.plugin.zsh
@@ -1,46 +1,9 @@
-if (( ${+commands[op]} )); then
-  eval "$(op completion zsh)"
-  compdef _op op
-fi
+# Do nothing if op is not installed
+(( ${+commands[op]} )) || return
 
-# opswd puts the password of the named service into the clipboard. If there's a
-# one time password, it will be copied into the clipboard after 10 seconds. The
-# clipboard is cleared after another 20 seconds.
-function opswd() {
-  if [[ $# -lt 1 ]]; then
-    echo "Usage: opswd <service>"
-    return 1
-  fi
+# Load op completion
+eval "$(op completion zsh)"
+compdef _op op
 
-  local service=$1
-
-  # If not logged in, print error and return
-  op user list > /dev/null || return
-
-  local password
-  # Copy the password to the clipboard
-  if ! password=$(op item get "$service" --fields password 2>/dev/null); then
-    echo "error: could not obtain password for $service"
-    return 1
-  fi
-
-  echo -n "$password" | clipcopy
-  echo "✔ password for $service copied to clipboard"
-
-  # If there's a one time password, copy it to the clipboard after 10 seconds
-  local totp
-  if totp=$(op item get --otp "$service" 2>/dev/null) && [[ -n "$totp" ]]; then
-    sleep 10 && echo -n "$totp" | clipcopy
-    echo "✔ TOTP for $service copied to clipboard"
-  fi
-
-  (sleep 20 && clipcopy </dev/null 2>/dev/null) &!
-}
-
-function _opswd() {
-  local -a services
-  services=("${(@f)$(op item list --categories Login 2>/dev/null | op item get - --fields title 2>/dev/null)}")
-  [[ -z "$services" ]] || compadd -a -- services
-}
-
-compdef _opswd opswd
+# Load opswd function
+autoload -Uz opswd

--- a/plugins/1password/README.md
+++ b/plugins/1password/README.md
@@ -34,3 +34,5 @@ a TOTP is available, it will be copied to the clipboard after 10 seconds.
 ## Requirements
 
 - [1Password CLI 2](https://developer.1password.com/docs/cli/get-started#install)
+
+  > NOTE: if you're using 1Password CLI 1, [see how to upgrade to CLI 2](https://developer.1password.com/docs/cli/upgrade).

--- a/plugins/1password/README.md
+++ b/plugins/1password/README.md
@@ -25,11 +25,12 @@ which service you want to get.
 For example, `opswd github.com` will put your GitHub password into your clipboard, and if
 a TOTP is available, it will be copied to the clipboard after 10 seconds.
 
-> NOTE: you need to be logged in for `opswd` to work. See:
+> NOTE: you need to be signed in for `opswd` to work. If you are using biometric unlock, 
+> 1Password CLI will automatically prompt you to sign in. See:
 >
-> - [Sign in or out](https://support.1password.com/command-line/#sign-in-or-out)
-> - [Session management](https://support.1password.com/command-line/#appendix-session-management)
+> - [Get started with 1Password CLI 2: Sign in](https://developer.1password.com/docs/cli/get-started#sign-in)
+> - [Sign in to your 1Password account manually](https://developer.1password.com/docs/cli/sign-in-manually)
 
 ## Requirements
 
-- [1Password's command line utility](https://1password.com/downloads/command-line/).
+- [1Password CLI 2](https://developer.1password.com/docs/cli/get-started#install)

--- a/plugins/1password/_opswd
+++ b/plugins/1password/_opswd
@@ -1,0 +1,9 @@
+#compdef opswd
+
+function _opswd() {
+  local -a services
+  services=("${(@f)$(op item list --categories Login 2>/dev/null | op item get - --fields title 2>/dev/null)}")
+  [[ -z "$services" ]] || compadd -a -- services
+}
+
+_opswd "$@"

--- a/plugins/1password/_opswd
+++ b/plugins/1password/_opswd
@@ -2,7 +2,7 @@
 
 function _opswd() {
   local -a services
-  services=("${(@f)$(op item list --categories Login 2>/dev/null | op item get - --fields title 2>/dev/null)}")
+  services=("${(@f)$(op item list --categories Login --cache 2>/dev/null | awk 'NR != 1 { print $2 }')}")
   [[ -z "$services" ]] || compadd -a -- services
 }
 

--- a/plugins/1password/_opswd
+++ b/plugins/1password/_opswd
@@ -6,4 +6,14 @@ function _opswd() {
   [[ -z "$services" ]] || compadd -a -- services
 }
 
+# TODO: 2022-03-24: Remove support for op CLI 1
+autoload -Uz is-at-least
+is-at-least 2.0.0 $(op --version) || {
+  function _opswd() {
+    local -a services
+    services=("${(@f)$(op list items --categories Login 2>/dev/null | op get item - --fields title 2>/dev/null)}")
+    [[ -z "$services" ]] || compadd -a -- services
+  }
+}
+
 _opswd "$@"

--- a/plugins/1password/opswd
+++ b/plugins/1password/opswd
@@ -1,0 +1,37 @@
+#autoload
+
+# opswd puts the password of the named service into the clipboard. If there's a
+# one time password, it will be copied into the clipboard after 10 seconds. The
+# clipboard is cleared after another 20 seconds.
+function opswd() {
+  if [[ $# -lt 1 ]]; then
+    echo "Usage: opswd <service>"
+    return 1
+  fi
+
+  local service=$1
+
+  # If not logged in, print error and return
+  op user list > /dev/null || return
+
+  local password
+  # Copy the password to the clipboard
+  if ! password=$(op item get "$service" --fields password 2>/dev/null); then
+    echo "error: could not obtain password for $service"
+    return 1
+  fi
+
+  echo -n "$password" | clipcopy
+  echo "✔ password for $service copied to clipboard"
+
+  # If there's a one time password, copy it to the clipboard after 10 seconds
+  local totp
+  if totp=$(op item get --otp "$service" 2>/dev/null) && [[ -n "$totp" ]]; then
+    sleep 10 && echo -n "$totp" | clipcopy
+    echo "✔ TOTP for $service copied to clipboard"
+  fi
+
+  (sleep 20 && clipcopy </dev/null 2>/dev/null) &!
+}
+
+opswd "$@"

--- a/plugins/1password/opswd
+++ b/plugins/1password/opswd
@@ -34,4 +34,45 @@ function opswd() {
   (sleep 20 && clipcopy </dev/null 2>/dev/null) &!
 }
 
+# TODO: 2022-03-24: Remove support for op CLI 1
+autoload -Uz is-at-least
+is-at-least 2.0.0 $(op --version) || {
+  print -ru2 ${(%):-"%F{yellow}opswd: usage with op version $(op --version) is deprecated. Upgrade to CLI 2 and reload zsh.
+For instructions, see https://developer.1password.com/docs/cli/upgrade.%f"}
+
+  # opswd puts the password of the named service into the clipboard. If there's a
+  # one time password, it will be copied into the clipboard after 10 seconds. The
+  # clipboard is cleared after another 20 seconds.
+  function opswd() {
+    if [[ $# -lt 1 ]]; then
+      echo "Usage: opswd <service>"
+      return 1
+    fi
+
+    local service=$1
+
+    # If not logged in, print error and return
+    op list users > /dev/null || return
+
+    local password
+    # Copy the password to the clipboard
+    if ! password=$(op get item "$service" --fields password 2>/dev/null); then
+      echo "error: could not obtain password for $service"
+      return 1
+    fi
+
+    echo -n "$password" | clipcopy
+    echo "✔ password for $service copied to clipboard"
+
+    # If there's a one time password, copy it to the clipboard after 5 seconds
+    local totp
+    if totp=$(op get totp "$service" 2>/dev/null) && [[ -n "$totp" ]]; then
+      sleep 10 && echo -n "$totp" | clipcopy
+      echo "✔ TOTP for $service copied to clipboard"
+    fi
+
+    (sleep 20 && clipcopy </dev/null 2>/dev/null) &!
+  }
+}
+
 opswd "$@"


### PR DESCRIPTION
Minor changes to allow the plugin to work with 1Password CLI 2. Hi from 1Password! 👋🏻

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- refactored plugin for syntax changes in the latest version of 1Password CLI
- updated readme to reflect the updated name, change in sign-in behaviour, and documentation links

## Other comments:

1Password CLI 2.0 has recently been released with several added features and a new command schema (see [Upgrade to 1Password CLI 2](https://developer.1password.com/docs/cli/upgrade)). This PR is mainly a refactor, with a small change in behaviour of the underlying software used by this plugin (optional biometric login prompt), but no changes to the plugin's functionality.

Full disclosure: I work for 1Password.

Fixes #10789