### PR TITLE
fix(frontcube): fix escape of reset color sequence

### DIFF
--- a/themes/frontcube.zsh-theme
+++ b/themes/frontcube.zsh-theme
@@ -1,7 +1,7 @@
 
 PROMPT='
 %{$fg_bold[gray]%}%~%{$fg_bold[blue]%}%{$fg_bold[blue]%} % %{$reset_color%}
-%{$fg[green]%}➞  %{$reset_color%'
+%{$fg[green]%}➞  %{$reset_color%}'
 
 RPROMPT='$(git_prompt_info) $(ruby_prompt_info)'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Addition of closing curly brace to color reset field in prompt line for the **frontcube** theme.
- Files changed: ohmyzsh/themes/frontcube.zsh-theme

## Other comments:

- This is my first open source PR so I would appreciate any feedback in the verbosity of the PR title, branch naming or anything else. Thank you!
