### PR TITLE
feat(git): alias `gluc` to sync with current branch in upstream

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -184,6 +184,7 @@ plugins=(... git)
 | gupom                | git pull --rebase origin $(git_main_branch)                                                                                      |
 | gupomi               | git pull --rebase=interactive origin $(git_main_branch)                                                                          |
 | glum                 | git pull upstream $(git_main_branch)                                                                                             |
+| gluc                 | git pull upstream $(git_current_branch)                                                                                             |
 | gwch                 | git whatchanged -p --abbrev-commit --pretty=medium                                                                               |
 | gwip                 | git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"           |
 | gam                  | git am                                                                                                                           |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -310,6 +310,7 @@ alias gupav='git pull --rebase --autostash -v'
 alias gupom='git pull --rebase origin $(git_main_branch)'
 alias gupomi='git pull --rebase=interactive origin $(git_main_branch)'
 alias glum='git pull upstream $(git_main_branch)'
+alias gluc='git pull upstream $(git_current_branch)'
 
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'
 alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign -m "--wip-- [skip ci]"'


### PR DESCRIPTION
`glum` works great in most cases when you develop based on `master` or `main` branch, however, it's also common to work against a particular feature or release branch. In this case, it'd be efficient to have an alias to sync with that particular branch in upstream.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Introduce alias `gluc` to `git pull upstream $(git_current_branch)`
- Update README to reflect the new alias

## Other comments:

Fixes #11087.
