### PR TITLE
feat(git): add gbc alias to show last commit authors per branch

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -22,6 +22,7 @@ plugins=(... git)
 | gapt                 | git apply --3way                                                                                                                                                                         |
 | gb                   | git branch                                                                                                                                                                               |
 | gba                  | git branch --all                                                                                                                                                                         |
+| gbc                  | git for-each-ref --format="%(committerdate) %09 %(authorname) %09 %(refname)" --sort committerdate                                                                                       |
 | gbd                  | git branch --delete                                                                                                                                                                      |
 | gbda                 | git branch --no-color --merged \| grep -vE "^([+*]\|\s*(<span>$</span>(git_main_branch)\|<span>$</span>(git_develop_branch))\s*<span>$</span>)" \| xargs git branch --delete 2>/dev/null |
 | gbD                  | git branch --delete --force                                                                                                                                                              |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -70,6 +70,7 @@ alias gapt='git apply --3way'
 
 alias gb='git branch'
 alias gba='git branch --all'
+alias gbc='git for-each-ref --format="%(committerdate) %09 %(authorname) %09 %(refname)" --sort committerdate'
 alias gbd='git branch --delete'
 alias gbda='git branch --no-color --merged | command grep -vE "^([+*]|\s*($(git_main_branch)|$(git_develop_branch))\s*$)" | command xargs git branch --delete 2>/dev/null'
 alias gbD='git branch --delete --force'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- added `gbc` alias to `plugins/git` to show git branch creators

## Other comments:

alias `gbc` uses the git for-each-ref command to list branches including:
- reference date 
- authorname
- reference name

### Comand Aliased
```bash
 git for-each-ref --format="%(committerdate) %09 %(authorname) %09 %(refname)" --sort committerdate                                                                                       
```

### Sample Output
```bash
➜  ohmyzsh git:(feature/plugns/git/gbc) gbc
Fri Jan 27 16:22:27 2023 +0100   Marc Cornellà   refs/heads/master
Fri Jan 27 16:22:27 2023 +0100   Marc Cornellà   refs/remotes/origin/HEAD
Fri Jan 27 16:22:27 2023 +0100   Marc Cornellà   refs/remotes/origin/master
```
...
