### PR TITLE
feat(lib/directories): Add an escape hatch to the file

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -1,3 +1,5 @@
+[[ "${OMZ_DIRECTORY_ALIASES:-true}" == "false" ]] && return
+
 # Changing/making/removing directory
 setopt auto_pushd
 setopt pushd_ignore_dups


### PR DESCRIPTION
These aliases don't seem particularly high-value, and can interfere with other workflows given the global nature of some of the aliases.

This change makes it possible to bypass these aliases by setting `OMZ_DIRECTORY_ALIASES=false` before sourcing `oh-my-zsh.sh`. The default behavior is not changed to not break existing workflows.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Add `OMZ_DIRECTORY_ALIASES` environment variable