### PR TITLE
feat(git): add `gmff`, `gprum(i)`, `grbum` aliases to work with `upstream` remotes

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -89,7 +89,7 @@ plugins=(... git)
 | `gdnolock`             | `git diff $@ ":(exclude)package-lock.json" ":(exclude)\*.lock"`                                                                 |
 | `gdt`                  | `git diff-tree --no-commit-id --name-only -r`                                                                                   |
 | `gf`                   | `git fetch`                                                                                                                     |
-| `gfa`                  | `git fetch --all --tags --prune`                                                                                                       |
+| `gfa`                  | `git fetch --all --tags --prune`                                                                                                |
 | `gfo`                  | `git fetch origin`                                                                                                              |
 | `gg`                   | `git gui citool`                                                                                                                |
 | `gga`                  | `git gui citool --amend`                                                                                                        |
@@ -114,6 +114,7 @@ plugins=(... git)
 | `gma`                  | `git merge --abort`                                                                                                             |
 | `gmc`                  | `git merge --continue`                                                                                                          |
 | `gms`                  | `git merge --squash`                                                                                                            |
+| `gmff`                 | `git merge --ff-only`                                                                                                           |
 | `gmom`                 | `git merge origin/$(git_main_branch)`                                                                                           |
 | `gmum`                 | `git merge upstream/$(git_main_branch)`                                                                                         |
 | `gmtl`                 | `git mergetool --no-prompt`                                                                                                     |
@@ -125,6 +126,8 @@ plugins=(... git)
 | `gprav`                | `git pull --rebase --autostash -v`                                                                                              |
 | `gprom`                | `git pull --rebase origin $(git_main_branch)`                                                                                   |
 | `gpromi`               | `git pull --rebase=interactive origin $(git_main_branch)`                                                                       |
+| `gprum`                | `git pull --rebase upstream $(git_main_branch)`                                                                                 |
+| `gprumi`               | `git pull --rebase=interactive upstream $(git_main_branch)`                                                                     |
 | `ggpull`               | `git pull origin "$(git_current_branch)"`                                                                                       |
 | `ggl`                  | `git pull origin $(current_branch)`                                                                                             |
 | `gluc`                 | `git pull upstream $(git_current_branch)`                                                                                       |
@@ -154,6 +157,7 @@ plugins=(... git)
 | `grbd`                 | `git rebase $(git_develop_branch)`                                                                                              |
 | `grbm`                 | `git rebase $(git_main_branch)`                                                                                                 |
 | `grbom`                | `git rebase origin/$(git_main_branch)`                                                                                          |
+| `grbum`                | `git rebase upstream/$(git_main_branch)`                                                                                        |
 | `grf`                  | `git reflog`                                                                                                                    |
 | `gr`                   | `git remote`                                                                                                                    |
 | `grv`                  | `git remote --verbose`                                                                                                          |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -255,6 +255,7 @@ alias gm='git merge'
 alias gma='git merge --abort'
 alias gmc='git merge --continue'
 alias gms="git merge --squash"
+alias gmff="git merge --ff-only"
 alias gmom='git merge origin/$(git_main_branch)'
 alias gmum='git merge upstream/$(git_main_branch)'
 alias gmtl='git mergetool --no-prompt'
@@ -274,6 +275,8 @@ compdef _git ggu=git-checkout
 
 alias gprom='git pull --rebase origin $(git_main_branch)'
 alias gpromi='git pull --rebase=interactive origin $(git_main_branch)'
+alias gprum='git pull --rebase upstream $(git_main_branch)'
+alias gprumi='git pull --rebase=interactive upstream $(git_main_branch)'
 alias ggpull='git pull origin "$(git_current_branch)"'
 
 function ggl() {
@@ -337,6 +340,7 @@ alias grbs='git rebase --skip'
 alias grbd='git rebase $(git_develop_branch)'
 alias grbm='git rebase $(git_main_branch)'
 alias grbom='git rebase origin/$(git_main_branch)'
+alias grbum='git rebase upstream/$(git_main_branch)'
 alias grf='git reflog'
 alias gr='git remote'
 alias grv='git remote --verbose'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine, or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users below.

## Changes:

- Add `gmff` for `git merge --ff-only`
- Add `grpum(i?)` for `git pull --rebase (--interactive)? upstream $(git_main_branch)` (analogously to already existing `grpom(i?)`)
- Add `grbum` for `git rebase upstream $(git_main_branch)` (analogously to already existing `grbom`)

## Other comments:

The first change for `--ff-only` merge is similar to the abandoned #8119.

The need behind these aliases stem from workflows where a dedicated central repository enforces things like linear history, but the conventional workflow involves the user itself having a fork where they exert total control. From my personal perspective, the project in question is [LLVM](http://github.com/llvm/llvm-project). In my local fork, I go wild with branches and merge commits, but the official upstream does **not** use pull requests and mandates a strict linear history, so there is often the need to squash and rebase my local contents against the upstream cleanly often before creating patches. As such, I expect these commands to be generally useful for project of similar size and rules, such as [Linux](http://github.com/torvalds/linux).

Two of the aliases in question just duplicate existing ones but embed the conventional `upstream` repository name instead of `origin`. Other aliases where `upstream` is used are already in the codebase of the plugin.

I've been having [`git ffmerge`, here proposed as `gmff`](https://github.com/whisperity/dotfiles/commit/dd2b31f42ad7becf2bfd7c753158c7704a35fa2b#diff-3cbe50069f7ffe4d55b4d1fe7a72fb79e9c9545af55d8326a728b98f00481bf2R41) as an alias for close to a decade now (the versioning of the Dotfiles was not happening when I already had some of the personal aliases, long before I knew Zsh even existed!) and I can track down [`git rbum`, here proposed as `grbum`](https://github.com/whisperity/dotfiles/commit/fb99a984abfd5d9e89369e2ad761165963c7bed9#diff-10b8a5fda4d7bc4e07047f39c757c2cee2951366f030179d680c74866b1d096dR72) to roundabout 4.5 years ago, when I started doing major contributions to upstream LLVM as opposed to working on an in-house downstream derivative.