### PR TITLE
fix(pip): fix `pipupall` error with `freeze` format

### DIFF
--- a/plugins/pip/pip.plugin.zsh
+++ b/plugins/pip/pip.plugin.zsh
@@ -94,12 +94,12 @@ alias pipreq="pip freeze > requirements.txt"
 # Install packages from requirements file
 alias pipir="pip install -r requirements.txt"
 
-# Update all installed packages
+# Upgrade all installed packages
 function pipupall {
   # non-GNU xargs does not support nor need `--no-run-if-empty`
   local xargs="xargs --no-run-if-empty"
   xargs --version 2>/dev/null | grep -q GNU || xargs="xargs"
-  pip list --outdated --format freeze | cut -d= -f1 | ${=xargs} pip install --upgrade
+  pip list -o | awk "NR>=3" | cut -d " " -f 1 | ${=xargs} pip install -U
 }
 
 # Uninstalled all installed packages

--- a/plugins/pip/pip.plugin.zsh
+++ b/plugins/pip/pip.plugin.zsh
@@ -99,7 +99,7 @@ function pipupall {
   # non-GNU xargs does not support nor need `--no-run-if-empty`
   local xargs="xargs --no-run-if-empty"
   xargs --version 2>/dev/null | grep -q GNU || xargs="xargs"
-  pip list -o | awk "NR>=3" | cut -d " " -f 1 | ${=xargs} pip install -U
+  pip list --outdated | awk 'NR > 2 { print $1 }' | ${=xargs} pip install --upgrade
 }
 
 # Uninstalled all installed packages


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

Fix #11279 
