### PR TITLE
fix(doctl): standardize plugin completion

### DIFF
--- a/plugins/doctl/doctl.plugin.zsh
+++ b/plugins/doctl/doctl.plugin.zsh
@@ -4,7 +4,14 @@
 #
 # Author: https://github.com/HalisCz
 
-if [ $commands[doctl] ]; then
-  source <(doctl completion zsh)
-  compdef _doctl doctl
+if (( ! $+commands[doctl] )); then
+  return
 fi
+
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_doctl" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _doctl
+  _comps[doctl]=_doctl
+fi
+
+doctl completion zsh >| "$ZSH_CACHE_DIR/completions/_doctl" &|

--- a/plugins/doctl/doctl.plugin.zsh
+++ b/plugins/doctl/doctl.plugin.zsh
@@ -6,4 +6,5 @@
 
 if [ $commands[doctl] ]; then
   source <(doctl completion zsh)
+  compdef _doctl doctl
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- fix(doctl): add compdef line

## Other comments:

Reported to upstream doctl at: https://github.com/digitalocean/doctl/issues/1329
