### PR TITLE
feat(tmux): add `$ZSH_TMUX_SKIP_CONFIG`

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -39,5 +39,6 @@ The plugin also supports the following:
 | `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `screen`)                |
 | `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `screen-256color`            |
 | `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`)                      |
+| `ZSH_TMUX_SKIP_CONFIG`              | Skip using `$ZSH_TMUX_CONFIG` (default: `false`)                              |
 | `ZSH_TMUX_UNICODE`                  | Set `tmux -u` option to support unicode                                       |
 | `ZSH_TMUX_DEFAULT_SESSION_NAME`     | Set tmux default session name when autostart is enabled                       |

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -27,6 +27,8 @@ fi
 : ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=screen-256color}
 # Set the configuration path
 : ${ZSH_TMUX_CONFIG:=$HOME/.tmux.conf}
+# Skip $ZSH_TMUX_CONFIG usage
+: ${ZSH_TMUX_SKIP_CONFIG:=false}
 # Set -u option to support unicode
 : ${ZSH_TMUX_UNICODE:=false}
 
@@ -77,9 +79,9 @@ function _zsh_tmux_plugin_run() {
 
   # If failed, just run tmux, fixing the TERM variable if requested.
   if [[ $? -ne 0 ]]; then
-    if [[ "$ZSH_TMUX_FIXTERM" == "true" ]]; then
+    if [[ "$ZSH_TMUX_FIXTERM" == "true" "$ZSH_TMUX_SKIP_CONFIG" == "false" ]]; then
       tmux_cmd+=(-f "$_ZSH_TMUX_FIXED_CONFIG")
-    elif [[ -e "$ZSH_TMUX_CONFIG" ]]; then
+    elif [[ -e "$ZSH_TMUX_CONFIG" && "$ZSH_TMUX_SKIP_CONFIG" == "false" ]]; then
       tmux_cmd+=(-f "$ZSH_TMUX_CONFIG")
     fi
     if [[ -n "$ZSH_TMUX_DEFAULT_SESSION_NAME" ]]; then

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -79,7 +79,7 @@ function _zsh_tmux_plugin_run() {
 
   # If failed, just run tmux, fixing the TERM variable if requested.
   if [[ $? -ne 0 ]]; then
-    if [[ "$ZSH_TMUX_FIXTERM" == "true" "$ZSH_TMUX_SKIP_CONFIG" == "false" ]]; then
+    if [[ "$ZSH_TMUX_FIXTERM" == "true" && "$ZSH_TMUX_SKIP_CONFIG" == "false" ]]; then
       tmux_cmd+=(-f "$_ZSH_TMUX_FIXED_CONFIG")
     elif [[ -e "$ZSH_TMUX_CONFIG" && "$ZSH_TMUX_SKIP_CONFIG" == "false" ]]; then
       tmux_cmd+=(-f "$ZSH_TMUX_CONFIG")


### PR DESCRIPTION
Resolve #10367

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add `$ZSH_TMUX_SKIP_CONFIG` to skip `$ZSH_TMUX_CONFIG` usage

## Other comments:

...
