### PR TITLE
Added vars for setting vi-mode cursor styles

### DIFF
--- a/plugins/vi-mode/README.md
+++ b/plugins/vi-mode/README.md
@@ -29,6 +29,8 @@ plugins=(... vi-mode)
   VI_MODE_SET_CURSOR=true
   ```
 
+  See [Cursor Styles](#cursor-styles) for controlling how the cursor looks in different modes
+
 - `MODE_INDICATOR`: controls the string displayed when the shell is in normal mode.
   See [Mode indicators](#mode-indicators) for details.
 
@@ -51,6 +53,25 @@ INSERT_MODE_INDICATOR="%F{yellow}+%f"
 
 You can also use the `vi_mode_prompt_info` function in your prompt, which will display
 this mode indicator.
+
+## Cursor Styles
+
+You can control the cursor style used in each active vim mode by changing the values of the following variables.
+
+```zsh
+# defaults
+VI_MODE_CURSOR_NORMAL=2
+VI_MODE_CURSOR_VISUAL=6
+VI_MODE_CURSOR_INSERT=6
+VI_MODE_CURSOR_OPPEND=0
+```
+
+- 0, 1 - Blinking block
+- 2 - Solid block
+- 3 - Blinking underline
+- 4 - Solid underline
+- 5 - Blinking line
+- 6 - Solid line
 
 ## Key bindings
 

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -14,6 +14,15 @@ typeset -g VI_MODE_RESET_PROMPT_ON_MODE_CHANGE
 # Unset or set to any other value to do the opposite.
 typeset -g VI_MODE_SET_CURSOR
 
+# Control how the cursor appears in the various vim modes. This only applies
+# if $VI_MODE_SET_CURSOR=true.
+#
+# See https://vt100.net/docs/vt510-rm/DECSCUSR for cursor styles
+typeset -g VI_MODE_CURSOR_NORMAL=2
+typeset -g VI_MODE_CURSOR_VISUAL=6
+typeset -g VI_MODE_CURSOR_INSERT=6
+typeset -g VI_MODE_CURSOR_OPPEND=0
+
 typeset -g VI_KEYMAP=main
 
 function _vi-mode-set-cursor-shape-for-keymap() {
@@ -22,13 +31,13 @@ function _vi-mode-set-cursor-shape-for-keymap() {
   # https://vt100.net/docs/vt510-rm/DECSCUSR
   local _shape=0
   case "${1:-${VI_KEYMAP:-main}}" in
-    main)    _shape=6 ;; # vi insert: line
-    viins)   _shape=6 ;; # vi insert: line
-    isearch) _shape=6 ;; # inc search: line
-    command) _shape=6 ;; # read a command name
-    vicmd)   _shape=2 ;; # vi cmd: block
-    visual)  _shape=2 ;; # vi visual mode: block
-    viopp)   _shape=0 ;; # vi operation pending: blinking block
+    main)    _shape=$VI_MODE_CURSOR_INSERT ;; # vi insert: line
+    viins)   _shape=$VI_MODE_CURSOR_INSERT ;; # vi insert: line
+    isearch) _shape=$VI_MODE_CURSOR_INSERT ;; # inc search: line
+    command) _shape=$VI_MODE_CURSOR_INSERT ;; # read a command name
+    vicmd)   _shape=$VI_MODE_CURSOR_NORMAL ;; # vi cmd: block
+    visual)  _shape=$VI_MODE_CURSOR_VISUAL ;; # vi visual mode: block
+    viopp)   _shape=$VI_MODE_CURSOR_OPPEND ;; # vi operation pending: blinking block
     *)       _shape=0 ;;
   esac
   printf $'\e[%d q' "${_shape}"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open. - not that I could see
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Added the following vi-mode variables which can be used to control the cursor style depending on the vi mode currently active.

- VI_MODE_CURSOR_NORMAL
- VI_MODE_CURSOR_VISUAL
- VI_MODE_CURSOR_INSERT
- VI_MODE_CURSOR_OPPEND

These default to the values used prior to this change and only apply if the existing variable `VI_MODE_SET_CURSOR=true`.

I have added this functionality after copy-pasting the `vi-mode` plugin to my custom dir and changing the default cursor styles. I really like a cursor indicator to help me keep track of what mode I am in, but I much prefer the underline when in insert mode.