### PR TITLE
feat(suse): add aliases for --no-recommends

### DIFF
--- a/plugins/suse/suse.plugin.zsh
+++ b/plugins/suse/suse.plugin.zsh
@@ -12,16 +12,20 @@ alias zvcmp='zypper vcmp'
 #Packages commands
 alias zin='sudo zypper in'
 alias zinr='sudo zypper inr'
+alias zinrc='sudo zypper inr --no-recommends'
+alias znrc='sudo zypper in --no-recommends'
 alias zrm='sudo zypper rm'
 alias zsi='sudo zypper si'
 alias zve='sudo zypper ve'
 
 #Updates commands
 alias zdup='sudo zypper dup'
+alias zdnrc='sudo zypper dup --no-recommends'
 alias zlp='zypper lp'
 alias zlu='zypper lu'
 alias zpchk='sudo zypper pchk'
 alias zup='sudo zypper up'
+alias zunrc='sudo zypper up --no-recommends'
 alias zpatch='sudo zypper patch'
 
 #Request commands


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

**Add the following aliases:**

- zdnrc for dup
- zunrc for up
- znrc for in
- zinrc for inr

## Other comments:

oS/SLE is a distro notorious for it's tendency to bloat the system with unnecessary weak dependencies. Therefore it is advisable to use the --no-recommends flag to preserve disk space and reduce the write count for SSD drives. when updating or installing packagns
...
