### PR TITLE
fix(avit): replace deprecated GREP_COLOR

### DIFF
--- a/themes/avit.zsh-theme
+++ b/themes/avit.zsh-theme
@@ -82,4 +82,4 @@ ZSH_THEME_GIT_TIME_SINCE_COMMIT_NEUTRAL="%{$fg[white]%}"
 # LS colors, made with https://geoff.greer.fm/lscolors/
 export LSCOLORS="exfxcxdxbxegedabagacad"
 export LS_COLORS='di=34;40:ln=35;40:so=32;40:pi=33;40:ex=31;40:bd=34;46:cd=34;43:su=0;41:sg=0;46:tw=0;42:ow=0;43:'
-export GREP_COLOR='1;33'
+export GREP_COLORS='mt=1;33'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] ~~If the code introduces new aliases, I provide a valid use case for all plugin users down below.~~

## Changes:

- fix(avit): Replace deprecated GREP_COLOR

## Other comments:

Fixes a warning in grep:
```
grep: warning: GREP_COLOR='1;33' is deprecated; use GREP_COLORS='mt=1;33'
```

GREP_COLOR was deprecated in grep 3.8.  https://git.savannah.gnu.org/cgit/grep.git/commit/?id=4ac5fa8959c6366f64815de3dd94e1327242af4a