### PR TITLE
Reduce unnecessary space in Fossil prompt

### DIFF
--- a/plugins/fossil/fossil.plugin.zsh
+++ b/plugins/fossil/fossil.plugin.zsh
@@ -13,12 +13,11 @@ ZSH_THEME_FOSSIL_PROMPT_DIRTY=" %{$fg_bold[red]%}✖"
 ZSH_THEME_FOSSIL_PROMPT_CLEAN=" %{$fg_bold[green]%}✔"
 
 function fossil_prompt_info() {
-  local info=$(fossil branch 2>&1)
+  local branch=$(fossil branch current 2>&1)
 
   # if we're not in a fossil repo, don't show anything
-  ! command grep -q "use --repo" <<< "$info" || return
+  ! command grep -q "use --repo" <<< "$branch" || return
 
-  local branch=$(echo $info | grep "* " | sed 's/* //g')
   local changes=$(fossil changes)
   local dirty="$ZSH_THEME_FOSSIL_PROMPT_CLEAN"
 

--- a/plugins/fossil/fossil.plugin.zsh
+++ b/plugins/fossil/fossil.plugin.zsh
@@ -7,10 +7,10 @@ ZSH_THEME_FOSSIL_PROMPT_PREFIX="%{$fg_bold[blue]%}fossil:(%{$fg_bold[red]%}"
 ZSH_THEME_FOSSIL_PROMPT_SUFFIX="%{$fg_bold[blue]%})"
 
 # Text to display if the branch is dirty
-ZSH_THEME_FOSSIL_PROMPT_DIRTY=" %{$fg_bold[red]%}✖"
+ZSH_THEME_FOSSIL_PROMPT_DIRTY="%{$fg_bold[red]%}✖"
 
 # Text to display if the branch is clean
-ZSH_THEME_FOSSIL_PROMPT_CLEAN=" %{$fg_bold[green]%}✔"
+ZSH_THEME_FOSSIL_PROMPT_CLEAN="%{$fg_bold[green]%}✔"
 
 function fossil_prompt_info() {
   local branch=$(fossil branch current 2>&1)
@@ -25,11 +25,11 @@ function fossil_prompt_info() {
     dirty="$ZSH_THEME_FOSSIL_PROMPT_DIRTY"
   fi
 
-  printf '%s %s %s %s %s' \
+  printf ' %s%s%s%s%s' \
     "$ZSH_THEME_FOSSIL_PROMPT_PREFIX" \
     "${branch:gs/%/%%}" \
-    "$ZSH_THEME_FOSSIL_PROMPT_SUFFIX" \
     "$dirty" \
+    "$ZSH_THEME_FOSSIL_PROMPT_SUFFIX" \
     "%{$reset_color%}"
 }
 


### PR DESCRIPTION
- Better branch name parsing for Fossil plugin.
- Better placement of Fossil prompt info
- Removed all unnecessary space from Fossil prompt

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
