### PR TITLE
feat(lib): support for tmux pane title

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -22,7 +22,8 @@ function title {
       print -Pn "\e]1;${1:q}\a" # set tab name
       ;;
     screen*|tmux*)
-      print -Pn "\ek${1:q}\e\\" # set screen hardstatus
+      print -Pn "\e]2;${2:q}\e\\" # set tmux pane title
+      print -Pn "\ek${1:q}\e\\" # set screen hardstatus/tmux window name if `allow-rename` is on
       ;;
     *)
       if [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add comment for better understanding
- Add escape sequence for setting tmux pane title

## Other comments:

As described in the [tmux man page](http://man.openbsd.org/OpenBSD-current/man1/tmux.1#NAMES_AND_TITLES), tmux has pane title. Currently, that pane title is only showing hostname for zsh, because zsh not editing the title with the current termsupport.

This PR adding escape sequence as described in the man page to set pane title.
This PR also add new comment for the current escape sequence for editing window name, that escape sequence would take effect/renaming tmux window name only if tmux configured with `set -g allow-rename on`.

### Before:
![image](https://user-images.githubusercontent.com/20012970/188345783-f6128b0b-d8be-4e80-8107-b87253c33971.png)
_all the tmux pane title is set to the default, which is only hostname, zsh not set the tmux pane title_

### After:
![image](https://user-images.githubusercontent.com/20012970/188345466-01366e85-b532-49e5-9086-da1de7c8efea.png)
_all the tmux pane title now set by zsh_

