### PR TITLE
feat(fzf): fix MacPorts auto-completion file location.

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -178,7 +178,7 @@ function fzf_setup_using_macports() {
   (( $+commands[fzf] )) || return 1
 
   # The fzf-zsh-completion package installs the auto-completion in
-  local completions="/opt/local/share/zsh/site-functions/fzf"
+  local completions="/opt/local/share/fzf/shell/completion.zsh"
   # The fzf-zsh-completion package installs the key-bindings file in
   local key_bindings="/opt/local/share/fzf/shell/key-bindings.zsh"
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

In function fzf_setup_using_macports, changed MacPorts fzf auto-completion file location.

MacPorts changed fzf auto-completion file location from /opt/local/share/zsh/site-functions/fzf to /opt/local/share/fzf/shell/completion.zsh .

You can check this macports fzf commit : 

https://github.com/macports/macports-ports/commit/b90c2574a1b62cabc202848d2b8684d771cdbd24

