### PR TITLE
chore: add vscode workspace settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cache/
 log/
 *.swp
 .DS_Store
+
+# editor configs
+.vscode


### PR DESCRIPTION
There are workspace settings for vscode plugins that make contributing to ohmyzsh easier. However, these would be noisy for users, especially for those that don't use vscode.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Simply adds `.vscode` workspace settings to the `.gitignore`.

This way, myself and others that have VS Code settings specifically for contributing to this repo don't have to keep ignoring the `.vscode` folder manually on every commit (or a different `.gitignore` that ignores the `.vscode` folder 🙃 )


## Other comments:

I had considered committing the `.vscode` settings, since there is already a precedent of adding editor settings to the repo in `.editorconfig`. However, I thought committing settings that would only work for one specific vendor's editor would only help users of vscode, and be noisy for the rest of folks. It also seemed like it might signal there is an "official" code editor for this project.

That said, the tradeoff is that there won't be useful workspace settings shared across VS Code-using contributors to this repo. 🤷  Happy to change this PR to not ignoring, but committing the `.vscode` folder if folks think that could be useful.

The settings I added in my personal setup were specifically for the [Conventional Commits VS Code plugin](https://marketplace.visualstudio.com/items?itemName=vivaxy.vscode-conventional-commits), to add the scopes definitions so it could auto-complete for this repo.