### PR TITLE
fix(gh): plugin only creates completion cache when needed

### DIFF
--- a/plugins/gh/README.md
+++ b/plugins/gh/README.md
@@ -17,7 +17,7 @@ plugin is loaded, which is usually when you start up a new terminal emulator.
 
 The cache is stored at:
 
-- `$ZSH/plugins/gh/_gh` completions script
+- `$ZSH_CACHE_DIR/completions/_gh` completions script
 
-- `$ZSH_CACHE_DIR/gh_version` version of GitHub CLI, used to invalidate
+- `$ZSH_CACHE_DIR/gh_cached_version` version of GitHub CLI, used to invalidate
   the cache.

--- a/plugins/gh/gh.plugin.zsh
+++ b/plugins/gh/gh.plugin.zsh
@@ -11,4 +11,21 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_gh" ]]; then
   _comps[gh]=_gh
 fi
 
-gh completion --shell zsh >| "$ZSH_CACHE_DIR/completions/_gh" &|
+# Cache gh completions
+#
+# - Caches the output of `gh completion --shell zsh` to $ZSH_CACHE_DIR/completions/_gh
+# - Refreshes when the version of gh changes
+function _gh_completions_cache() {
+  local gh_version version_cache completion_cache
+  version_cache="$ZSH_CACHE_DIR/gh_cached_version"
+  completion_cache="$ZSH_CACHE_DIR/completions/_gh"
+  gh_version=$(gh --version | awk '{print $3}')
+  if ! [ -f "$version_cache" ] || \
+     ! [ -f "$completion_cache" ] || \
+     [[ $(head -n 1 "$version_cache") != "$gh_version" ]]
+  then
+    echo "$gh_version" > "$version_cache"
+    gh completion --shell zsh >| "$ZSH_CACHE_DIR/completions/_gh" &|
+  fi
+}
+_gh_completions_cache


### PR DESCRIPTION
Completions were generated and cached on every shell opened. This fix caches the version the cache was last generated for and only runs the completion generator in case there is a mismatch or no completion cache file available.

Also fixed the readme, to state correct path for completions cache and version cached file.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- cache version of gh the completions were last cached for
- test if completion cache for cached version available
- only generate completions when version mismatch or no cache present

