### PR TITLE
fix(init): only check for upgrade if shell is interactive

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 110,
+  "proseWrap": "always"
+}

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -57,9 +57,7 @@ mkdir -p "$ZSH_CACHE_DIR/completions"
 (( ${fpath[(Ie)"$ZSH_CACHE_DIR/completions"]} )) || fpath=("$ZSH_CACHE_DIR/completions" $fpath)
 
 # Check for updates on initial load...
-if [[ "$DISABLE_AUTO_UPDATE" != true ]]; then
-  source "$ZSH/tools/check_for_upgrade.sh"
-fi
+source "$ZSH/tools/check_for_upgrade.sh"
 
 # Initializes Oh My Zsh
 

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -21,9 +21,11 @@ zstyle -s ':omz:update' mode update_mode || {
 # Cancel update if:
 # - the automatic update is disabled.
 # - the current user doesn't have write permissions nor owns the $ZSH directory.
+# - is not run from a tty
 # - git is unavailable on the system.
 if [[ "$update_mode" = disabled ]] \
    || [[ ! -w "$ZSH" || ! -O "$ZSH" ]] \
+   || [[ ! -t 1 ]] \
    || ! command git --version 2>&1 >/dev/null; then
   unset update_mode
   return


### PR DESCRIPTION
Fixes #11390

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

We are only using `check_for_upgrade.sh` on init file. I'd disable whole omz upgrade (no matter which mode is enabled by the user) to prevent auto updates that might introduce breaking changes and user would not notice about that.