### PR TITLE
Add the gfom alias to the git plugin

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -76,6 +76,7 @@ plugins=(... git)
 | gfa                  | git fetch --all --prune                                                                                                                                                                  |
 | gfg                  | git ls-files \| grep                                                                                                                                                                     |
 | gfo                  | git fetch origin                                                                                                                                                                         |
+| gfom                 | git fetch origin $(git_main_branch)                                                                                                                                                      |
 | gg                   | git gui citool                                                                                                                                                                           |
 | gga                  | git gui citool --amend                                                                                                                                                                   |
 | ggf                  | git push --force origin $(current_branch)                                                                                                                                                |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -141,6 +141,7 @@ is-at-least 2.8 "$git_version" \
   && alias gfa='git fetch --all --prune --jobs=10' \
   || alias gfa='git fetch --all --prune'
 alias gfo='git fetch origin'
+alias gfom='git fetch origin $(git_main_branch)'
 
 alias gfg='git ls-files | grep'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds the `gfom` alias to the git plugin

The alias is for `git fetch origin ${git_main_branch}` and follows a similar pattern to grbom and gmom.

It is useful when working on a branch and you want to update master before rebasing or merging without having to switch branches.

## Other comments:

...
