### PR TITLE
feat(autojump): add `$XDG_DATA_HOME` to config search path

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -1,5 +1,6 @@
 declare -a autojump_paths
 autojump_paths=(
+  ${XDG_DATA_HOME:-$HOME/.local/share}/autojump/autojump.zsh # XDG base directory specification
   $HOME/.autojump/etc/profile.d/autojump.zsh         # manual installation
   $HOME/.autojump/share/autojump/autojump.zsh        # manual installation
   $HOME/.nix-profile/etc/profile.d/autojump.sh       # NixOS installation


### PR DESCRIPTION
A user may prefer to install autojump to ~/.local (following XDG base
directory specification) to keep $HOME clean.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add $XDG_DATA_HOME to the list of search paths for autojump config files

## Other comments:

...
