### PR TITLE
feat(iterm2): add shell integration script

### DIFF
--- a/plugins/iterm2/README.md
+++ b/plugins/iterm2/README.md
@@ -13,7 +13,7 @@ You can enable the integration with zstyle. It's important to add this line
 before the line sourcing oh-my-zsh:
 
 ```
-zstyle :omz:plugins:iterm2 shell-integration true
+zstyle :omz:plugins:iterm2 shell-integration yes
 ```
 
 ## Plugin commands

--- a/plugins/iterm2/README.md
+++ b/plugins/iterm2/README.md
@@ -1,6 +1,7 @@
 # iTerm2 plugin
 
 This plugin adds a few functions that are useful when using [iTerm2](https://www.iterm2.com/).
+It also applies the [Shell Integration Script for iTerm2](https://iterm2.com/documentation-shell-integration.html).
 
 To use it, add _iterm2_ to the plugins array of your zshrc file:
 ```
@@ -23,6 +24,9 @@ plugins=(... iterm2)
 
 * `iterm2_tab_color_reset`
   resets the color of iTerm2's current tab back to default.
+
+
+For shell integration features see the [official documentation](https://iterm2.com/documentation-shell-integration.html).
 
 ## Contributors
 

--- a/plugins/iterm2/README.md
+++ b/plugins/iterm2/README.md
@@ -1,11 +1,19 @@
 # iTerm2 plugin
 
 This plugin adds a few functions that are useful when using [iTerm2](https://www.iterm2.com/).
-It also applies the [Shell Integration Script for iTerm2](https://iterm2.com/documentation-shell-integration.html).
+
 
 To use it, add _iterm2_ to the plugins array of your zshrc file:
 ```
 plugins=(... iterm2)
+```
+
+Optionally, the plugin also applies the [Shell Integration Script for iTerm2](https://iterm2.com/documentation-shell-integration.html).
+You can enable the integration with zstyle. It's important to add this line 
+before the line sourcing oh-my-zsh:
+
+```
+zstyle :omz:plugins:iterm2 shell-integration true
 ```
 
 ## Plugin commands

--- a/plugins/iterm2/iterm2.plugin.zsh
+++ b/plugins/iterm2/iterm2.plugin.zsh
@@ -7,6 +7,14 @@
 # This plugin is only relevant if the terminal is iTerm2 on OSX.
 if [[ "$OSTYPE" == darwin* ]] && [[ -n "$ITERM_SESSION_ID" ]] ; then
 
+  # Handle $0 according to the standard:
+  # https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
+  0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+  0="${${(M)0:#/*}:-$PWD/$0}"
+
+  # See official docs: https://iterm2.com/documentation-shell-integration.html
+  source "${0:A:h}/iterm2_shell_integration.zsh"
+
   ###
   # Executes an arbitrary iTerm2 command via an escape code sequence.
   # See https://iterm2.com/documentation-escape-codes.html for all supported commands.

--- a/plugins/iterm2/iterm2.plugin.zsh
+++ b/plugins/iterm2/iterm2.plugin.zsh
@@ -7,13 +7,16 @@
 # This plugin is only relevant if the terminal is iTerm2 on OSX.
 if [[ "$OSTYPE" == darwin* ]] && [[ -n "$ITERM_SESSION_ID" ]] ; then
 
-  # Handle $0 according to the standard:
-  # https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
-  0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
-  0="${${(M)0:#/*}:-$PWD/$0}"
+  # maybe make it the default in the future and allow opting out?
+  if zstyle -t ':omz:plugins:iterm2' shell-integration; then 
+    # Handle $0 according to the standard:
+    # https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
+    0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+    0="${${(M)0:#/*}:-$PWD/$0}"
 
-  # See official docs: https://iterm2.com/documentation-shell-integration.html
-  source "${0:A:h}/iterm2_shell_integration.zsh"
+    # See official docs: https://iterm2.com/documentation-shell-integration.html
+    source "${0:A:h}/iterm2_shell_integration.zsh"
+  fi
 
   ###
   # Executes an arbitrary iTerm2 command via an escape code sequence.

--- a/plugins/iterm2/iterm2_shell_integration.zsh
+++ b/plugins/iterm2/iterm2_shell_integration.zsh
@@ -1,0 +1,178 @@
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+if [[ -o interactive ]]; then
+  if [ "${ITERM_ENABLE_SHELL_INTEGRATION_WITH_TMUX-}""$TERM" != "tmux-256color" -a "${ITERM_ENABLE_SHELL_INTEGRATION_WITH_TMUX-}""$TERM" != "screen" -a "${ITERM_SHELL_INTEGRATION_INSTALLED-}" = "" -a "$TERM" != linux -a "$TERM" != dumb ]; then
+    ITERM_SHELL_INTEGRATION_INSTALLED=Yes
+    ITERM2_SHOULD_DECORATE_PROMPT="1"
+    # Indicates start of command output. Runs just before command executes.
+    iterm2_before_cmd_executes() {
+      if [ "$TERM_PROGRAM" = "iTerm.app" ]; then
+        printf "\033]133;C;\r\007"
+      else
+        printf "\033]133;C;\007"
+      fi
+    }
+
+    iterm2_set_user_var() {
+      printf "\033]1337;SetUserVar=%s=%s\007" "$1" $(printf "%s" "$2" | base64 | tr -d '\n')
+    }
+
+    # Users can write their own version of this method. It should call
+    # iterm2_set_user_var but not produce any other output.
+    # e.g., iterm2_set_user_var currentDirectory $PWD
+    # Accessible in iTerm2 (in a badge now, elsewhere in the future) as
+    # \(user.currentDirectory).
+    whence -v iterm2_print_user_vars > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+      iterm2_print_user_vars() {
+          true
+      }
+    fi
+
+    iterm2_print_state_data() {
+      local _iterm2_hostname="${iterm2_hostname-}"
+      if [ -z "${iterm2_hostname:-}" ]; then
+        _iterm2_hostname=$(hostname -f 2>/dev/null)
+      fi
+      printf "\033]1337;RemoteHost=%s@%s\007" "$USER" "${_iterm2_hostname-}"
+      printf "\033]1337;CurrentDir=%s\007" "$PWD"
+      iterm2_print_user_vars
+    }
+
+    # Report return code of command; runs after command finishes but before prompt
+    iterm2_after_cmd_executes() {
+      printf "\033]133;D;%s\007" "$STATUS"
+      iterm2_print_state_data
+    }
+
+    # Mark start of prompt
+    iterm2_prompt_mark() {
+      printf "\033]133;A\007"
+    }
+
+    # Mark end of prompt
+    iterm2_prompt_end() {
+      printf "\033]133;B\007"
+    }
+
+    # There are three possible paths in life.
+    #
+    # 1) A command is entered at the prompt and you press return.
+    #    The following steps happen:
+    #    * iterm2_preexec is invoked
+    #      * PS1 is set to ITERM2_PRECMD_PS1
+    #      * ITERM2_SHOULD_DECORATE_PROMPT is set to 1
+    #    * The command executes (possibly reading or modifying PS1)
+    #    * iterm2_precmd is invoked
+    #      * ITERM2_PRECMD_PS1 is set to PS1 (as modified by command execution)
+    #      * PS1 gets our escape sequences added to it
+    #    * zsh displays your prompt
+    #    * You start entering a command
+    #
+    # 2) You press ^C while entering a command at the prompt.
+    #    The following steps happen:
+    #    * (iterm2_preexec is NOT invoked)
+    #    * iterm2_precmd is invoked
+    #      * iterm2_before_cmd_executes is called since we detected that iterm2_preexec was not run
+    #      * (ITERM2_PRECMD_PS1 and PS1 are not messed with, since PS1 already has our escape
+    #        sequences and ITERM2_PRECMD_PS1 already has PS1's original value)
+    #    * zsh displays your prompt
+    #    * You start entering a command
+    #
+    # 3) A new shell is born.
+    #    * PS1 has some initial value, either zsh's default or a value set before this script is sourced.
+    #    * iterm2_precmd is invoked
+    #      * ITERM2_SHOULD_DECORATE_PROMPT is initialized to 1
+    #      * ITERM2_PRECMD_PS1 is set to the initial value of PS1
+    #      * PS1 gets our escape sequences added to it
+    #    * Your prompt is shown and you may begin entering a command.
+    #
+    # Invariants:
+    # * ITERM2_SHOULD_DECORATE_PROMPT is 1 during and just after command execution, and "" while the prompt is
+    #   shown and until you enter a command and press return.
+    # * PS1 does not have our escape sequences during command execution
+    # * After the command executes but before a new one begins, PS1 has escape sequences and
+    #   ITERM2_PRECMD_PS1 has PS1's original value.
+    iterm2_decorate_prompt() {
+      # This should be a raw PS1 without iTerm2's stuff. It could be changed during command
+      # execution.
+      ITERM2_PRECMD_PS1="$PS1"
+      ITERM2_SHOULD_DECORATE_PROMPT=""
+
+      # Add our escape sequences just before the prompt is shown.
+      # Use ITERM2_SQUELCH_MARK for people who can't mdoify PS1 directly, like powerlevel9k users.
+      # This is gross but I had a heck of a time writing a correct if statetment for zsh 5.0.2.
+      local PREFIX=""
+      if [[ $PS1 == *"$(iterm2_prompt_mark)"* ]]; then
+        PREFIX=""
+      elif [[ "${ITERM2_SQUELCH_MARK-}" != "" ]]; then
+        PREFIX=""
+      else
+        PREFIX="%{$(iterm2_prompt_mark)%}"
+      fi
+      PS1="$PREFIX$PS1%{$(iterm2_prompt_end)%}"
+      ITERM2_DECORATED_PS1="$PS1"
+    }
+
+    iterm2_precmd() {
+      local STATUS="$?"
+      if [ -z "${ITERM2_SHOULD_DECORATE_PROMPT-}" ]; then
+        # You pressed ^C while entering a command (iterm2_preexec did not run)
+        iterm2_before_cmd_executes
+        if [ "$PS1" != "${ITERM2_DECORATED_PS1-}" ]; then
+          # PS1 changed, perhaps in another precmd. See issue 9938.
+          ITERM2_SHOULD_DECORATE_PROMPT="1"
+        fi
+      fi
+
+      iterm2_after_cmd_executes "$STATUS"
+
+      if [ -n "$ITERM2_SHOULD_DECORATE_PROMPT" ]; then
+        iterm2_decorate_prompt
+      fi
+    }
+
+    # This is not run if you press ^C while entering a command.
+    iterm2_preexec() {
+      # Set PS1 back to its raw value prior to executing the command.
+      PS1="$ITERM2_PRECMD_PS1"
+      ITERM2_SHOULD_DECORATE_PROMPT="1"
+      iterm2_before_cmd_executes
+    }
+
+    # If hostname -f is slow on your system set iterm2_hostname prior to
+    # sourcing this script. We know it is fast on macOS so we don't cache
+    # it. That lets us handle the hostname changing like when you attach
+    # to a VPN.
+    if [ -z "${iterm2_hostname-}" ]; then
+      if [ "$(uname)" != "Darwin" ]; then
+        iterm2_hostname=`hostname -f 2>/dev/null`
+        # Some flavors of BSD (i.e. NetBSD and OpenBSD) don't have the -f option.
+        if [ $? -ne 0 ]; then
+          iterm2_hostname=`hostname`
+        fi
+      fi
+    fi
+
+    [[ -z ${precmd_functions-} ]] && precmd_functions=()
+    precmd_functions=($precmd_functions iterm2_precmd)
+
+    [[ -z ${preexec_functions-} ]] && preexec_functions=()
+    preexec_functions=($preexec_functions iterm2_preexec)
+
+    iterm2_print_state_data
+    printf "\033]1337;ShellIntegrationVersion=14;shell=zsh\007"
+  fi
+fi

--- a/plugins/iterm2/update
+++ b/plugins/iterm2/update
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+curl -s -L https://iterm2.com/shell_integration/zsh \
+  -o iterm2_shell_integration.zsh


### PR DESCRIPTION
Mirror the official script and source it with the iterm2 plugin.

The integration script brings features like automatic marks on each prompt, drag and drop scp support, or automatic profile switching.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- adds script from https://iterm2.com/documentation-shell-integration.html
- sources that script

## Other comments:

