### PR TITLE
A plugin for Taskfile.yml completion & alias

### DIFF
--- a/plugins/taskfile/README.md
+++ b/plugins/taskfile/README.md
@@ -1,0 +1,20 @@
+# `Taskfile` plugin
+
+This plugin provides completion for [Task](https://taskfile.dev/), as well as the shortcut alias `t`
+
+To use it add `taskfile` to the plugins array in your zshrc file.
+
+```bash
+plugins=(... taskfile)
+```
+
+## Usage
+
+Of course, you need [Task](https://taskfile.dev/installation/) to be installed.
+
+Typing `t [TAB]` will give you a list of commands provided by your `Taskfile.yml` 
+
+<br/>
+---
+
+Thanks to [Berger91](https://github.com/Berger91/taskfile-zsh-autocompletion) for the original completion method.

--- a/plugins/taskfile/_taskfile
+++ b/plugins/taskfile/_taskfile
@@ -1,0 +1,28 @@
+#compdef task
+local state line
+declare -A opt_args
+
+_task_get_tasks () {
+  sed '1,/tasks:/d' Taskfile.yml | grep -iwE "^\ \ [a-z](.*)$" | sed 's/.$//' | awk '{ print $1 }'
+  while read included_task
+  do
+    taskfile_path=$(sed "1,/$included_task:/d" Taskfile.yml | grep -m 1 -iwE "^\  \ \ taskfile: .*$" | awk '{ print $2 }')
+    sed '1,/tasks:/d' $taskfile_path | grep -iwE "^\ \ [a-z](.*)$" | sed 's/.$//' | awk -v included_task="$included_task" '{ print included_task":"$1 }'
+    
+  done < <(sed '1,/includes:/d' Taskfile.yml | grep -iwE "^\ \ [a-z](.*)$" | sed 's/.$//' | awk '{ print $1 }')
+}
+
+_taskfile () {
+  local state line
+  typeset -A opt_args
+
+  _arguments \
+    '*: :->args'
+  if [ -f Taskfile.yml ]; then
+    compadd `_task_get_tasks`
+  else
+   echo -e "\nNo taskfile found"
+  fi
+}
+
+compdef _taskfile t=task

--- a/plugins/taskfile/taskfile.plugin.zsh
+++ b/plugins/taskfile/taskfile.plugin.zsh
@@ -1,0 +1,1 @@
+alias t=task


### PR DESCRIPTION
# Give completion & alias for [Task](https://taskfile.dev/installation/)

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [✅] The PR title is descriptive.
- [✅] The PR doesn't replicate another PR which is already open.
- [✅] I have read the contribution guide and followed all the instructions.
- [✅] The code follows the code style guide detailed in the wiki.
- [✅] The code is mine or it's from somewhere with an MIT-compatible license. **-> Credit in the readme**
- [✅] The code is efficient, to the best of my ability, and does not waste computer resources.
- [✅] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [✅] Add alias `t` for `task`
- [✅] Add completion for task by typing `t [TAB]` or `task [TAB]`


