### PR TITLE
feat(docker): add alias for `docker stop $(docker ps -q)`

### DIFF
--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -35,39 +35,40 @@ the lines below to your zshrc file**, but be aware of the side effects:
 
 ## Aliases
 
-| Alias   | Command                     | Description                                                                              |
-| :------ | :-------------------------- | :--------------------------------------------------------------------------------------- |
-| dbl     | `docker build`              | Build an image from a Dockerfile                                                         |
-| dcin    | `docker container inspect`  | Display detailed information on one or more containers                                   |
-| dlo     | `docker container logs`     | Fetch the logs of a docker container                                                     |
-| dcls     | `docker container ls`       | List all the running docker containers                                                   |
-| dclsa    | `docker container ls -a`    | List all running and stopped containers                                                  |
-| dpo     | `docker container port`     | List port mappings or a specific mapping for the container                               |
-| dpu     | `docker pull`               | Pull an image or a repository from a registry                                            |
-| dr      | `docker container run`      | Create a new container and start it using the specified command                          |
-| drit    | `docker container run -it`  | Create a new container and start it in an interactive shell                              |
-| drm     | `docker container rm`       | Remove the specified container(s)                                                        |
-| drm!    | `docker container rm -f`    | Force the removal of a running container (uses SIGKILL)                                  |
-| dst     | `docker container start`    | Start one or more stopped containers                                                     |
-| dstp    | `docker container stop`     | Stop one or more running containers                                                      |
-| dtop    | `docker top`                | Display the running processes of a container                                             |
-| dxc     | `docker container exec`     | Run a new command in a running container                                                 |
-| dxcit   | `docker container exec -it` | Run a new command in a running container in an interactive shell                         |
-|         |                             | **Docker Images**                                                                        |
-| dib     | `docker image build`        | Build an image from a Dockerfile (same as docker build)                                  |
-| dii     | `docker image inspect`      | Display detailed information on one or more images                                       |
-| dils    | `docker image ls`           | List docker images                                                                       |
-| dipu     | `docker image push`         | Push an image or repository to a remote registry                                         |
-| dirm    | `docker image rm`           | Remove one or more images                                                                |
-| dit     | `docker image tag`          | Add a name and tag to a particular image                                                 |
-|         |                             | **Docker Network**                                                                       |
-| dnc     | `docker network create`     | Create a new network                                                                     |
-| dncn    | `docker network connect`    | Connect a container to a network                                                         |
-| dndcn   | `docker network disconnect` | Disconnect a container from a network                                                    |
-| dni     | `docker network inspect`    | Return information about one or more networks                                            |
-| dnls    | `docker network ls`         | List all networks the engine daemon knows about, including those spanning multiple hosts |
-| dnrm    | `docker network rm`         | Remove one or more networks                                                              |
-|         |                             | **Docker Volume**                                                                        |
-| dvi     | `docker volume inspect`     | Display detailed information about one or more volumes                                   |
-| dvls    | `docker volume ls`          | List all the volumes known to  docker                                                    |
-| dvprune | `docker volume prune`       | Cleanup dangling volumes                                                                 |
+| Alias   | Command                         | Description                                                                              |
+| :------ |:--------------------------------| :--------------------------------------------------------------------------------------- |
+| dbl     | `docker build`                  | Build an image from a Dockerfile                                                         |
+| dsta    | `docker stop $(docker ps -q)`   | Stop all running containers                                                              |
+| dcin    | `docker container inspect`      | Display detailed information on one or more containers                                   |
+| dlo     | `docker container logs`         | Fetch the logs of a docker container                                                     |
+| dcls    | `docker container ls`           | List all the running docker containers                                                   |
+| dclsa   | `docker container ls -a`        | List all running and stopped containers                                                  |
+| dpo     | `docker container port`         | List port mappings or a specific mapping for the container                               |
+| dpu     | `docker pull`                   | Pull an image or a repository from a registry                                            |
+| dr      | `docker container run`          | Create a new container and start it using the specified command                          |
+| drit    | `docker container run -it`      | Create a new container and start it in an interactive shell                              |
+| drm     | `docker container rm`           | Remove the specified container(s)                                                        |
+| drm!    | `docker container rm -f`        | Force the removal of a running container (uses SIGKILL)                                  |
+| dst     | `docker container start`        | Start one or more stopped containers                                                     |
+| dstp    | `docker container stop`         | Stop one or more running containers                                                      |
+| dtop    | `docker top`                    | Display the running processes of a container                                             |
+| dxc     | `docker container exec`         | Run a new command in a running container                                                 |
+| dxcit   | `docker container exec -it`     | Run a new command in a running container in an interactive shell                         |
+|         |                                 | **Docker Images**                                                                        |
+| dib     | `docker image build`            | Build an image from a Dockerfile (same as docker build)                                  |
+| dii     | `docker image inspect`          | Display detailed information on one or more images                                       |
+| dils    | `docker image ls`               | List docker images                                                                       |
+| dipu    | `docker image push`             | Push an image or repository to a remote registry                                         |
+| dirm    | `docker image rm`               | Remove one or more images                                                                |
+| dit     | `docker image tag`              | Add a name and tag to a particular image                                                 |
+|         |                                 | **Docker Network**                                                                       |
+| dnc     | `docker network create`         | Create a new network                                                                     |
+| dncn    | `docker network connect`        | Connect a container to a network                                                         |
+| dndcn   | `docker network disconnect`     | Disconnect a container from a network                                                    |
+| dni     | `docker network inspect`        | Return information about one or more networks                                            |
+| dnls    | `docker network ls`             | List all networks the engine daemon knows about, including those spanning multiple hosts |
+| dnrm    | `docker network rm`             | Remove one or more networks                                                              |
+|         |                                 | **Docker Volume**                                                                        |
+| dvi     | `docker volume inspect`         | Display detailed information about one or more volumes                                   |
+| dvls    | `docker volume ls`              | List all the volumes known to  docker                                                    |
+| dvprune | `docker volume prune`           | Cleanup dangling volumes                                                                 |

--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -1,6 +1,7 @@
 alias dbl='docker build'
 alias dpu='docker pull'
 alias dtop='docker top'
+alias dsta='docker stop $(docker ps -q)'
 
 # docker containers
 alias dcin='docker container inspect'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Add a command for `docker stop $(docker ps -q)` to stop all running containers. This is very useful when we are running containers from a project and we want to quickly stop all containers when already in the directory of another project, or when we have multiple containers from different projects and we just want to stop them all.

## Other comments:

...
