### PR TITLE
fix(theme-and-appearance): fix `diff` completion in macOS

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -41,7 +41,11 @@ fi
 
 # enable diff color if possible.
 if command diff --color /dev/null /dev/null &>/dev/null; then
-  alias diff='diff --color'
+  function color-diff {
+    diff --color $@
+  }
+  alias diff="color-diff"
+  compdef _diff color-diff # compdef is already loaded by this point
 fi
 
 setopt auto_cd


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Fix `diff` completion for macOS