### PR TITLE
feat(pipenv): standarize completion generation

### DIFF
--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -1,5 +1,16 @@
-# Pipenv completion
-eval "$(_PIPENV_COMPLETE=zsh_source pipenv)"
+if (( ! $+commands[pipenv] )); then
+  return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `pipenv`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_pipenv" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _pipenv
+  _comps[pipenv]=_pipenv
+fi
+
+_PIPENV_COMPLETE=zsh_source pipenv >| "$ZSH_CACHE_DIR/completions/_pipenv" &|
 
 # Automatic pipenv shell activation/deactivation
 _togglePipenvShell() {

--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -1,8 +1,5 @@
 # Pipenv completion
-_pipenv() {
-  eval $(env COMMANDLINE="${words[1,$CURRENT]}" _PIPENV_COMPLETE=complete-zsh pipenv)
-}
-compdef _pipenv pipenv
+eval "$(_PIPENV_COMPLETE=zsh_source pipenv)"
 
 # Automatic pipenv shell activation/deactivation
 _togglePipenvShell() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Remove existing _pipenv function, replace with recommended completion generation

## Other comments:

...
