### PR TITLE
fix(af-magic): fix python venv checking logic

### DIFF
--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -10,7 +10,7 @@ function afmagic_dashes {
 
   # if there is a python virtual environment and it is displayed in
   # the prompt, account for it when returning the number of dashes
-  if [[ -n "$python_env" && "$PS1" = \(* ]]; then
+  if [[ -n "$python_env" && "$PS1" = *\(${python_env}\)* ]]; then
     echo $(( COLUMNS - ${#python_env} - 3 ))
   else
     echo $COLUMNS


### PR DESCRIPTION
In some cases, such as command decorations in vscode's integrated terminal, PS1 doesn't start with `(` when venv is displayed. Therefore, it should check whether `($python_env)` exits in PS1 somewhere.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- In some cases, such as command decorations in vscode's integrated terminal, PS1 doesn't start with `(` when venv is displayed. Therefore, it should check whether `($python_env)` exits in PS1 somewhere. `\(*`->`*\(${python_env}\)*`