### PR TITLE
Plugin: zsh-script-prefix

### DIFF
--- a/plugins/zsh-script-prefix/README.md
+++ b/plugins/zsh-script-prefix/README.md
@@ -1,0 +1,55 @@
+# zsh-script-prefix
+
+Easily prefix your current or previous commands with `./` by pressing <kbd>esc</kbd> once.
+
+_Modified version of ohmyzsh_ [plugins/sudo](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/sudo)
+
+To use it, add `zsh-script-prefix` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... zsh-script-prefix)
+```
+
+## Usage
+
+### Current typed commands
+
+Say you have typed a script name and forgot to add `./` in front:
+
+```bash
+$ somescript.sh
+```
+
+By pressing the <kbd>esc</kbd> key once, you will have the same command with `./` prefixed without typing:
+
+```bash
+$ ./somescript.sh
+```
+
+### Previous executed commands
+
+By pressing the <kbd>esc</kbd> key once, you will have the same command with `./` prefixed without typing:
+
+```bash
+$ somescript.sh
+zsh: command not found: somescript.sh
+$ ./somescript.sh
+```
+
+## Key binding
+
+By default, the `zsh-script-prefix` plugin uses <kbd>Esc</kbd> as the trigger.
+If you want to change it, you can use the `bindkey` command to bind it to a different key:
+
+```sh
+bindkey -M emacs '<seq>' script-prefix-command-line
+bindkey -M vicmd '<seq>' script-prefix-command-line
+bindkey -M viins '<seq>' script-prefix-command-line
+```
+
+where `<seq>` is the sequence you want to use. You can find the keyboard sequence
+by running `cat` and pressing the keyboard combination you want to use.
+
+### Credits
+
+ohmyzsh [plugins/sudo](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/sudo)

--- a/plugins/zsh-script-prefix/zsh-script-prefix.plugin.zsh
+++ b/plugins/zsh-script-prefix/zsh-script-prefix.plugin.zsh
@@ -1,0 +1,49 @@
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+# zsh-script-prefix ./ (replacement for script-prefix) will be inserted before the script
+# Based on sudo plugin
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+# * tmiland <kontakt@tmiland.com>
+# - Original sudo script:
+# * Dongweiming <ciici123@gmail.com>
+# * Subhaditya Nath <github.com/subnut>
+# * Marc Cornellà <github.com/mcornella>
+# * Carlo Sala <carlosalag@protonmail.com>
+#
+# ------------------------------------------------------------------------------
+
+__script-prefix-replace-buffer() {
+  local old=$1 new=$2
+
+  # if the cursor is positioned in the $old part of the text, make
+  # the substitution and leave the cursor after the $new text
+  if [[ $CURSOR -le ${#old} ]]; then
+    BUFFER="${new}${BUFFER#$old }"
+    CURSOR=${#new}
+  # otherwise just replace $old with $new in the text before the cursor
+  else
+    LBUFFER="${new}${LBUFFER#$old }"
+  fi
+}
+
+script-prefix-command-line() {
+  # If line is empty, get the last run command from history
+  [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
+      case "$BUFFER" in
+        \./\ *) __script-prefix-replace-buffer "./" "" ;;
+        *) LBUFFER="./$LBUFFER" ;;
+      esac
+      return
+}
+
+zle -N script-prefix-command-line
+
+# Defined shortcut keys: [Esc]
+bindkey -M emacs '\e' script-prefix-command-line
+bindkey -M vicmd '\e' script-prefix-command-line
+bindkey -M viins '\e' script-prefix-command-line


### PR DESCRIPTION


## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [Added zsh-script-prefix plugin]

## Other comments:

...
I first shared this here: #11369
And thought I'd add this as a pr so more people can take advantage of this plugin.

Why did i create this? Because i was tired of; when using autocomplete to get a script name, i would have to manually go back and add the `./` prefix to the script name, which when working with lots of script, gets really tiresome. 

Now, all you have to do is hit [Esc] button **once**.