### PR TITLE
feat(aws): load profiles from credentials file

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -146,7 +146,9 @@ function aws_change_access_key() {
 }
 
 function aws_profiles() {
-  aws --no-cli-pager configure list-profiles
+  aws --no-cli-pager configure list-profiles 2> /dev/null && return
+  [[ -r "${AWS_CONFIG_FILE:-$HOME/.aws/config}" ]] || return 1
+  grep --color=never -Eo '\[.*\]' "${AWS_CONFIG_FILE:-$HOME/.aws/config}" | sed -E 's/^[[:space:]]*\[(profile)?[[:space:]]*([^[:space:]]+)\][[:space:]]*$/\2/g'
 }
 
 function _aws_profiles() {

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -146,7 +146,7 @@ function aws_change_access_key() {
 }
 
 function aws_profiles() {
-  AWS_PAGER="" aws configure list-profiles
+  aws --no-cli-pager configure list-profiles
 }
 
 function _aws_profiles() {

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -146,8 +146,7 @@ function aws_change_access_key() {
 }
 
 function aws_profiles() {
-  [[ -r "${AWS_CONFIG_FILE:-$HOME/.aws/config}" ]] || return 1
-  grep --color=never -Eo '\[.*\]' "${AWS_CONFIG_FILE:-$HOME/.aws/config}" | sed -E 's/^[[:space:]]*\[(profile)?[[:space:]]*([^[:space:]]+)\][[:space:]]*$/\2/g'
+  AWS_PAGER="" aws configure list-profiles
 }
 
 function _aws_profiles() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Use `aws configure list-profiles` to list the available profiles instead of manually parsing the config files.

## Other comments:

Using `aws configure list-profiles` makes sure we parse both config and credentials files.
Doing so will also make the function not prone to future changes of file format or creating / removing configurations files by AWS CLI.

Fixes #8472
