### PR TITLE
fix(nvm): source nvm script only when used

### DIFF
--- a/plugins/nvm/README.md
+++ b/plugins/nvm/README.md
@@ -22,9 +22,9 @@ These settings should go in your zshrc file, before Oh My Zsh is sourced:
   nvm has been installed, regardless of chip architecture, use `NVM_HOMEBREW=$(brew --prefix nvm)`.
 
 - **`NVM_LAZY`**: if you want the plugin to defer the load of nvm to speed-up the start of your zsh session,
-  set `NVM_LAZY` to `1`. This will use the `--no-use` parameter when loading nvm, and will create a function
-  for `node`, `npm`, `yarn`, and the command(s) specified by `NVM_LAZY_CMD`, so when you call either of them,
-  nvm will load with `nvm use default`.
+  set `NVM_LAZY` to `1`. This will source nvm script only when using it, and will create a function for `node`,
+  `npm`, `pnpm`, `yarn`, and the command(s) specified by `NVM_LAZY_CMD`, so when you call either of them,
+  nvm will be loaded and run with default version.
 
 - **`NVM_LAZY_CMD`**: if you want additional command(s) to trigger lazy loading of nvm, set `NVM_LAZY_CMD` to
   the command or an array of the commands.


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Source `nvm` in an async way. This `nvm.sh` takes 50ms even if using `NVM_LAZY` so let's load it only when needs to be used the first time

closes #11042