### PR TITLE
Remove aliases for non-standard commands

### DIFF
--- a/lib/correction.zsh
+++ b/lib/correction.zsh
@@ -1,13 +1,8 @@
 if [[ "$ENABLE_CORRECTION" == "true" ]]; then
   alias cp='nocorrect cp'
-  alias ebuild='nocorrect ebuild'
-  alias gist='nocorrect gist'
-  alias heroku='nocorrect heroku'
-  alias hpodder='nocorrect hpodder'
   alias man='nocorrect man'
   alias mkdir='nocorrect mkdir'
   alias mv='nocorrect mv'
-  alias mysql='nocorrect mysql'
   alias sudo='nocorrect sudo'
   alias su='nocorrect su'
 


### PR DESCRIPTION
These aliases were for non-standard (installed by default) unix/linux commands and should not be included here.   They should be put into their appropriate plugin to be optionally added by users using those commands.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
