### PR TITLE
Removing duplicate rebase alias from plugins and README.md

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -118,8 +118,7 @@ plugins=(... git)
 | gpd                  | git push --dry-run                                                                                                               |
 | gpf                  | git push --force-with-lease                                                                                                      |
 | gpf!                 | git push --force                                                                                                                 |
-| gpoat                | git push origin --all && git push origin --tags                                                                                  |
-| gpr                  | git pull --rebase                                                                                                                |
+| gpoat                | git push origin --all && git push origin --tags                                                                                  |                                                                                                                |
 | gpu                  | git push upstream                                                                                                                |
 | gpv                  | git push -v                                                                                                                      |
 | gr                   | git remote                                                                                                                       |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -237,7 +237,6 @@ alias gpd='git push --dry-run'
 alias gpf='git push --force-with-lease'
 alias gpf!='git push --force'
 alias gpoat='git push origin --all && git push origin --tags'
-alias gpr='git pull --rebase'
 alias gpu='git push upstream'
 alias gpv='git push -v'
 


### PR DESCRIPTION
Removing duplicate rebase alias from plugins and README.md. Keeping things together also. Fixes #11104

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fix #11104

## Other comments:

...
