### PR TITLE
feat(kubectl): add aliases for kubectl create

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -42,26 +42,31 @@ plugins=(... kubectl)
 | kes     | `kubectl edit svc`                  | Edit services(svc) from the default editor                                                       |
 | kds     | `kubectl describe svc`              | Describe all services in detail                                                                  |
 | kdels   | `kubectl delete svc`                | Delete all services matching passed argument                                                     |
+| kcs   | `kubectl create svc`                | Create a service                     |
 |         |                                     | **Ingress management**                                                                           |
 | kgi     | `kubectl get ingress`               | List ingress resources in ps output format                                                       |
 | kei     | `kubectl edit ingress`              | Edit ingress resource from the default editor                                                    |
 | kdi     | `kubectl describe ingress`          | Describe ingress resource in detail                                                              |
 | kdeli   | `kubectl delete ingress`            | Delete ingress resources matching passed argument                                                |
+| kci   | `kubectl create ingress`            | Create an ingress resource with the specified name                                               |
 |         |                                     | **Namespace management**                                                                         |
 | kgns    | `kubectl get namespaces`            | List the current namespaces in a cluster                                                         |
 | kcn     | `kubectl config set-context --current --namespace` | Change current namespace |
 | kens    | `kubectl edit namespace`            | Edit namespace resource from the default editor                                                  |
 | kdns    | `kubectl describe namespace`        | Describe namespace resource in detail                                                            |
 | kdelns  | `kubectl delete namespace`          | Delete the namespace. WARNING! This deletes everything in the namespace                          |
+| kcns  | `kubectl create namespace`          | Create the namespace with the specified name                          |
 |         |                                     | **ConfigMap management**                                                                         |
 | kgcm    | `kubectl get configmaps`            | List the configmaps in ps output format                                                          |
 | kecm    | `kubectl edit configmap`            | Edit configmap resource from the default editor                                                  |
 | kdcm    | `kubectl describe configmap`        | Describe configmap resource in detail                                                            |
 | kdelcm  | `kubectl delete configmap`          | Delete the configmap                                                                             |
+| kccm  | `kubectl create configmap`          | Create the configmap                                                                             |
 |         |                                     | **Secret management**                                                                            |
 | kgsec   | `kubectl get secret`                | Get secret for decoding                                                                          |
 | kdsec   | `kubectl describe secret`           | Describe secret resource in detail                                                               |
 | kdelsec | `kubectl delete secret`             | Delete the secret                                                                                |
+| kcsec | `kubectl create secret`             | Create the secret                                                                                |
 |         |                                     | **Deployment management**                                                                        |
 | kgd     | `kubectl get deployment`            | Get the deployment                                                                               |
 | kgdw    | `kgd --watch`                       | After getting the deployment, watch for changes                                                  |
@@ -70,6 +75,7 @@ plugins=(... kubectl)
 | kdd     | `kubectl describe deployment`       | Describe deployment resource in detail                                                           |
 | kdeld   | `kubectl delete deployment`         | Delete the deployment                                                                            |
 | ksd     | `kubectl scale deployment`          | Scale a deployment                                                                               |
+| kcd     | `kubectl create deployment`          | Create a deployment                                                                               |
 | krsd    | `kubectl rollout status deployment` | Check the rollout status of a deployment                                                         |
 | kres    | `kubectl set env $@ REFRESHED_AT=...` | Recreate all pods in deployment with zero-downtime                                             |
 |         |                                     | **Rollout management**                                                                           |
@@ -111,6 +117,7 @@ plugins=(... kubectl)
 |         |                                     | **Service Accounts management**                                                                  |
 | kdsa    | `kubectl describe sa`               | Describe a service account in details                                                            |
 | kdelsa  | `kubectl delete sa`                 | Delete the service account                                                                       |
+| kcsa  | `kubectl create sa`                 | Create the service account                                                                       |
 |         |                                     | **DaemonSet management**                                                                         |
 | kgds    | `kubectl get daemonset`             | List all DaemonSets in ps output format                                                          |
 | kgdsw   | `kgds --watch`                      | After listing all DaemonSets, watch for changes                                                  |
@@ -122,11 +129,13 @@ plugins=(... kubectl)
 | kecj    | `kubectl edit cronjob`              | Edit CronJob from the default editor                                                             |
 | kdcj    | `kubectl describe cronjob`          | Describe a CronJob in details                                                                    |
 | kdelcj  | `kubectl delete cronjob`            | Delete the CronJob                                                                               |
+| kccj  | `kubectl create cronjob`            | Create the CronJob                                                                               |
 |         |                                     | **Job management**                                                                               |
 | kgj     | `kubectl get job`                   | List all Job in ps output format                                                                 |
 | kej     | `kubectl edit job`                  | Edit a Job in details                                                                            |
 | kdj     | `kubectl describe job`              | Describe the Job                                                                                 |
 | kdelj   | `kubectl delete job`                | Delete the Job                                                                                   |
+| kcj   | `kubectl create job`                | Create the Job                                                                                   |
 
 ## Wrappers
 

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -43,6 +43,7 @@ alias kcgc='kubectl config get-contexts'
 # General aliases
 alias kdel='kubectl delete'
 alias kdelf='kubectl delete -f'
+alias kc='kubectl create'
 
 # Pod management.
 alias kgp='kubectl get pods'
@@ -68,6 +69,7 @@ alias kgswide='kgs -o wide'
 alias kes='kubectl edit svc'
 alias kds='kubectl describe svc'
 alias kdels='kubectl delete svc'
+alias kcs='kubectl create svc'
 
 # Ingress management
 alias kgi='kubectl get ingress'
@@ -75,6 +77,7 @@ alias kgia='kubectl get ingress --all-namespaces'
 alias kei='kubectl edit ingress'
 alias kdi='kubectl describe ingress'
 alias kdeli='kubectl delete ingress'
+alias kci='kubectl create ingress'
 
 # Namespace management
 alias kgns='kubectl get namespaces'
@@ -82,6 +85,7 @@ alias kens='kubectl edit namespace'
 alias kdns='kubectl describe namespace'
 alias kdelns='kubectl delete namespace'
 alias kcn='kubectl config set-context --current --namespace'
+alias kcns='kubectl create namespace'
 
 # ConfigMap management
 alias kgcm='kubectl get configmaps'
@@ -89,12 +93,14 @@ alias kgcma='kubectl get configmaps --all-namespaces'
 alias kecm='kubectl edit configmap'
 alias kdcm='kubectl describe configmap'
 alias kdelcm='kubectl delete configmap'
+alias kccm='kubectl create configmap'
 
 # Secret management
 alias kgsec='kubectl get secret'
 alias kgseca='kubectl get secret --all-namespaces'
 alias kdsec='kubectl describe secret'
 alias kdelsec='kubectl delete secret'
+alias kcsec='kubectl create secret'
 
 # Deployment management.
 alias kgd='kubectl get deployment'
@@ -106,6 +112,7 @@ alias kdd='kubectl describe deployment'
 alias kdeld='kubectl delete deployment'
 alias ksd='kubectl scale deployment'
 alias krsd='kubectl rollout status deployment'
+alias kcd='kubectl create deployment'
 
 function kres(){
   kubectl set env $@ REFRESHED_AT=$(date +%Y%m%d%H%M%S)
@@ -166,6 +173,7 @@ alias kdelpvc='kubectl delete pvc'
 # Service account management.
 alias kdsa="kubectl describe sa"
 alias kdelsa="kubectl delete sa"
+alias kcsa='kubectl create sa'
 
 # DaemonSet management.
 alias kgds='kubectl get daemonset'
@@ -179,12 +187,14 @@ alias kgcj='kubectl get cronjob'
 alias kecj='kubectl edit cronjob'
 alias kdcj='kubectl describe cronjob'
 alias kdelcj='kubectl delete cronjob'
+alias kccj='kubectl create cronjob'
 
 # Job management.
 alias kgj='kubectl get job'
 alias kej='kubectl edit job'
 alias kdj='kubectl describe job'
 alias kdelj='kubectl delete job'
+alias kcj='kubectl create job'
 
 # Only run if the user actually has kubectl installed
 if (( ${+_comps[kubectl]} )); then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Added aliases for kubectl create command for different k8s resources (svc,ingress,namespace,configmap,secret,deployment,serviceaccount, cronjob and job). 

## Other comments:

...
