### PR TITLE
feat(stale): Mark PRs and Issues stale after certain time

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,39 @@
+name: 'Close stale issues and PR'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 1 * * *' # https://crontab.guru/#30_1_*_*_* (everyday at 0130)
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5.0.0
+        with:
+          operations-per-run: 200
+          ascending: true
+          delete-branch: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Number of days of inactivity before an issue becomes stale
+          days-before-stale: 180
+          # Number of days of inactivity before a stale issue is closed
+          days-before-close: 10
+          # Issues with these labels will never be considered stale
+          exempt-issue-labels: "awaiting-approval,work-in-progress,on-hold,pinned,security"
+          exempt-pr-labels: "awaiting-approval,work-in-progress,on-hold,pinned,security"
+          # Comment to post when marking an issue as stale.
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          # Label to use when marking an issue as stale
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
Mark PRs and Issues stale after 180 days of no activity
Delete them 10 days after they are marked stale

From creation of this pull request, 180 days ago is Saturday, November 27, 2021 which means 340 PRs would currently be marked as stale.  This allows the authors to update their PR within 10 days or it gets deleted.  That seems fair IMO.

I think this is a good idea so maintainers/reviewers can focus on "active" Issues and PRs

This relates to #9401
I'm willing to close this and have @awasum reopen theirs, not trying to steal anyones thunder

Signed-off-by: jmeridth <jmeridth@gmail.com>

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [x] Add stale github action to mark PRs and Issues stale after 180 days and then close them 10 days later with no activity

## Other comments:

...
