### PR TITLE
feat(archlinux): optimize `paclist` and `pacdisowned`

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -181,3 +181,4 @@ whether the package manager is installed, checked in the following order:
 - Ybalrid (Arthur Brainville) - ybalrid@ybalrid.info
 - Jeff M. Hubbard - jeffmhubbard@gmail.com
 - K. Harishankar(harishnkr) - hari2menon1234@gmail.com
+- WH-2099 - wh2099@outlook.com

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -28,7 +28,7 @@ alias upgrade='sudo pacman -Syu'
 function paclist() {
   local pkgs=$(LC_ALL=C pacman -Qqe)
   for pkg in ${(f)pkgs}; do
-      pacman -Qs --color=auto "^${pkg}\$"
+      pacman -Qs --color=auto "^${pkg}\$" || break
   done
 }
 

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -33,20 +33,21 @@ function paclist() {
 }
 
 function pacdisowned() {
-  local tmp db fs
-  tmp=${TMPDIR-/tmp}/pacman-disowned-$UID-$$
-  db=$tmp/db
-  fs=$tmp/fs
+  local tmp_dir db fs
+  tmp_dir=$(mktemp --directory)
+  db=$tmp_dir/db
+  fs=$tmp_dir/fs
 
-  mkdir "$tmp"
-  trap 'rm -rf "$tmp"' EXIT
+  trap "rm -rf $tmp_dir" EXIT
 
   pacman -Qlq | sort -u > "$db"
 
-  find /bin /etc /lib /sbin /usr ! -name lost+found \
+  find /etc /usr ! -name lost+found \
     \( -type d -printf '%p/\n' -o -print \) | sort > "$fs"
 
   comm -23 "$fs" "$db"
+
+  rm -rf tmp_dir
 }
 
 alias pacmanallkeys='sudo pacman-key --refresh-keys'

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -26,10 +26,10 @@ alias pacupd="sudo pacman -Sy"
 alias upgrade='sudo pacman -Syu'
 
 function paclist() {
-  # Based on https://bbs.archlinux.org/viewtopic.php?id=93683
-  pacman -Qqe | \
-    xargs -I '{}' \
-      expac "${bold_color}% 20n ${fg_no_bold[white]}%d${reset_color}" '{}'
+  local pkgs=$(LC_ALL=C pacman -Qqe)
+  for pkg in ${(f)pkgs}; do
+      pacman -Qs --color=auto "^${pkg}\$"
+  done
 }
 
 function pacdisowned() {

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -47,7 +47,7 @@ function pacdisowned() {
 
   comm -23 "$fs" "$db"
 
-  rm -rf tmp_dir
+  rm -rf $tmp_dir
 }
 
 alias pacmanallkeys='sudo pacman-key --refresh-keys'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
### 1. Optimize the implementation of `pacdisowned`
- Use `mktemp` to create the temporary directory.
In the Archlinux environment, **`mktemp` is part of the base installation**, so there is no need to worry about its existence.

- Remove search path `/bin`, `/sbin` and `/lib`
In the Archlinux environment, `/bin`, `/sbin`, `/lib` and `/lib64` (which even not mentioned in the current version) are just **soft links** to the folders under /usr.
```bash
$ ls -ld /bin /sbin /lib /lib64
lrwxrwxrwx 1 root root 7 Dec  7 10:41 /bin -> usr/bin
lrwxrwxrwx 1 root root 7 Dec  7 10:41 /lib -> usr/lib
lrwxrwxrwx 1 root root 7 Dec  7 10:41 /lib64 -> usr/lib
lrwxrwxrwx 1 root root 7 Dec  7 10:41 /sbin -> usr/bin
```

- The command string passed to the `trap` command should use **double quotes** to ensure that parameter expansion inside is done immediately (`tmp_dir` is declared as `local`).

- Temporary files should be cleaned up **as soon as possible** after use, instead of waiting for the `trap` to take effect.

### 2. Use `pacman` rather than `expac` in `paclist`
The **`expac`** command is a community repository, **usually not installed** by users.
*Using only  `pacman`, the output information is more useful and more acceptable to native users.*

## Other comments:
This PR is rebuilt from #10919 .
