### PR TITLE
feat(toolbox): load toolbox command completion, name in prompt

### DIFF
--- a/plugins/toolbox/README.md
+++ b/plugins/toolbox/README.md
@@ -10,7 +10,7 @@ plugins=(... toolbox)
 
 ## Prompt function
 
-This plugins adds `toolbox_prompt_info()` function. Using it in your prompt, it will show the toolbox indicator ⬢ (if you are running in a toolbox container), and nothing if not.
+This plugin provides the `toolbox_prompt_info()` function. Use this in your prompt to show the toolbox indicator (`⬢`) if you are running in a toolbox container, and nothing if not.
 
 You can use it by adding `$(toolbox_prompt_info)` to your `PROMPT` or `RPROMPT` variable:
 
@@ -18,8 +18,19 @@ You can use it by adding `$(toolbox_prompt_info)` to your `PROMPT` or `RPROMPT` 
 RPROMPT='$(toolbox_prompt_info)'
 ```
 
+Additionally, this also provides `toolbox_prompt_info_name()`, which will display the toolbox name following the toolbox indicator (e.g. `⬢ example`).
+
+```zsh
+RPROMPT='$(toolbox_prompt_info_name)'
+```
+
 ## Aliases
 
 | Alias | Command              | Description                            |
 |-------|----------------------|----------------------------------------|
 | tb    | `toolbox enter`      | Enters the toolbox environment         |
+
+
+## Completion
+
+As of version `0.0.99.3`, toolbox includes shell completion commands via `toolbox completion`. This plugin will load these completions if available.

--- a/plugins/toolbox/toolbox.plugin.zsh
+++ b/plugins/toolbox/toolbox.plugin.zsh
@@ -1,5 +1,18 @@
+# just exit if toolbox isnt found
+if ! type toolbox &>/dev/null; then
+  return
+fi
+
 function toolbox_prompt_info() {
   [[ -f /run/.toolboxenv ]] && echo "⬢"
 }
+
+# check if completion command exists
+# (exit status 16 for "no manual entry" (command exists), 1 for bad command)
+toolbox completion >| /dev/null
+if [[ $? == 16 ]]; then
+  source <(toolbox completion zsh)
+  compdef _toolbox toolbox
+fi
 
 alias tb="toolbox enter"

--- a/plugins/toolbox/toolbox.plugin.zsh
+++ b/plugins/toolbox/toolbox.plugin.zsh
@@ -7,6 +7,11 @@ function toolbox_prompt_info() {
   [[ -f /run/.toolboxenv ]] && echo "⬢"
 }
 
+function toolbox_prompt_info_name () {
+  # Loads the container name from .containerenv and prints that as well
+  [[ -f /run/.toolboxenv ]] && (. /run/.containerenv && echo "⬢ $name")
+}
+
 # check if completion command exists
 # (exit status 16 for "no manual entry" (command exists), 1 for bad command)
 toolbox completion >| /dev/null


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Toolbox 0.0.99.3 introduced `toolbox completion` to set up shell autocompletion. This PR will load this completion, if it exists.

Additionally, this PR adds a second prompt function `toolbox_prompt_info_name`, which will display the name of the current toolbox in addition to the icon.

The README has been updated to document these features.