### PR TITLE
fix(per-directory-history): print toggle message properly

### DIFF
--- a/plugins/per-directory-history/per-directory-history.zsh
+++ b/plugins/per-directory-history/per-directory-history.zsh
@@ -68,14 +68,14 @@ function per-directory-history-toggle-history() {
   if [[ $_per_directory_history_is_global == true ]]; then
     _per-directory-history-set-directory-history
     _per_directory_history_is_global=false
-    print -n "\nusing local history"
+    zle -I
+    echo "using local history"
   else
     _per-directory-history-set-global-history
     _per_directory_history_is_global=true
-    print -n "\nusing global history"
+    zle -I
+    echo "using global history"
   fi
-  zle .push-line
-  zle .accept-line
 }
 
 autoload per-directory-history-toggle-history


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- fixed per-directory-history plugin toggle message

## Other comments:

PR is open since February at https://github.com/jimhester/per-directory-history/pull/42. However, it seems @jimhester is not active in that repo, so I'm opening a PR here now with the fix. This fixes https://github.com/jimhester/per-directory-history/issues/2. More info at https://github.com/romkatv/powerlevel10k/issues/1779.