### PR TITLE
fix(autojump): fix autojump sourcing in nix (-darwin)

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -1,18 +1,18 @@
 declare -a autojump_paths
 autojump_paths=(
-  $HOME/.autojump/etc/profile.d/autojump.zsh         # manual installation
-  $HOME/.autojump/share/autojump/autojump.zsh        # manual installation
-  $HOME/.nix-profile/etc/profile.d/autojump.sh       # NixOS installation
-  /run/current-system/sw/share/autojump/autojump.zsh # NixOS installation
-  /usr/share/autojump/autojump.zsh                   # Debian and Ubuntu package
-  /etc/profile.d/autojump.zsh                        # manual installation
-  /etc/profile.d/autojump.sh                         # Gentoo installation
-  /usr/local/share/autojump/autojump.zsh             # FreeBSD installation
-  /usr/pkg/share/autojump/autojump.zsh               # NetBSD installation
-  /opt/local/etc/profile.d/autojump.sh               # macOS with MacPorts
-  /usr/local/etc/profile.d/autojump.sh               # macOS with Homebrew (default)
-  /opt/homebrew/etc/profile.d/autojump.sh            # macOS with Homebrew (default on M1 macs)
-  /etc/profiles/per-user/$USER/bin/autojump          # macOS Nix, Home Manager and flakes
+  $HOME/.autojump/etc/profile.d/autojump.zsh             # manual installation
+  $HOME/.autojump/share/autojump/autojump.zsh            # manual installation
+  $HOME/.nix-profile/etc/profile.d/autojump.sh           # NixOS installation
+  /run/current-system/sw/share/autojump/autojump.zsh     # NixOS installation
+  /usr/share/autojump/autojump.zsh                       # Debian and Ubuntu package
+  /etc/profile.d/autojump.zsh                            # manual installation
+  /etc/profile.d/autojump.sh                             # Gentoo installation
+  /usr/local/share/autojump/autojump.zsh                 # FreeBSD installation
+  /usr/pkg/share/autojump/autojump.zsh                   # NetBSD installation
+  /opt/local/etc/profile.d/autojump.sh                   # macOS with MacPorts
+  /usr/local/etc/profile.d/autojump.sh                   # macOS with Homebrew (default)
+  /opt/homebrew/etc/profile.d/autojump.sh                # macOS with Homebrew (default on M1 macs)
+  /etc/profiles/per-user/$USER/etc/profile.d/autojump.sh # macOS Nix, Home Manager and flakes
 )
 
 for file in $autojump_paths; do

--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -1,18 +1,18 @@
 declare -a autojump_paths
 autojump_paths=(
-  $HOME/.autojump/etc/profile.d/autojump.zsh             # manual installation
-  $HOME/.autojump/share/autojump/autojump.zsh            # manual installation
-  $HOME/.nix-profile/etc/profile.d/autojump.sh           # NixOS installation
-  /run/current-system/sw/share/autojump/autojump.zsh     # NixOS installation
-  /usr/share/autojump/autojump.zsh                       # Debian and Ubuntu package
-  /etc/profile.d/autojump.zsh                            # manual installation
-  /etc/profile.d/autojump.sh                             # Gentoo installation
-  /usr/local/share/autojump/autojump.zsh                 # FreeBSD installation
-  /usr/pkg/share/autojump/autojump.zsh                   # NetBSD installation
-  /opt/local/etc/profile.d/autojump.sh                   # macOS with MacPorts
-  /usr/local/etc/profile.d/autojump.sh                   # macOS with Homebrew (default)
-  /opt/homebrew/etc/profile.d/autojump.sh                # macOS with Homebrew (default on M1 macs)
-  /etc/profiles/per-user/$USER/etc/profile.d/autojump.sh # macOS Nix, Home Manager and flakes
+  $HOME/.autojump/etc/profile.d/autojump.zsh              # manual installation
+  $HOME/.autojump/share/autojump/autojump.zsh             # manual installation
+  $HOME/.nix-profile/etc/profile.d/autojump.sh            # NixOS installation
+  /run/current-system/sw/share/autojump/autojump.zsh      # NixOS installation
+  /usr/share/autojump/autojump.zsh                        # Debian and Ubuntu package
+  /etc/profile.d/autojump.zsh                             # manual installation
+  /etc/profile.d/autojump.sh                              # Gentoo installation
+  /usr/local/share/autojump/autojump.zsh                  # FreeBSD installation
+  /usr/pkg/share/autojump/autojump.zsh                    # NetBSD installation
+  /opt/local/etc/profile.d/autojump.sh                    # macOS with MacPorts
+  /usr/local/etc/profile.d/autojump.sh                    # macOS with Homebrew (default)
+  /opt/homebrew/etc/profile.d/autojump.sh                 # macOS with Homebrew (default on M1 macs)
+  /etc/profiles/per-user/$USER/etc/profile.d/autojump.zsh # macOS Nix, Home Manager and flakes
 )
 
 for file in $autojump_paths; do


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

This commit fixes an apparent bug when sourcing autojump when it is installed through nix-darwin in MacOS. Instead of sourcing a shell script (like the other entries), the changes line tries to source the binary (which is a python script), which fails as expected with the following message.
```
...
/etc/profiles/per-user/username/bin/autojump:21: command not found: from
...
```

I am not sure if/how the old PR (#11291) worked, as it should have failed then aswell. 

Let me know if you need anything changed.
