### PR TITLE
fix(gcloud): add location of latest snap install

### DIFF
--- a/plugins/gcloud/gcloud.plugin.zsh
+++ b/plugins/gcloud/gcloud.plugin.zsh
@@ -10,6 +10,7 @@ if [[ -z "${CLOUDSDK_HOME}" ]]; then
     "/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk"
     "/usr/share/google-cloud-sdk"
     "/snap/google-cloud-sdk/current"
+    "/snap/google-cloud-cli/current"
     "/usr/lib/google-cloud-sdk"
     "/usr/lib64/google-cloud-sdk"
     "/opt/google-cloud-sdk"


### PR DESCRIPTION
Latest snap installs gcloud at /snap/google-cloud-cli, so add that to the list of possible locations.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds `/snap/google-cloud-cli/current` to the list of possible locations for gcloud installation

## Other comments:

...
