### PR TITLE
fix(brew): do not source `brew shellenv` if already on path

### DIFF
--- a/plugins/brew/README.md
+++ b/plugins/brew/README.md
@@ -10,7 +10,10 @@ plugins=(... brew)
 
 ## Shellenv
 
-This plugin also executes `brew shellenv` at plugin load to set up many useful variables, such as `HOMEBREW_PREFIX` or `HOMEBREW_REPOSITORY`.
+If `brew` is not found in the PATH, this plugin will attempt to find it in common
+locations, and execute `brew shellenv` to set the environment appropriately.
+This plugin will also export `HOMEBREW_PREFIX="$(brew --prefix)"` if not previously
+defined for convenience.
 
 ## Aliases
 

--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -10,17 +10,20 @@ if (( ! $+commands[brew] )); then
   else
     return
   fi
+
+  # Only add Homebrew installation to PATH, MANPATH, and INFOPATH if brew is
+  # not already on the path, to prevent duplicate entries. This aligns with
+  # the behavior of the brew installer.sh post-install steps.
+  eval "$("$BREW_LOCATION" shellenv)"
+  unset BREW_LOCATION
 fi
 
 if [[ -z "$HOMEBREW_PREFIX" ]]; then
-  if [[ -z $BREW_LOCATION ]]; then
-    eval "$(brew shellenv)"
-  else
-    eval "$("$BREW_LOCATION" shellenv)"
-  fi
+  # Maintain compatability with potential custom user profiles, where we had
+  # previously relied on always sourcing shellenv. OMZ plugins should not rely
+  # on this to be defined due to out of order processing.
+  export HOMEBREW_PREFIX="$(brew --prefix)"
 fi
-
-unset BREW_LOCATION
 
 alias bcubc='brew upgrade --cask && brew cleanup'
 alias bcubo='brew update && brew outdated --cask'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

This changes the brew plugin to only source `brew shellenv` if brew cannot be found in `PATH`. This aligns with the brew installer.sh post install steps, and will prevent duplicate entries for `/usr/local/bin` in PATH on MacOS Intel.

The plugin will continue to export `HOMEBREW_PREFIX` for custom user config which previously relied on the behavior.

Fixes #11166
