### PR TITLE
feat(nvm): add NVM_SILENT variable to disable verbose output when plugin switches between versions

### DIFF
--- a/plugins/nvm/README.md
+++ b/plugins/nvm/README.md
@@ -32,3 +32,6 @@ These settings should go in your zshrc file, before Oh My Zsh is sourced:
 - **`NVM_AUTOLOAD`**: if `NVM_AUTOLOAD` is set to `1`, the plugin will automatically load a node version when
   if finds a [`.nvmrc` file](https://github.com/nvm-sh/nvm#nvmrc) in the current working directory indicating
   which node version to load.
+
+- **`NVM_SILENT`**: if `NVM_SILENT` is set to `1`, the plugin will disable verbose output of nvm when switching
+  between versions.

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -28,11 +28,17 @@ else
   return
 fi
 
+if (( $+$NVM_SILENT )); then
+  alias nvmUse="nvm use --silent"
+else
+  alias nvmUse="nvm use"
+fi
+
 # Call nvm when first using node, npm or yarn
 if (( $+NVM_LAZY )); then
   function node npm yarn $NVM_LAZY_CMD {
     unfunction node npm yarn $NVM_LAZY_CMD
-    nvm use default
+    nvmUse default
     command "$0" "$@"
   }
 fi
@@ -50,11 +56,13 @@ if (( $+NVM_AUTOLOAD )); then
       if [[ "$nvmrc_node_version" = "N/A" ]]; then
         nvm install
       elif [[ "$nvmrc_node_version" != "$node_version" ]]; then
-        nvm use
+        nvmUse
       fi
     elif [[ "$node_version" != "$(nvm version default)" ]]; then
-      echo "Reverting to nvm default version"
-      nvm use default
+      if [[ $NVM_SILENT -ne 1 ]]; then
+        echo "Reverting to nvm default version"
+      fi
+      nvmUse default
     fi
   }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- handling of NVM_SILENT variable has been added
- documentation has been updated accordingly.

## Other comments:

Right now when the plugin switches versions of 'node', it prints the version which will be used from now. The feature I introduced might be useful for people that use themes with version printing, such as powerlevel10k.