### PR TITLE
docs(term_tab): plugin can only be used with linux and solaris

### DIFF
--- a/plugins/term_tab/README.md
+++ b/plugins/term_tab/README.md
@@ -1,5 +1,7 @@
 # term_tab plugin
 
+This plugin only works for Solaris and linux.
+
 term_tab - `cwd` for all open zsh sessions
 
 ## What it does:


### PR DESCRIPTION
This plugin only works for OSTYPE solaris* and linux* - let users know in the readme

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X ] The PR doesn't replicate another PR which is already open.
- [X ] I have read the contribution guide and followed all the instructions.
- [X ] The code follows the code style guide detailed in the wiki.
- [X ] The code is mine or it's from somewhere with an MIT-compatible license.
- [X ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X ] The code is stable and I have tested it myself, to the best of my abilities.
- [X ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [X] Let non-solaris and non-linux users they need not bother with this.

## Other comments:

...
