### PR TITLE
docs: fix some capitalization typos

### DIFF
--- a/plugins/coffee/_coffee
+++ b/plugins/coffee/_coffee
@@ -1,6 +1,6 @@
 #compdef coffee
 # ------------------------------------------------------------------------------
-# Copyright (c) 2011 Github zsh-users - https://github.com/zsh-users
+# Copyright (c) 2011 GitHub zsh-users - https://github.com/zsh-users
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/plugins/docker-machine/_docker-machine
+++ b/plugins/docker-machine/_docker-machine
@@ -335,9 +335,9 @@ _docker-machine() {
         '--tls-ca-key[Private key to generate certificates]:file:_files' \
         '--tls-client-cert[Client cert to use for TLS]:file:_files' \
         '--tls-client-key[Private key used in client TLS auth]:file:_files' \
-        '--github-api-token[Token to use for requests to the Github API]' \
+        '--github-api-token[Token to use for requests to the GitHub API]' \
         '--native-ssh[Use the native (Go-based) SSH implementation.]' \
-        '--bugsnag-api-token[BugSnag API token for crash reporting]' \
+        '--bugsnag-api-token[Bugsnag API token for crash reporting]' \
         '(- :)'{-v,--version}'[Print the version]' \
         "(-): :->command" \
         "(-)*:: :->option-or-argument" && ret=0

--- a/plugins/frontend-search/_frontend
+++ b/plugins/frontend-search/_frontend
@@ -37,7 +37,7 @@ function _frontend() {
     'lodash: Search in Lo-Dash website'
     'mdn: Search in MDN website'
     'nodejs: Search in NodeJS website'
-    'npmjs: Search in NPMJS website'
+    'npmjs: Search in npmjs website'
     'packagephobia: Search in Packagephobia website'
     'qunit: Search in Qunit website'
     'reactjs: Search in React website'

--- a/plugins/httpie/_httpie
+++ b/plugins/httpie/_httpie
@@ -1,6 +1,6 @@
 #compdef http
 # ------------------------------------------------------------------------------
-# Copyright (c) 2015 Github zsh-users - http://github.com/zsh-users
+# Copyright (c) 2015 GitHub zsh-users - http://github.com/zsh-users
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/plugins/kitchen/_kitchen
+++ b/plugins/kitchen/_kitchen
@@ -1,6 +1,6 @@
 #compdef kitchen
 # ------------------------------------------------------------------------------
-# Copyright (c) 2014 Github zsh-users - https://github.com/zsh-users
+# Copyright (c) 2014 GitHub zsh-users - https://github.com/zsh-users
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/plugins/pod/_pod
+++ b/plugins/pod/_pod
@@ -6,7 +6,7 @@
 
 # -----------------------------------------------------------------------------
 #          FILE:  _pod
-#   DESCRIPTION:  Cocoapods (0.33.1) autocomplete plugin for Oh-My-Zsh
+#   DESCRIPTION:  CocoaPods (0.33.1) autocomplete plugin for Oh-My-Zsh
 #                 https://cocoapods.org
 #                 Generated with `pod --completion-script
 #        AUTHOR:  Alexandre Joly (alexandre.joly@mekanics.ch)

--- a/plugins/rails/_rails
+++ b/plugins/rails/_rails
@@ -1,6 +1,6 @@
 #compdef rails
 # ------------------------------------------------------------------------------
-# Copyright (c) 2016 Github zsh-users - http://github.com/zsh-users
+# Copyright (c) 2016 GitHub zsh-users - http://github.com/zsh-users
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/plugins/ripgrep/_ripgrep
+++ b/plugins/ripgrep/_ripgrep
@@ -591,7 +591,7 @@ _rg "$@"
 ################################################################################
 
 # ------------------------------------------------------------------------------
-# Copyright (c) 2011 Github zsh-users - http://github.com/zsh-users
+# Copyright (c) 2011 GitHub zsh-users - http://github.com/zsh-users
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/plugins/scala/_scala
+++ b/plugins/scala/_scala
@@ -1,6 +1,6 @@
 #compdef scala scalac
 # ------------------------------------------------------------------------------
-# Copyright (c) 2012 Github zsh-users - https://github.com/zsh-users
+# Copyright (c) 2012 GitHub zsh-users - https://github.com/zsh-users
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -31,7 +31,7 @@ function xx {
   open -a "Xcode.app" "$@"
 }
 
-# "XCode-SELect by Version" - select Xcode by just version number
+# "Xcode-Select by Version" - select Xcode by just version number
 # Uses naming convention:
 #  - different versions of Xcode are named Xcode-<version>.app or stored
 #     in a folder named Xcode-<version>

--- a/themes/refined.zsh-theme
+++ b/themes/refined.zsh-theme
@@ -11,11 +11,11 @@
 # more about both of these fantastic two people here:
 #
 # Sindre Sorhus
-#   Github:   https://github.com/sindresorhus
+#   GitHub:   https://github.com/sindresorhus
 #   Twitter:  https://twitter.com/sindresorhus
 #
 # Julien Nicoulaud
-#   Github:   https://github.com/nicoulaj
+#   GitHub:   https://github.com/nicoulaj
 #   Twitter:  https://twitter.com/nicoulaj
 #
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Just a few minor capitalization fixes, e.g. `Github` -> `GitHub`.