### PR TITLE
fix(lib): fix mismatch between ls colors and zsh tab completion colors

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -1,9 +1,6 @@
 # ls colors
 autoload -U colors && colors
 
-# Enable ls colors
-export LSCOLORS="Gxfxcxdxbxegedabagacad"
-
 # TODO organise this chaotic logic
 
 if [[ "$DISABLE_LS_COLORS" != "true" ]]; then
@@ -20,12 +17,9 @@ if [[ "$DISABLE_LS_COLORS" != "true" ]]; then
     gls --color -d . &>/dev/null && alias ls='gls --color=tty'
     colorls -G -d . &>/dev/null && alias ls='colorls -G'
   elif [[ "$OSTYPE" == (darwin|freebsd)* ]]; then
-    # this is a good alias, it works by default just using $LSCOLORS
+    # Prefer gls over ls if available 
     ls -G . &>/dev/null && alias ls='ls -G'
-
-    # only use coreutils ls if there is a dircolors customization present ($LS_COLORS or .dircolors file)
-    # otherwise, gls will use the default color scheme which is ugly af
-    [[ -n "$LS_COLORS" || -f "$HOME/.dircolors" ]] && gls --color -d . &>/dev/null && alias ls='gls --color=tty'
+    gls --color -d . &>/dev/null && alias ls='gls --color=tty'
   else
     # For GNU ls, we use the default ls color theme. They can later be overwritten by themes.
     if [[ -z "$LS_COLORS" ]]; then
@@ -34,9 +28,17 @@ if [[ "$DISABLE_LS_COLORS" != "true" ]]; then
 
     ls --color -d . &>/dev/null && alias ls='ls --color=tty' || { ls -G . &>/dev/null && alias ls='ls -G' }
 
-    # Take advantage of $LS_COLORS for completion as well.
-    zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
   fi
+fi
+
+# Set default lscolors
+if [[ -z "$LSCOLORS" ]]; then
+  export LSCOLORS="Gxfxcxdxbxegedabagacad"
+fi
+
+# Set default ls_colors
+if [[ -z "$LS_COLORS" ]]; then
+  export LS_COLORS="di=1;36:ln=35:so=32:pi=33:ex=31:bd=34;46:cd=34;43:su=30;41:sg=30;46:tw=30;42:ow=30;43"
 fi
 
 # enable diff color if possible.

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -185,3 +185,9 @@ if [[ -n "$ZSH_THEME" ]]; then
     echo "[oh-my-zsh] theme '$ZSH_THEME' not found"
   fi
 fi
+
+# Take advantage of $LS_COLORS for completion as well.
+# In order for tab completion folders to have the same colors as ls
+# we need to set the zstyle for completion after the theme is sourced
+zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
+


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- added default LS_COLORS (derived from LSCOLORS using https://geoff.greer.fm/lscolors/) if no LS_COLORS have been set
The logic for setting LS_COLORS is as follows:
1. if the user has set the value for LS_COLORS use that one unless it is not overwritten by a theme
2. If the user does not have a value for LS_COLORS then if the value can be determined from the system by using dircolors then use that one, if not then use the default LS_COLORS unless it is not overwritten by a theme

Not having a default LS_COLORS value on MacOS results in the following situation:
- ls will take the values from LSCOLORS which have a default color, or are overwritten by theams
- zsh tab completion will have no colors set because on mac there is no default value for LS_COLORS
this results in the mismatch of colors between ls and zsh tab completion

- move the setup for zsh tab completion from lib/theme-and-appearance.zsh to the end of oh-my-zsh.sh
while ls evaluates the LS_COLORS value every time it is called, it seems that zsh tab completion does not.
in this case we need to set zsh tab completion only after the theme is sourced in order to have the correct colors.

Testing was done on wsl and macos:
Wsl(theme: arrow)
no fix: ![wls_no_fix](https://user-images.githubusercontent.com/3298487/183012465-992efbbd-40bd-4195-a101-0187af345ead.png)
with fix: ![wls_with_fix](https://user-images.githubusercontent.com/3298487/183012519-ab1fffc2-4cb3-4cad-b970-d9584ae52532.png)

MacOS(theme: arrow)
no fix: <img width="795" alt="macos_no_fix" src="https://user-images.githubusercontent.com/3298487/183012550-c181b703-2fc8-458c-98eb-9e5bcae7b1f8.png">
with fix: <img width="795" alt="macos_with_fix" src="https://user-images.githubusercontent.com/3298487/183012555-f05fe99f-bdfb-4ddf-b753-f02358b2639b.png">

MacOS(theme: robbyrussell)
no fix: <img width="795" alt="macos_no_fix_default" src="https://user-images.githubusercontent.com/3298487/183012552-8738a087-0336-4db5-85df-68c763d8135c.png">
with fix: <img width="795" alt="macos_with_fix_default" src="https://user-images.githubusercontent.com/3298487/183012556-82971189-2fcf-4829-9788-46d0bf924428.png">

## Other comments:

This proposal is related to the following:
- https://github.com/ohmyzsh/ohmyzsh/pull/6353
- https://github.com/ohmyzsh/ohmyzsh/issues/6060