### PR TITLE
fix(clipboard): `uname` seems to be slow in wsl2

### DIFF
--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -57,6 +57,9 @@ function detect-clipboard() {
   elif [[ "${OSTYPE}" == (cygwin|msys)* ]]; then
     function clipcopy() { cat "${1:-/dev/stdin}" > /dev/clipboard; }
     function clippaste() { cat /dev/clipboard; }
+  elif (( $+commands[clip.exe] )) && (( $+commands[powershell.exe] )); then
+    function clipcopy() { cat "${1:-/dev/stdin}" | clip.exe; }
+    function clippaste() { powershell.exe -noprofile -command Get-Clipboard; }
   elif [ -n "${WAYLAND_DISPLAY:-}" ] && (( ${+commands[wl-copy]} )) && (( ${+commands[wl-paste]} )); then
     function clipcopy() { cat "${1:-/dev/stdin}" | wl-copy &>/dev/null &|; }
     function clippaste() { wl-paste; }
@@ -81,9 +84,6 @@ function detect-clipboard() {
   elif [ -n "${TMUX:-}" ] && (( ${+commands[tmux]} )); then
     function clipcopy() { tmux load-buffer "${1:--}"; }
     function clippaste() { tmux save-buffer -; }
-  elif [[ $(uname -r) = *icrosoft* ]]; then
-    function clipcopy() { cat "${1:-/dev/stdin}" | clip.exe; }
-    function clippaste() { powershell.exe -noprofile -command Get-Clipboard; }
   else
     function _retry_clipboard_detection_or_fail() {
       local clipcmd="${1}"; shift


### PR DESCRIPTION
Closes #8827

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Avoid the usage of `uname` in clipboard detection.