### PR TITLE
Add auto-completion support for gcloud when installed by MacPorts

### DIFF
--- a/plugins/gcloud/gcloud.plugin.zsh
+++ b/plugins/gcloud/gcloud.plugin.zsh
@@ -12,6 +12,7 @@ if [[ -z "${CLOUDSDK_HOME}" ]]; then
     "/snap/google-cloud-sdk/current"
     "/usr/lib64/google-cloud-sdk/"
     "/opt/google-cloud-sdk"
+    "/opt/local/libexec/google-cloud-sdk/"
   )
 
   for gcloud_sdk_location in $search_locations; do


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds the path for gcloud completions when installed via MacPorts https://ports.macports.org/port/google-cloud-sdk/details/
https://github.com/macports/macports-ports/blob/master/devel/google-cloud-sdk/Portfile#L158

## Other comments:

None