### PR TITLE
Allow alternate patterns for choosing green vs. red depending on AWS_PROFILE

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -224,20 +224,27 @@ prompt_status() {
   [[ $RETVAL -ne 0 ]] && symbols+="%{%F{red}%}✘"
   [[ $UID -eq 0 ]] && symbols+="%{%F{yellow}%}⚡"
   [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{cyan}%}⚙"
-
+#
   [[ -n "$symbols" ]] && prompt_segment black default "$symbols"
 }
 
 #AWS Profile:
 # - display current AWS_PROFILE name
-# - displays yellow on red if profile name contains 'production' or
-#   ends in '-prod'
+# - displays yellow on red if profile name matches contents of AWS_SENSITIVE_PROFILES 
+#   if AWS_SENSITIVE_PROFILES is not set, then check if profile name ends with -prod or contains *production*
 # - displays black on green otherwise
 prompt_aws() {
   [[ -z "$AWS_PROFILE" || "$SHOW_AWS_PROMPT" = false ]] && return
+
+  if [ -z $AWS_SENSITIVE_PROFILES ]; then
+    aws_sensitive_profiles="*-prod|*production*"
+  else
+    aws_sensitive_profiles=$AWS_SENSITIVE_PROFILES
+  fi
+
   case "$AWS_PROFILE" in
-    *-prod|*production*) prompt_segment red yellow  "AWS: ${AWS_PROFILE:gs/%/%%}" ;;
-    *) prompt_segment green black "AWS: ${AWS_PROFILE:gs/%/%%}" ;;
+    $~aws_sensitive_profiles) prompt_segment red yellow  "$AWS_PROFILE" ;;
+    *) prompt_segment green black "$AWS_PROFILE" ;;
   esac
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- in addition to the built-in `"*-prod|*production*"` pattern for coloring the AWS_PROFILE in red over yellow vs. black over green, you can define alternate patterns through an environment variable `"AWS_SENSITIVE_PROFILES"` with values like "*-prod-admin"


...
