### PR TITLE
feat(watson): add completion

### DIFF
--- a/plugins/watson/README.md
+++ b/plugins/watson/README.md
@@ -1,0 +1,9 @@
+# Watson
+
+This plugin provides completion for [Watson](https://tailordev.github.io/Watson/).
+
+To use it add `watson` to the plugins array in your zshrc file.
+
+```zsh
+plugins=(... watson)
+```

--- a/plugins/watson/_watson
+++ b/plugins/watson/_watson
@@ -1,0 +1,34 @@
+#compdef watson
+
+_watson_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[watson] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _WATSON_COMPLETE=zsh_complete watson)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+compdef _watson_completion watson;


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Add completion for watson time tracker https://tailordev.github.io/Watson/

## Other comments:
With #8847 there was a PR for watson. It was closed because of a missing Readme.

I'm a first time contributor. It'd be great if there were  links to the stuff I need to read in the PR template.