### PR TITLE
Add doas support in sudo plugin.

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -12,10 +12,18 @@
 # * Subhaditya Nath <github.com/subnut>
 # * Marc Cornellà <github.com/mcornella>
 # * Carlo Sala <carlosalag@protonmail.com>
+# * Marcelina Hołub <mjholub.me>
 #
 # ------------------------------------------------------------------------------
 
 __sudo-replace-buffer() {
+  #Store the command to use for escalating privileges
+  ROOT_COMMAND=sudo
+  #Check if sudo isn't present
+  if [[ ! $(command -v sudo) ]]; then
+    ROOT_COMMAND=doas
+  fi
+
   local old=$1 new=$2 space=${2:+ }
 
   # if the cursor is positioned in the $old part of the text, make
@@ -48,8 +56,8 @@ sudo-command-line() {
     # If $EDITOR is not set, just toggle the sudo prefix on and off
     if [[ -z "$EDITOR" ]]; then
       case "$BUFFER" in
-        sudo\ -e\ *) __sudo-replace-buffer "sudo -e" "" ;;
-        sudo\ *) __sudo-replace-buffer "sudo" "" ;;
+        $ROOT_COMMAND\ -e\ *) __sudo-replace-buffer "sudo -e" "" ;;
+        $ROOT_COMMAND\ *) __sudo-replace-buffer "sudo" "" ;;
         *) LBUFFER="sudo $LBUFFER" ;;
       esac
       return
@@ -85,11 +93,11 @@ sudo-command-line() {
 
     # Check for editor commands in the typed command and replace accordingly
     case "$BUFFER" in
-      $editorcmd\ *) __sudo-replace-buffer "$editorcmd" "sudo -e" ;;
-      \$EDITOR\ *) __sudo-replace-buffer '$EDITOR' "sudo -e" ;;
-      sudo\ -e\ *) __sudo-replace-buffer "sudo -e" "$EDITOR" ;;
-      sudo\ *) __sudo-replace-buffer "sudo" "" ;;
-      *) LBUFFER="sudo $LBUFFER" ;;
+      $editorcmd\ *) __sudo-replace-buffer "$editorcmd" "$ROOT_COMMAND -e" ;;
+      \$EDITOR\ *) __sudo-replace-buffer '$EDITOR' "$ROOT_COMMAND -e" ;;
+      $ROOT_COMMAND\ -e\ *) __sudo-replace-buffer "sudo -e" "$EDITOR" ;;
+      $ROOT_COMMAND\ *) __sudo-replace-buffer "$ROOT_COMMAND" "" ;;
+      *) LBUFFER="$ROOT_COMMAND $LBUFFER" ;;
     esac
   } always {
     # Preserve beginning space


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add non-interactive  (dependent on whether sudo is present in the system) support for doas in sudo plugin, as suggested in PR#8669

## Other comments:

Tested under Alpine Linux 3.17
@mcornella 

...
