### PR TITLE
fix(macos): fix `man-preview` for macOS Ventura

### DIFF
--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -224,8 +224,9 @@ function quick-look() {
 }
 
 function man-preview() {
+  local location
   # Don't let Preview.app steal focus if the man page doesn't exist
-  man -w "$@" &>/dev/null && man -t "$@" | open -f -a Preview || man "$@"
+  location=$(man -w "$@") && mandoc -Tpdf $location | open -f -a Preview
 }
 compdef _man man-preview
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Preview.app on macOS Ventura drops support for PostScript on which the current `man-preview` function with `man -t` (basically `mandoc -Tps`) relies. This commit switches to `mandoc -Tpdf` and keeps it simple.

