### PR TITLE
fix(npm): ignore `rm` alias

### DIFF
--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -1,5 +1,5 @@
 (( $+commands[npm] )) && {
-  rm -f "${ZSH_CACHE_DIR:-$ZSH/cache}/npm_completion"
+  command rm -f "${ZSH_CACHE_DIR:-$ZSH/cache}/npm_completion"
 
   _npm_completion() {
     local si=$IFS


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- npm plugin: disregard `rm` alias if set.

## Other comments:

See also: #11156.
