### PR TITLE
fix(httpie): remove unnecessary `https` alias

### DIFF
--- a/plugins/httpie/README.md
+++ b/plugins/httpie/README.md
@@ -11,10 +11,4 @@ plugins=(... httpie)
 
 It uses completion from [zsh-completions](https://github.com/zsh-users/zsh-completions).
 
-## Aliases
-
-| Alias        | Command                                                          |
-| ------------ | ---------------------------------------------------------------- |
-| `https`      | `http --default-scheme=https`                                    |
-
 **Maintainer:** [lululau](https://github.com/lululau)

--- a/plugins/httpie/httpie.plugin.zsh
+++ b/plugins/httpie/httpie.plugin.zsh
@@ -1,7 +1,0 @@
-#
-# Aliases
-# (sorted alphabetically)
-#
-
-alias https='http --default-scheme=https'
-


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

This change reverts https://github.com/ohmyzsh/ohmyzsh/commit/93e9b80d3ff160c7d7f5be4c2c1862da97b273dc as httpie already has an https command which obviates the need for an https alias.

fixes https://github.com/ohmyzsh/ohmyzsh/issues/10855

## Other comments:

Relevant httpie issue/commit:

https://github.com/httpie/httpie/issues/608
https://github.com/httpie/httpie/commit/8e04a24b90475608d65ad13ce66d59a41ed8b457
