### PR TITLE
fix(lib/termsupport): Add carriage return after changing window/tab titles (#11314)

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -36,6 +36,8 @@ function title {
       fi
       ;;
   esac
+
+  print -Pn "\r" # move the cursor to the beginning of the line
 }
 
 ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add a `print -Pn "\r"` after setting window/tab titles to force the cursor back to the start of the line

Window and tab titles are changed by emitting unprintable escape sequences to the terminal. These escape sequences do not play nicely with the TAB character on multiple terminal emulators—they create un-deletable characters on the first line after command execution. Sending "\r" after changing the window and tab titles allows all characters on the first line to be deleted.

Fixes #11314