### PR TITLE
Revert "fix(debian)!: remove ar alias" and add apr alias

### DIFF
--- a/plugins/debian/README.md
+++ b/plugins/debian/README.md
@@ -45,7 +45,7 @@ Set `$apt_pref` and `$apt_upgr` to whatever command you want (before sourcing Oh
 | `ail`    | `sed -e 's/  */ /g' -e 's/ *//' \| cut -s -d ' ' -f 1 \| xargs sudo $apt_pref install` | Install all packages given on the command line while using only the first word of each line |
 | `alu`    | `sudo apt update && apt list -u && sudo apt upgrade`                                   | Update, list and upgrade packages                                                           |
 | `ap`     | `sudo $apt_pref purge`                                                                 | Removes packages along with configuration files                                             |
-| `ar`     | `sudo $apt_pref remove`                                                                | Removes packages, keeps the configuration files                                             |
+| `apr`     | `sudo $apt_pref remove`                                                                | Removes packages, keeps the configuration files                                             |
 | `au`     | `sudo $apt_pref $apt_upgr`                                                             | Install package upgrades                                                                    |
 | `di`     | `sudo dpkg -i`                                                                         | Install all .deb files in the current directory                                             |
 | `dia`    | `sudo dpkg -i ./*.deb`                                                                 | Install all .deb files in the current directory                                             |

--- a/plugins/debian/README.md
+++ b/plugins/debian/README.md
@@ -30,25 +30,26 @@ Set `$apt_pref` and `$apt_upgr` to whatever command you want (before sourcing Oh
 
 ## Superuser Operations Aliases
 
-| Alias    | Command                                                                               | Description                                                                                 |
-| -------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `aac`    | `sudo $apt_pref autoclean`                                                            | Clears out the local repository of retrieved package files                                  |
-| `aar`    | `sudo $apt_pref autoremove`                                                           | Removes packages installed automatically that are no longer needed                          |
-| `abd`    | `sudo $apt_pref build-dep`                                                            | Installs all dependencies for building packages                                             |
-| `ac`     | `sudo $apt_pref clean`                                                                | Clears out the local repository of retrieved package files except lock files                |
-| `ad`     | `sudo $apt_pref update`                                                               | Updates the package lists for upgrades for packages                                         |
-| `adg`    | `sudo $apt_pref update && sudo $apt_pref $apt_upgr`                                   | Update and upgrade packages                                                                 |
-| `ads`    | `sudo apt-get dselect-upgrade`                                                        | Installs packages from list and removes all not in the list                                 |
-| `adu`    | `sudo $apt_pref update && sudo $apt_pref dist-upgrade`                                | Smart upgrade that handles dependencies                                                     |
-| `afu`    | `sudo apt-file update`                                                                | Update the files in packages                                                                |
-| `ai`     | `sudo $apt_pref install`                                                              | Command-line tool to install package                                                        |
-| `ail`    | `sed -e 's/ */ /g' -e 's/ *//' \| cut -s -d ' ' -f 1 \| xargs sudo $apt_pref install` | Install all packages given on the command line while using only the first word of each line |
-| `alu`    | `sudo apt update && apt list -u && sudo apt upgrade`                                  | Update, list and upgrade packages                                                           |
-| `ap`     | `sudo $apt_pref purge`                                                                | Removes packages along with configuration files                                             |
-| `au`     | `sudo $apt_pref $apt_upgr`                                                            | Install package upgrades                                                                    |
-| `di`     | `sudo dpkg -i`                                                                        | Install all .deb files in the current directory                                             |
-| `dia`    | `sudo dpkg -i ./*.deb`                                                                | Install all .deb files in the current directory                                             |
-| `kclean` | `sudo aptitude remove -P ?and(~i~nlinux-(ima\|hea) ?not(~n$(uname -r)))`              | Remove ALL kernel images and headers EXCEPT the one in use                                  |
+| Alias    | Command                                                                                | Description                                                                                 |
+| -------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `aac`    | `sudo $apt_pref autoclean`                                                             | Clears out the local repository of retrieved package files                                  |
+| `aar`    | `sudo $apt_pref autoremove`                                                            | Removes packages installed automatically that are no longer needed                          |
+| `abd`    | `sudo $apt_pref build-dep`                                                             | Installs all dependencies for building packages                                             |
+| `ac`     | `sudo $apt_pref clean`                                                                 | Clears out the local repository of retrieved package files except lock files                |
+| `ad`     | `sudo $apt_pref update`                                                                | Updates the package lists for upgrades for packages                                         |
+| `adg`    | `sudo $apt_pref update && sudo $apt_pref $apt_upgr`                                    | Update and upgrade packages                                                                 |
+| `ads`    | `sudo apt-get dselect-upgrade`                                                         | Installs packages from list and removes all not in the list                                 |
+| `adu`    | `sudo $apt_pref update && sudo $apt_pref dist-upgrade`                                 | Smart upgrade that handles dependencies                                                     |
+| `afu`    | `sudo apt-file update`                                                                 | Update the files in packages                                                                |
+| `ai`     | `sudo $apt_pref install`                                                               | Command-line tool to install package                                                        |
+| `ail`    | `sed -e 's/  */ /g' -e 's/ *//' \| cut -s -d ' ' -f 1 \| xargs sudo $apt_pref install` | Install all packages given on the command line while using only the first word of each line |
+| `alu`    | `sudo apt update && apt list -u && sudo apt upgrade`                                   | Update, list and upgrade packages                                                           |
+| `ap`     | `sudo $apt_pref purge`                                                                 | Removes packages along with configuration files                                             |
+| `ar`     | `sudo $apt_pref remove`                                                                | Removes packages, keeps the configuration files                                             |
+| `au`     | `sudo $apt_pref $apt_upgr`                                                             | Install package upgrades                                                                    |
+| `di`     | `sudo dpkg -i`                                                                         | Install all .deb files in the current directory                                             |
+| `dia`    | `sudo dpkg -i ./*.deb`                                                                 | Install all .deb files in the current directory                                             |
+| `kclean` | `sudo aptitude remove -P ?and(~i~nlinux-(ima\|hea) ?not(~n$(uname -r)))`               | Remove ALL kernel images and headers EXCEPT the one in use                                  |
 
 ## Aliases - Commands using `su`
 

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -55,7 +55,7 @@ if [[ $use_sudo -eq 1 ]]; then
 
     alias ail="sed -e 's/  */ /g' -e 's/ *//' | cut -s -d ' ' -f 1 | xargs sudo $apt_pref install"
     alias ap="sudo $apt_pref purge"
-    alias ar="sudo $apt_pref remove"
+    alias apr="sudo $apt_pref remove"
     alias aar="sudo $apt_pref autoremove"
 
     # apt-get only
@@ -98,7 +98,7 @@ else
         print "$cmd"
         eval "$cmd"
     }
-    function ar() {
+    function apr() {
         cmd="su -lc '$apt_pref remove $@' root"
         print "$cmd"
         eval "$cmd"
@@ -147,7 +147,7 @@ apt_pref_compdef au  "$apt_upgr"
 apt_pref_compdef ai  "install"
 apt_pref_compdef ail "install"
 apt_pref_compdef ap  "purge"
-apt_pref_compdef ar  "remove"
+apt_pref_compdef apr  "remove"
 apt_pref_compdef aar  "autoremove"
 apt_pref_compdef ads "dselect-upgrade"
 

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -55,6 +55,7 @@ if [[ $use_sudo -eq 1 ]]; then
 
     alias ail="sed -e 's/  */ /g' -e 's/ *//' | cut -s -d ' ' -f 1 | xargs sudo $apt_pref install"
     alias ap="sudo $apt_pref purge"
+    alias ar="sudo $apt_pref remove"
     alias aar="sudo $apt_pref autoremove"
 
     # apt-get only
@@ -94,6 +95,11 @@ else
     }
     function ap() {
         cmd="su -lc '$apt_pref purge $@' root"
+        print "$cmd"
+        eval "$cmd"
+    }
+    function ar() {
+        cmd="su -lc '$apt_pref remove $@' root"
         print "$cmd"
         eval "$cmd"
     }
@@ -141,6 +147,7 @@ apt_pref_compdef au  "$apt_upgr"
 apt_pref_compdef ai  "install"
 apt_pref_compdef ail "install"
 apt_pref_compdef ap  "purge"
+apt_pref_compdef ar  "remove"
 apt_pref_compdef aar  "autoremove"
 apt_pref_compdef ads "dselect-upgrade"
 


### PR DESCRIPTION
This reverts commit 818f3de.## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Replaces `ar` command with `apr`, instead of removing it completely.

## Other comments:

...
