### PR TITLE
feat(linkerd): add plugin for Linkerd CLI

### DIFF
--- a/plugins/linkerd/README.md
+++ b/plugins/linkerd/README.md
@@ -1,0 +1,9 @@
+# Linkerd plugin
+
+This plugin adds completion for linkerd command-line tool that is used for interacting with the [Linkerd](https://linkerd.io) service mesh.
+
+To use it, add `linkerd` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... linkerd)
+```

--- a/plugins/linkerd/linkerd.plugin.zsh
+++ b/plugins/linkerd/linkerd.plugin.zsh
@@ -1,0 +1,4 @@
+if (( $+commands[linkerd] )); then
+  source <(linkerd completion zsh)
+  compdef _linkerd linkerd
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

I see https://github.com/ohmyzsh/ohmyzsh/pull/9333 but:
1. I would prefer to name the plugin just "linkerd" (as the utility name itself), not "linkerd2". "2" is used only for the github repo name (https://github.com/linkerd/linkerd2).
2. `compdef _linkerd linkerd` is missing (`linkerd completion zsh` doesn't generate it itself).
