### PR TITLE
feat(is_os): functions to test for major OS

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -33,6 +33,26 @@ function open_command() {
   ${=open_cmd} "$@" &>/dev/null
 }
 
+# CPU architecture
+function is_arm64 { [[ "$CPUTYPE" == arm64 ]] }
+function is_amd64 { [[ "$CPUTYPE" == x86_64 ]] }
+# linux
+function is_linux { [[ "$OSTYPE" == linux* ]]; }
+function is_android { [[ "$OSTYPE" == linux-android* ]]; }
+# bsd derivates
+function is_netbsd() { [[ "$OSTYPE" == netbsd* ]]; }
+function is_openbsd() { [[ "$OSTYPE" == openbsd* ]]; }
+function is_freebsd() { [[ "$OSTYPE" == freebsd* ]]; }
+function is_mac() { [[ "$OSTYPE" == darwin* ]]; }
+function is_mac_arm() { is_mac && is_arm64; }
+function is_mac_intel() { is_mac && is_amd64; }
+function is_bsd() { [[ "$OSTYPE" == (darwin|freebsd|openbsd|netbsd)* ]]; }
+function is_solaris { [[ "$OSTYPE" == solaris* ]]; }
+# on windows
+function is_cygwin { [[ "$OSTYPE" == cygwin* ]]; }
+function is_msys { [[ "$OSTYPE" == msys* ]]; }
+function is_windows { [[ "$OSTYPE" == (cygwin|msys)* ]]; }
+
 # take functions
 
 # mkcd is equivalent to takedir


### PR DESCRIPTION
All over oh-my-zsh I found plenty of functions and plugins testing for the current OS or Platform.

For this PR I basically made simple is_[OS] functions that can be used anywhere in plugins or oh-my-zsh code, instead of repeating these over and over again.

I basically need such tests often, because my personal custom oh my zsh additions run on macOS with Intel and M1 chips plus on different linux's.

Functions:

- is_linux - the CPUTYPE env is linux*
- is_android - the CPUTYPE env is linux-android*
- is_netbsd the CPUTYPE env is netbsd*
- is_openbsd - the CPUTYPE env is openbsd*
- is_freebsd - the CPUTYPE env is freebsd*
- is_mac - the CPUTYPE env is darwin*
- is_mac_arm - it is darwin and has CPUTYPE arm64
- is_mac_intel - it is darwin and has CPUTYPE x86_64
- is_bsd - any BSD like OS - the CPUTYPE env is (darwin|freebsd|openbsd|netbsd)*
- is_solaris - the CPUTYPE env is solaris*
- is_cygwin - the CPUTYPE env is cygwin*
- is_msys - the CPUTYPE env is msys*
- is_windows - the CPUTYPE env is (cygwin|msys)*
- is_arm64 - the CPUTYPE env is arm64
- is_amd64 - the CPUTYPE env is x86_64

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

