### PR TITLE
fix(per-directory-history): prevent adding an empty command to history

### DIFF
--- a/plugins/per-directory-history/per-directory-history.zsh
+++ b/plugins/per-directory-history/per-directory-history.zsh
@@ -112,6 +112,12 @@ function _per-directory-history-change-directory() {
 }
 
 function _per-directory-history-addhistory() {
+  cmd=$*
+  len=${#cmd}
+  if (( len < 2 )); then
+    return
+  fi
+
   # respect hist_ignore_space
   if [[ -o hist_ignore_space ]] && [[ "$1" == \ * ]]; then
       true


### PR DESCRIPTION

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Prevent adding an empty command to history in per-directory-history plugin.
