### PR TITLE
feat(nvm)!: settings now are zstyle-based

### DIFF
--- a/plugins/nvm/README.md
+++ b/plugins/nvm/README.md
@@ -1,7 +1,7 @@
 # nvm plugin
 
-This plugin adds autocompletions for [nvm](https://github.com/nvm-sh/nvm) — a Node.js version manager.
-It also automatically sources nvm, so you don't need to do it manually in your `.zshrc`.
+This plugin adds autocompletions for [nvm](https://github.com/nvm-sh/nvm) — a Node.js version manager. It also
+automatically sources nvm, so you don't need to do it manually in your `.zshrc`.
 
 To use it, add `nvm` to the plugins array of your zshrc file:
 
@@ -21,14 +21,32 @@ These settings should go in your zshrc file, before Oh My Zsh is sourced:
   [Homebrew is installed in `/opt/homebrew`](https://docs.brew.sh/Installation). To get the directory where
   nvm has been installed, regardless of chip architecture, use `NVM_HOMEBREW=$(brew --prefix nvm)`.
 
-- **`NVM_LAZY`**: if you want the plugin to defer the load of nvm to speed-up the start of your zsh session,
-  set `NVM_LAZY` to `1`. This will source nvm script only when using it, and will create a function for `node`,
-  `npm`, `pnpm`, `yarn`, and the command(s) specified by `NVM_LAZY_CMD`, so when you call either of them,
-  nvm will be loaded and run with default version.
+## Customization
 
-- **`NVM_LAZY_CMD`**: if you want additional command(s) to trigger lazy loading of nvm, set `NVM_LAZY_CMD` to
-  the command or an array of the commands.
+#### Lazy startup
 
-- **`NVM_AUTOLOAD`**: if `NVM_AUTOLOAD` is set to `1`, the plugin will automatically load a node version when
-  if finds a [`.nvmrc` file](https://github.com/nvm-sh/nvm#nvmrc) in the current working directory indicating
-  which node version to load.
+This option will help you to defer nvm's load until you use it to speed-up your zsh startup. This will source
+nvm script only when using it, and will create a function for `node`, `npm`, `pnpm`, `yarn`, and the
+command(s) specified by `lazy-cmd` option, so when you call either of them, nvm will be loaded and run with
+default version. To enable it, you can add this snippet to your zshrc, before Oh My Zsh is sourced:
+
+```zsh
+zstyle ':omz:plugins:nvm' lazy yes
+```
+
+Then, to define extra commands that will also trigger nvm load, you can use a similar syntax, adding as many
+as you want:
+
+```zsh
+zstyle ':omz:plugins:nvm' lazy-cmd eslint prettier typescript ...
+```
+
+#### `.nvmrc` autoload
+
+If set, the plugin will automatically load a node version when if finds a
+[`.nvmrc` file](https://github.com/nvm-sh/nvm#nvmrc) in the current working directory indicating which node
+version to load. This can be done, similar as previous options, adding:
+
+```zsh
+zstyle ':omz:plugins:nvm' autoload true
+```

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -17,24 +17,26 @@ fi
 which nvm &>/dev/null && return
 
 # TODO: 2022-11-11: Remove soft-deprecate options
-if (( $+NVM_LAZY + $+NVM_LAZY_CMD + $+NVM_AUTOLOAD)); then
-  local -a used_commands
-  [[ -n $NVM_LAZY ]] && used_commands+=("\$NVM_LAZY")
-  [[ -n $NVM_LAZY_CMD ]] && used_commands+=("\$NVM_LAZY_CMD")
-  [[ -n $NVM_AUTOLOAD ]] && used_commands+=("\$NVM_AUTOLOAD")
-  echo "$fg[yellow][nvm plugin] Variable-style settings are deprecated, instead of $used_commands, use:"
-fi
-if (( $+NVM_LAZY )); then
-  echo "$fg[yellow][nvm plugin] zstyle ':omz:plugins:nvm' lazy true$reset_color"
-  zstyle ':omz:plugins:nvm' lazy yes
-fi
-if (( $+NVM_LAZY_CMD )); then
-  echo "$fg[yellow][nvm plugin] zstyle ':omz:plugins:nvm' lazy-cmd $NVM_LAZY_CMD$reset_color"
-  zstyle ':omz:plugins:nvm' lazy-cmd $NVM_LAZY_CMD
-fi
-if (( $+NVM_AUTOLOAD )); then
-  echo "$fg[yellow][nvm plugin] zstyle ':omz:plugins:nvm' lazy true$reset_color"
-  zstyle ':omz:plugins:nvm' autoload yes
+if (( ${+NVM_LAZY} + ${+NVM_LAZY_CMD} + ${+NVM_AUTOLOAD} )); then
+  # Get list of NVM_* variable settings defined
+  local -a used_vars
+  used_vars=(${(o)parameters[(I)NVM_(AUTOLOAD|LAZY|LAZY_CMD)]})
+  # Nicely print the list in the style `var1, var2 and var3`
+  echo "${fg[yellow]}[nvm plugin] Variable-style settings are deprecated. Instead of ${(j:, :)used_vars[1,-2]}${used_vars[-2]+ and }${used_vars[-1]}, use:\n"
+  if (( $+NVM_AUTOLOAD )); then
+    echo "  zstyle ':omz:plugins:nvm' autoload true"
+    zstyle ':omz:plugins:nvm' autoload yes
+  fi
+  if (( $+NVM_LAZY )); then
+    echo "  zstyle ':omz:plugins:nvm' lazy true"
+    zstyle ':omz:plugins:nvm' lazy yes
+  fi
+  if (( $+NVM_LAZY_CMD )); then
+    echo "  zstyle ':omz:plugins:nvm' lazy-cmd $NVM_LAZY_CMD"
+    zstyle ':omz:plugins:nvm' lazy-cmd $NVM_LAZY_CMD
+  fi
+  echo "$reset_color"
+  unset used_vars NVM_AUTOLOAD NVM_LAZY NVM_LAZY_CMD
 fi
 
 if zstyle -t ':omz:plugins:nvm' lazy; then
@@ -93,5 +95,4 @@ for nvm_completion in "$NVM_DIR/bash_completion" "$NVM_HOMEBREW/etc/bash_complet
   fi
 done
 
-# TODO: 2022-11-11: Remove NVM_LAZY NVM_AUTOLOAD
-unset NVM_HOMEBREW NVM_LAZY NVM_AUTOLOAD nvm_completion
+unset NVM_HOMEBREW nvm_completion

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -40,15 +40,17 @@ if (( ${+NVM_LAZY} + ${+NVM_LAZY_CMD} + ${+NVM_AUTOLOAD} )); then
 fi
 
 if zstyle -t ':omz:plugins:nvm' lazy; then
-  # Call nvm when first using nvm, node, npm, pnpm, yarn or $EXTRA_LAZY_CMD
-  zstyle -a ':omz:plugins:nvm' lazy-cmd EXTRA_LAZY_CMD
-  function nvm node npm pnpm yarn $EXTRA_LAZY_CMD {
-    unfunction nvm node npm pnpm yarn $EXTRA_LAZY_CMD
-    # Load nvm if it exists in $NVM_DIR
-    [[ -f "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
-    "$0" "$@"
-  }
-  unset EXTRA_LAZY_CMD
+  # Call nvm when first using nvm, node, npm, pnpm, yarn or other commands in lazy-cmd
+  zstyle -a ':omz:plugins:nvm' lazy-cmd nvm_lazy_cmd
+  eval "
+    function nvm node npm pnpm yarn $nvm_lazy_cmd {
+      unfunction nvm node npm pnpm yarn $nvm_lazy_cmd
+      # Load nvm if it exists in \$NVM_DIR
+      [[ -f \"\$NVM_DIR/nvm.sh\" ]] && source \"\$NVM_DIR/nvm.sh\"
+      \"\$0\" \"\$@\"
+    }
+  "
+  unset nvm_lazy_cmd
 elif [[ -f "$NVM_DIR/nvm.sh" ]]; then
   # Load nvm if it exists in $NVM_DIR
   source "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Move plugin customization to `zstyle` and soft-deprecate old options.