### PR TITLE
feat(git): automatically skip `git status` for huge repo

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -37,22 +37,23 @@ function parse_git_dirty() {
   local STATUS
   local -a FLAGS
   FLAGS=('--porcelain')
-  if [[ "$(__git_prompt_git config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
-    if [[ "${DISABLE_UNTRACKED_FILES_DIRTY:-}" == "true" ]]; then
-      FLAGS+='--untracked-files=no'
-    fi
-    case "${GIT_STATUS_IGNORE_SUBMODULES:-}" in
-      git)
-        # let git decide (this respects per-repo config in .gitmodules)
-        ;;
-      *)
-        # if unset: ignore dirty submodules
-        # other values are passed to --ignore-submodules
-        FLAGS+="--ignore-submodules=${GIT_STATUS_IGNORE_SUBMODULES:-dirty}"
-        ;;
-    esac
-    STATUS=$(__git_prompt_git status ${FLAGS} 2> /dev/null | tail -n 1)
+  if [[ "$(__git_prompt_git config --get oh-my-zsh.hide-dirty)" == "1" ]]; then
+    return 0
   fi
+  if [[ "${DISABLE_UNTRACKED_FILES_DIRTY:-}" == "true" ]]; then
+    FLAGS+='--untracked-files=no'
+  fi
+  case "${GIT_STATUS_IGNORE_SUBMODULES:-}" in
+    git)
+      # let git decide (this respects per-repo config in .gitmodules)
+      ;;
+    *)
+      # if unset: ignore dirty submodules
+      # other values are passed to --ignore-submodules
+      FLAGS+="--ignore-submodules=${GIT_STATUS_IGNORE_SUBMODULES:-dirty}"
+      ;;
+  esac
+  STATUS=$(__git_prompt_git status ${FLAGS} 2> /dev/null | tail -n 1)
   if [[ -n $STATUS ]]; then
     echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
   else


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Overview:
There have been already two flags `oh-my-zsh.hide-status` and `oh-my-zsh.hide-dirty` for user to *manually* set for each heavy repo to prevent calling `git status` in those repos to improve performance. However, we can easily ***automate*** this performance improvement by checking the number of indexed files against a threshold. Moreover, we can dynamically change that threshold in the terminal whenever we see a notable change in performance.

- This PR subsumes the PR #10897

## New features:
- `git_repo_files_number()` prints the number of indexed files in this repo;
  returns 0 or error code: 128 = "not in git repo", 2 = "index read error",
  3 = "sharedindex read error"
- `ZSH_THEME_GIT_HUGE_REPO_THRESHOLD`: when there are more indexed files
  than this number (default 100 000), the repo is considered "huge"
- `git_huge_repo()` returns 0 when this repo is "huge", 1 when this repo
  is not "huge", otherwise the error number returned from `git_repo_files_number()`
- `ZSH_THEME_GIT_PROMPT_HUGE` is the prompt text indicating a "huge" repo, 
  e.g. `ZSH_THEME_GIT_PROMPT_HUGE="Ω"`
  This can be used together with `git_repo_files_number()`, 
  e.g. `"$(git_prompt_status)($(git_repo_files_number) files)"` => `"Ω(396604 files)"`

## Changes:

- `git_prompt_status()` prints `ZSH_THEME_GIT_PROMPT_HUGE` and does not
  call `git status` (returns 2) for "huge" repo
- `parse_git_dirty()` returns immediately (prints nothing) for "huge" repo

## Test result:
### System info:
| | |
| ----------- | ----------- |
| Model: | iMac | 
| CPU: | Apple M1, 8 cores |
| RAM: | 8 GB |
| OS: | MacOS Monterey |

### Performance (`time`) for a 396,604-file repo (`chromium`):

| as a sub-huge repo | ZSH_THEME_GIT_HUGE_REPO_THRESHOLD=1000000 |
| ----------- | ----------- |
| git status              | 0.36s user 4.72s system 64% cpu 7.890 total |
| ( git_prompt_status; )  | 0.37s user 4.66s system 64% cpu 7.828 total |
| ( parse_git_dirty; )    | 0.37s user 4.70s system 63% cpu 7.913 total |
| ( git_prompt_info; )    | 0.37s user 4.71s system 65% cpu 7.799 total |
| ( git_repo_files_number; )  | 0.01s user 0.01s system 73% cpu 0.032 total |
| ( git_huge_repo; )          | 0.01s user 0.01s system 75% cpu 0.034 total |

| as a huge repo | ZSH_THEME_GIT_HUGE_REPO_THRESHOLD=100000 |
| ----------- | ----------- |
| git status              | 0.36s user 4.77s system 63% cpu 8.094 total |
| ( git_prompt_status; )  | 0.01s user 0.02s system 74% cpu 0.042 total |
| ( parse_git_dirty; )    | 0.01s user 0.01s system 75% cpu 0.030 total |
| ( git_prompt_info; )    | 0.02s user 0.03s system 74% cpu 0.064 total |
| ( git_repo_files_number; )  | 0.01s user 0.01s system 74% cpu 0.032 total |
| ( git_huge_repo; )          | 0.01s user 0.01s system 71% cpu 0.032 total |
