### PR TITLE
Add `gdn` alias for `git diff --name-only`

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -120,6 +120,7 @@ alias gcss='git commit -S -s'
 alias gcssm='git commit -S -s -m'
 
 alias gd='git diff'
+alias gdn='git diff --name-only'
 alias gdca='git diff --cached'
 alias gdcw='git diff --cached --word-diff'
 alias gdct='git describe --tags $(git rev-list --tags --max-count=1)'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `gdn` alias to git plugin for `git diff --name-only`
- Common use case is to quickly list all files that have changed against whatever branch is given as argument
- Doesn't conflict with any existing aliases as far as I can tell
- I'm not seeing any other issues/PRs that address this suggestion