### PR TITLE
fix(docker): rename `dip` -> `dip` to avoid conflict with `dip` CLI tool

### DIFF
--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -21,7 +21,7 @@ alias dxcit='docker container exec -it'
 alias dib='docker image build'
 alias dii='docker image inspect'
 alias dils='docker image ls'
-alias dip='docker image push'
+alias dipu='docker image push'
 alias dirm='docker image rm'
 alias dit='docker image tag'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Renamed alias `dip` to `dipu`
## Other comments:

Alias `dip` conflicts with another popular tool https://github.com/bibendi/dip . I suggest renaming it.

