### PR TITLE
fix(updater): correct spelling of `curl` flag

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -65,7 +65,7 @@ function is_update_available() {
   local remote_head
   remote_head=$(
     if (( ${+commands[curl]} )); then
-      curl --conect-timeout 2 -fsSL -H 'Accept: application/vnd.github.v3.sha' $api_url 2>/dev/null
+      curl --connect-timeout 2 -fsSL -H 'Accept: application/vnd.github.v3.sha' $api_url 2>/dev/null
     elif (( ${+commands[wget]} )); then
       wget -T 2 -O- --header='Accept: application/vnd.github.v3.sha' $api_url 2>/dev/null
     elif (( ${+commands[fetch]} )); then


### PR DESCRIPTION
omz will not auto-update on some systems using `curl`, failing at the modified line

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open. (searched for 'timeout')
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- `--conect-timeout 2` changed to `--connect-timeout 2`

## Other comments:

This bug (not auto-updating on console start) occurs on a WSL2 Ubuntu distribution where `tools/upgrade.sh` is modified and `git update-index --assume-unchanged tools/upgrade.sh` has executed. Tracing the script, `curl` exits unexpectedly. The script functions as expected after the change in the PR.
