### PR TITLE
feat(fzf): support `fzf` installed with MacPorts

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -154,7 +154,7 @@ function fzf_setup_using_cygwin() {
   if [[ "$OSTYPE" != cygwin* ]] || (( ! $+commands[fzf] )); then
     return 1
   fi
-  
+
   # The fzf-zsh-completion package installs the auto-completion in
   local completions="/etc/profile.d/fzf-completion.zsh"
   # The fzf-zsh package installs the key-bindings file in

--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -173,7 +173,6 @@ function fzf_setup_using_cygwin() {
   return 0
 }
 
-
 function fzf_setup_using_macports() {
   # If the command is not found, the package isn't installed
   (( $+commands[fzf] )) || return 1

--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -154,11 +154,38 @@ function fzf_setup_using_cygwin() {
   if [[ "$OSTYPE" != cygwin* ]] || (( ! $+commands[fzf] )); then
     return 1
   fi
-
+  
   # The fzf-zsh-completion package installs the auto-completion in
   local completions="/etc/profile.d/fzf-completion.zsh"
   # The fzf-zsh package installs the key-bindings file in
   local key_bindings="/etc/profile.d/fzf.zsh"
+
+  # Auto-completion
+  if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
+    source "$completions" 2>/dev/null
+  fi
+
+  # Key bindings
+  if [[ "$DISABLE_FZF_KEY_BINDINGS" != "true" ]]; then
+    source "$key_bindings" 2>/dev/null
+  fi
+
+  return 0
+}
+
+
+function fzf_setup_using_macports() {
+  # If the command is not found, the package isn't installed
+  (( $+commands[fzf] )) || return 1
+
+  # The fzf-zsh-completion package installs the auto-completion in
+  local completions="/opt/local/share/zsh/site-functions/fzf"
+  # The fzf-zsh-completion package installs the key-bindings file in
+  local key_bindings="/opt/local/share/fzf/shell/key-bindings.zsh"
+
+  if [[ ! -f "$completions" || ! -f "$key_bindings" ]]; then
+    return 1
+  fi
 
   # Auto-completion
   if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
@@ -185,6 +212,7 @@ fzf_setup_using_openbsd \
   || fzf_setup_using_debian \
   || fzf_setup_using_opensuse \
   || fzf_setup_using_cygwin \
+  || fzf_setup_using_macports \
   || fzf_setup_using_base_dir \
   || fzf_setup_error
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- This adds support for using fzf installed by macports

## Other comments:

I've been using this patch for since at least January without problems 
