### PR TITLE
feat(git): display tag in git-prompt when possible

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -19,6 +19,7 @@ function git_prompt_info() {
 
   local ref
   ref=$(__git_prompt_git symbolic-ref --short HEAD 2> /dev/null) \
+  || ref=$(__git_prompt_git describe --exact-match HEAD 2> /dev/null) \
   || ref=$(__git_prompt_git rev-parse --short HEAD 2> /dev/null) \
   || return 0
 

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -19,7 +19,7 @@ function git_prompt_info() {
 
   local ref
   ref=$(__git_prompt_git symbolic-ref --short HEAD 2> /dev/null) \
-  || ref=$(__git_prompt_git describe --exact-match HEAD 2> /dev/null) \
+  || ref=$(__git_prompt_git describe --tags --exact-match HEAD 2> /dev/null) \
   || ref=$(__git_prompt_git rev-parse --short HEAD 2> /dev/null) \
   || return 0
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add tag infromation to git prompt

## Other comments:

...
