### PR TITLE
fix(ubuntu)!: rename `acs` alias to `acse

### DIFF
--- a/plugins/debian/README.md
+++ b/plugins/debian/README.md
@@ -21,7 +21,7 @@ Set `$apt_pref` and `$apt_upgr` to whatever command you want (before sourcing Oh
 | ------ | ---------------------------------------------------------------------- | ---------------------------------------------------------- |
 | `age`  | `apt-get`                                                              | Command line tool for handling packages                    |
 | `api`  | `aptitude`                                                             | Same functionality as `apt-get`, provides extra options    |
-| `acs`  | `apt-cache search`                                                     | Command line tool for searching apt software package cache |
+| `acse` | `apt-cache search`                                                     | Command line tool for searching apt software package cache |
 | `aps`  | `aptitude search`                                                      | Searches installed packages using aptitude                 |
 | `as`   | `aptitude -F '* %p -> %d \n(%v/%V)' --no-gui --disable-columns search` | Print searched packages using a custom format              |
 | `afs`  | `apt-file search --regexp`                                             | Search file in packages                                    |

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -26,7 +26,7 @@ alias age='apt-get'
 alias api='aptitude'
 
 # Some self-explanatory aliases
-alias acs="apt-cache search"
+alias acse="apt-cache search"
 alias aps='aptitude search'
 alias as="aptitude -F '* %p -> %d \n(%v/%V)' --no-gui --disable-columns search"
 
@@ -51,7 +51,7 @@ if [[ $use_sudo -eq 1 ]]; then
     alias au="sudo $apt_pref $apt_upgr"
     alias ai="sudo $apt_pref install"
     # Install all packages given on the command line while using only the first word of each line:
-    # acs ... | ail
+    # acse ... | ail
 
     alias ail="sed -e 's/  */ /g' -e 's/ *//' | cut -s -d ' ' -f 1 | xargs sudo $apt_pref install"
     alias ap="sudo $apt_pref purge"

--- a/plugins/ubuntu/README.md
+++ b/plugins/ubuntu/README.md
@@ -15,7 +15,7 @@ Commands that use `$APT` will use `apt` if installed or defer to `apt-get` other
 | Alias   | Command                                                                  | Description                                                                                       |
 |---------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | age     | `sudo $APT`                                                              | Run apt-get with sudo                                                                             |
-| acs     | `apt-cache search`                                                       | Search the apt-cache with the specified criteria                                                  |
+| acse    | `apt-cache search`                                                       | Search the apt-cache with the specified criteria                                                  |
 | acsp    | `apt-cache showpkg`                                                      | Shows information about the listed packages                                                       |
 | acp     | `apt-cache policy`                                                       | Display the package source priorities                                                             |
 | afs     | `apt-file search --regexp`                                               | Perform a regular expression apt-file search                                                      |

--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -1,6 +1,6 @@
 (( $+commands[apt] )) && APT=apt || APT=apt-get
 
-alias acs='apt-cache search'
+alias acse='apt-cache search'
 
 alias afs='apt-file search --regexp'
 


### PR DESCRIPTION
See #11331 for details about this PR.

Closes #11331

Poke @carlosala for their suggestion on how to fix it. 

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Rename alias `acs` in `debian` plugin to `acse` and update documentation accordingly;
- Rename alias `acs` in `ubuntu` plugin to `acse` and update documentation accordingly.