### PR TITLE
fix(changelog): generate correct commit link in markdown

### DIFF
--- a/tools/changelog.sh
+++ b/tools/changelog.sh
@@ -209,7 +209,7 @@ function display-release {
     case "$output" in
     raw) printf '%s' "$hash" ;;
     text) printf '\e[33m%s\e[0m' "$hash" ;; # red
-    md) printf '[`%s`](https://github.com/ohmyzsh/ohmyzsh/commit/%s)' "$hash" ;;
+    md) printf '[`%s`](https://github.com/ohmyzsh/ohmyzsh/commit/%s)' "$hash" "$hash" ;;
     esac
   }
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Currently `tools/changelog.sh` would generate same link of `https://github.com/ohmyzsh/ohmyzsh/commit/` for each commit in markdown mode, without the commit hash properly included in the link
* Currently: ``[`my-commit-hash`](https://github.com/ohmyzsh/ohmyzsh/commit/)``
* Expected: ``[`my-commit-hash`](https://github.com/ohmyzsh/ohmyzsh/commit/my-commit-hash)``

