### PR TITLE
refactor(jira)!: rename myissues to mine and add completion

### DIFF
--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -18,11 +18,11 @@ This plugin supplies one command, `jira`, through which all its features are exp
 jira            # performs the default action
 
 jira new        # opens a new issue
+jira mine       # queries for your own issues
 jira dashboard  # opens your JIRA dashboard
 jira tempo      # opens your JIRA Tempo
 jira reported [username]  # queries for issues reported by a user
 jira assigned [username]  # queries for issues assigned to a user
-jira myissues   # queries for you own issues
 jira branch     # opens an existing issue matching the current branch name
                 # The branch name may have prefixes ending in "/": "feature/MP-1234",
                 # and also suffixes starting with "_": "MP-1234_fix_dashboard"

--- a/plugins/jira/_jira
+++ b/plugins/jira/_jira
@@ -4,6 +4,7 @@
 local -a _1st_arguments
 _1st_arguments=(
   'new:create a new issue'
+  'mine:open my issues'
   'dashboard:open the dashboard'
   'tempo:open the tempo'
   'reported:search for issues reported by a user'

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -44,7 +44,7 @@ function jira() {
     open_command "${jira_url}/secure/CreateIssue!default.jspa"
   elif [[ "$action" == "assigned" || "$action" == "reported" ]]; then
     _jira_query ${@:-$action}
-  elif [[ "$action" == "myissues" ]]; then
+  elif [[ "$action" == "mine" ]]; then
     echo "Opening my issues"
     open_command "${jira_url}/issues/?filter=-1"
   elif [[ "$action" == "dashboard" ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

Hi! I saw that there was missing an auto-completion for `myissues` so I added one. 

I also feel that `jira mine` feels more UX-y. If this is undesired I can revert the naming.