### PR TITLE
Better placement of Fossil prompt info

### DIFF
--- a/plugins/fossil/fossil.plugin.zsh
+++ b/plugins/fossil/fossil.plugin.zsh
@@ -35,18 +35,23 @@ function fossil_prompt_info() {
 }
 
 function _fossil_prompt () {
-  local current=`echo $PROMPT $RPROMPT | grep fossil`
-
-  if [ "$_FOSSIL_PROMPT" = "" -o "$current" = "" ]; then
-    local _prompt=${PROMPT}
-    local _rprompt=${RPROMPT}
-
-    local is_prompt=`echo $PROMPT | grep git`
-
-    if [ "$is_prompt" = "" ]; then
-      RPROMPT="$_rprompt"'$(fossil_prompt_info)'
-    else
-      PROMPT="$_prompt"'$(fossil_prompt_info) '
+  if [ -z "$_FOSSIL_PROMPT" ]; then
+    # Use substitutions to work out what other plugins and themes have
+    # done ahead of us so we don't duplicate their work.
+    #
+    # If $fossil_prompt_info isn't in the prompt strings already but we
+    # can find $git_prompt_info, put it immediately afterward so that
+    # one or the other appears in the prompt.  We're gambling that you
+    # aren't in a directory that's a checkout for both a Git repo and a
+    # Fossil repo.
+    #
+    # Otherwise, don't guess about where the user wants our prompt info
+    # placed.  They can edit their theme to place it manually.
+    if [ "${PROMPT/fossil_prompt_info//}" = "$PROMPT" ]; then
+      PROMPT="${PROMPT/git_prompt_info/git_prompt_info)\$(fossil_prompt_info}"
+    fi
+    if [ "${RPROMPT/fossil_prompt_info//}" = "$RPROMPT" ]; then
+      RPROMPT="${RPROMPT/git_prompt_info/git_prompt_info)\$(fossil_prompt_info}"
     fi
 
     _FOSSIL_PROMPT="1"


### PR DESCRIPTION
Instead of blindly tacking `$fossil_prompt_info` onto the end of the
prompt string and making assumptions about whether `$PROMPT` or
`$RPROMPT` are in use here, assume the user is using a theme that puts
`$git_prompt_info` in there somewhere and inject our info immediately
afterward.  The theme creator decided that's a good place for Git prompt
info, so that's a good place for Fossil prompt info, too.

This also replaces some calls out to `grep` with internal Zsh string
manipulation for less overhead.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
