### PR TITLE
fix(rust): plugin only create completion cache when needed

### DIFF
--- a/plugins/rust/rust.plugin.zsh
+++ b/plugins/rust/rust.plugin.zsh
@@ -18,9 +18,41 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_rustup" ]]; then
   _comps[rustup]=_rustup
 fi
 
-# Generate completion files in the background
-rustup completions zsh >| "$ZSH_CACHE_DIR/completions/_rustup" &|
-cat >| "$ZSH_CACHE_DIR/completions/_cargo" <<'EOF'
-#compdef cargo
-source "$(rustc +${${(z)$(rustup default)}[1]} --print sysroot)"/share/zsh/site-functions/_cargo
-EOF
+# Cache rustup completions
+#
+# - Caches the output of `rustup completions zsh` to $ZSH_CACHE_DIR/completions/_rustup
+# - Refreshes when the version of rustc changes
+function _rustup_completions_cache() {
+  local rustup_version version_cache completion_cache
+  version_cache="$ZSH_CACHE_DIR/rustc_cached_version"
+  completion_cache="$ZSH_CACHE_DIR/completions/_rustup"
+  rustup_version=$(rustc --version)
+  if ! [ -f "$version_cache" ] || \
+     ! [ -f "$completion_cache" ] || \
+     [[ $(head -n 1 "$version_cache") != "$rustup_version" ]]
+  then
+    echo "$rustup_version" > "$version_cache"
+    rustup completions zsh >| "$completion_cache" &|
+  fi
+}
+_rustup_completions_cache
+
+# Cache cargo completions
+#
+# - Caches cargo's completions to $ZSH_CACHE_DIR/completions/_cargo
+# - Refreshes when the version of rustc or cargo changes
+function _cargo_completions_cache() {
+  local cargo_version version_cache completion_cache
+  version_cache="$ZSH_CACHE_DIR/cargo_cached_version"
+  completion_cache="$ZSH_CACHE_DIR/completions/_cargo"
+  cargo_version="$(rustc --version) $(cargo -V)"
+  if ! [ -f "$version_cache" ] || \
+     ! [ -f "$completion_cache" ] || \
+     [[ $(head -n 1 "$version_cache") != "$cargo_version" ]]
+  then
+    echo "$cargo_version" > "$version_cache"
+    echo '#compdef cargo' > "$completion_cache"
+    echo "source $(rustc +${${(z)$(rustup default)}[1]} --print sysroot)/share/zsh/site-functions/_cargo" >> "$completion_cache"
+  fi
+}
+_cargo_completions_cache


### PR DESCRIPTION
Completions were generated and cached on every shell opened. This fix caches the version the cache was last generated for and only runs the completion generator in case there is a mismatch or no completion cache file available.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- cache version of rustc and cargo the completions were last cached for
- test if completion cache for cached version available
- only generate completions when version mismatch or no cache present

