### PR TITLE
Add auto-completion plugin for kubeadm

### DIFF
--- a/plugins/kubeadm/README.md
+++ b/plugins/kubeadm/README.md
@@ -1,0 +1,10 @@
+# kubeadm plugin
+
+This plugin adds completion for the [kubernetes cluster creator](https://kubernetes.io/docs/reference/setup-tools/kubeadm/).
+Kubeadm is a tool built to provide kubeadm init and kubeadm join as best-practice "fast paths" for creating Kubernetes clusters.
+
+To use it, add `kubeadm` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... kubeadm)
+```

--- a/plugins/kubeadm/kubeadm.plugin.zsh
+++ b/plugins/kubeadm/kubeadm.plugin.zsh
@@ -1,0 +1,11 @@
+if (( $+commands[kubeadm] )); then
+  # If the completion file does not exist, generate it and then source it
+  # Otherwise, source it and regenerate in the background
+  if [[ ! -f "$ZSH_CACHE_DIR/completions/_kubeadm" ]]; then
+    kubeadm completion zsh | tee "$ZSH_CACHE_DIR/completions/_kubeadm" >/dev/null
+    source "$ZSH_CACHE_DIR/completions/_kubeadm"
+  else
+    source "$ZSH_CACHE_DIR/completions/_kubeadm"
+    kubeadm completion zsh | tee "$ZSH_CACHE_DIR/completions/_kubeadm" >/dev/null &|
+  fi
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add simple plugin for kubeadm auto-completion
- No alias added

## Other comments:

This plugin currently is useful only on Linux as the tool is not available on other OS's.

