### PR TITLE
feat(fzf): support macOS ARM brew install dir

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -9,6 +9,7 @@ function fzf_setup_using_base_dir() {
       "${HOME}/.nix-profile/share/fzf"
       "${XDG_DATA_HOME:-$HOME/.local/share}/fzf"
       "/usr/local/opt/fzf"
+      "/opt/homebrew/bin/fzf"
       "/usr/share/fzf"
       "/usr/local/share/examples/fzf"
     )


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- this change allows the `fzf` plugin to find `fzf` when installed with homebrew on an Apple Silicon mac (homebrew's directory changes to `/opt/homebrew` on AS)

## Other comments:

none?