### PR TITLE
perf(fzf): speed up startup on debian

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -59,8 +59,8 @@ function fzf_setup_using_base_dir() {
 
 
 function fzf_setup_using_debian() {
-  if (( ! $+commands[dpkg] )) || ! dpkg -s fzf &>/dev/null; then
-    # Either not a debian based distro, or no fzf installed
+  if (( ! $+commands[dpkg] )); then
+    # Not a debian based distro
     return 1
   fi
 
@@ -71,11 +71,19 @@ function fzf_setup_using_debian() {
 
   case $PREFIX in
     *com.termux*)
+      if [[ ! -f "${PREFIX}/bin/fzf" ]]; then
+        # fzf not installed
+        return 1
+      fi
       # Support Termux package
       completions="${PREFIX}/share/fzf/completion.zsh"
       key_bindings="${PREFIX}/share/fzf/key-bindings.zsh"
       ;;
     *)
+      if [[ ! -f /usr/bin/fzf ]]; then
+        # fzf not installed
+        return 1
+      fi
       # Determine completion file path: first bullseye/sid, then buster/stretch
       completions="/usr/share/doc/fzf/examples/completion.zsh"
       [[ -f "$completions" ]] || completions="/usr/share/zsh/vendor-completions/_fzf"


### PR DESCRIPTION
The code calls the external command `dpkg -s fzf` to check fzf installation and is therefore inefficient. 

I use `time zsh -i -c exit` to measure start up time. With this if condition, my startup time is 0.16-0.19s. Without this if condition, my startup time is 0.09-0.12s. This check almost doubles my start up time.

Replace it by checking the fzf binary exists at the right place.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
