### PR TITLE
feat(mlh): add separate prompt symbol for root user

### DIFF
--- a/themes/mlh.zsh-theme
+++ b/themes/mlh.zsh-theme
@@ -47,6 +47,10 @@ if [ -z "$MLH_SHELL_SYMBOL" ]; then
   MLH_SHELL_SYMBOL="$ "
 fi
 
+if [ -z "$MLH_SHELL_SYMBOL_ROOT" ]; then
+  MLH_SHELL_SYMBOL_ROOT="# "
+fi
+
 # colors
 USER_COLOR="%F{001}"
 DEVICE_COLOR="%F{033}"
@@ -83,7 +87,11 @@ exit_code() {
 }
 
 prompt_end() {
-  printf "\n$MLH_SHELL_SYMBOL"
+  if [ "$UID" -eq "0" ]; then
+    printf "\n$MLH_SHELL_SYMBOL_ROOT"
+  else
+    printf "\n$MLH_SHELL_SYMBOL"
+  fi
 }
 
 # Set git_prompt_info text

--- a/themes/mlh.zsh-theme
+++ b/themes/mlh.zsh-theme
@@ -87,7 +87,7 @@ exit_code() {
 }
 
 prompt_end() {
-  if [ "$UID" -eq "0" ]; then
+  if [ "$UID" -eq 0 ]; then
     printf "\n$MLH_SHELL_SYMBOL_ROOT"
   else
     printf "\n$MLH_SHELL_SYMBOL"


### PR DESCRIPTION
The `mlh` theme lacks this config option.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- if `MLH_SHELL_SYMBOL_ROOT` env var is defined, `mlh` theme will use it. If it's not defined, it defaults to `# `.

  `MLH_SHELL_SYMBOL_ROOT` is used when `$UID` is `0` (root user).