### PR TITLE
feat(installer): Enable chsh in non-interactive terminal

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -458,7 +458,6 @@ main() {
   # Run as unattended if stdin is not a tty
   if [ ! -t 0 ]; then
     RUNZSH=no
-    CHSH=no
   fi
 
   # Parse arguments


### PR DESCRIPTION
Fixes #11092

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Do not set to no CHSH when running in non-interactive terminal
