### PR TITLE
Update debian.plugin.zsh

### DIFF
--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -89,22 +89,22 @@ else
     alias afu="su -lc '$apt-file update'"
     alias au="su -lc '$apt_pref $apt_upgr' root"
     function ai() {
-        cmd="su -lc 'aptitude -P install $@' root"
+        cmd="su -lc '$apt_pref install $@' root"
         print "$cmd"
         eval "$cmd"
     }
     function ap() {
-        cmd="su -lc '$apt_pref -P purge $@' root"
+        cmd="su -lc '$apt_pref purge $@' root"
         print "$cmd"
         eval "$cmd"
     }
     function ar() {
-        cmd="su -lc '$apt_pref -P remove $@' root"
+        cmd="su -lc '$apt_pref remove $@' root"
         print "$cmd"
         eval "$cmd"
     }
     function aar() {
-        cmd="su -lc '$apt_pref -P autoremove $@' root"
+        cmd="su -lc '$apt_pref autoremove $@' root"
         print "$cmd"
         eval "$cmd"
     }


### PR DESCRIPTION
bug-fix

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- typo `aptitude` should be generic `$apt_pref`
- `-P` is an aptitude-only feature, but **not available by apt**