### PR TITLE
fix(jump)!: only resolve mark symlink

### DIFF
--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -8,8 +8,10 @@
 #
 export MARKPATH=$HOME/.marks
 
+
 jump() {
-	builtin cd -P "$MARKPATH/$1" 2>/dev/null || {echo "No such mark: $1"; return 1}
+	local markpath="$(readlink $MARKPATH/$1)" || {echo "No such mark: $1"; return 1}
+	builtin cd "$markpath" 2>/dev/null || {echo "Destination does not exist for mark [$1]: $markpath"; return 2}
 }
 
 mark() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

BREAKING CHANGE

jumping previously took you to the absolute path of the marked
directory. If you create a mark to a symlinked path, then when you jump
you'll end up at the absolute version of that path:

```
$ mkdir /real-path
$ ln -s /real-path /link-path
$ cd /link-path
$ mark
Mark /link-path as link-path? (y/n) y
$ jump link-path
$ pwd
/real-path
```

this seems unintuitive to me, so this commit changes the jump function
to take you to the actual path of the mark (`/link-path` in the example
above) rather than the absolute path.

## Other comments:

although this is a breaking change, I felt conflicted about the value of adding an environment variable to preserve the old functionality, since this seems more intuitive and is such a small change. But I can totally imagine how this could inconvenience people, so if requested I'm happy to add an env var to keep the old functionality.
