### PR TITLE
feat(updater): check for typed input before automatically updating

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -180,23 +180,17 @@ function has_typed_input() {
     return
   fi
 
+  # If in reminder mode or user has typed input, show reminder and exit
+  if [[ "$update_mode" = reminder ]] || has_typed_input; then
+    printf '\r\e[0K' # move cursor to first column and clear whole line
+    echo "[oh-my-zsh] It's time to update! You can do that by running \`omz update\`"
+    return 0
+  fi
+
   # Don't ask for confirmation before updating if in auto mode
   if [[ "$update_mode" = auto ]]; then
     update_ohmyzsh
     return $?
-  fi
-
-  # If in reminder mode show reminder and exit
-  if [[ "$update_mode" = reminder ]]; then
-    echo "[oh-my-zsh] It's time to update! You can do that by running \`omz update\`"
-    return 0
-  fi
-
-  # If user has typed input, show reminder and exit
-  if has_typed_input; then
-    echo
-    echo "[oh-my-zsh] It's time to update! You can do that by running \`omz update\`"
-    return 0
   fi
 
   # Ask for confirmation and only update on 'y', 'Y' or Enter


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Move check for `reminder` mode and typed user input together.
- Clear line and move cursor to the first column when displaying the reminder.
- Move check for `auto` mode after the check for typed user input. This aborts the automatic update if the user has started typing, meaning that they have stuff to do.
