### PR TITLE
fix(plugin/jump): fix text alignment when printing marks

### DIFF
--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -35,12 +35,11 @@ marks() {
 			max=${#link:t}
 		fi
 	done
-	local printf_markname_template="$(printf -- "%%%us " "$max")"
 	for link in $MARKPATH/{,.}*(@N); do
-		local markname="$fg[cyan]${link:t}$reset_color"
-		local markpath="$fg[blue]$(readlink $link)$reset_color"
-		printf -- "$printf_markname_template" "$markname"
-		printf -- "-> %s\n" "$markpath"
+		local markname="${link:t}"
+		local markpath="$(readlink $link)"
+		printf -- "%s%${max}s%s" "$fg[cyan]" "$markname" "$reset_color"
+		printf -- " -> %s%s%s\n" "$fg[blue]" "$markpath" "$reset_color"
 	done
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

the `marks` function right-justifies mark names, to make the output
easier to read. However, because of the escape sequences for colors in
the output, the printf command doesn't calculate the padding correctly.
This results in the mark names not actually being right-justified
correctly, with short names not being padded enough. E.g.:

     code -> /home/ditzy/code
     misc -> /home/ditzy/misc
    sys-conf -> /home/ditzy/.sys-conf

this commit fixes this problem by only applying padding to the actual
mark name itself, and not the name+colors. E.g.:

        code -> /home/ditzy/code
        misc -> /home/ditzy/misc
    sys-conf -> /home/ditzy/.sys-conf
