### PR TITLE
feat(asdf): add ZSH completions support

### DIFF
--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -12,7 +12,13 @@ fi
 if [[ ! -f "$ASDF_DIR/asdf.sh" || ! -f "$ASDF_COMPLETIONS/asdf.bash" ]] && (( $+commands[brew] )); then
   brew_prefix="$(brew --prefix asdf)"
   ASDF_DIR="${brew_prefix}/libexec"
-  ASDF_COMPLETIONS="${brew_prefix}/etc/bash_completion.d"
+
+  # Find correct completions path if ZSH is used
+  if [ -n "$ZSH_VERSION" ]; then
+    ASDF_COMPLETIONS="${brew_prefix}/share/zsh/site-functions"
+  else
+    ASDF_COMPLETIONS="${brew_prefix}/etc/bash_completion.d"
+  fi
   unset brew_prefix
 fi
 
@@ -21,7 +27,11 @@ if [[ -f "$ASDF_DIR/asdf.sh" ]]; then
   . "$ASDF_DIR/asdf.sh"
 
   # Load completions
-  if [[ -f "$ASDF_COMPLETIONS/asdf.bash" ]]; then
-    . "$ASDF_COMPLETIONS/asdf.bash"
+  if [ -n "$ZSH_VERSION" ]; then
+    source "$ASDF_COMPLETIONS/_asdf"
+  else
+    if [[ -f "$ASDF_COMPLETIONS/asdf.bash" ]]; then
+      . "$ASDF_COMPLETIONS/asdf.bash"
+    fi
   fi
 fi


### PR DESCRIPTION
If ZSH is used, it's better to use the completions of the shell.
If ZSH isn't used, it will used the bash completions by default.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x ] The PR title is descriptive.
- [ x ] The PR doesn't replicate another PR which is already open.
- [ x ] I have read the contribution guide and followed all the instructions.
- [ x ] The code follows the code style guide detailed in the wiki.
- [ x ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x ] The code is stable and I have tested it myself, to the best of my abilities.
- [ x ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Use correct completion path if ZSH is used

## Other comments:

By default it will use bash completion
