### PR TITLE
fix(emacs): fix check for open frames w/ extra output

### DIFF
--- a/plugins/emacs/emacsclient.sh
+++ b/plugins/emacs/emacsclient.sh
@@ -11,7 +11,7 @@ emacsfun() {
   esac
 
   # Check if there are suitable frames
-  frames="$(emacsclient -a '' -n -e "$cmd" 2>/dev/null)"
+  frames="$(emacsclient -a '' -n -e "$cmd" 2>/dev/null |sed 's/.*\x07//g' )"
 
   # Only create another X frame if there isn't one present
   if [ -z "$frames" -o "$frames" = nil ]; then


### PR DESCRIPTION
Fixes #10991

This is only necessitated by some plugin or emacs itself writing to
stdout when it shouldn't. But that is out of our control - so being
tolerant becomes necessary.

Since the output in question always ends in \0x07 (ASCII BELL), we just
sed it away.

Signed-off-by: Marcus Müller <marcus@hostalia.de>

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Strip the "noise" emacs starting can output, depending on emacs plugins out of our control

## Other comments:

See discussion at the end of the report in #10991 why this is necessary, and to my best ability.
