### PR TITLE
fix(systemadmin): handle error for no IPv6 route in `geteip`

### DIFF
--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -140,7 +140,13 @@ function d0() {
 # gather external ip address
 function geteip() {
     curl -s -S -4 https://icanhazip.com
-    curl -s -S -6 https://icanhazip.com
+
+    # handle case when there is no IPv6 external IP, which shows error
+    # curl: (7) Couldn't connect to server
+    curl -s -S -6 https://icanhazip.com 2>/dev/null
+    local ret=$?
+    (( ret == 7 )) && print -P -u2 "%F{red}error: no IPv6 route to host%f"
+    return $ret
 }
 
 # determine local IP address(es)


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Swallows curl error for IPv6 request to icanhazip.com and checks for return code 7 which indicates no route was accessible using IPv6 external IP.

This has been verified by checking https://test-ipv6.com/. See https://github.com/ohmyzsh/ohmyzsh/issues/11457#issuecomment-1405475594.

Fixes #11457
