### PR TITLE
fix(git): remove redundant escapes from WIP commit message

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -176,7 +176,7 @@ plugins=(... git)
 | gtv                  | git tag \| sort -V                                                                                                               |
 | gtl                  | gtl(){ git tag --sort=-v:refname -n -l ${1}* }; noglob gtl                                                                       |
 | gunignore            | git update-index --no-assume-unchanged                                                                                           |
-| gunwip               | git log -n 1 \| grep -q -c "\-\-wip\-\-" && git reset HEAD~1                                                                     |
+| gunwip               | git log -n 1 \| grep -q -- "--wip--" && git reset HEAD~1                                                                     |
 | gup                  | git pull --rebase                                                                                                                |
 | gupv                 | git pull --rebase -v                                                                                                             |
 | gupa                 | git pull --rebase --autostash                                                                                                    |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -302,7 +302,7 @@ alias gtv='git tag | sort -V'
 alias gtl='gtl(){ git tag --sort=-v:refname -n -l "${1}*" }; noglob gtl'
 
 alias gunignore='git update-index --no-assume-unchanged'
-alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
+alias gunwip='git log -n 1 | grep -q -c -- "--wip--" && git reset HEAD~1'
 alias gup='git pull --rebase'
 alias gupv='git pull --rebase -v'
 alias gupa='git pull --rebase --autostash'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Remove redundant escaping of WIP commit message for `gwip` and `gunwip`.

## Other comments:

When running `gunwip` I get the following error, three times:

    grep: warning: stray \ before -

This appears to be due to the second, third and fourth hyphens in `--wip--` being escaped when only the first needs to be. This PR addresses these warnings by removing the need to escape the hyphens entirely.
