### PR TITLE
Added Cmaker plugin - Allows users to use cmake with c++ more easily

### DIFF
--- a/plugins/Cmaker/Cmaker.plugin.zsh
+++ b/plugins/Cmaker/Cmaker.plugin.zsh
@@ -1,0 +1,49 @@
+alias cjump="nvim $(mdfind -onlyin . -name 'main' | grep -A 1 /Users)"
+
+alias clist="mdfind -onlyin . -interpret .cpp & mdfind -onlyin . -interpret .cc"
+
+function cgen(){
+  mkdir $1
+  cd $1
+  touch CMakeLists.txt
+  cat ~/.oh-my-zsh/custom/plugins/cMaker/ListTemplate.txt >> CMakeLists.txt
+  mkdir src
+  cd src
+  touch main.cpp
+  cd ../..
+}
+
+function crun(){
+  #VAR=${1:-.} 
+  cd $1
+  cmake .
+  cmake --build .
+}
+
+function cbin(){
+  cbuild CPP
+  cat $1 >> CPP/src/main.cpp
+  crun CPP
+  mv cpc ../
+  cd ..
+  rm -r CPP
+}
+
+function cput(){
+  mv $1/*(DN) $2/
+}
+
+function ccomp(){
+  cbuild qwertyu
+  cd qwertyu/src
+  rm main.cpp
+  cd ../..
+  mv $1/*(DN) qwertyu/src/
+  crun qwertyu
+  mv cpc ../
+  rm -r qwertyu
+}
+
+function ctemp(){
+  open ~/.oh-my-zsh/custom/plugins/cMaker/ListTemplate.txt
+}

--- a/plugins/Cmaker/ListTemplate.txt
+++ b/plugins/Cmaker/ListTemplate.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(wat)
+cmake_minimum_required(VERSION 3.15)
+add_executable(cpc /Users/aadipalnitkar/c++/wat/src/main.cpp)
+#find_package()
+#target_incldue_directories()
+#target_link_directories()
+#target_link_libraries()

--- a/plugins/Cmaker/README.md
+++ b/plugins/Cmaker/README.md
@@ -1,0 +1,23 @@
+# Cmaker
+An oh-my-zsh plugin to make using cmake easier.
+
+## How It Works
+Cmaker uses a template text file located in the ```~/.oh-my-zsh/custom/plugins/cMaker``` directory to create a CMakeLists.txt file which will act as a config file when commands like ```cgen```,```ccomp``` and ```cbin``` are run. You can use ```ctemp``` to edit the template file or you can use ```cgen``` and then edit the CMakeLists.txt file after it has been generated. However, this not possible with commands like ```ccomp``` and ```cbin``` as they instantly run the code after generating the cmake files. In that case, you mest edit the template. A basic template has already been setup for you.
+
+## Commands
+* ```cjump``` -> If you are in the directory of your project ```cjump``` will open the 'main' file in your project. No arguements for this commands
+* ```clist``` -> ```clist``` will list every file ending with .cpp or .cc in your current directory.  No arguements for this commands
+* ```cgen``` -> Creates the ```CMakeLists.txt``` file (with basic configs allowing you to run instantly) as well as the src directory along with main.cpp in the src. Usage : ```cgen <project name>``
+* ```crun``` -> This will produce a binary file after you have used ```cgen``` and written in the main.cpp file. Use ```crun <directory name>```
+* ```cbin``` -> This will instantly create a binary file called cpc. Pass filename as an arguement : ```cbin <file path>```
+* ```cput``` -> Moves all files from one directory to another. Usage : ```cput <directory> <directory to move files to>```
+* ```ccomp``` -> Runs a directory of cpp files containing main.cpp and which are part of one project. Usage : ```ccomp <dir name>```
+* ```ctemp``` -> Allows you to edit the template with which CMakeLists.txt will be created. No arguements required
+
+## Notes:
+* cbuild | Make sure your project name doesnt conflict with other directory names.
+* cbin | This only works with single files but is faster than ccomp.
+* ccomp | Make sure that you don't have a directory called qwertyu in your current dir when you're running this.
+* This plugin can only be used to generate templates for binary projects not library projects.
+
+***Created by Aadi P***


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- I have added added a new plugin called "Cmaker"
- Cmaker adds two new aliases : ```cjump``` and ```clist```.
- ```cjump``` allows the user to open the 'main' file from the cmake project directory. This is often useful as cmake directories are often large and this allows users to quickly open the main file. It is especially useful in smaller projects.
- ```clist``` prints out every single file ending with .cc or .cpp (including hidden files) in the current directory. This allows users to make sense of their project. 

## Other comments:
Six other commands have also been added in the form of functions to automatically create cmake config files and run cmake commands. There is also a txt file which acts as a template for the ```CMakeLists.txt``` file. More details can be found in the readme of the plugin.
