### PR TITLE
feat(mix): add file patterns for `mix test` and `mix run`

### DIFF
--- a/plugins/mix/_mix
+++ b/plugins/mix/_mix
@@ -146,10 +146,10 @@ case $state in
          _arguments ':feature:__task_list'
          ;;
       (test)
-         _files
+         _path_files -X "All tests" -g "test/**/*_test.exs" -g "apps/*/test/**/*_test.exs"
          ;;
       (run)
-         _files
+         _files -g "*.(exs|ex)"
          ;;
     esac
   ;;


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Changed `mix test` file fetching command from `_files` to `_path_files` - because Elixir tests are run in the project directory and not in the test directory
- Added test file patterns to `mix test`
- Added Elixir file patterns to `mix run`

## Other comments:

...
