### PR TITLE
feat(transfer): Add new flags in the plugin

### DIFF
--- a/plugins/transfer/README.md
+++ b/plugins/transfer/README.md
@@ -19,13 +19,13 @@ plugins=(... transfer)
 - Encrypt and upload a file with symmetric cipher and create ASCII armored output:
 
   ```zsh
-  transfer file -ca
+  transfer -c file
   ```
 
 - Encrypt and upload directory with symmetric cipher and gpg output:
 
   ```zsh
-  transfer directory -ca
+  transfer -c directory
   ```
 
 - Decrypt file:
@@ -39,3 +39,24 @@ plugins=(... transfer)
   ```zsh
   gpg -d your_archive.tgz.gpg | tar xz
   ```
+
+### Capturing code to remove file and removing it
+
+- Capturing code
+
+```zsh
+transfer -d file
+```
+
+- Copy Delete Code
+```
+Delete Code: vvacju8zyC6P
+URL: https://transfer.sh/vaDdEiRpsR/test.md
+```
+
+- Removing file
+
+```
+# curl <URL>/<Delete Code>
+curl https://transfer.sh/vaDdEiRpsR/test.md/vvacju8zyC6P
+```

--- a/plugins/transfer/README.md
+++ b/plugins/transfer/README.md
@@ -8,13 +8,25 @@ To use it, add `transfer` to the plugins array in your zshrc file:
 plugins=(... transfer)
 ```
 
-## Usage
+## Basic Usage
 
 - Transfer a file: `transfer file.txt`.
 
 - Transfer a whole directory (it will be automatically compressed): `transfer dir`.
 
-### Encryption / Decryption
+## Custom URL
+
+If you have a private instance of Transfer, you can add your custom URL
+
+To use it, add `TRANSFER_CUSTOM_URL` before the plugins array in your zshrc file:
+
+```zsh
+TRANSFER_CUSTOM_URL="https://localhost:8080"
+
+plugins=(... transfer)
+```
+
+## Encryption / Decryption
 
 - Encrypt and upload a file with symmetric cipher and create ASCII armored output:
 
@@ -40,7 +52,7 @@ plugins=(... transfer)
   gpg -d your_archive.tgz.gpg | tar xz
   ```
 
-### Capturing code to remove file and removing it
+## Capturing code to remove file and removing it
 
 - Capturing code
 

