### PR TITLE
feat(tmux): allow all standard config files

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -28,16 +28,16 @@ The plugin also supports the following:
 
 ## Configuration Variables
 
-| Variable                            | Description                                                                   |
-| ----------------------------------- | ----------------------------------------------------------------------------- |
-| `ZSH_TMUX_AUTOSTART`                | Automatically starts tmux (default: `false`)                                  |
-| `ZSH_TMUX_AUTOSTART_ONCE`           | Autostart only if tmux hasn't been started previously (default: `true`)       |
-| `ZSH_TMUX_AUTOCONNECT`              | Automatically connect to a previous session if it exits (default: `true`)     |
-| `ZSH_TMUX_AUTOQUIT`                 | Automatically closes terminal once tmux exits (default: `ZSH_TMUX_AUTOSTART`) |
-| `ZSH_TMUX_FIXTERM`                  | Sets `$TERM` to 256-color term or not based on current terminal support       |
-| `ZSH_TMUX_ITERM2`                   | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)          |
-| `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `screen`)                |
-| `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `screen-256color`            |
-| `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`)                      |
-| `ZSH_TMUX_UNICODE`                  | Set `tmux -u` option to support unicode                                       |
-| `ZSH_TMUX_DEFAULT_SESSION_NAME`     | Set tmux default session name when autostart is enabled                       |
+| Variable                            | Description                                                                                 |
+| ----------------------------------- | ------------------------------------------------------------------------------------------- |
+| `ZSH_TMUX_AUTOSTART`                | Automatically starts tmux (default: `false`)                                                |
+| `ZSH_TMUX_AUTOSTART_ONCE`           | Autostart only if tmux hasn't been started previously (default: `true`)                     |
+| `ZSH_TMUX_AUTOCONNECT`              | Automatically connect to a previous session if it exits (default: `true`)                   |
+| `ZSH_TMUX_AUTOQUIT`                 | Automatically closes terminal once tmux exits (default: `ZSH_TMUX_AUTOSTART`)               |
+| `ZSH_TMUX_FIXTERM`                  | Sets `$TERM` to 256-color term or not based on current terminal support                     |
+| `ZSH_TMUX_ITERM2`                   | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)                        |
+| `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `screen`)                              |
+| `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `screen-256color`                          |
+| `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$XDG_CONFIG_HOME/tmux/tmux.conf`, `$HOME/.tmux.conf`) |
+| `ZSH_TMUX_UNICODE`                  | Set `tmux -u` option to support unicode                                                     |
+| `ZSH_TMUX_DEFAULT_SESSION_NAME`     | Set tmux default session name when autostart is enabled                                     |

--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -38,6 +38,6 @@ The plugin also supports the following:
 | `ZSH_TMUX_ITERM2`                   | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)                        |
 | `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `screen`)                              |
 | `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `screen-256color`                          |
-| `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$XDG_CONFIG_HOME/tmux/tmux.conf`, `$HOME/.tmux.conf`) |
+| `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`, `$XDG_CONFIG_HOME/tmux/tmux.conf`) |
 | `ZSH_TMUX_UNICODE`                  | Set `tmux -u` option to support unicode                                                     |
 | `ZSH_TMUX_DEFAULT_SESSION_NAME`     | Set tmux default session name when autostart is enabled                                     |

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -30,6 +30,7 @@ if [[ -e ${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf ]]; then
   : ${ZSH_TMUX_CONFIG:=${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf}
 else
   : ${ZSH_TMUX_CONFIG:=$HOME/.tmux.conf}
+fi
 # Set -u option to support unicode
 : ${ZSH_TMUX_UNICODE:=false}
 

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -26,12 +26,14 @@ fi
 # systems without the proper terminfo
 : ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=screen-256color}
 # Set the configuration path
-: ${ZSH_TMUX_CONFIG:=$HOME/.tmux.conf}
+if [[ -e ${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf ]]; then
+  : ${ZSH_TMUX_CONFIG:=${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf}
+else
+  : ${ZSH_TMUX_CONFIG:=$HOME/.tmux.conf}
 # Set -u option to support unicode
 : ${ZSH_TMUX_UNICODE:=false}
 
 # ALIASES
-
 alias ta='tmux attach -t'
 alias tad='tmux attach -d -t'
 alias ts='tmux new-session -s'

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -26,7 +26,9 @@ fi
 # systems without the proper terminfo
 : ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=screen-256color}
 # Set the configuration path
-if [[ -e ${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf ]]; then
+if [[ -e $HOME/.tmux.conf ]]; then
+  : ${ZSH_TMUX_CONFIG:=$HOME/.tmux.conf}
+elif [[ -e ${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf ]]; then
   : ${ZSH_TMUX_CONFIG:=${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf}
 else
   : ${ZSH_TMUX_CONFIG:=$HOME/.tmux.conf}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Respect XDG_CONFIG_HOME

## Other comments:

...
