### PR TITLE
fix(github): deprecate the `git.io` command

### DIFF
--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -11,7 +11,6 @@ This plugin supports working with GitHub from the command line. It provides a fe
 * `empty_gh` - Creates a new empty repo (with a `README.md`) and pushes it to GitHub
 * `new_gh` - Initializes an existing directory as a repo and pushes it to GitHub
 * `exist_gh` - Takes an existing repo and pushes it to GitHub
-* `git.io` - Shortens a URL using [git.io](https://git.io)
 
 
 ## Installation

--- a/plugins/github/github.plugin.zsh
+++ b/plugins/github/github.plugin.zsh
@@ -68,8 +68,9 @@ exist_gh() { # [DIRECTORY]
 # documentation: https://github.com/blog/985-git-io-github-url-shortener
 #
 git.io() {
-  emulate -L zsh
-  curl -i -s https://git.io -F "url=$1" | grep "Location" | cut -f 2 -d " "
+  # emulate -L zsh
+  # curl -i -s https://git.io -F "url=$1" | grep "Location" | cut -f 2 -d " "
+  print -u2 ${(%):-"%F{yellow}%BThe \`git.io\` is deprecated.%b\nView the announcement made by GitHub: https://github.blog/changelog/2022-01-11-git-io-no-longer-accepts-new-urls/%f"}
 }
 
 # End Functions #############################################################


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Deprecating the `git.io` command.

## Other comments:

GitHub no longer accepts the new URL: https://github.blog/changelog/2022-01-11-git-io-no-longer-accepts-new-urls/
