### PR TITLE
fix(brew): renamed buf alias to bfu

### DIFF
--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -29,7 +29,7 @@ alias brewsp='brew list --pinned'
 alias bubc='brew upgrade && brew cleanup'
 alias bubo='brew update && brew outdated'
 alias bubu='bubo && bubc'
-alias buf='brew upgrade --formula'
+alias bfu='brew upgrade --formula'
 
 function brews() {
   local formulae="$(brew leaves | xargs brew deps --installed --for-each)"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- renamed `buf` alias to `bfu`

## Other comments:

The alias `buf` collides with the protobuf tooling (buf)[https://buf.build/].

This commit renames the `buf` alias to `bfu` (`brew upgrade --formula`) so its semantically more aligned with `bcu` (`brew upgrade --cask`) as well as to avoid command collision especially with existing scripts that refers to `buf` as the tool and not the alias.

Fixes #11169 
