### PR TITLE
create poetry plugin dir if it doesn't exist

### DIFF
--- a/plugins/poetry/poetry.plugin.zsh
+++ b/plugins/poetry/poetry.plugin.zsh
@@ -11,4 +11,5 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_poetry" ]]; then
   _comps[poetry]=_poetry
 fi
 
+mkdir -p $ZSH_CACHE_DIR/completions
 poetry completions zsh >| "$ZSH_CACHE_DIR/completions/_poetry" &|


### PR DESCRIPTION
Currently this script fails with errors if the `$ZSH_CACHE_DIR/completions` doesn't exist. This should fix it.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- fix for the poetry plugin that removes the error when the plugin directory is not yet created
