### PR TITLE
feat(git): accept `default` and `mainline` as main branches

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -31,7 +31,7 @@ function work_in_progress() {
 function git_main_branch() {
   command git rev-parse --git-dir &>/dev/null || return
   local ref
-  for ref in refs/{heads,remotes/{origin,upstream}}/{main,trunk}; do
+  for ref in refs/{heads,remotes/{origin,upstream}}/{main,trunk,mainline,default}; do
     if command git show-ref -q --verify $ref; then
       echo ${ref:t}
       return


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Update git plugin: accept "mainline" and "default" as main branch name

## Other comments:

The [Git documentation branch management page](https://git-scm.com/book/en/v2/Git-Branching-Branch-Management) mentioned `master/main/mainline/default` in a side note as common main branch names:

> Changing the name of a branch like **master/main/mainline/default ** will break the integrations, services, helper utilities and build/release scripts that your repository uses.
> ...

I also personally encountered companies using `mainline` and `default` as their main branches' naming convention. The plugin would partially broken in such environments.

Having this change not only aligns with what Git's branch management documentation, but also making many folks who work in corporate environments a bit easier.
