### PR TITLE
Export GIT_PROMPT in git-prompt plugin

### DIFF
--- a/plugins/git-prompt/README.md
+++ b/plugins/git-prompt/README.md
@@ -11,6 +11,14 @@ plugins=(... git-prompt)
 
 See the [original repository](https://github.com/olivierverdier/zsh-git-prompt).
 
+# Usage
+
+Use `$GIT_PROMPT` in PROMPT/RPROMPT variable in `.zshrc` file
+
+```zsh
+PROMPT="%~ in $(GIT_PROMPT) "
+```
+
 ## Requirements
 
 This plugin uses `python3`, so your host needs to have it installed.

--- a/plugins/git-prompt/git-prompt.plugin.zsh
+++ b/plugins/git-prompt/git-prompt.plugin.zsh
@@ -98,4 +98,4 @@ ZSH_THEME_GIT_PROMPT_STASHED="%{$fg_bold[blue]%}%{⚑%G%}"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[green]%}%{✔%G%}"
 
 # Set the prompt.
-RPROMPT='$(git_super_status)'
+export GIT_PROMPT='$(git_super_status)'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- export GIT_PROMPT

## Other comments:

git prompt plugin is awesome, ‌but the user may need to use it in their PROMPT or elsewhere...
So instead of setting it as a RPROMPT in [this file](https://github.com/ohmyzsh/ohmyzsh/blob/846f417eb8ec76e8eee70000e289b8b81f19d480/plugins/git-prompt/git-prompt.plugin.zsh#L101), I think we should export `GIT_PROMPT` variable to the user to use wherever he wants!