### PR TITLE
fix(frisk): fix color typo in `PS2`

### DIFF
--- a/themes/frisk.zsh-theme
+++ b/themes/frisk.zsh-theme
@@ -2,7 +2,7 @@ PROMPT=$'
 %{$fg[blue]%}%/%{$reset_color%} $(git_prompt_info)$(bzr_prompt_info)%{$fg[white]%}[%n@%m]%{$reset_color%} %{$fg[white]%}[%T]%{$reset_color%}
 %{$fg_bold[black]%}>%{$reset_color%} '
 
-PROMPT2="%{$fg_blod[black]%}%_> %{$reset_color%}"
+PROMPT2="%{$fg_bold[black]%}%_> %{$reset_color%}"
 
 GIT_CB="git::"
 ZSH_THEME_SCM_PROMPT_PREFIX="%{$fg[green]%}["


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Fix typo in frisk theme.

Fixes #10838.