### PR TITLE
fix(git-auto-fetch): avoid password prompt with `GIT_TERMINAL_PROMPT=0`

### DIFF
--- a/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
+++ b/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
@@ -28,6 +28,7 @@ function git-fetch-all {
     # Fetch all remotes (avoid ssh passphrase prompt)
     date -R &>! "$gitdir/FETCH_LOG"
     GIT_SSH_COMMAND="command ssh -o BatchMode=yes" \
+      GIT_TERMINAL_PROMPT=0 \
       command git fetch --all 2>/dev/null &>> "$gitdir/FETCH_LOG"
   ) &|
 }

--- a/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
+++ b/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
@@ -28,7 +28,7 @@ function git-fetch-all {
     # Fetch all remotes (avoid ssh passphrase prompt)
     date -R &>! "$gitdir/FETCH_LOG"
     GIT_SSH_COMMAND="command ssh -o BatchMode=yes" \
-      GIT_TERMINAL_PROMPT=0 \
+    GIT_TERMINAL_PROMPT=0 \
       command git fetch --all 2>/dev/null &>> "$gitdir/FETCH_LOG"
   ) &|
 }


### PR DESCRIPTION
If the remote is using HTTP authentication (and does not use a credential helper) it triggers writes to the terminal that cannot be responded to. This happens every time the repository is fetched by git-auto-fetch.

`GIT_TERMINAL_PROMPT=0` prevents prompts to the terminal. The man page explicitly names HTTP authentication as an example: https://git-scm.com/docs/git#Documentation/git.txt-codeGITTERMINALPROMPTcode

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Adds environment variable to `git fetch` command in the git-auto-fetch plugin

## Other comments:

Actually I am not 100% on if the indentation is correct. I believe it is though.
Also would be great if the PR would count for the Hacktoberfest even tough it is just one line :)