### PR TITLE
Add Paru aliases to Archlinux Plugin

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -155,17 +155,41 @@ upgrades were available. Use `pacman -Que` instead.
 | yasu    | `yay -Syu --no-confirm`        | Same as `yaupg`, but without confirmation                         |
 | upgrade[¹](#f1) | `yay -Syu`             | Sync with repositories before upgrading packages                  |
 
+#### Paru
+
+| Alias   | Command                         | Description                                                        |
+|---------|---------------------------------|--------------------------------------------------------------------|
+| paclean | `paru -Sc`                      | Clean out old and unused caches and packages                      |
+| paclr   | `paru -Scc`                     | Remove all files from the cache                                   |
+| pain    | `paru -S`                       | Install packages from the repositories                            |
+| pains   | `paru -U`                       | Install a package from a local file                               |
+| painsd  | `paru -S --asdeps`              | Install packages as dependencies of another package               |
+| paloc   | `paru -Qi`                      | Display information about a package in the local database         |
+| palocs  | `paru -Qs`                      | Search for packages in the local database                         |
+| palst   | `paru -Qe`                      | List installed packages including from AUR (tagged as "local")    |
+| pamir   | `paru -Syy`                     | Force refresh of all package lists after updating mirrorlist      |
+| paorph  | `paru -Qtd`                     | Remove orphans using paru                                         |
+| pare    | `paru -R`                       | Remove packages, keeping its settings and dependencies            |
+| parem   | `paru -Rns`                     | Remove packages, including its settings and unneeded dependencies |
+| parep   | `paru -Si`                      | Display information about a package in the repositories           |
+| pareps  | `paru -Ss`                      | Search for packages in the repositories                           |
+| paupd   | `paru -Sy`                      | Update and refresh local package, ABS and AUR databases           |
+| paupg   | `paru -Syu`                     | Sync with repositories before upgrading packages                  |
+| pasu    | `paru -Syu --noconfirm`        | Same as `paupg`, but without confirmation                         |
+| upgrade[¹](#f1) | `paru -Syu`             | Sync with repositories before upgrading packages                  |
+
 ---
 
 <span id="f1">¹</span>
 The `upgrade` alias is set for all package managers. Its value will depend on
 whether the package manager is installed, checked in the following order:
 
-1. `yay`
-2. `trizen`
-3. `pacaur`
-4. `aura`
-5. `pacman`
+1. `paru`
+2. `yay`
+3. `trizen`
+4. `pacaur`
+5. `aura`
+6. `pacman`
 
 ## Contributors
 
@@ -181,3 +205,4 @@ whether the package manager is installed, checked in the following order:
 - Ybalrid (Arthur Brainville) - ybalrid@ybalrid.info
 - Jeff M. Hubbard - jeffmhubbard@gmail.com
 - K. Harishankar(harishnkr) - hari2menon1234@gmail.com
+- MiguelNdeCarvalho - geral@miguelndecarvalho.pt

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -182,3 +182,25 @@ if (( $+commands[yay] )); then
   alias yaupd="yay -Sy"
   alias upgrade='yay -Syu'
 fi
+
+
+if (( $+commands[paru] )); then
+  alias paclean='paru -Sc'
+  alias paclr='paru -Scc'
+  alias paupg='paru -Syu'
+  alias pasu='paru -Syu --noconfirm'
+  alias pain='paru -S'
+  alias pains='paru -U'
+  alias pare='paru -R'
+  alias parem='paru -Rns'
+  alias parep='paru -Si'
+  alias pareps='paru -Ss'
+  alias paloc='paru -Qi'
+  alias palocs='paru -Qs'
+  alias palst='paru -Qe'
+  alias paorph='paru -Qtd'
+  alias painsd='paru -S --asdeps'
+  alias pamir='paru -Syy'
+  alias paupd="paru -Sy"
+  alias upgrade='paru -Syu'
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [plugins: archlinux: archlinux.plugin.zsh: Add Paru aliases](https://github.com/ohmyzsh/ohmyzsh/pull/10883/commits/1dd2be9d98e58bce37104e7a4dda8054ba153967)
- [plugins: archlinux: README.md: Add paru](https://github.com/ohmyzsh/ohmyzsh/pull/10883/commits/3fad2c897433109700e4695bbf2fb2b7b11423d5)

## Other comments:
- Paru is the most popular AUR helper
- There is currently a PR open #10440 but it is abandoned!
- Closes https://github.com/ohmyzsh/ohmyzsh/issues/9874