### PR TITLE
fix(emacs): Fixes terminal not reacting to `emacs -nw` with `emacs` plugin

### DIFF
--- a/plugins/emacs/emacs.plugin.zsh
+++ b/plugins/emacs/emacs.plugin.zsh
@@ -24,7 +24,6 @@ export EMACS_PLUGIN_LAUNCHER="${0:A:h}/emacsclient.sh"
 # set EDITOR if not already defined.
 export EDITOR="${EDITOR:-${EMACS_PLUGIN_LAUNCHER}}"
 
-alias emacs="$EMACS_PLUGIN_LAUNCHER --no-wait"
 alias e=emacs
 # open terminal emacsclient
 alias te="$EMACS_PLUGIN_LAUNCHER -nw"
@@ -65,4 +64,14 @@ function ecd {
   local file
   file="$(efile)" || return $?
   echo "${file:h}"
+}
+
+# Opens emacs with --no-wait argument
+function emacs {
+  # Checks for emacs terminal arguments which are incompatible with --no-wait
+  if [[ $* =~ "-nw" || $* =~ "-t" || $* =~ "-tty" ]]; then
+    $EMACS_PLUGIN_LAUNCHER $@
+  else
+    $EMACS_PLUGIN_LAUNCHER --no-wait $@
+  fi
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Replaced `emacs` alias with a function that does not use the `--no-wait` argument when any of the incompatible emacs terminal arguments are used.

## Other comments:

Fixes #10940
