### PR TITLE
Update CODEOWNERS to remove maksyms

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # Plugin owners
 plugins/archlinux/                  @ratijas
-plugins/aws/                        @maksyms
 plugins/genpass/                    @atoponce
 plugins/git-lfs/                    @hellovietduc
 plugins/gitfast/                    @felipec


### PR DESCRIPTION
@mcornella I'm afraid I no longer use `ohmyzsh` or even `zsh` in favour of `fish`. Hence, it doesn't make sense for me to continue being the code owner for the plugin. Good luck with supporting a fantastic tool!