### PR TITLE
fix(installer): don't use `$ZDOTDIR` in zshrc file if same as `$HOME`

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -61,9 +61,9 @@ custom_zsh=${ZSH:+yes}
 zdot="${ZDOTDIR:-$HOME}"
 
 # Default value for $ZSH
-# a) if $ZDOTDIR is supplied: $ZDOTDIR/ohmyzsh
+# a) if $ZDOTDIR is supplied and not $HOME: $ZDOTDIR/ohmyzsh
 # b) otherwise, $HOME/.oh-my-zsh
-ZSH="${ZSH:-${ZDOTDIR:+$ZDOTDIR/ohmyzsh}}"
+[ "$ZDOTDIR" = "$HOME" ] || ZSH="${ZSH:-${ZDOTDIR:+$ZDOTDIR/ohmyzsh}}"
 ZSH="${ZSH:-$HOME/.oh-my-zsh}"
 
 # Default settings
@@ -350,7 +350,9 @@ setup_zshrc() {
 
   # Modify $ZSH variable in .zshrc directory to use the literal $ZDOTDIR or $HOME
   omz="$ZSH"
-  [ -z "$ZDOTDIR" ] || omz=$(echo "$omz" | sed "s|^$ZDOTDIR/|\$ZDOTDIR/|")
+  if [ -n "$ZDOTDIR" ] && [ "$ZDOTDIR" != "$HOME" ]; then
+    omz=$(echo "$omz" | sed "s|^$ZDOTDIR/|\$ZDOTDIR/|")
+  fi
   omz=$(echo "$omz" | sed "s|^$HOME/|\$HOME/|")
 
   sed "s|^export ZSH=.*$|export ZSH=\"${omz}\"|" "$ZSH/templates/zshrc.zsh-template" > "$zdot/.zshrc-omztemp"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -523,6 +523,11 @@ EOF
     exit 1
   fi
 
+  # Create ZDOTDIR folder structure if it doesn't exist
+  if [ -n "$ZDOTDIR" ]; then
+    mkdir -p "$ZDOTDIR"
+  fi
+
   setup_ohmyzsh
   setup_zshrc
   setup_shell


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Fixes #11471
