### PR TITLE
Reduced unnecessary space in Fossil plugin prompt

### DIFF
--- a/plugins/fossil/fossil.plugin.zsh
+++ b/plugins/fossil/fossil.plugin.zsh
@@ -1,16 +1,16 @@
 _FOSSIL_PROMPT=""
 
 # Prefix at the very beginning of the prompt, before the branch name
-ZSH_THEME_FOSSIL_PROMPT_PREFIX="%{$fg_bold[blue]%}fossil:(%{$fg_bold[red]%}"
+ZSH_THEME_FOSSIL_PROMPT_PREFIX="%{$fg_bold[blue]%}fossil:("
 
 # At the very end of the prompt
 ZSH_THEME_FOSSIL_PROMPT_SUFFIX="%{$fg_bold[blue]%})"
 
 # Text to display if the branch is dirty
-ZSH_THEME_FOSSIL_PROMPT_DIRTY=" %{$fg_bold[red]%}✖"
+ZSH_THEME_FOSSIL_PROMPT_DIRTY="%{$fg_bold[red]%}✖"
 
 # Text to display if the branch is clean
-ZSH_THEME_FOSSIL_PROMPT_CLEAN=" %{$fg_bold[green]%}✔"
+ZSH_THEME_FOSSIL_PROMPT_CLEAN="%{$fg_bold[green]%}✔"
 
 function fossil_prompt_info() {
   local info=$(fossil branch 2>&1)
@@ -26,11 +26,11 @@ function fossil_prompt_info() {
     dirty="$ZSH_THEME_FOSSIL_PROMPT_DIRTY"
   fi
 
-  printf '%s %s %s %s %s' \
+  printf ' %s%s%s%s%s' \
     "$ZSH_THEME_FOSSIL_PROMPT_PREFIX" \
     "${branch:gs/%/%%}" \
-    "$ZSH_THEME_FOSSIL_PROMPT_SUFFIX" \
     "$dirty" \
+    "$ZSH_THEME_FOSSIL_PROMPT_SUFFIX" \
     "%{$reset_color%}"
 }
 


### PR DESCRIPTION
The prior version was way too opinionated, adding space between each element of the prompt string, unlike common Git prompt strings.  If the user wants more space, they can override our public variables to suit.  The inverse argument doesn't hold: it's easy to add space to existing variables, but not as easy to remove it after the fact.

As part of this, changed the branch name from red to blue (matching the preceding part of the prompt) so the red "X" added to indicate a dirty branch doesn't get lost in the branch name.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Other comments:

I realize this is a purely cosmetic change based on personal taste, but as I explain in the commit comment, it’s easier to add space from too-little than to remove it from too-much.  I believe that makes this a better way to ship the plugin: end users who don’t like the change can add whatever space they like back in by overriding our public variables.
