### PR TITLE
chore: Add .dir-locals.el for emacs users

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,7 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((auto-mode-alist . (
+		     ("\\.zsh-theme\\'" . sh-mode)
+		     ("\\.zsh-template\\'" . sh-mode)
+		     )))


### PR DESCRIPTION
Initially, we only enable sh-mode on a few additional .zsh-* files,
but this could be extended to incorporate the editor settings in
.editorconfig for people not using that package.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x ] The PR title is descriptive.
- [ x ] The PR doesn't replicate another PR which is already open.
- [ x ] I have read the contribution guide and followed all the instructions.
- [ x ] The code follows the code style guide detailed in the wiki.
- [ x ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x ] The code is stable and I have tested it myself, to the best of my abilities.
- [ x ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
