### PR TITLE
fix(plugin/virtualenvwrapper): Fix incomplete virtualenvwrapper.sh detection

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -6,7 +6,8 @@ function {
       /usr/local/bin/virtualenvwrapper{_lazy,}.sh \
       /etc/bash_completion.d/virtualenvwrapper \
       /usr/share/bash-completion/completions/virtualenvwrapper \
-      $HOME/.local/bin/virtualenvwrapper.sh
+      $HOME/.local/bin/virtualenvwrapper.sh \
+      /usr/bin/virtualenvwrapper.sh
     do
         if [[ -f "$virtualenvwrapper" ]]; then
             source "$virtualenvwrapper"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
On Arch Linux (at least) the `virtualenvwrapper.sh` script is installed in `/usr/bin/virtualenvwrapper.sh`, after enabling `virtualenvwrapper` plugin on Oh My Zsh the following error is displayed:

```bash
$ source ~/.zshrc
[oh-my-zsh] virtualenvwrapper plugin: Cannot find virtualenvwrapper.sh.
 Please install with `pip install virtualenvwrapper`

$ pip list
Package           Version
----------------- -----------------
[...]
virtualenv        20.16.2
virtualenv-clone  0.5.7
virtualenvwrapper 4.8.4
```

I added the path `/usr/bin/virtualenvwrapper.sh` on `virtualenvwrapper.plugin.zsh` because it was not included in https://github.com/ohmyzsh/ohmyzsh/pull/8521 in order to fix this error.
