### PR TITLE
feat(term_tab): add support for macOS

### DIFF
--- a/plugins/term_tab/term_tab.plugin.zsh
+++ b/plugins/term_tab/term_tab.plugin.zsh
@@ -28,6 +28,7 @@ function _term_list(){
   case $OSTYPE in
     solaris*) dirs=( ${(M)${${(f)"$(pgrep -U $UID -x zsh|xargs pwdx)"}:#$$:*}%%/*} ) ;;
     linux*) dirs=( /proc/${^$(pidof zsh):#$$}/cwd(N:A) ) ;;
+    darwin*) dirs=($( lsof -d cwd | grep  "^zsh" | awk '{if ( $(NF-1) > 2 ) printf( "%s ", $NF); }' ) ) ;;
   esac
   dirs=( ${(D)dirs} )
 

--- a/plugins/term_tab/term_tab.plugin.zsh
+++ b/plugins/term_tab/term_tab.plugin.zsh
@@ -28,7 +28,7 @@ function _term_list(){
   case $OSTYPE in
     solaris*) dirs=( ${(M)${${(f)"$(pgrep -U $UID -x zsh|xargs pwdx)"}:#$$:*}%%/*} ) ;;
     linux*) dirs=( /proc/${^$(pidof zsh):#$$}/cwd(N:A) ) ;;
-    darwin*) dirs=($( lsof -d cwd | grep  "^zsh" | awk '{if ( $(NF-1) > 2 ) printf( "%s ", $NF); }' ) ) ;;
+    darwin*) dirs=( $( lsof -d cwd -c zsh -a -w -Fn | sed -n 's/^n//p' ) ) ;;
   esac
   dirs=( ${(D)dirs} )
 


### PR DESCRIPTION
This can probably be improved with better lsof and zsh zen, but it works reasonably well on my system.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [x] use lsof, grep, and awk to generate list of CWDs of zsh sessions to support macOS that lacks /proc 

## Other comments:

...
