### PR TITLE
feat(git): fix logic in `parse_git_dirty()`: Do not output when `oh-my-zsh.hide-dirty`

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -37,22 +37,23 @@ function parse_git_dirty() {
   local STATUS
   local -a FLAGS
   FLAGS=('--porcelain')
-  if [[ "$(__git_prompt_git config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
-    if [[ "${DISABLE_UNTRACKED_FILES_DIRTY:-}" == "true" ]]; then
-      FLAGS+='--untracked-files=no'
-    fi
-    case "${GIT_STATUS_IGNORE_SUBMODULES:-}" in
-      git)
-        # let git decide (this respects per-repo config in .gitmodules)
-        ;;
-      *)
-        # if unset: ignore dirty submodules
-        # other values are passed to --ignore-submodules
-        FLAGS+="--ignore-submodules=${GIT_STATUS_IGNORE_SUBMODULES:-dirty}"
-        ;;
-    esac
-    STATUS=$(__git_prompt_git status ${FLAGS} 2> /dev/null | tail -n 1)
+  if [[ "$(__git_prompt_git config --get oh-my-zsh.hide-dirty)" == "1" ]]; then
+    return 0
   fi
+  if [[ "${DISABLE_UNTRACKED_FILES_DIRTY:-}" == "true" ]]; then
+    FLAGS+='--untracked-files=no'
+  fi
+  case "${GIT_STATUS_IGNORE_SUBMODULES:-}" in
+    git)
+      # let git decide (this respects per-repo config in .gitmodules)
+      ;;
+    *)
+      # if unset: ignore dirty submodules
+      # other values are passed to --ignore-submodules
+      FLAGS+="--ignore-submodules=${GIT_STATUS_IGNORE_SUBMODULES:-dirty}"
+      ;;
+  esac
+  STATUS=$(__git_prompt_git status ${FLAGS} 2> /dev/null | tail -n 1)
   if [[ -n $STATUS ]]; then
     echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
   else


### PR DESCRIPTION
Do not output when `oh-my-zsh.hide-dirty`

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Previous behavior: output `$ZSH_THEME_GIT_PROMPT_CLEAN` when `oh-my-zsh.hide-dirty`
  Issue: in some big repo that we don't want waste CPU on `git status`, it is falsely shown as "clean", e.g. with an "🆗" mark
- New behavior: output nothing when `oh-my-zsh.hide-dirty`
  Rationale: the dirty state is unknown, so it is neither "clean" nor "dirty"
