### PR TITLE
feat(krr): Add krr as alias for kubectl rollout restart

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -78,6 +78,8 @@ plugins=(... kubectl)
 | kers    | `kubectl edit replicaset`           | Edit ReplicaSet from the default editor                                                          |
 | krh     | `kubectl rollout history`           | Check the revisions of this deployment                                                           |
 | kru     | `kubectl rollout undo`              | Rollback to the previous revision                                                                |
+| krr     | `kubectl rollout restart`           | Execute a rolling restart
+|
 |         |                                     | **Port forwarding**                                                                              |
 | kpf     | `kubectl port-forward`              | Forward one or more local ports to a pod                                                         |
 |         |                                     | **Tools for accessing all information**                                                          |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -108,6 +108,7 @@ alias kdrs='kubectl describe replicaset'
 alias kers='kubectl edit replicaset'
 alias krh='kubectl rollout history'
 alias kru='kubectl rollout undo'
+alias krr='kubectl rollout restart'
 
 # Statefulset management.
 alias kgss='kubectl get statefulset'


### PR DESCRIPTION
Adding krr alias for kubectl rollout restart command to rollout restart for example a deployment or daemonset.
examples: 
`krr ds/abcde`
`krr deployment xyz` 

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- alias krr='kubectl rollout restart'

## Other comments:

...
