### PR TITLE
document how to disable aliases

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -3,6 +3,11 @@ setopt auto_pushd
 setopt pushd_ignore_dups
 setopt pushdminus
 
+# add (uncommented):
+# zstyle ':omz:directories' aliases no
+# to your `zshrc` before loading `oh-my-zsh.sh`
+# to disable the following aliases and functions
+
 zstyle -T ':omz:directories' aliases || return
 
 alias -g ...='../..'


### PR DESCRIPTION
Recent change allows disabling aliases for common directory commands, document directly in the file instead of requiring the user to parse a markdown file. (file has extremely long lines making it ugly to read with a simple pager.)

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
