### PR TITLE
perf(nvm): source nvm async

### DIFF
--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -13,14 +13,14 @@ fi
 
 if [[ -f "$NVM_DIR/nvm.sh" ]]; then
   # Load nvm if it exists in $NVM_DIR
-  source "$NVM_DIR/nvm.sh" ${NVM_LAZY+"--no-use"}
+  source "$NVM_DIR/nvm.sh" ${NVM_LAZY+"--no-use"} &|
 elif (( $+commands[brew] )); then
   # Otherwise try to load nvm installed via Homebrew
   # User can set this if they have an unusual Homebrew setup
   NVM_HOMEBREW="${NVM_HOMEBREW:-${HOMEBREW_PREFIX:-$(brew --prefix)}/opt/nvm}"
   # Load nvm from Homebrew location if it exists
   if [[ -f "$NVM_HOMEBREW/nvm.sh" ]]; then
-    source "$NVM_HOMEBREW/nvm.sh" ${NVM_LAZY+"--no-use"}
+    source "$NVM_HOMEBREW/nvm.sh" ${NVM_LAZY+"--no-use"} &|
   else
     return
   fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Source `nvm` in an async way. This `nvm.sh` takes 50ms even if using `NVM_LAZY` so let's load it asyncronously.