### PR TITLE
feat(swiftpm): update completion for Swift 5.7

### DIFF
--- a/plugins/swiftpm/README.md
+++ b/plugins/swiftpm/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This plugin provides a few utilities that make you faster on your daily work with the [Swift Package Manager](https://github.com/apple/swift-package-manager), as well as autocompletion for Swift 5.1.
+This plugin provides a few utilities that make you faster on your daily work with the [Swift Package Manager](https://github.com/apple/swift-package-manager), as well as autocompletion for Swift 5.7.
 
 To start using it, add the `swiftpm` plugin to your `plugins` array in `~/.zshrc`:
 

--- a/plugins/swiftpm/_swift
+++ b/plugins/swiftpm/_swift
@@ -1,474 +1,876 @@
 #compdef swift
 local context state state_descr line
+_swift_commandname=$words[1]
 typeset -A opt_args
 
 _swift() {
-    _arguments -C \
-        '(- :)--help[prints the synopsis and a list of the most commonly used commands]: :->arg' \
-        '(-): :->command' \
-        '(-)*:: :->arg' && return
-
+    integer ret=1
+    local -a args
+    args+=(
+        '(-h --help)'{-h,--help}'[Show help information.]'
+        '(-): :->command'
+        '(-)*:: :->arg'
+    )
+    _arguments -w -s -S $args[@] && ret=0
     case $state in
         (command)
-            local tools
-            tools=(
-                'build:build sources into binary products'
-                'run:build and run an executable product'
-                'package:perform operations on Swift packages'
-                'test:build and run tests'
+            local subcommands
+            subcommands=(
+                'run:Build and run an executable product'
+                'build:Build sources into binary products'
+                'test:Build and run tests'
+                'package:Perform operations on Swift packages'
+                'help:Show subcommand help information.'
             )
-            _alternative \
-                'tools:common:{_describe "tool" tools }' \
-                'compiler: :_swift_compiler' && _ret=0
+            _describe "subcommand" subcommands
             ;;
         (arg)
             case ${words[1]} in
-                (build)
-                    _swift_build
-                    ;;
                 (run)
                     _swift_run
                     ;;
-                (package)
-                    _swift_package
+                (build)
+                    _swift_build
                     ;;
                 (test)
                     _swift_test
                     ;;
-                (*)
-                    _swift_compiler
+                (package)
+                    _swift_package
+                    ;;
+                (help)
+                    _swift_help
                     ;;
             esac
             ;;
     esac
+
+    return ret
 }
 
-_swift_dependency() {
-    local dependencies
-    dependencies=( $(swift package completion-tool list-dependencies) )
-    _describe '' dependencies
-}
-
-_swift_executable() {
-    local executables
-    executables=( $(swift package completion-tool list-executables) )
-    _describe '' executables
-}
-
-# Generates completions for swift build
-#
-# In the final compdef file, set the following file header:
-#
-#     #compdef _swift_build
-#     local context state state_descr line
-#     typeset -A opt_args
-_swift_build() {
-    arguments=(
-        "-Xcc[Pass flag through to all C compiler invocations]:Pass flag through to all C compiler invocations: "
-        "-Xswiftc[Pass flag through to all Swift compiler invocations]:Pass flag through to all Swift compiler invocations: "
-        "-Xlinker[Pass flag through to all linker invocations]:Pass flag through to all linker invocations: "
-        "-Xcxx[Pass flag through to all C++ compiler invocations]:Pass flag through to all C++ compiler invocations: "
-        "(--configuration -c)"{--configuration,-c}"[Build with configuration (debug|release) ]: :{_values '' 'debug[build with DEBUG configuration]' 'release[build with RELEASE configuration]'}"
-        "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
-        "(--chdir -C)"{--chdir,-C}"[]: :_files"
-        "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
-        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
-        "--disable-prefetching[]"
-        "--skip-update[Skip updating dependencies from their remote during a resolution]"
-        "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
-        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
-        "--version[]"
-        "--destination[]: :_files"
-        "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
-        "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
-        "--static-swift-stdlib[Link Swift stdlib statically]"
-        "--force-resolved-versions[]"
-        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
-        "--enable-index-store[Enable indexing-while-building feature]"
-        "--disable-index-store[Disable indexing-while-building feature]"
-        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
-        "--enable-parseable-module-interfaces[]"
-        "--trace-resolver[]"
-        "(--jobs -j)"{--jobs,-j}"[The number of jobs to spawn in parallel during the build process]:The number of jobs to spawn in parallel during the build process: "
-        "--enable-test-discovery[Enable test discovery on platforms without Objective-C runtime]"
-        "--build-tests[Build both source and test targets]"
-        "--product[Build the specified product]:Build the specified product: "
-        "--target[Build the specified target]:Build the specified target: "
-        "--show-bin-path[Print the binary output path]"
-    )
-    _arguments $arguments && return
-}
-
-# Generates completions for swift run
-#
-# In the final compdef file, set the following file header:
-#
-#     #compdef _swift_run
-#     local context state state_descr line
-#     typeset -A opt_args
 _swift_run() {
-    arguments=(
-        ":The executable to run:_swift_executable"
-        "-Xcc[Pass flag through to all C compiler invocations]:Pass flag through to all C compiler invocations: "
-        "-Xswiftc[Pass flag through to all Swift compiler invocations]:Pass flag through to all Swift compiler invocations: "
-        "-Xlinker[Pass flag through to all linker invocations]:Pass flag through to all linker invocations: "
-        "-Xcxx[Pass flag through to all C++ compiler invocations]:Pass flag through to all C++ compiler invocations: "
-        "(--configuration -c)"{--configuration,-c}"[Build with configuration (debug|release) ]: :{_values '' 'debug[build with DEBUG configuration]' 'release[build with RELEASE configuration]'}"
-        "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
-        "(--chdir -C)"{--chdir,-C}"[]: :_files"
-        "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
-        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
-        "--disable-prefetching[]"
-        "--skip-update[Skip updating dependencies from their remote during a resolution]"
-        "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
-        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
-        "--version[]"
-        "--destination[]: :_files"
-        "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
-        "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
-        "--static-swift-stdlib[Link Swift stdlib statically]"
-        "--force-resolved-versions[]"
-        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
-        "--enable-index-store[Enable indexing-while-building feature]"
-        "--disable-index-store[Disable indexing-while-building feature]"
-        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
-        "--enable-parseable-module-interfaces[]"
-        "--trace-resolver[]"
-        "(--jobs -j)"{--jobs,-j}"[The number of jobs to spawn in parallel during the build process]:The number of jobs to spawn in parallel during the build process: "
-        "--enable-test-discovery[Enable test discovery on platforms without Objective-C runtime]"
-        "--skip-build[Skip building the executable product]"
-        "--build-tests[Build both source and test targets]"
-        "--repl[Launch Swift REPL for the package]"
+    integer ret=1
+    local -a args
+    args+=(
+        '--package-path[Specify the package path to operate on (default current directory). This changes the working directory before any other operation]:package-path:_files -/'
+        '--cache-path[Specify the shared cache directory path]:cache-path:_files -/'
+        '--config-path[Specify the shared configuration directory path]:config-path:_files -/'
+        '--security-path[Specify the shared security directory path]:security-path:_files -/'
+        '--scratch-path[Specify a custom scratch directory path (default .build)]:scratch-path:_files -/'
+        '--enable-dependency-cache[Use a shared cache when fetching dependencies]'
+        '--disable-dependency-cache[Use a shared cache when fetching dependencies]'
+        '--enable-build-manifest-caching'
+        '--disable-build-manifest-caching'
+        '--manifest-cache[Caching mode of Package.swift manifests (shared: shared cache, local: package'"'"'s build directory, none: disabled]:manifest-cache:'
+        '(--verbose -v)'{--verbose,-v}'[Increase verbosity to include informational output]'
+        '(--very-verbose --vv)'{--very-verbose,--vv}'[Increase verbosity to include debug output]'
+        '--disable-sandbox[Disable using the sandbox when executing subprocesses]'
+        '--enable-netrc[Load credentials from a .netrc file]'
+        '--disable-netrc[Load credentials from a .netrc file]'
+        '--netrc-file[Specify the .netrc file path.]:netrc-file:_files'
+        '--enable-keychain[Search credentials in macOS keychain]'
+        '--disable-keychain[Search credentials in macOS keychain]'
+        '--resolver-fingerprint-checking:resolver-fingerprint-checking:'
+        '--enable-prefetching'
+        '--disable-prefetching'
+        '(--force-resolved-versions --disable-automatic-resolution --only-use-versions-from-resolved-file)'{--force-resolved-versions,--disable-automatic-resolution,--only-use-versions-from-resolved-file}'[Only use versions from the Package.resolved file and fail resolution if it is out-of-date]'
+        '--skip-update[Skip updating dependencies from their remote during a resolution]'
+        '--disable-scm-to-registry-transformation[disable source control to registry transformation]'
+        '--use-registry-identity-for-scm[look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins]'
+        '--replace-scm-with-registry[look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible]'
+        '(--configuration -c)'{--configuration,-c}'[Build with configuration]:configuration:(debug release)'
+        '-Xcc[Pass flag through to all C compiler invocations]:Xcc:'
+        '-Xswiftc[Pass flag through to all Swift compiler invocations]:Xswiftc:'
+        '-Xlinker[Pass flag through to all linker invocations]:Xlinker:'
+        '-Xcxx[Pass flag through to all C++ compiler invocations]:Xcxx:'
+        '--triple:triple:'
+        '--sdk:sdk:_files -/'
+        '--toolchain:toolchain:_files -/'
+        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:'
+        '--auto-index-store[Enable or disable indexing-while-building feature]'
+        '--enable-index-store[Enable or disable indexing-while-building feature]'
+        '--disable-index-store[Enable or disable indexing-while-building feature]'
+        '--enable-parseable-module-interfaces'
+        '(--jobs -j)'{--jobs,-j}'[The number of jobs to spawn in parallel during the build process]:jobs:'
+        '--emit-swift-module-separately'
+        '--use-integrated-swift-driver'
+        '--experimental-explicit-module-build'
+        '--print-manifest-job-graph[Write the command graph for the build manifest as a graphviz file]'
+        '--build-system:build-system:(native xcode)'
+        '--enable-dead-strip[Disable/enable dead code stripping by the linker]'
+        '--disable-dead-strip[Disable/enable dead code stripping by the linker]'
+        '--static-swift-stdlib[Link Swift stdlib statically]'
+        '--no-static-swift-stdlib[Link Swift stdlib statically]'
+        '--repl[Launch Swift REPL for the package]'
+        '--debugger[Launch the executable in a debugger session]'
+        '--run[Launch the executable with the provided arguments]'
+        '--skip-build[Skip building the executable product]'
+        '--build-tests[Build both source and test targets]'
+        ':executable:{local -a list; list=(${(f)"$(swift package completion-tool list-executables)"}); _describe '''' list}'
+        ':arguments:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
-    _arguments $arguments && return
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
 }
 
-# Generates completions for swift package
-#
-# In the final compdef file, set the following file header:
-#
-#     #compdef _swift_package
-#     local context state state_descr line
-#     typeset -A opt_args
+_swift_build() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--package-path[Specify the package path to operate on (default current directory). This changes the working directory before any other operation]:package-path:_files -/'
+        '--cache-path[Specify the shared cache directory path]:cache-path:_files -/'
+        '--config-path[Specify the shared configuration directory path]:config-path:_files -/'
+        '--security-path[Specify the shared security directory path]:security-path:_files -/'
+        '--scratch-path[Specify a custom scratch directory path (default .build)]:scratch-path:_files -/'
+        '--enable-dependency-cache[Use a shared cache when fetching dependencies]'
+        '--disable-dependency-cache[Use a shared cache when fetching dependencies]'
+        '--enable-build-manifest-caching'
+        '--disable-build-manifest-caching'
+        '--manifest-cache[Caching mode of Package.swift manifests (shared: shared cache, local: package'"'"'s build directory, none: disabled]:manifest-cache:'
+        '(--verbose -v)'{--verbose,-v}'[Increase verbosity to include informational output]'
+        '(--very-verbose --vv)'{--very-verbose,--vv}'[Increase verbosity to include debug output]'
+        '--disable-sandbox[Disable using the sandbox when executing subprocesses]'
+        '--enable-netrc[Load credentials from a .netrc file]'
+        '--disable-netrc[Load credentials from a .netrc file]'
+        '--netrc-file[Specify the .netrc file path.]:netrc-file:_files'
+        '--enable-keychain[Search credentials in macOS keychain]'
+        '--disable-keychain[Search credentials in macOS keychain]'
+        '--resolver-fingerprint-checking:resolver-fingerprint-checking:'
+        '--enable-prefetching'
+        '--disable-prefetching'
+        '(--force-resolved-versions --disable-automatic-resolution --only-use-versions-from-resolved-file)'{--force-resolved-versions,--disable-automatic-resolution,--only-use-versions-from-resolved-file}'[Only use versions from the Package.resolved file and fail resolution if it is out-of-date]'
+        '--skip-update[Skip updating dependencies from their remote during a resolution]'
+        '--disable-scm-to-registry-transformation[disable source control to registry transformation]'
+        '--use-registry-identity-for-scm[look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins]'
+        '--replace-scm-with-registry[look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible]'
+        '(--configuration -c)'{--configuration,-c}'[Build with configuration]:configuration:(debug release)'
+        '-Xcc[Pass flag through to all C compiler invocations]:Xcc:'
+        '-Xswiftc[Pass flag through to all Swift compiler invocations]:Xswiftc:'
+        '-Xlinker[Pass flag through to all linker invocations]:Xlinker:'
+        '-Xcxx[Pass flag through to all C++ compiler invocations]:Xcxx:'
+        '--triple:triple:'
+        '--sdk:sdk:_files -/'
+        '--toolchain:toolchain:_files -/'
+        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:'
+        '--auto-index-store[Enable or disable indexing-while-building feature]'
+        '--enable-index-store[Enable or disable indexing-while-building feature]'
+        '--disable-index-store[Enable or disable indexing-while-building feature]'
+        '--enable-parseable-module-interfaces'
+        '(--jobs -j)'{--jobs,-j}'[The number of jobs to spawn in parallel during the build process]:jobs:'
+        '--emit-swift-module-separately'
+        '--use-integrated-swift-driver'
+        '--experimental-explicit-module-build'
+        '--print-manifest-job-graph[Write the command graph for the build manifest as a graphviz file]'
+        '--build-system:build-system:(native xcode)'
+        '--enable-dead-strip[Disable/enable dead code stripping by the linker]'
+        '--disable-dead-strip[Disable/enable dead code stripping by the linker]'
+        '--static-swift-stdlib[Link Swift stdlib statically]'
+        '--no-static-swift-stdlib[Link Swift stdlib statically]'
+        '--build-tests[Build both source and test targets]'
+        '--show-bin-path[Print the binary output path]'
+        '--target[Build the specified target]:target:'
+        '--product[Build the specified product]:product:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_test() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--package-path[Specify the package path to operate on (default current directory). This changes the working directory before any other operation]:package-path:_files -/'
+        '--cache-path[Specify the shared cache directory path]:cache-path:_files -/'
+        '--config-path[Specify the shared configuration directory path]:config-path:_files -/'
+        '--security-path[Specify the shared security directory path]:security-path:_files -/'
+        '--scratch-path[Specify a custom scratch directory path (default .build)]:scratch-path:_files -/'
+        '--enable-dependency-cache[Use a shared cache when fetching dependencies]'
+        '--disable-dependency-cache[Use a shared cache when fetching dependencies]'
+        '--enable-build-manifest-caching'
+        '--disable-build-manifest-caching'
+        '--manifest-cache[Caching mode of Package.swift manifests (shared: shared cache, local: package'"'"'s build directory, none: disabled]:manifest-cache:'
+        '(--verbose -v)'{--verbose,-v}'[Increase verbosity to include informational output]'
+        '(--very-verbose --vv)'{--very-verbose,--vv}'[Increase verbosity to include debug output]'
+        '--disable-sandbox[Disable using the sandbox when executing subprocesses]'
+        '--enable-netrc[Load credentials from a .netrc file]'
+        '--disable-netrc[Load credentials from a .netrc file]'
+        '--netrc-file[Specify the .netrc file path.]:netrc-file:_files'
+        '--enable-keychain[Search credentials in macOS keychain]'
+        '--disable-keychain[Search credentials in macOS keychain]'
+        '--resolver-fingerprint-checking:resolver-fingerprint-checking:'
+        '--enable-prefetching'
+        '--disable-prefetching'
+        '(--force-resolved-versions --disable-automatic-resolution --only-use-versions-from-resolved-file)'{--force-resolved-versions,--disable-automatic-resolution,--only-use-versions-from-resolved-file}'[Only use versions from the Package.resolved file and fail resolution if it is out-of-date]'
+        '--skip-update[Skip updating dependencies from their remote during a resolution]'
+        '--disable-scm-to-registry-transformation[disable source control to registry transformation]'
+        '--use-registry-identity-for-scm[look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins]'
+        '--replace-scm-with-registry[look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible]'
+        '(--configuration -c)'{--configuration,-c}'[Build with configuration]:configuration:(debug release)'
+        '-Xcc[Pass flag through to all C compiler invocations]:Xcc:'
+        '-Xswiftc[Pass flag through to all Swift compiler invocations]:Xswiftc:'
+        '-Xlinker[Pass flag through to all linker invocations]:Xlinker:'
+        '-Xcxx[Pass flag through to all C++ compiler invocations]:Xcxx:'
+        '--triple:triple:'
+        '--sdk:sdk:_files -/'
+        '--toolchain:toolchain:_files -/'
+        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:'
+        '--auto-index-store[Enable or disable indexing-while-building feature]'
+        '--enable-index-store[Enable or disable indexing-while-building feature]'
+        '--disable-index-store[Enable or disable indexing-while-building feature]'
+        '--enable-parseable-module-interfaces'
+        '(--jobs -j)'{--jobs,-j}'[The number of jobs to spawn in parallel during the build process]:jobs:'
+        '--emit-swift-module-separately'
+        '--use-integrated-swift-driver'
+        '--experimental-explicit-module-build'
+        '--print-manifest-job-graph[Write the command graph for the build manifest as a graphviz file]'
+        '--build-system:build-system:(native xcode)'
+        '--enable-dead-strip[Disable/enable dead code stripping by the linker]'
+        '--disable-dead-strip[Disable/enable dead code stripping by the linker]'
+        '--static-swift-stdlib[Link Swift stdlib statically]'
+        '--no-static-swift-stdlib[Link Swift stdlib statically]'
+        '--skip-build[Skip building the test target]'
+        '--parallel[Run the tests in parallel.]'
+        '--num-workers[Number of tests to execute in parallel.]:num-workers:'
+        '(--list-tests -l)'{--list-tests,-l}'[Lists test methods in specifier format]'
+        '--show-codecov-path[Print the path of the exported code coverage JSON file]'
+        '(-s --specifier)'{-s,--specifier}':specifier:'
+        '--filter[Run test cases matching regular expression, Format: <test-target>.<test-case> or <test-target>.<test-case>/<test>]:filter:'
+        '--skip[Skip test cases matching regular expression, Example: --skip PerformanceTests]:skip:'
+        '--xunit-output[Path where the xUnit xml file should be generated.]:xunit-output:_files -/'
+        '--test-product[Test the specified product.]:test-product:'
+        '--enable-testable-imports[Enable or disable testable imports. Enabled by default.]'
+        '--disable-testable-imports[Enable or disable testable imports. Enabled by default.]'
+        '--enable-code-coverage[Enable code coverage]'
+        '--disable-code-coverage[Enable code coverage]'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
 _swift_package() {
-    arguments=(
-        "-Xcc[Pass flag through to all C compiler invocations]:Pass flag through to all C compiler invocations: "
-        "-Xswiftc[Pass flag through to all Swift compiler invocations]:Pass flag through to all Swift compiler invocations: "
-        "-Xlinker[Pass flag through to all linker invocations]:Pass flag through to all linker invocations: "
-        "-Xcxx[Pass flag through to all C++ compiler invocations]:Pass flag through to all C++ compiler invocations: "
-        "(--configuration -c)"{--configuration,-c}"[Build with configuration (debug|release) ]: :{_values '' 'debug[build with DEBUG configuration]' 'release[build with RELEASE configuration]'}"
-        "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
-        "(--chdir -C)"{--chdir,-C}"[]: :_files"
-        "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
-        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
-        "--disable-prefetching[]"
-        "--skip-update[Skip updating dependencies from their remote during a resolution]"
-        "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
-        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
-        "--version[]"
-        "--destination[]: :_files"
-        "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
-        "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
-        "--static-swift-stdlib[Link Swift stdlib statically]"
-        "--force-resolved-versions[]"
-        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
-        "--enable-index-store[Enable indexing-while-building feature]"
-        "--disable-index-store[Disable indexing-while-building feature]"
-        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
-        "--enable-parseable-module-interfaces[]"
-        "--trace-resolver[]"
-        "(--jobs -j)"{--jobs,-j}"[The number of jobs to spawn in parallel during the build process]:The number of jobs to spawn in parallel during the build process: "
-        "--enable-test-discovery[Enable test discovery on platforms without Objective-C runtime]"
+    integer ret=1
+    local -a args
+    args+=(
+        '--package-path[Specify the package path to operate on (default current directory). This changes the working directory before any other operation]:package-path:_files -/'
+        '--cache-path[Specify the shared cache directory path]:cache-path:_files -/'
+        '--config-path[Specify the shared configuration directory path]:config-path:_files -/'
+        '--security-path[Specify the shared security directory path]:security-path:_files -/'
+        '--scratch-path[Specify a custom scratch directory path (default .build)]:scratch-path:_files -/'
+        '--enable-dependency-cache[Use a shared cache when fetching dependencies]'
+        '--disable-dependency-cache[Use a shared cache when fetching dependencies]'
+        '--enable-build-manifest-caching'
+        '--disable-build-manifest-caching'
+        '--manifest-cache[Caching mode of Package.swift manifests (shared: shared cache, local: package'"'"'s build directory, none: disabled]:manifest-cache:'
+        '(--verbose -v)'{--verbose,-v}'[Increase verbosity to include informational output]'
+        '(--very-verbose --vv)'{--very-verbose,--vv}'[Increase verbosity to include debug output]'
+        '--disable-sandbox[Disable using the sandbox when executing subprocesses]'
+        '--enable-netrc[Load credentials from a .netrc file]'
+        '--disable-netrc[Load credentials from a .netrc file]'
+        '--netrc-file[Specify the .netrc file path.]:netrc-file:_files'
+        '--enable-keychain[Search credentials in macOS keychain]'
+        '--disable-keychain[Search credentials in macOS keychain]'
+        '--resolver-fingerprint-checking:resolver-fingerprint-checking:'
+        '--enable-prefetching'
+        '--disable-prefetching'
+        '(--force-resolved-versions --disable-automatic-resolution --only-use-versions-from-resolved-file)'{--force-resolved-versions,--disable-automatic-resolution,--only-use-versions-from-resolved-file}'[Only use versions from the Package.resolved file and fail resolution if it is out-of-date]'
+        '--skip-update[Skip updating dependencies from their remote during a resolution]'
+        '--disable-scm-to-registry-transformation[disable source control to registry transformation]'
+        '--use-registry-identity-for-scm[look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins]'
+        '--replace-scm-with-registry[look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible]'
+        '(--configuration -c)'{--configuration,-c}'[Build with configuration]:configuration:(debug release)'
+        '-Xcc[Pass flag through to all C compiler invocations]:Xcc:'
+        '-Xswiftc[Pass flag through to all Swift compiler invocations]:Xswiftc:'
+        '-Xlinker[Pass flag through to all linker invocations]:Xlinker:'
+        '-Xcxx[Pass flag through to all C++ compiler invocations]:Xcxx:'
+        '--triple:triple:'
+        '--sdk:sdk:_files -/'
+        '--toolchain:toolchain:_files -/'
+        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:'
+        '--auto-index-store[Enable or disable indexing-while-building feature]'
+        '--enable-index-store[Enable or disable indexing-while-building feature]'
+        '--disable-index-store[Enable or disable indexing-while-building feature]'
+        '--enable-parseable-module-interfaces'
+        '(--jobs -j)'{--jobs,-j}'[The number of jobs to spawn in parallel during the build process]:jobs:'
+        '--emit-swift-module-separately'
+        '--use-integrated-swift-driver'
+        '--experimental-explicit-module-build'
+        '--print-manifest-job-graph[Write the command graph for the build manifest as a graphviz file]'
+        '--build-system:build-system:(native xcode)'
+        '--enable-dead-strip[Disable/enable dead code stripping by the linker]'
+        '--disable-dead-strip[Disable/enable dead code stripping by the linker]'
+        '--static-swift-stdlib[Link Swift stdlib statically]'
+        '--no-static-swift-stdlib[Link Swift stdlib statically]'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
         '(-): :->command'
         '(-)*:: :->arg'
     )
-    _arguments $arguments && return
+    _arguments -w -s -S $args[@] && ret=0
     case $state in
         (command)
-            local modes
-            modes=(
-                'completion-tool:Completion tool (for shell completions)'
-                'dump-package:Print parsed Package.swift as JSON'
-                'describe:Describe the current package'
+            local subcommands
+            subcommands=(
                 'clean:Delete build artifacts'
-                'show-dependencies:Print the resolved dependency graph'
-                'init:Initialize a new package'
-                'unedit:Remove a package from editable mode'
-                'tools-version:Manipulate tools version of the current package'
-                'fetch:'
-                'resolve:Resolve package dependencies'
+                'purge-cache:Purge the global repository cache.'
                 'reset:Reset the complete cache/build directory'
-                'generate-xcodeproj:Generates an Xcode project'
-                'edit:Put a package in editable mode'
-                'config:Manipulate configuration of the package'
                 'update:Update package dependencies'
+                'describe:Describe the current package'
+                'init:Initialize a new package'
+                '_format:'
+                'diagnose-api-breaking-changes:Diagnose API-breaking changes to Swift modules in a package'
+                'experimental-api-diff:Deprecated - use `swift package diagnose-api-breaking-changes` instead'
+                'dump-symbol-graph:Dump Symbol Graph'
+                'dump-pif:'
+                'dump-package:Print parsed Package.swift as JSON'
+                'edit:Put a package in editable mode'
+                'unedit:Remove a package from editable mode'
+                'config:Manipulate configuration of the package'
+                'resolve:Resolve package dependencies'
+                'fetch:'
+                'show-dependencies:Print the resolved dependency graph'
+                'tools-version:Manipulate tools version of the current package'
+                'generate-xcodeproj:Generates an Xcode project. This command will be deprecated soon.'
+                'compute-checksum:Compute the checksum for a binary artifact.'
+                'archive-source:Create a source archive for the package'
+                'completion-tool:Completion tool (for shell completions)'
+                'plugin:Invoke a command plugin or perform other actions on command plugins'
+                'default-command:'
             )
-            _describe "mode" modes
+            _describe "subcommand" subcommands
             ;;
         (arg)
             case ${words[1]} in
-                (completion-tool)
-                    _swift_package_completion-tool
-                    ;;
-                (dump-package)
-                    _swift_package_dump-package
-                    ;;
-                (describe)
-                    _swift_package_describe
-                    ;;
                 (clean)
                     _swift_package_clean
                     ;;
-                (show-dependencies)
-                    _swift_package_show-dependencies
-                    ;;
-                (init)
-                    _swift_package_init
-                    ;;
-                (unedit)
-                    _swift_package_unedit
-                    ;;
-                (tools-version)
-                    _swift_package_tools-version
-                    ;;
-                (fetch)
-                    _swift_package_fetch
-                    ;;
-                (resolve)
-                    _swift_package_resolve
+                (purge-cache)
+                    _swift_package_purge-cache
                     ;;
                 (reset)
                     _swift_package_reset
                     ;;
-                (generate-xcodeproj)
-                    _swift_package_generate-xcodeproj
+                (update)
+                    _swift_package_update
+                    ;;
+                (describe)
+                    _swift_package_describe
+                    ;;
+                (init)
+                    _swift_package_init
+                    ;;
+                (_format)
+                    _swift_package__format
+                    ;;
+                (diagnose-api-breaking-changes)
+                    _swift_package_diagnose-api-breaking-changes
+                    ;;
+                (experimental-api-diff)
+                    _swift_package_experimental-api-diff
+                    ;;
+                (dump-symbol-graph)
+                    _swift_package_dump-symbol-graph
+                    ;;
+                (dump-pif)
+                    _swift_package_dump-pif
+                    ;;
+                (dump-package)
+                    _swift_package_dump-package
                     ;;
                 (edit)
                     _swift_package_edit
                     ;;
+                (unedit)
+                    _swift_package_unedit
+                    ;;
                 (config)
                     _swift_package_config
                     ;;
-                (update)
-                    _swift_package_update
+                (resolve)
+                    _swift_package_resolve
+                    ;;
+                (fetch)
+                    _swift_package_fetch
+                    ;;
+                (show-dependencies)
+                    _swift_package_show-dependencies
+                    ;;
+                (tools-version)
+                    _swift_package_tools-version
+                    ;;
+                (generate-xcodeproj)
+                    _swift_package_generate-xcodeproj
+                    ;;
+                (compute-checksum)
+                    _swift_package_compute-checksum
+                    ;;
+                (archive-source)
+                    _swift_package_archive-source
+                    ;;
+                (completion-tool)
+                    _swift_package_completion-tool
+                    ;;
+                (plugin)
+                    _swift_package_plugin
+                    ;;
+                (default-command)
+                    _swift_package_default-command
                     ;;
             esac
             ;;
     esac
-}
 
-_swift_package_completion-tool() {
-    arguments=(
-        ": :{_values '' 'generate-bash-script[generate Bash completion script]' 'generate-zsh-script[generate Bash completion script]' 'list-dependencies[list all dependencies' names]' 'list-executables[list all executables' names]'}"
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_dump-package() {
-    arguments=(
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_describe() {
-    arguments=(
-        "--type[json|text]: :{_values '' 'text[describe using text format]' 'json[describe using JSON format]'}"
-    )
-    _arguments $arguments && return
+    return ret
 }
 
 _swift_package_clean() {
-    arguments=(
+    integer ret=1
+    local -a args
+    args+=(
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
-    _arguments $arguments && return
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
 }
 
-_swift_package_show-dependencies() {
-    arguments=(
-        "--format[text|dot|json|flatlist]: :{_values '' 'text[list dependencies using text format]' 'dot[list dependencies using dot format]' 'json[list dependencies using JSON format]'}"
+_swift_package_purge-cache() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
-    _arguments $arguments && return
-}
+    _arguments -w -s -S $args[@] && ret=0
 
-_swift_package_init() {
-    arguments=(
-        "--type[empty|library|executable|system-module|manifest]: :{_values '' 'empty[generates an empty project]' 'library[generates project for a dynamic library]' 'executable[generates a project for a cli executable]' 'system-module[generates a project for a system module]'}"
-        "--name[Provide custom package name]:Provide custom package name: "
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_unedit() {
-    arguments=(
-        ":The name of the package to unedit:_swift_dependency"
-        "--force[Unedit the package even if it has uncommitted and unpushed changes.]"
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_tools-version() {
-    arguments=(
-        "--set[Set tools version of package to the given value]:Set tools version of package to the given value: "
-        "--set-current[Set tools version of package to the current tools version in use]"
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_fetch() {
-    arguments=(
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_resolve() {
-    arguments=(
-        ":The name of the package to resolve:_swift_dependency"
-        "--version[The version to resolve at]:The version to resolve at: "
-        "--branch[The branch to resolve at]:The branch to resolve at: "
-        "--revision[The revision to resolve at]:The revision to resolve at: "
-    )
-    _arguments $arguments && return
+    return ret
 }
 
 _swift_package_reset() {
-    arguments=(
+    integer ret=1
+    local -a args
+    args+=(
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
-    _arguments $arguments && return
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
 }
 
-_swift_package_generate-xcodeproj() {
-    arguments=(
-        "--xcconfig-overrides[Path to xcconfig file]:Path to xcconfig file:_files"
-        "--enable-code-coverage[Enable code coverage in the generated project]"
-        "--output[Path where the Xcode project should be generated]:Path where the Xcode project should be generated:_files"
-        "--legacy-scheme-generator[Use the legacy scheme generator]"
-        "--watch[Watch for changes to the Package manifest to regenerate the Xcode project]"
-        "--skip-extra-files[Do not add file references for extra files to the generated Xcode project]"
+_swift_package_update() {
+    integer ret=1
+    local -a args
+    args+=(
+        '(--dry-run -n)'{--dry-run,-n}'[Display the list of dependencies that can be updated]'
+        ':packages:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
-    _arguments $arguments && return
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_describe() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--type[json | text]:type:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_init() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--type[Package type: empty | library | executable | system-module | manifest]:type:'
+        '--name[Provide custom package name]:name:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package__format() {
+    integer ret=1
+    local -a args
+    args+=(
+        ':swift-format-flags:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_diagnose-api-breaking-changes() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--breakage-allowlist-path[The path to a text file containing breaking changes which should be ignored by the API comparison. Each ignored breaking change in the file should appear on its own line and contain the exact message to be ignored (e.g. '"'"'API breakage: func foo() has been removed'"'"').]:breakage-allowlist-path:_files -/'
+        ':treeish:'
+        '--products[One or more products to include in the API comparison. If present, only the specified products (and any targets specified using `--targets`) will be compared.]:products:'
+        '--targets[One or more targets to include in the API comparison. If present, only the specified targets (and any products specified using `--products`) will be compared.]:targets:'
+        '--baseline-dir[The path to a directory used to store API baseline files. If unspecified, a temporary directory will be used.]:baseline-dir:_files -/'
+        '--regenerate-baseline[Regenerate the API baseline, even if an existing one is available.]'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_experimental-api-diff() {
+    integer ret=1
+    local -a args
+    args+=(
+        ':args:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_dump-symbol-graph() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--pretty-print[Pretty-print the output JSON.]'
+        '--skip-synthesized-members[Skip members inherited through classes or default implementations.]'
+        '--minimum-access-level[Include symbols with this access level or more. Possible values: private | fileprivate | internal | public | open]:minimum-access-level:(private fileprivate internal public open)'
+        '--skip-inherited-docs[Skip emitting doc comments for members inherited through classes or default implementations.]'
+        '--include-spi-symbols[Add symbols with SPI information to the symbol graph.]'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_dump-pif() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--preserve-structure[Preserve the internal structure of PIF]'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_dump-package() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
 }
 
 _swift_package_edit() {
-    arguments=(
-        ":The name of the package to edit:_swift_dependency"
-        "--revision[The revision to edit]:The revision to edit: "
-        "--branch[The branch to create]:The branch to create: "
-        "--path[Create or use the checkout at this path]:Create or use the checkout at this path:_files"
+    integer ret=1
+    local -a args
+    args+=(
+        '--revision[The revision to edit]:revision:'
+        '--branch[The branch to create]:branch:'
+        '--path[Create or use the checkout at this path]:path:_files -/'
+        ':package-name:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
-    _arguments $arguments && return
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_unedit() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--force[Unedit the package even if it has uncommited and unpushed changes]'
+        ':package-name:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
 }
 
 _swift_package_config() {
-    arguments=(
+    integer ret=1
+    local -a args
+    args+=(
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
         '(-): :->command'
         '(-)*:: :->arg'
     )
-    _arguments $arguments && return
+    _arguments -w -s -S $args[@] && ret=0
     case $state in
         (command)
-            local modes
-            modes=(
+            local subcommands
+            subcommands=(
+                'set-mirror:Set a mirror for a dependency'
                 'unset-mirror:Remove an existing mirror'
                 'get-mirror:Print mirror configuration for the given package dependency'
-                'set-mirror:Set a mirror for a dependency'
             )
-            _describe "mode" modes
+            _describe "subcommand" subcommands
             ;;
         (arg)
             case ${words[1]} in
+                (set-mirror)
+                    _swift_package_config_set-mirror
+                    ;;
                 (unset-mirror)
                     _swift_package_config_unset-mirror
                     ;;
                 (get-mirror)
                     _swift_package_config_get-mirror
                     ;;
-                (set-mirror)
-                    _swift_package_config_set-mirror
-                    ;;
             esac
             ;;
     esac
-}
 
-_swift_package_config_unset-mirror() {
-    arguments=(
-        "--package-url[The package dependency url]:The package dependency url: "
-        "--mirror-url[The mirror url]:The mirror url: "
-    )
-    _arguments $arguments && return
-}
-
-_swift_package_config_get-mirror() {
-    arguments=(
-        "--package-url[The package dependency url]:The package dependency url: "
-    )
-    _arguments $arguments && return
+    return ret
 }
 
 _swift_package_config_set-mirror() {
-    arguments=(
-        "--package-url[The package dependency url]:The package dependency url: "
-        "--mirror-url[The mirror url]:The mirror url: "
+    integer ret=1
+    local -a args
+    args+=(
+        '--package-url[The package dependency url]:package-url:'
+        '--original-url[The original url]:original-url:'
+        '--mirror-url[The mirror url]:mirror-url:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
-    _arguments $arguments && return
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
 }
 
-_swift_package_update() {
-    arguments=(
+_swift_package_config_unset-mirror() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--package-url[The package dependency url]:package-url:'
+        '--original-url[The original url]:original-url:'
+        '--mirror-url[The mirror url]:mirror-url:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
-    _arguments $arguments && return
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
 }
 
-# Generates completions for swift test
-#
-# In the final compdef file, set the following file header:
-#
-#     #compdef _swift_test
-#     local context state state_descr line
-#     typeset -A opt_args
-_swift_test() {
-    arguments=(
-        "-Xcc[Pass flag through to all C compiler invocations]:Pass flag through to all C compiler invocations: "
-        "-Xswiftc[Pass flag through to all Swift compiler invocations]:Pass flag through to all Swift compiler invocations: "
-        "-Xlinker[Pass flag through to all linker invocations]:Pass flag through to all linker invocations: "
-        "-Xcxx[Pass flag through to all C++ compiler invocations]:Pass flag through to all C++ compiler invocations: "
-        "(--configuration -c)"{--configuration,-c}"[Build with configuration (debug|release) ]: :{_values '' 'debug[build with DEBUG configuration]' 'release[build with RELEASE configuration]'}"
-        "--build-path[Specify build/cache directory ]:Specify build/cache directory :_files"
-        "(--chdir -C)"{--chdir,-C}"[]: :_files"
-        "--package-path[Change working directory before any other operation]:Change working directory before any other operation:_files"
-        "--sanitize[Turn on runtime checks for erroneous behavior]: :{_values '' 'address[enable Address sanitizer]' 'thread[enable Thread sanitizer]' 'undefined[enable Undefined Behavior sanitizer]'}"
-        "--disable-prefetching[]"
-        "--skip-update[Skip updating dependencies from their remote during a resolution]"
-        "--disable-sandbox[Disable using the sandbox when executing subprocesses]"
-        "--disable-package-manifest-caching[Disable caching Package.swift manifests]"
-        "--version[]"
-        "--destination[]: :_files"
-        "(--verbose -v)"{--verbose,-v}"[Increase verbosity of informational output]"
-        "--no-static-swift-stdlib[Do not link Swift stdlib statically \[default\]]"
-        "--static-swift-stdlib[Link Swift stdlib statically]"
-        "--force-resolved-versions[]"
-        "--disable-automatic-resolution[Disable automatic resolution if Package.resolved file is out-of-date]"
-        "--enable-index-store[Enable indexing-while-building feature]"
-        "--disable-index-store[Disable indexing-while-building feature]"
-        "--enable-pubgrub-resolver[\[Experimental\] Enable the new Pubgrub dependency resolver]"
-        "--enable-parseable-module-interfaces[]"
-        "--trace-resolver[]"
-        "(--jobs -j)"{--jobs,-j}"[The number of jobs to spawn in parallel during the build process]:The number of jobs to spawn in parallel during the build process: "
-        "--enable-test-discovery[Enable test discovery on platforms without Objective-C runtime]"
-        "--skip-build[Skip building the test target]"
-        "(--list-tests -l)"{--list-tests,-l}"[Lists test methods in specifier format]"
-        "--generate-linuxmain[Generate LinuxMain.swift entries for the package]"
-        "--parallel[Run the tests in parallel.]"
-        "--num-workers[Number of tests to execute in parallel.]:Number of tests to execute in parallel.: "
-        "(--specifier -s)"{--specifier,-s}"[]: : "
-        "--xunit-output[]: :_files"
-        "--filter[Run test cases matching regular expression, Format: <test-target>.<test-case> or <test-target>.<test-case>/<test>]:Run test cases matching regular expression, Format: <test-target>.<test-case> or <test-target>.<test-case>/<test>: "
-        "--enable-code-coverage[Test with code coverage enabled]"
+_swift_package_config_get-mirror() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--package-url[The package dependency url]:package-url:'
+        '--original-url[The original url]:original-url:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
-    _arguments $arguments && return
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
 }
 
-_swift_compiler() {
+_swift_package_resolve() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--version[The version to resolve at]:version:'
+        '--branch[The branch to resolve at]:branch:'
+        '--revision[The revision to resolve at]:revision:'
+        ':package-name:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_fetch() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--version[The version to resolve at]:version:'
+        '--branch[The branch to resolve at]:branch:'
+        '--revision[The revision to resolve at]:revision:'
+        ':package-name:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_show-dependencies() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--format[text | dot | json | flatlist]:format:'
+        '(--output-path -o)'{--output-path,-o}'[The absolute or relative path to output the resolved dependency graph.]:output-path:_files -/'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_tools-version() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--set-current[Set tools version of package to the current tools version in use]'
+        '--set[Set tools version of package to the given value]:set:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_generate-xcodeproj() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--xcconfig-overrides[Path to xcconfig file]:xcconfig-overrides:_files'
+        '--output[Path where the Xcode project should be generated]:output:_files -/'
+        '--legacy-scheme-generator[Use the legacy scheme generator]'
+        '--watch[Watch for changes to the Package manifest to regenerate the Xcode project]'
+        '--skip-extra-files[Do not add file references for extra files to the generated Xcode project]'
+        '--enable-code-coverage[Enable code coverage]'
+        '--disable-code-coverage[Enable code coverage]'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_compute-checksum() {
+    integer ret=1
+    local -a args
+    args+=(
+        ':path:_files -/'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_archive-source() {
+    integer ret=1
+    local -a args
+    args+=(
+        '(-o --output)'{-o,--output}'[The absolute or relative path for the generated source archive]:output:_files -/'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_completion-tool() {
+    integer ret=1
+    local -a args
+    args+=(
+        ':mode:(generate-bash-script generate-zsh-script generate-fish-script list-dependencies list-executables list-snippets)'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_plugin() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--list[List the available command plugins]'
+        '--allow-writing-to-package-directory[Allow the plugin to write to the package directory]'
+        '--allow-writing-to-directory[Allow the plugin to write to an additional directory]:allow-writing-to-directory:'
+        ':command:'
+        ':arguments:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_package_default-command() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--allow-writing-to-package-directory[Allow the plugin to write to the package directory]'
+        '--allow-writing-to-directory[Allow the plugin to write to an additional directory]:allow-writing-to-directory:'
+        ':remaining:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_help() {
+    integer ret=1
+    local -a args
+    args+=(
+        ':subcommands:'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+
+_custom_completion() {
+    local completions=("${(@f)$($*)}")
+    _describe '' completions
 }
 
 _swift

--- a/plugins/swiftpm/_swift
+++ b/plugins/swiftpm/_swift
@@ -614,7 +614,7 @@ _swift_package_unedit() {
     integer ret=1
     local -a args
     args+=(
-        '--force[Unedit the package even if it has uncommited and unpushed changes]'
+        '--force[Unedit the package even if it has uncommitted and unpushed changes]'
         ':package-name:'
         '--version[Show the version.]'
         '(-help -h --help)'{-help,-h,--help}'[Show help information.]'


### PR DESCRIPTION
This PR updates the SwiftPM plugin autocomplete information for Swift 5.7.

`_swift` file was generated by running `swift package completion-tool generate-zsh-script` with Swift [5.7](https://github.com/apple/swift-package-manager/releases/tag/swift-5.7-RELEASE) (with small modification to include and a [manual fix approved by Apple](https://github.com/apple/swift-package-manager/pull/5852) as otherwise the autocompletion would not work)

Result autocompletion

![SwiftAutocompletion (1)](https://user-images.githubusercontent.com/4176826/198693952-6a3b1f09-17c9-4bd5-8022-31e8a5fa2d8a.gif)

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- feat(swiftpm): update completion for Swift 5.7
- chore(docs): fix typo
