### PR TITLE
feat(agnoster): add VRF name to prompt if available

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -241,12 +241,25 @@ prompt_aws() {
   esac
 }
 
+
+# VRF Profile
+# Display current VRF name
+prompt_vrf() {
+  if ((${+commands[ip]} )); then
+    VRF=$(ip vrf identify)
+    [[ -z "$VRF" ]] && return
+    prompt_segment green black  "${VRF:gs/%/%%}"
+  fi
+}
+
+
 ## Main prompt
 build_prompt() {
   RETVAL=$?
   prompt_status
   prompt_virtualenv
   prompt_aws
+  prompt_vrf
   prompt_context
   prompt_dir
   prompt_git


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
- add VRF name to prompt if available("ip" command available and a vrf is actually in use)

![Screenshot 2022-08-14 at 23 51 19](https://user-images.githubusercontent.com/7582586/184556188-4c7f3c74-2278-427c-9b35-fe97e5ac7763.png)

