### PR TITLE
use loop to create aliases for dir stack

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -9,16 +9,13 @@ alias -g .....='../../../..'
 alias -g ......='../../../../..'
 
 alias -- -='cd -'
-alias 1='cd -1'
-alias 2='cd -2'
-alias 3='cd -3'
-alias 4='cd -4'
-alias 5='cd -5'
-alias 6='cd -6'
-alias 7='cd -7'
-alias 8='cd -8'
-alias 9='cd -9'
 
+local n lim
+[[ -v DIRSTACKSIZE ]] && lim=$DIRSTACKSIZE || lim=9
+for n in {1..$lim}; do
+  alias $n="cd -$n"
+done
+  
 alias md='mkdir -p'
 alias rd=rmdir
 


### PR DESCRIPTION
If DIRSTACKSIZE is set, create alias for each stack entry.
if DIRSTACKSIZE is not set, create same as previous hard coded method.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ X] The PR title is descriptive.
- [ X] The PR doesn't replicate another PR which is already open.
- [ X] I have read the contribution guide and followed all the instructions.
- [ X] The code follows the code style guide detailed in the wiki.
- [ X] The code is mine or it's from somewhere with an MIT-compatible license.
- [ X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- rewrote hardcoded lines into a loop to match DIRSTACKSIZE

## Other comments:

...
