### PR TITLE
feat(symfony2): Simplify bin/console script location discovery

### DIFF
--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -1,7 +1,13 @@
 # Symfony2 basic command completion
 
 _symfony_console () {
-  echo "php $(find . -maxdepth 2 -mindepth 1 -name 'console' -type f | head -n 1)"
+  if [[ -f "bin/console" || -h "bin/console" ]]; then
+    echo "php bin/console"
+  elif [[ -f "app/console" || -h "app/console" ]]; then
+    echo "php app/console"
+  else
+    echo "php $(find . -maxdepth 2 -mindepth 1 -name 'console' -type f | head -n 1)"
+  fi
 }
 
 _symfony2_get_command_list () {

--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -6,7 +6,7 @@ _symfony_console () {
   elif [[ -f "app/console" || -h "app/console" ]]; then
     echo "php app/console"
   else
-    echo "php $(find . -maxdepth 2 -mindepth 1 -name 'console' -type f | head -n 1)"
+    echo "symfony-console-not-found"
   fi
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Based on the contents of the current directory, either return a `bin/console`, `app/console`, that are essentially the two most likely location for a Symfony console script to exist.
- In case console is not found in either location, fail with an error that contains a somewhat-informative text `symfony-console-not-found`.

## Other comments:

- Removal of find-based fallback mechanism is done to avoid running a somewhat expensive find command in a directory that has nothing to do with symfony (intentionally or otherwise), in which case, `php` interpreter would run **with no arguments**, or in a directory that contains _many_ subdirectories, to little or no effect.
