### PR TITLE
feat(git)!: add `force-if-includes` flag

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -89,7 +89,8 @@ plugins=(... git)
 | ggsup                | git branch --set-upstream-to=origin/$(git_current_branch)                                                                                                                                |
 | ggu                  | git pull --rebase origin $(current_branch)                                                                                                                                               |
 | gpsup                | git push --set-upstream origin $(git_current_branch)                                                                                                                                     |
-| gpsupf                | git push --set-upstream origin $(git_current_branch) --force-with-lease                                                                                                                                     |
+| gpsupf               | git push --set-upstream origin $(git_current_branch) --force-with-lease --force-if-includes (git version >= 2.30)                                                                        |
+| gpsupf               | git push --set-upstream origin $(git_current_branch) --force-with-lease (git version < 2.30)                                                                                             |
 | ghh                  | git help                                                                                                                                                                                 |
 | gignore              | git update-index --assume-unchanged                                                                                                                                                      |
 | gignored             | git ls-files -v \| grep "^[[:lower:]]"                                                                                                                                                   |
@@ -120,6 +121,8 @@ plugins=(... git)
 | gp                   | git push                                                                                                                                                                                 |
 | gpd                  | git push --dry-run                                                                                                                                                                       |
 | gpf                  | git push --force-with-lease                                                                                                                                                              |
+| gpf                  | git push --force-with-lease --force-if-includes (git version >= 2.30)                                                                                                                    |
+| gpf                  | git push --force-with-lease (git version < 2.30)                                                                                                                                         |
 | gpf!                 | git push --force                                                                                                                                                                         |
 | gpoat                | git push origin --all && git push origin --tags                                                                                                                                          |
 | gpr                  | git pull --rebase                                                                                                                                                                        |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -199,7 +199,9 @@ alias ggpush='git push origin "$(git_current_branch)"'
 
 alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'
 alias gpsup='git push --set-upstream origin $(git_current_branch)'
-alias gpsupf='git push --set-upstream origin $(git_current_branch) --force-with-lease'
+is-at-least 2.30 "$git_version" \
+  && alias gpsupf='git push --set-upstream origin $(git_current_branch) --force-with-lease --force-if-includes' \
+  || alias gpsupf='git push --set-upstream origin $(git_current_branch) --force-with-lease'
 
 alias ghh='git help'
 
@@ -235,7 +237,9 @@ alias gma='git merge --abort'
 
 alias gp='git push'
 alias gpd='git push --dry-run'
-alias gpf='git push --force-with-lease --force-if-includes'
+is-at-least 2.30 "$git_version" \
+  && alias gpf='git push --force-with-lease --force-if-includes' \
+  || alias gpf='git push --force-with-lease'
 alias gpf!='git push --force'
 alias gpoat='git push origin --all && git push origin --tags'
 alias gpr='git pull --rebase'

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -235,7 +235,7 @@ alias gma='git merge --abort'
 
 alias gp='git push'
 alias gpd='git push --dry-run'
-alias gpf='git push --force-with-lease'
+alias gpf='git push --force-with-lease --force-if-includes'
 alias gpf!='git push --force'
 alias gpoat='git push origin --all && git push origin --tags'
 alias gpr='git pull --rebase'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- As per the issue #11388 adds a new safer flag in git plugin `--force-if-includes`
