### PR TITLE
feat(plugins/rushjs) - Adds RushJS plugin 

### DIFF
--- a/plugins/rushjs/README.md
+++ b/plugins/rushjs/README.md
@@ -1,0 +1,32 @@
+# RushJS
+
+This plugin adds aliases for frequent [rush](https://rushjs.io/) commands.
+
+## Commands
+
+The commands aliased are non-destructive; non of them ought to create, delete, or modify any non-generated files. There is a convenience alias (`rj`) where you can add your preferred impactful commands (e.g. `rj init`, `rj update`).
+
+| Alias    | Command                    |
+| -------- | -------------------------- |
+| *rj*     | `rush`                     |
+| *rji*    | `rush install`             |
+| *rjb*    | `rush build`               |
+| *rjbv*   | `rush build --verbose`     |
+| *rjr*    | `rush rebuild`             |
+| *rjrv*   | `rush rebuild --verbose`   |
+| *rjcl*   | `rush clean`               |
+| *rjp*    | `rush purge`               |
+| *rjt*    | `rush test`                |
+| *rjtv*   | `rush test --verbose`      |
+| *rjc*    | `rush check`               |
+
+
+## Installation
+
+**Required**: You must install the rush monorepo manager yourself before you can use this plugin.
+
+To use it, add `rushjs` to the plugins array in your `.zshrc` file:
+
+```zsh
+plugins=(... rushjs)
+```

--- a/plugins/rushjs/rushjs.plugin.zsh
+++ b/plugins/rushjs/rushjs.plugin.zsh
@@ -1,0 +1,11 @@
+alias rj=rush
+alias rji="rush install"
+alias rjb="rush build"
+alias rjbv="rush build -v"
+alias rjr="rush rebuild"
+alias rjrv="rush rebuild -v"
+alias rjcl="rush clean"
+alias rjp="rush purge"
+alias rjt="rush test"
+alias rjtv="rush test -v"
+alias rjc="rush check"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Adds a new plugin `rushjs` to ohmyzsh. The plugin consists of several aliases for developer convenience for those using the [RushJS](https://rushjs.io/) monorepo manager.

## Other comments:
