### PR TITLE
fix(avit): `RPROMPT` Fix for #10307.  Allows for Plugin Prompt customization

### DIFF
--- a/themes/avit.zsh-theme
+++ b/themes/avit.zsh-theme
@@ -11,7 +11,12 @@ $(_user_host)${_current_dir} $(git_prompt_info) $(ruby_prompt_info)
 
 PROMPT2='%{%(!.${fg[red]}.${fg[white]})%}◀%{$reset_color%} '
 
-RPROMPT='$(vi_mode_prompt_info)%{$(echotc UP 1)%}$(_git_time_since_commit) $(git_prompt_status) ${_return_status}%{$(echotc DO 1)%}'
+__RPROMPT='$(vi_mode_prompt_info)%{$(echotc UP 1)%}$(_git_time_since_commit) $(git_prompt_status) ${_return_status}%{$(echotc DO 1)%}'
+if [[ -z $RPROMPT ]]; then
+  RPROMPT=$__RPROMPT
+else
+  RPROMPT="${RPROMPT} ${__RPROMPT}"  
+fi
 
 function _user_host() {
   local me


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixed how the theme set `RPROMPT`. The theme was causing plugins that would decorate the prompt to not load properly.  See Issue #10307 

## Other comments:

...
