### PR TITLE
feat(tmux): Auto reconnect if ZSH_TMUX_AUTOCONNECT=true

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -99,11 +99,15 @@ compdef _tmux _zsh_tmux_plugin_run
 # Alias tmux to our wrapper function.
 alias tmux=_zsh_tmux_plugin_run
 
-# Autostart if not already in tmux and enabled.
-if [[ -z "$TMUX" && "$ZSH_TMUX_AUTOSTART" == "true" && -z "$INSIDE_EMACS" && -z "$EMACS" && -z "$VIM" ]]; then
-  # Actually don't autostart if we already did and multiple autostarts are disabled.
-  if [[ "$ZSH_TMUX_AUTOSTART_ONCE" == "false" || "$ZSH_TMUX_AUTOSTARTED" != "true" ]]; then
-    export ZSH_TMUX_AUTOSTARTED=true
-    _zsh_tmux_plugin_run
+# Autostart if not already in tmux.
+if [[ -z "$TMUX" && -z "$INSIDE_EMACS" && -z "$EMACS" && -z "$VIM" ]]; then
+  if [[ "$ZSH_TMUX_AUTOSTART" == "true" ]]; then
+    # Actually don't autostart if we already did and multiple autostarts are disabled.
+    if [[ "$ZSH_TMUX_AUTOSTART_ONCE" == "false" || "$ZSH_TMUX_AUTOSTARTED" != "true" ]]; then
+      export ZSH_TMUX_AUTOSTARTED=true
+      _zsh_tmux_plugin_run
+    fi
+  elif [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]]; then
+    command tmux attach
   fi
 fi


### PR DESCRIPTION
If you use *tmux* occasionally and `ZSH_TMUX_AUTOSTART=false` it is very easy to forget about suspended session.
If `ZSH_TMUX_AUTOCONNECT=true` then such suspended sessions should be automatically restored.