### PR TITLE
fix(last-working-dir): use builtin `pwd`

### DIFF
--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -9,7 +9,7 @@ chpwd_last_working_dir() {
   [[ "$ZSH_SUBSHELL" -eq 0 ]] || return 0
   # Add ".$SSH_USER" suffix to cache file if $SSH_USER is set and non-empty
   local cache_file="$ZSH_CACHE_DIR/last-working-dir${SSH_USER:+.$SSH_USER}"
-  pwd >| "$cache_file"
+  command pwd >| "$cache_file"
 }
 
 # Changes directory to the last working directory

--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -9,7 +9,7 @@ chpwd_last_working_dir() {
   [[ "$ZSH_SUBSHELL" -eq 0 ]] || return 0
   # Add ".$SSH_USER" suffix to cache file if $SSH_USER is set and non-empty
   local cache_file="$ZSH_CACHE_DIR/last-working-dir${SSH_USER:+.$SSH_USER}"
-  command pwd >| "$cache_file"
+  builtin pwd >| "$cache_file"
 }
 
 # Changes directory to the last working directory


### PR DESCRIPTION
Use system 'pwd' instead of possible user's alias or function.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