--- a/plugins/transfer/transfer.plugin.zsh
+++ b/plugins/transfer/transfer.plugin.zsh
@@ -44,6 +44,8 @@ transfer() {
 
   local tmpfile tarfile item basename
 
+  local TRANSFER_URL=$(echo ${TRANSFER_CUSTOM_URL:-https://transfer.sh} | sed 's/\/$//g')
+
   # get temporarily filename, output is written to this file show progress can be showed
   tmpfile=$(mktemp -t transferXXX)
 
@@ -100,9 +102,9 @@ transfer() {
   if ! tty -s; then
     # transfer from pipe
     if (( crypt )); then
-      gpg -aco - | curl -X PUT --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" -T - "https://transfer.sh/$item" >> $tmpfile
+      gpg -aco - | curl -X PUT --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" -T - "${TRANSFER_URL}/$item" >> $tmpfile
     else
-      curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" --upload-file - "https://transfer.sh/$item" >> $tmpfile
+      curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" --upload-file - "${TRANSFER_URL}/$item" >> $tmpfile
     fi
   else 
     basename=$(basename "$item" | sed -e 's/[^a-zA-Z0-9._-]/-/g')
@@ -122,17 +124,17 @@ transfer() {
 
       tar -czf $tarfile $(basename $item)
       if (( crypt )); then
-        gpg -cao - "$tarfile" | curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" -T "-" "https://transfer.sh/$basename.tar.gz.gpg" >> $tmpfile
+        gpg -cao - "$tarfile" | curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" -T "-" "${TRANSFER_URL}/$basename.tar.gz.gpg" >> $tmpfile
       else
-        curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" --upload-file "$tarfile" "https://transfer.sh/$basename.tar.gz" >> $tmpfile
+        curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" --upload-file "$tarfile" "${TRANSFER_URL}/$basename.tar.gz" >> $tmpfile
       fi
       rm -f $tarfile
     else
       # transfer file
       if (( crypt )); then
-        gpg -cao - "$item" | curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" -T "-" "https://transfer.sh/$basename.gpg" >> $tmpfile
+        gpg -cao - "$item" | curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" -T "-" "${TRANSFER_URL}/$basename.gpg" >> $tmpfile
       else
-        curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" --upload-file "$item" "https://transfer.sh/$basename" >> $tmpfile
+        curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" --upload-file "$item" "${TRANSFER_URL}/$basename" >> $tmpfile
       fi
     fi
   fi

--- a/plugins/transfer/transfer.plugin.zsh
+++ b/plugins/transfer/transfer.plugin.zsh
@@ -3,25 +3,38 @@
 #   https://gist.github.com/nl5887/a511f172d3fb3cd0e42d
 #   Modified to use tar command instead of zip
 #
+usage() {
+  cat <<EOF
+Error: no arguments specified.
+
+Usage: transfer [options] <file/folder>
+
+Examples:
+  transfer /tmp/test.md
+  transfer -c /tmp/test.md
+  transfer -d /tmp/test.md
+  transfer -q /tmp/test.md
+  transfer -m 10 /tmp/test.md
+
+  cat /tmp/test.md | transfer test.md
+  cat /tmp/test.md | transfer -c test.md
+  cat /tmp/test.md | transfer -d test.md
+  cat /tmp/test.md | transfer -q test.md
+  cat /tmp/test.md | transfer -m 10 test.md
+
+Options:
+  -c   Encrypt file with symmetric cipher and create ASCII armored output
+  -m   Sets the maximum number of downloads
+  -d   Display the code to delete the file
+  -q   Run without progress bar
+EOF
+}
 
 transfer() {
   # check arguments
   if [[ $# -eq 0 ]]; then
-  cat <<EOF
-Error: no arguments specified.
-
-Usage: transfer [file/folder] [options]
-
-Examples:
-  transfer /tmp/test.md
-  transfer /tmp/test.md -ca
-  cat /tmp/test.md | transfer test.md
-  cat /tmp/test.md | transfer test.md -ca
-
-Options:
-  -ca  Encrypt file with symmetric cipher and create ASCII armored output
-EOF
-  return 1
+    usage;
+    return 1
   fi
 
   if (( ! $+commands[curl] )); then
@@ -47,14 +60,51 @@ EOF
     fi
   fi
 
+  local maxDownloads=""
+  local displayDeleteCode=0
+  local isNewVersion=0
+  local progress="--progress-bar"
+
+  while getopts ":m:dcf:q" flag; do
+    isNewVersion=1
+
+    case "$flag" in
+      c)
+        crypt=1
+        if (( ! $+commands[gpg] )); then
+          echo "Error: gpg is not installed"
+          return 1
+        fi
+        ;;
+      m)
+        maxDownloads="Max-Downloads: ${OPTARG}"
+        ;;
+      d)
+        displayDeleteCode=1
+        ;;
+      f)
+        item=${OPTARG}
+        ;;
+      q)
+        progress="-s"
+        ;;
+    esac
+  done
+
+  # Maintains compatibility with previous modification
+  if [[ $isNewVersion -eq 1 ]]; then
+    item="$@[-1]"
+  fi
+
+  
   if ! tty -s; then
     # transfer from pipe
     if (( crypt )); then
-      gpg -aco - | curl -X PUT --progress-bar -T - "https://transfer.sh/$item" >> $tmpfile
+      gpg -aco - | curl -X PUT --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" -T - "https://transfer.sh/$item" >> $tmpfile
     else
-      curl --progress-bar --upload-file - "https://transfer.sh/$item" >> $tmpfile
+      curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" --upload-file - "https://transfer.sh/$item" >> $tmpfile
     fi
-  else
+  else 
     basename=$(basename "$item" | sed -e 's/[^a-zA-Z0-9._-]/-/g')
 
     if [[ ! -e $item ]]; then
@@ -72,26 +122,34 @@ EOF
 
       tar -czf $tarfile $(basename $item)
       if (( crypt )); then
-        gpg -cao - "$tarfile" | curl --progress-bar -T "-" "https://transfer.sh/$basename.tar.gz.gpg" >> $tmpfile
+        gpg -cao - "$tarfile" | curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" -T "-" "https://transfer.sh/$basename.tar.gz.gpg" >> $tmpfile
       else
-        curl --progress-bar --upload-file "$tarfile" "https://transfer.sh/$basename.tar.gz" >> $tmpfile
+        curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" --upload-file "$tarfile" "https://transfer.sh/$basename.tar.gz" >> $tmpfile
       fi
       rm -f $tarfile
     else
       # transfer file
       if (( crypt )); then
-        gpg -cao - "$item" | curl --progress-bar -T "-" "https://transfer.sh/$basename.gpg" >> $tmpfile
+        gpg -cao - "$item" | curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" -T "-" "https://transfer.sh/$basename.gpg" >> $tmpfile
       else
-        curl --progress-bar --upload-file "$item" "https://transfer.sh/$basename" >> $tmpfile
+        curl --dump-header "$tmpfile.dump" -H "$maxDownloads" "$progress" --upload-file "$item" "https://transfer.sh/$basename" >> $tmpfile
       fi
     fi
   fi
 
-  # cat output link
-  cat $tmpfile
+  if [[ $displayDeleteCode -eq 1 ]]; then
+    deleteCode="$(grep x-url-delete $tmpfile.dump | rev | cut -f1 -d'/' | rev)"
+    echo "Delete Code: ${deleteCode}"
+    echo "URL: $(cat $tmpfile)"
+  else
+    # cat output link
+    cat $tmpfile
+  fi
+
   # add newline
   echo
 
   # cleanup
   rm -f $tmpfile
+  rm -f $tmpfile.dump
 }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Add new flags in the plugin Transfer. The new flags are:

| Option | Description | Example |
| ------ | ----------- | ------- |
| -c     | Encrypt file with symmetric cipher and create ASCII armored output | transfer -c file |
| -m     | Sets the maximum number of downloads | transfer -m 2 |
| -d     | Display the code to delete the file | transfer -d |
| -q     | Run without progress bar | transfer -q |

## Other comments:

Compatibility with the previous version has been maintained. The examples below do the same thing

Old Version
```zsh
transfer /path/to/file -ca
```

New Version
```zsh
transfer -c /path/to/file
```