### PR TITLE
feat(maven): add `quarkus` command support

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -196,7 +196,7 @@ function listMavenCompletions {
     # spring-boot
     spring-boot:run spring-boot:repackage
     # quarkus
-    quarkus:dev quarkus:list-extensions quarkus:add-extension quarkus:add-extensions quarkus:generate-config quarkus:help
+    quarkus:dev quarkus:list-extensions quarkus:add-extension quarkus:add-extensions quarkus:remove-extension quarkus:remove-extensions quarkus:generate-config quarkus:help
     # exec
     exec:exec exec:java
     # versions
@@ -287,7 +287,7 @@ function listMavenCompletions {
     vaadin:prepare-frontend vaadin:build-frontend vaadin:clean-frontend vaadin:dance
 
     # options
-    "-Dmaven.test.skip=true" -DskipTests -DskipITs -Dmaven.surefire.debug -DenableCiProfile "-Dpmd.skip=true" "-Dcheckstyle.skip=true" "-Dtycho.mode=maven" "-Dmaven.test.failure.ignore=true" "-DgroupId=" "-DartifactId=" "-Dversion=" "-Dpackaging=jar" "-Dfile="
+    "-Dmaven.test.skip=true" -DskipTests -DskipITs -Dmaven.surefire.debug -DenableCiProfile "-Dpmd.skip=true" "-Dcheckstyle.skip=true" "-Dtycho.mode=maven" "-Dmaven.test.failure.ignore=true" "-DgroupId=" "-DartifactId=" "-Dversion=" "-Dpackaging=jar" "-Dfile=" "-Dextensions="
 
     # arguments
     -am --also-make


### PR DESCRIPTION
Add `quarkus:remove-exitension` and `quarkus:remove-extensions` command support in `maven` plugin with `-Dextensions=` option

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add `quarkus:remove-extension` and `quarkus:remove-extensions`
- add `-Dextensions=` option

## Other comments:

N/A
