### PR TITLE
feat(1password): add username copy to `opswd`

### DIFF
--- a/plugins/1password/README.md
+++ b/plugins/1password/README.md
@@ -14,16 +14,18 @@ clipboard.
 ## `opswd`
 
 The `opswd` command is a wrapper around the `op` command. It takes a service
-name as an argument and copies the password for that service to the clipboard.
+name as an argument and copies the username, then the password for that service
+to the clipboard, after confirmation on the user part.
 
-If the service also contains a TOTP, it is copied to the clipboard after 10 seconds.
-Finally, after 20 seconds, the clipboard is cleared.
+If the service also contains a TOTP, it is copied to the clipboard after confirmation
+on the user part. Finally, after 20 seconds, the clipboard is cleared.
 
-The function has completion support, so you can use tab completion to select
-which service you want to get.
+For example, `opswd github.com` will put your GitHub username into your clipboard. Then,
+it will ask for confirmation to continue, and copy the password to your clipboard. Finally,
+if a TOTP is available, it will be copied to the clipboard after your confirmation.
 
-For example, `opswd github.com` will put your GitHub password into your clipboard, and if
-a TOTP is available, it will be copied to the clipboard after 10 seconds.
+This function has completion support, so you can use tab completion to select which
+service you want to get.
 
 > NOTE: you need to be signed in for `opswd` to work. If you are using biometric unlock,
 > 1Password CLI will automatically prompt you to sign in. See:

--- a/plugins/1password/opswd
+++ b/plugins/1password/opswd
@@ -14,6 +14,17 @@ function opswd() {
   # If not logged in, print error and return
   op user list > /dev/null || return
 
+  local username
+  # Copy the username to the clipboard
+  if ! username=$(op item get "$service" --fields username 2>/dev/null); then
+    echo "error: could not obtain username for $service"
+    return 1
+  fi
+
+  echo -n "$username" | clipcopy
+  echo "✔ username for service $service copied to the clipboard. Press Enter to continue"
+  read
+
   local password
   # Copy the password to the clipboard
   if ! password=$(op item get "$service" --fields password 2>/dev/null); then
@@ -22,12 +33,13 @@ function opswd() {
   fi
 
   echo -n "$password" | clipcopy
-  echo "✔ password for $service copied to clipboard"
+  echo "✔ password for $service copied to clipboard. Press Enter to continue"
+  read
 
-  # If there's a one time password, copy it to the clipboard after 10 seconds
+  # If there's a one time password, copy it to the clipboard
   local totp
   if totp=$(op item get --otp "$service" 2>/dev/null) && [[ -n "$totp" ]]; then
-    sleep 10 && echo -n "$totp" | clipcopy
+    echo -n "$totp" | clipcopy
     echo "✔ TOTP for $service copied to clipboard"
   fi
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- This commit updates the `opswd` command to also copy the username of a
service into the clipboard
- The README was updated to take those changes into account

## Other comments:

This only works for v2 of the 1password CLI, and I closed my previous PR doing this for v1 of the CLI (#10637 )
