### PR TITLE
fix(oc): fix completion for oc 4.9 and 4.10

### DIFF
--- a/plugins/oc/oc.plugin.zsh
+++ b/plugins/oc/oc.plugin.zsh
@@ -4,4 +4,5 @@
 
 if [ $commands[oc] ]; then
   source <(oc completion zsh)
+  compdef _oc oc
 fi


### PR DESCRIPTION
See kubernetes / kubectl issue [106968](https://github.com/kubernetes/kubernetes/issues/106968) for more information about this breaking issue.

Alternative fix vs PR #10939 — this proposed change used `compdef` instead of directly modifying the completions generated by the `oc` utility.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- adds a single `compdef` statement to the `oc` plugin:
```sh
if [ $commands[oc] ]; then
  source <(oc completion zsh)
  compdef _oc oc
fi
```