### PR TITLE
feat(plugins/term_tab): MacOS support for completion of zsh sessions working directory

### DIFF
--- a/plugins/term_tab/README
+++ b/plugins/term_tab/README
@@ -11,6 +11,10 @@ to show you the current working directory of the other open zsh sessions.
 
 How it works:
 *************
-* It uses 'pidof zsh' to determine all zsh PIDs
-* It reads procfs to get the current working directory of this session
-* Everything is fed into zsh's completion magic
+* On Linux:
+  * It uses 'pidof zsh' to determine all zsh PIDs
+  * It reads procfs to get the current working directory of this session
+  * Everything is fed into zsh's completion magic
+* On Mac:
+  * It uses 'pidof -c zsh -d cwd' to find the working directories of all zsh processes
+  * This list is fed into zsh's completion magic

--- a/plugins/term_tab/term_tab.plugin.zsh
+++ b/plugins/term_tab/term_tab.plugin.zsh
@@ -28,6 +28,7 @@ function _term_list(){
   case $OSTYPE in
     solaris*) dirs=( ${(M)${${(f)"$(pgrep -U $UID -x zsh|xargs pwdx)"}:#$$:*}%%/*} ) ;;
     linux*) dirs=( /proc/${^$(pidof zsh):#$$}/cwd(N:A) ) ;;
+    darwin*) dirs=( $(lsof -d cwd -c zsh -a -Fn | grep '^n' | cut -c 2- ) ) ;;
   esac
   dirs=( ${(D)dirs} )
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Extended term_tab plugin to work on Mac
- Updated Readme of plugin term_tab

## Other comments:
The term_tab plugin only Linux and Solaris hosts, as the logic is OS specific.
This adds the same functionality for MacOS.

Tested on MacOS 12.2.1 ARM, zsh 5.8 (x86_64-apple-darwin21.0)