### PR TITLE
common-aliases: Don't overshadow `duf`

### DIFF
--- a/plugins/common-aliases/README.md
+++ b/plugins/common-aliases/README.md
@@ -35,8 +35,10 @@ plugins=(... common-aliases)
 | mv    | `mv -i`               | Move a file                                                                     |
 | zshrc | `${=EDITOR} ~/.zshrc` | Quickly access the ~/.zshrc file                                                |
 | dud   | `du -d 1 -h`          | Display the size of files at depth 1 in current location in human-readable form |
-| duf   | `du -sh`              | Display the size of files in current location in human-readable form            |
+| duf\* | `du -sh`              | Display the size of files in current location in human-readable form            |
 | t     | `tail -f`             | Shorthand for tail which outputs the last part of a file                        |
+
+\* Only if the [`duf`](https://github.com/muesli/duf) command isn't installed.
 
 ### find and grep
 
@@ -66,12 +68,15 @@ These aliases are expanded in any position in the command line, meaning you can 
 end of the command you've typed. Examples:
 
 Quickly pipe to less:
+
 ```zsh
 $ ls -l /var/log L
 # will run
 $ ls -l /var/log | less
 ```
+
 Silences stderr output:
+
 ```zsh
 $ find . -type f NE
 # will run

--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -35,7 +35,7 @@ alias -g NUL="> /dev/null 2>&1"
 alias -g P="2>&1| pygmentize -l pytb"
 
 alias dud='du -d 1 -h'
-alias duf='du -sh *'
+(( $+commands[duf] )) || alias duf='du -sh *'
 (( $+commands[fd] )) || alias fd='find . -type d -name'
 alias ff='find . -type f -name'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- common-aliases: Don't overshadow `duf`

## Other comments:

...
