### PR TITLE
feat(gnu-utils): include `ghostname` if present

### DIFF
--- a/plugins/gnu-utils/gnu-utils.plugin.zsh
+++ b/plugins/gnu-utils/gnu-utils.plugin.zsh
@@ -27,7 +27,7 @@ __gnu_utils() {
   'gsplit' 'gstat' 'gstty' 'gsum' 'gsync' 'gtac' 'gtail' 'gtee' 'gtest'
   'gtimeout' 'gtouch' 'gtr' 'gtrue' 'gtruncate' 'gtsort' 'gtty' 'guname'
   'gunexpand' 'guniq' 'gunlink' 'guptime' 'gusers' 'gvdir' 'gwc' 'gwho'
-  'gwhoami' 'gyes')
+  'gwhoami' 'gyes' 'ghostname')
 
   # findutils
   gcmds+=('gfind' 'gxargs' 'glocate')

--- a/plugins/gnu-utils/gnu-utils.plugin.zsh
+++ b/plugins/gnu-utils/gnu-utils.plugin.zsh
@@ -27,13 +27,16 @@ __gnu_utils() {
   'gsplit' 'gstat' 'gstty' 'gsum' 'gsync' 'gtac' 'gtail' 'gtee' 'gtest'
   'gtimeout' 'gtouch' 'gtr' 'gtrue' 'gtruncate' 'gtsort' 'gtty' 'guname'
   'gunexpand' 'guniq' 'gunlink' 'guptime' 'gusers' 'gvdir' 'gwc' 'gwho'
-  'gwhoami' 'gyes' 'ghostname')
+  'gwhoami' 'gyes')
 
   # findutils
   gcmds+=('gfind' 'gxargs' 'glocate')
 
   # Not part of either coreutils or findutils, installed separately.
   gcmds+=('gsed' 'gtar' 'gtime' 'gmake' 'ggrep')
+
+  # can be built optionally
+  gcmds+=('ghostname')
 
   for gcmd in "${gcmds[@]}"; do
     # Do nothing if the command isn't found


### PR DESCRIPTION
Signed-off-by: Robbie Lankford <robert.lankford@grafana.com>

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [x]  coreutils can optionally be built with the hostname program enabled, this includes it in gcmds so it gets aliased with the rest of the coreutils programs.

## Other comments:

...
