### PR TITLE
feat(functions/take): make `.tgz` behave as `.tar.gz`

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -56,7 +56,7 @@ function takegit() {
 }
 
 function take() {
-  if [[ $1 =~ ^(https?|ftp).*\.tar\.(gz|bz2|xz)$ ]]; then
+  if [[ $1 =~ ^(https?|ftp).*\.(tar\.(gz|bz2|xz)|tgz)$ ]]; then
     takeurl "$1"
   elif [[ $1 =~ ^([A-Za-z0-9]\+@|https?|git|ssh|ftps?|rsync).*\.git/?$ ]]; then
     takegit "$1"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- The `take` now also accepts files ending with the extension `.tgz`.

## Other comments:

The `take` command only accepts files ending with the extensions `.tar.gz`, `.tar.bz2`, or `.tar.xz`. This also allows also for files ending in `.tgz`. This extension is quite used. An example of this usage is the python source code files (https://www.python.org/ftp/python/3.11.1/Python-3.11.1.tgz)
