### PR TITLE
fix: encode urls in `web-search` and `frontend-search` plugins

### DIFF
--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -103,8 +103,7 @@ function frontend() {
 
   # build search url:
   # join arguments passed with '%20', then append to search context URL
-  # TODO substitute for proper urlencode method
-  url="${urls[$1]}${(j:%20:)@[2,-1]}"
+  url="${urls[$1]}$(omz_urlencode ${(j:%20:)@[2,-1]})"
 
   echo "Opening $url ..."
 

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -35,7 +35,7 @@ function web_search() {
   if [[ $# -gt 1 ]]; then
     # build search url:
     # join arguments passed with '+', then append to search engine URL
-    url="${urls[$1]}${(j:+:)@[2,-1]}"
+    url="${urls[$1]}$(omz_urlencode ${(j:+:)@[2,-1]})"
   else
     # build main page url:
     # split by '/', then rejoin protocol (1) and domain (2) parts with '//'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- I encode the arguments of urls when using web-search and frontend-search.

Fixes [#10884](https://github.com/ohmyzsh/ohmyzsh/issues/10884)