### PR TITLE
feat(git): add function for `git`

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -96,6 +96,16 @@ alias gcasm='git commit --all --signoff --message'
 alias gcb='git checkout -b'
 alias gcf='git config --list'
 
+function ghop(){
+    branch=$(git rev-parse --abbrev-ref HEAD)
+    if [ -n "$1" ]; then
+      path=$(echo $@|gsed -e "s/ /%20/g ; s|^|blob/$branch/|")
+    else
+      path="tree/$branch"
+    fi
+    git config --get remote.origin.url|gsed -re "/https/b;s|^.*:|https://github.com/|;s|(\.git\|)$|/$path|"|xargs open
+}
+
 function gccd() {
   command git clone --recurse-submodules "$@"
   [[ -d "$_" ]] && cd "$_" || cd "${${_:t}%.git}"


### PR DESCRIPTION
Signed-off-by: James Hopbourn <jameshopbourn@gmail.com>

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- feat(git): add function for `git`


## Other comments:

add new function to quicky open file or homepage in browser.

example:
`ghop` open current branch homepage, e.g. master, test, dev
`ghop oh-my-zsh.sh` open oh-my-zsh.sh code page directly
`ghop plugins/git` open git plugin directory page
`ghop Keyboard\ Maestro/README.md` open path with space

support three type of git remote url such as:
- https url: https://github.com/JamesHopbourn/Apple-Automation
- ssh protocol: git@github.com:JamesHopbourn/Apple-Automation.git
- Host config in ssh config file: hopbourn:JamesHopbourn/CompanyPorject.git
