### PR TITLE
fix(nvm): `brew` prefix changed for Apple M1 users

### DIFF
--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -16,7 +16,7 @@ if [[ -f "$NVM_DIR/nvm.sh" ]]; then
 else
   # Otherwise try to load nvm installed via Homebrew
   # User can set this if they have an unusual Homebrew setup
-  NVM_HOMEBREW="${NVM_HOMEBREW:-/usr/local/opt/nvm}"
+  NVM_HOMEBREW="${NVM_HOMEBREW:-${HOMEBREW_PREFIX:-$(brew --prefix)}/opt/nvm}"
   # Load nvm from Homebrew location if it exists
   if [[ -f "$NVM_HOMEBREW/nvm.sh" ]]; then
     source "$NVM_HOMEBREW/nvm.sh" ${NVM_LAZY+"--no-use"}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Closes #10784 