### PR TITLE
chore(lib): only create `afind` alias if `ack` is installed

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -24,6 +24,7 @@ env_default 'LESS' '-R'
 ## super user alias
 alias _='sudo '
 
+## more intelligent acking for ubuntu users and no alias for users without ack
 if (( $+commands[ack-grep] )); then
   alias afind='ack-grep -il'
 else

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -24,10 +24,11 @@ env_default 'LESS' '-R'
 ## super user alias
 alias _='sudo '
 
-## more intelligent acking for ubuntu users
 if (( $+commands[ack-grep] )); then
   alias afind='ack-grep -il'
 else
+  if ! command -v ack >/dev/null 2>&1; then
+  fi
   alias afind='ack -il'
 fi
 

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -27,9 +27,7 @@ alias _='sudo '
 ## more intelligent acking for ubuntu users and no alias for users without ack
 if (( $+commands[ack-grep] )); then
   alias afind='ack-grep -il'
-else
-  if ! command -v ack >/dev/null 2>&1; then
-  fi
+elif (( $+commands[ack] )); then
   alias afind='ack -il'
 fi
 


### PR DESCRIPTION
> idk if ack is supposed to exist on every distro if not then thats fine but this keeps the alias command a bit cleaner :/## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:
added new if block to change alias ;/
https://patch-diff.githubusercontent.com/raw/ohmyzsh/ohmyzsh/pull/11017.diff
## Other comments:
this could probably be added withsome elses bigger merge because its really small