### PR TITLE
feat(zoxide): Add support for zoxide init flags

### DIFF
--- a/plugins/zoxide/README.md
+++ b/plugins/zoxide/README.md
@@ -12,3 +12,17 @@ plugins=(... zoxide)
 ```
 
 **Note:** you have to [install zoxide](https://github.com/ajeetdsouza/zoxide#step-1-install-zoxide) first.
+
+### Init flags
+Some zoxide options are set when `zoxide init` is run. Because this plugin 
+automates that for you, environment variables are given to set these options.
+
+Here are some examples:
+```zsh
+# Set to add the `--cmd j` flag during `zoxide init`
+export _ZO_OMZ_CMD=j
+# Set to 1 to add the `--no-cmd` flag during `zoxide init`
+export _ZO_OMZ_NOCMD=1
+# Set to add the `--hook never` during `zoxide init`
+export _ZO_OMZ_HOOK=never
+```

--- a/plugins/zoxide/zoxide.plugin.zsh
+++ b/plugins/zoxide/zoxide.plugin.zsh
@@ -1,5 +1,21 @@
-if (( $+commands[zoxide] )); then
-  eval "$(zoxide init zsh)"
-else
-  echo '[oh-my-zsh] zoxide not found, please install it from https://github.com/ajeetdsouza/zoxide'
-fi
+() {
+  local flags
+
+  if [[ -n "$_ZO_OMZ_CMD" ]]; then
+    flags+=(--cmd "$_ZO_OMZ_CMD")
+  fi
+
+  if [[ "$_ZO_OMZ_NOCMD" == 1 ]]; then
+    flags+=(--no-cmd)
+  fi
+
+  if [[ -n "$_ZO_OMZ_HOOK" ]]; then
+    flags+=(--hook "$_ZO_OMZ_HOOK")
+  fi
+
+  if (( $+commands[zoxide] )); then
+    eval "$(zoxide init zsh $flags)"
+  else
+    echo '[oh-my-zsh] zoxide not found, please install it from https://github.com/ajeetdsouza/zoxide'
+  fi
+}


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add support for flags to be set for `zoxide init` in the `zoxide` plugin.

## Other comments:
These options can only be set during `zoxide init`, so they're important to include for users who want to use them.


