### PR TITLE
Add an alias for git pull --recurse-submodules

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -238,6 +238,7 @@ alias gpf='git push --force-with-lease'
 alias gpf!='git push --force'
 alias gpoat='git push origin --all && git push origin --tags'
 alias gpr='git pull --rebase'
+alias gprs='git pull --recurse-submodules'
 alias gpu='git push upstream'
 alias gpv='git push -v'
 


### PR DESCRIPTION
The command `git pull --recurse-submodules` is a nice shorthand which allows you to pull the git repo as well as its submodules, all in one command. It would be great if an alias for it would be included in omz.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds a new alias for the command `git pull --recurse-submodules`

