### PR TITLE
fix(kubectl): sanity checks to improve compatibility with non OMZ users

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -1,7 +1,14 @@
 if (( $+commands[kubectl] )); then
   # If the completion file does not exist, generate it and then source it
   # Otherwise, source it and regenerate in the background
+  if ! (( ${+ZSH_CACHE_DIR} )); then
+    echo "The \$ZSH_CACHE_DIR variable is not set, please set it\!"
+  fi
+  
   if [[ ! -f "$ZSH_CACHE_DIR/completions/_kubectl" ]]; then
+    if [[ ! -d "$ZSH_CACHE_DIR/completions" ]]; then
+      mkdir -p $ZSH_CACHE_DIR/completions
+    fi
     kubectl completion zsh | tee "$ZSH_CACHE_DIR/completions/_kubectl" >/dev/null
     source "$ZSH_CACHE_DIR/completions/_kubectl"
   else


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Check if ZSH_CACHE_DIR is set, if it isn't, ask user to set it
- Check if completions directory exists, if it doesn't, create it
