### PR TITLE
feat(cakephp3): add compatibility with CakePHP 3.7+

### DIFF
--- a/plugins/cakephp3/cakephp3.plugin.zsh
+++ b/plugins/cakephp3/cakephp3.plugin.zsh
@@ -1,10 +1,10 @@
 # CakePHP 3 basic command completion
 _cakephp3_get_command_list () {
-	bin/cake Completion commands
+	bin/cake completion commands
 }
 
 _cakephp3_get_sub_command_list () {
-	bin/cake Completion subcommands ${words[2]}
+	bin/cake completion subcommands ${words[2]}
 }
 
 _cakephp3_get_3rd_argument () {
@@ -34,5 +34,5 @@ compdef _cakephp3 cake
 
 #Alias
 alias c3='bin/cake'
-alias c3cache='bin/cake orm_cache clear'
+alias c3cache='bin/cake schema_cache clear'
 alias c3migrate='bin/cake migrations migrate'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- `orm_cache` command has been replaced with `schema_cache` command (to make it compatible with CakePHP 3.7+)
- Also fixed the case in "completion" command

## Other comments:

PR #6262 has fixed the case issue, but somehow the latest revision still has this issue. Oh, well. Here's the fix. 