### PR TITLE
feat(systemd): add support for user units in prompt

### DIFF
--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -107,6 +107,8 @@ function systemd_prompt_info {
 
     if systemctl is-active "$unit" &>/dev/null; then
       echo -n "$ZSH_THEME_SYSTEMD_PROMPT_ACTIVE"
+    elif systemctl --user is-active "$unit" &>/dev/null; then
+      echo -n "$ZSH_THEME_SYSTEMD_PROMPT_ACTIVE"
     else
       echo -n "$ZSH_THEME_SYSTEMD_PROMPT_NOTACTIVE"
     fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- test if systemd unit is active in user space if it is not active in on the system level.

## Other comments:

...
