### PR TITLE
feat(sigstore): Add new sigstore completions plugin

### DIFF
--- a/plugins/sigstore/README.md
+++ b/plugins/sigstore/README.md
@@ -1,0 +1,13 @@
+# Sigstore plugin
+
+This plugin sets up completion for the following [Sigstore](https://sigstore.io/) CLI tools.
+
+- [Cosign](https://docs.sigstore.dev/cosign/overview)
+- [Sget](https://docs.sigstore.dev/cosign/installation#alpine-linux)
+- [Rekor](https://docs.sigstore.dev/rekor/overview)
+
+To use it, add `sigstore` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... sigstore)
+```

--- a/plugins/sigstore/sigstore.plugin.zsh
+++ b/plugins/sigstore/sigstore.plugin.zsh
@@ -1,0 +1,19 @@
+function install_autocompletion {
+  if ! (( $+commands[$1] )); then
+    return
+  fi
+
+  # If the completion file doesn't exist yet, we need to autoload it and
+  # bind it to `$1` (cosign, sget, rekor-cli). Otherwise, compinit will have already done that
+  if [[ ! -f "$ZSH_CACHE_DIR/completions/_$1" ]]; then
+    autoload -Uz _$1
+    typeset -g -A _comps
+    _comps[$1]=_$1
+  fi
+
+  $1 completion zsh >| "$ZSH_CACHE_DIR/completions/_$1" &|
+}
+
+install_autocompletion cosign
+install_autocompletion sget
+install_autocompletion rekor-cli


### PR DESCRIPTION
This plugin adds completion for:

- [Cosign](https://docs.sigstore.dev/cosign/overview)
- [Sget](https://docs.sigstore.dev/cosign/installation#alpine-linux)
- [Rekor](https://docs.sigstore.dev/rekor/overview)

Signed-off-by: Marco Franssen <marco.franssen@gmail.com>