### PR TITLE
Add two aliases

### DIFF
--- a/plugins/laravel/README.md
+++ b/plugins/laravel/README.md
@@ -10,6 +10,7 @@ plugins=(... laravel)
 |:-:|:-:|
 | `artisan`  | `php artisan`  |
 | `pas`  | `php artisan serve` |
+| `pa`  | `php artisan`  |
 
 ## Database
 
@@ -55,3 +56,9 @@ plugins=(... laravel)
 | `paqr`  |  `php artisan queue:retry` |
 | `paqt`  |  `php artisan queue:table` |
 | `paqw`  |  `php artisan queue:work` |
+
+## tinker
+
+| Alias | Description |
+|:-:|:-:|
+| `pat`  |  `php artisan tinker` |

--- a/plugins/laravel/laravel.plugin.zsh
+++ b/plugins/laravel/laravel.plugin.zsh
@@ -1,6 +1,7 @@
 #!zsh
 alias artisan='php artisan'
 alias bob='php artisan bob::build'
+alias pa='php artisan'
 
 # Development
 alias pas='php artisan serve'
@@ -39,3 +40,6 @@ alias paql='php artisan queue:listen'
 alias paqr='php artisan queue:retry'
 alias paqt='php artisan queue:table'
 alias paqw='php artisan queue:work'
+
+# tinker
+alias pat='php artisan tinker'


### PR DESCRIPTION
1.Easier to use `pa` than `artisan`
2.Added `pat` as an alias for `php artisan tinker`

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
