### PR TITLE
fix(lol): use https for `yolo` calls

### DIFF
--- a/plugins/lol/README.md
+++ b/plugins/lol/README.md
@@ -49,7 +49,7 @@ plugins=(... lol)
 | `violenz`    | `git rebase`                                                    |
 | `visible`    | `echo`                                                          |
 | `wtf`        | `dmesg`                                                         |
-| `yolo`       | `git commit -m "$(curl -s http://whatthecommit.com/index.txt)"` |
+| `yolo`       | `git commit -m "$(curl -s https://whatthecommit.com/index.txt)"` |
 
 ## Usage Examples
 
@@ -66,6 +66,6 @@ nowai u=r,go= some.file
 # ssh root@catserver.org
 pwned root@catserver.org
 
-# git commit -m "$(curl -s http://whatthecommit.com/index.txt)"
+# git commit -m "$(curl -s https://whatthecommit.com/index.txt)"
 yolo
 ```

--- a/plugins/lol/lol.plugin.zsh
+++ b/plugins/lol/lol.plugin.zsh
@@ -45,7 +45,7 @@ alias bringz='git pull'
 alias chicken='git add'
 alias oanward='git commit -m'
 alias ooanward='git commit -am'
-alias yolo='git commit -m "$(curl -s http://whatthecommit.com/index.txt)"'
+alias yolo='git commit -m "$(curl -s https://whatthecommit.com/index.txt)"'
 alias letcat='git checkout'
 alias violenz='git rebase'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
The http URL used by the `yolo` alias of the `lol` plugin is now returning a default http redirect response:
```
➜   yolo
[master 6de2761d] <html> <head><title>301 Moved Permanently</title></head> <body> <center><h1>301 Moved Permanently</h1></center> </body> </html>
 1 file changed, 0 insertions(+), 0 deletions(-)
```

Using https seems to solve the issue:
With http:
```
➜   curl -s http://whatthecommit.com/index.txt  
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
</body>
</html>
```

With https:
```
➜   curl -s https://whatthecommit.com/index.txt
Revert "fuckup".
```

## Other comments:

<!-- left empty -->
