### PR TITLE
fix(git-auto-fetch): don't override native `stat` command

### DIFF
--- a/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
+++ b/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
@@ -2,7 +2,8 @@
 : ${GIT_AUTO_FETCH_INTERVAL:=60}
 
 # Necessary for the git-fetch-all function
-zmodload zsh/datetime zsh/stat
+zmodload zsh/datetime
+zmodload -F zsh/stat b:zstat  # only zstat command, not stat command
 
 function git-fetch-all {
   (


### PR DESCRIPTION

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Only load zstat builtin command from zsh/stat module

## Other comments:

According to man page `zshbuiltins` are the builtins `stat` and `zstat` synonymous, but because the builtin `stat` will shadow any `stat` executable in the path, it is recommended to only load `zstat`.

The plugin already used `zstat`.

~~I will fix the commit message ASAP to respect the Commit Guidelines.~~ **EDIT:** Changed commit message.