### PR TITLE
Fix `gradle` plugin completion not working

### DIFF
--- a/plugins/gradle/_gradle
+++ b/plugins/gradle/_gradle
@@ -1,3 +1,6 @@
+#compdef gradle gradlew gw
+# THE LINE ABOVE MUST BE THE FIRST LINE OF THIS FILE IN ORDER FOR COMPLETION TO WORK
+
 #
 # Taken from https://github.com/gradle/gradle-completion
 # Copyright (c) 2017 Eric Wendelin
@@ -20,8 +23,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # Terms
-
-#compdef gradle gradlew gw
 
 __gradle-set-project-root-dir() {
     local dir=`pwd`


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixed `gradle` plugin completion not working. Apparently the line `compdef gradle gradlew gw` must be the first line of the `_gradle` file. I broke this in #11485 – sorry about this.