### PR TITLE
fix(ensure path): create dir for completions file before generating.

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -2,6 +2,9 @@ if (( $+commands[kubectl] )); then
   # If the completion file does not exist, generate it and then source it
   # Otherwise, source it and regenerate in the background
   if [[ ! -f "$ZSH_CACHE_DIR/completions/_kubectl" ]]; then
+    if [[ ! -d "$ZSH_CACHE_DIR/completions" ]]; then
+      command mkdir -p "$ZSH_CACHE_DIR/completions"
+    fi
     kubectl completion zsh | tee "$ZSH_CACHE_DIR/completions/_kubectl" >/dev/null
     source "$ZSH_CACHE_DIR/completions/_kubectl"
   else


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

If missing create the directory before generating the completions file.

https://github.com/ohmyzsh/ohmyzsh/blob/59b3ccaeb82bdb5c2f2ca303bcf7d45fef7edac7/plugins/kubectl/kubectl.plugin.zsh#L5-L7