### PR TITLE
fix(colorize): support args when input is stdin

### DIFF
--- a/plugins/colorize/colorize.plugin.zsh
+++ b/plugins/colorize/colorize.plugin.zsh
@@ -42,12 +42,12 @@ colorize_cat() {
         ZSH_COLORIZE_STYLE="emacs"
     fi
 
-    # Use stdin if no arguments have been passed.
-    if [ $# -eq 0 ]; then
+    # Use stdin if stdin is not attached to a terminal.
+    if [ ! -t 0 ]; then
         if [[ "$ZSH_COLORIZE_TOOL" == "pygmentize" ]]; then
             pygmentize -O style="$ZSH_COLORIZE_STYLE" -g
         else
-            chroma --style="$ZSH_COLORIZE_STYLE" --formatter="${ZSH_COLORIZE_CHROMA_FORMATTER:-terminal}"
+            chroma --style="$ZSH_COLORIZE_STYLE" --formatter="${ZSH_COLORIZE_CHROMA_FORMATTER:-terminal}" "$@"
         fi
         return $?
     fi


### PR DESCRIPTION
This will allow users to select the lexer and consequently get some good ol' colouring when the input is from a pipe:

```shell
cat ~/.oh-my-zsh/plugins/colorize/colorize.plugin.zsh | ZSH_COLORIZE_TOOL=chroma ccat -lzsh # using chroma
cat ~/.oh-my-zsh/plugins/colorize/colorize.plugin.zsh | ZSH_COLORIZE_TOOL=pygmentize ccat -lzsh # using pygmentize
```
 
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
