### PR TITLE
A plugin for the Kitty terminal

### DIFF
--- a/plugins/kitty/README.md
+++ b/plugins/kitty/README.md
@@ -1,0 +1,23 @@
+# Kitty plugin
+
+This plugin adds a few aliases and functions that are useful for users of the [Kitty](https://sw.kovidgoyal.net/kitty/) terminal.
+
+To use it, add _kitty_ to the plugins array of your zshrc file:
+```
+plugins=(... kitty)
+```
+
+## Plugin commands
+
+* `kssh`
+  Runs a kitten ssh session that ensures your terminfo settings are copied
+  correctly to the remote hose.
+* `kssh-slow`
+  A slower form of `kssh` that should always work. Use this if `kssh` fails
+  to set terminfo correctly for you on the remote host.
+* `kitty-theme`
+  Browse and change the theme of your Kitty terminal.
+
+## Contributors
+
+- [Ian Chesal](https://github.com/ianchesal)

--- a/plugins/kitty/kitty.plugin.zsh
+++ b/plugins/kitty/kitty.plugin.zsh
@@ -2,12 +2,15 @@
 # Kitty plugin for oh-my-zsh                        #
 #####################################################
 
-# kssh
-# Use this when your terminfo isn't recognized on remote hosts.
-# See: https://sw.kovidgoyal.net/kitty/faq/#i-get-errors-about-the-terminal-being-unknown-or-opening-the-terminal-failing-when-sshing-into-a-different-computer
-alias kssh="kitty +kitten ssh"
-# Use this if kssh fails
-alias kssh-slow="infocmp -a xterm-kitty | ssh myserver tic -x -o \~/.terminfo /dev/stdin"
+if [[ "$TERM" == 'xterm-kitty' ]]; then
+  ## kssh
+  # Use this when your terminfo isn't recognized on remote hosts.
+  # See: https://sw.kovidgoyal.net/kitty/faq/#i-get-errors-about-the-terminal-being-unknown-or-opening-the-terminal-failing-when-sshing-into-a-different-computer
+  alias kssh="kitty +kitten ssh"
+  compdef kssh='ssh'
+  # Use this if kssh fails
+  alias kssh-slow="infocmp -a xterm-kitty | ssh myserver tic -x -o \~/.terminfo /dev/stdin"
 
-# Change the colour theme
-alias kitty-theme="kitty +kitten themes"
+  # Change the colour theme
+  alias kitty-theme="kitty +kitten themes"
+fi

--- a/plugins/kitty/kitty.plugin.zsh
+++ b/plugins/kitty/kitty.plugin.zsh
@@ -1,0 +1,13 @@
+#####################################################
+# Kitty plugin for oh-my-zsh                        #
+#####################################################
+
+# kssh
+# Use this when your terminfo isn't recognized on remote hosts.
+# See: https://sw.kovidgoyal.net/kitty/faq/#i-get-errors-about-the-terminal-being-unknown-or-opening-the-terminal-failing-when-sshing-into-a-different-computer
+alias kssh="kitty +kitten ssh"
+# Use this if kssh fails
+alias kssh-slow="infocmp -a xterm-kitty | ssh myserver tic -x -o \~/.terminfo /dev/stdin"
+
+# Change the colour theme
+alias kitty-theme="kitty +kitten themes"


### PR DESCRIPTION
## Standards checklist:

- [ ✅ ] The PR title is descriptive.
- [ ✅ ] The PR doesn't replicate another PR which is already open.
- [ ✅ ] I have read the contribution guide and followed all the instructions.
- [ ✅ ] The code follows the code style guide detailed in the wiki.
- [ ✅ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ✅ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ✅ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds a `kitty` plugin.
- Only loads if the terminal identifies as xterm-kitty
- Provides a very useful `kssh` alias that one can use to ssh and correct terminfo issues on remote hosts.
- There's also a `kssh-slow` which does a slower form of the special ssh should `kssh` not work.
- There's a less useful `kitty-theme` alias to change the terminal theme.

## Other comments:

It's pretty simple, not much else to say about it. 😁 
