### PR TITLE
chore(react-native): add maintainer for `react-native` plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@ plugins/aws/                        @maksyms
 plugins/genpass/                    @atoponce
 plugins/git-lfs/                    @hellovietduc
 plugins/gitfast/                    @felipec
+plugins/react-native                @esthor
 plugins/sdk/                        @rgoldberg
 plugins/shell-proxy/                @septs
 plugins/universalarchive/           @Konfekt


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Adds myself as maintainer of the `react-native` plugin.

## Other comments:

I had contributed in the past and am contributing now, but I don't get notifications for changes, so it's really just whenever I remember to come check if there's anything. The main reasons I'd like to be added here are:
1. reviews seem to take a while for contributors to get. Example: [This very simple PR from 2 months ago](https://github.com/ohmyzsh/ohmyzsh/pull/10998)
2. there seems to be some inconsistencies in code merged that a maintainer could keep an eye on and remind contributors of in their PRs. Example: [This commit that updated the aliases, but didn't update the corresponding docs](https://github.com/ohmyzsh/ohmyzsh/commit/3f50482674c2b3153590a4aba92fbfa1c01bc583)

I'm not sure if just adding myself is "the process" or not, but please let me know if this requires some additional steps.