### PR TITLE
feat(git): add `gpsupf` alias

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -89,6 +89,7 @@ plugins=(... git)
 | ggsup                | git branch --set-upstream-to=origin/$(git_current_branch)                                                                                                                                |
 | ggu                  | git pull --rebase origin $(current_branch)                                                                                                                                               |
 | gpsup                | git push --set-upstream origin $(git_current_branch)                                                                                                                                     |
+| gpsupf                | git push --set-upstream origin $(git_current_branch) --force-with-lease                                                                                                                                     |
 | ghh                  | git help                                                                                                                                                                                 |
 | gignore              | git update-index --assume-unchanged                                                                                                                                                      |
 | gignored             | git ls-files -v \| grep "^[[:lower:]]"                                                                                                                                                   |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -199,6 +199,7 @@ alias ggpush='git push origin "$(git_current_branch)"'
 
 alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'
 alias gpsup='git push --set-upstream origin $(git_current_branch)'
+alias gpsupf='git push --set-upstream origin $(git_current_branch) --force-with-lease'
 
 alias ghh='git help'
 


### PR DESCRIPTION
```gpsupf``` works great in most cases when want to sync force upstream branch with the current local branch for the first time.

## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
* Introduce alias gpsupf to 'git push --set-upstream origin $(git_current_branch) --force'
* Update README to reflect the new alias