### PR TITLE
Agnoster theme : parameterize kubernetes context displayed

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -242,10 +242,45 @@ prompt_aws() {
   esac
 }
 
+#KUBERNETES icon:
+# - display KUBERNETES icon if context set
+# - displays red icon on black if context name contains 'prod'
+# - displays green icon on black if context name contains 'dev' or 'stage'
+# - displays yellow icon on black otherwise
+prompt_kubernetes_icon() {
+  KUBERNETES_SYMBOL=$'\xE2\x8E\x88'
+  KUBERNETES_CONTEXT=$1
+
+  case "$KUBERNETES_CONTEXT" in
+    *prod*) prompt_segment black red "$KUBERNETES_SYMBOL";;
+    *dev*|*stage*) prompt_segment black green "$KUBERNETES_SYMBOL";;
+    *) prompt_segment black yellow "$KUBERNETES_SYMBOL";;
+  esac
+
+}
+#KUBERNETES context:
+# - display current KUBERNETES context for connection
+# - from file .kube/config or env $KUBECONFIG
+# - displays context name
+# - displays namespace if set
+prompt_kubernetes() {
+  KUBERNETES_BINARY="${KUBERNETES_BINARY:-kubectl}"
+  [[ -z "$KUBECONFIG" && -z "$(${KUBERNETES_BINARY} config current-context 2>/dev/null)" ]] && return
+
+  KUBERNETES_CONTEXT="$(${KUBERNETES_BINARY} config current-context 2>/dev/null)"
+  KUBERNETES_CONTEXT="${KUBERNETES_CONTEXT:-N/A}"
+  KUBERNETES_NAMESPACE="$(${KUBERNETES_BINARY} config view --minify -o jsonpath={..namespace} 2>/dev/null)"
+  KUBERNETES_NAMESPACE="${KUBERNETES_NAMESPACE:+ ns:$KUBERNETES_NAMESPACE}"
+
+  prompt_kubernetes_icon "$KUBERNETES_CONTEXT"
+  prompt_segment $CURRENT_BG default "$KUBERNETES_CONTEXT$KUBERNETES_NAMESPACE"
+}
+
 ## Main prompt
 build_prompt() {
   RETVAL=$?
   prompt_status
+  prompt_kubernetes
   prompt_virtualenv
   prompt_aws
   prompt_context

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -261,30 +261,44 @@ prompt_kubernetes_icon() {
 #KUBERNETES context:
 # - display current KUBERNETES context for connection
 # - from file .kube/config or env $KUBECONFIG
-# - displays context name
-# - displays namespace if set
+# - displays kubernetes icon if $OMZ_THEME_AGNOSTER_KUBERNETES_ICON is not set to hidden
+# - displays context name if $OMZ_THEME_AGNOSTER_KUBERNETES_CONTEXT is not set to hidden
+# - displays namespace if $OMZ_THEME_AGNOSTER_KUBERNETES_NAMESPACE is not set to hidden
 prompt_kubernetes() {
   KUBERNETES_BINARY="${KUBERNETES_BINARY:-kubectl}"
   [[ -z "$KUBECONFIG" && -z "$(${KUBERNETES_BINARY} config current-context 2>/dev/null)" ]] && return
 
-  KUBERNETES_CONTEXT="$(${KUBERNETES_BINARY} config current-context 2>/dev/null)"
-  KUBERNETES_CONTEXT="${KUBERNETES_CONTEXT:-N/A}"
-  KUBERNETES_NAMESPACE="$(${KUBERNETES_BINARY} config view --minify -o jsonpath={..namespace} 2>/dev/null)"
-  KUBERNETES_NAMESPACE="${KUBERNETES_NAMESPACE:+ ns:$KUBERNETES_NAMESPACE}"
+  KUBERNETES_PROMPT=""
 
-  prompt_kubernetes_icon "$KUBERNETES_CONTEXT"
-  prompt_segment $CURRENT_BG default "$KUBERNETES_CONTEXT$KUBERNETES_NAMESPACE"
+  if [[ "$OMZ_THEME_AGNOSTER_KUBERNETES_CONTEXT" != "hidden" ]]; then
+    KUBERNETES_CONTEXT="$(${KUBERNETES_BINARY} config current-context 2>/dev/null)"
+    KUBERNETES_CONTEXT="${KUBERNETES_CONTEXT:-N/A}"
+    KUBERNETES_PROMPT="$KUBERNETES_PROMPT$KUBERNETES_CONTEXT"
+  fi
+
+  if [[ "$OMZ_THEME_AGNOSTER_KUBERNETES_NAMESPACE" != "hidden" ]]; then
+    KUBERNETES_NAMESPACE="$(${KUBERNETES_BINARY} config view --minify -o jsonpath={..namespace} 2>/dev/null)"
+    KUBERNETES_NAMESPACE="${KUBERNETES_NAMESPACE:+ ns:$KUBERNETES_NAMESPACE}"
+    KUBERNETES_PROMPT="$KUBERNETES_PROMPT -$KUBERNETES_NAMESPACE"
+  fi
+
+  if [[ "$KUBERNETES_PROMPT" != "" ]]; then
+    if [[ "$OMZ_THEME_AGNOSTER_KUBERNETES_ICON" != "hidden" ]]; then
+      prompt_kubernetes_icon "$KUBERNETES_CONTEXT"
+    fi
+    prompt_segment $CURRENT_BG default "$KUBERNETES_PROMPT"
+  fi
 }
 
 ## Main prompt
 build_prompt() {
   RETVAL=$?
   prompt_status
-  prompt_kubernetes
   prompt_virtualenv
   prompt_aws
   prompt_context
   prompt_dir
+  prompt_kubernetes
   prompt_git
   prompt_bzr
   prompt_hg


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
Based on this PR https://github.com/ohmyzsh/ohmyzsh/pull/10086, I have added some environment variables to be able to choose which part of the kubernetes prompt to display.

Rules applied :
- displays kubernetes icon if $OMZ_THEME_AGNOSTER_KUBERNETES_ICON is not set to "hidden"
- displays context name if $OMZ_THEME_AGNOSTER_KUBERNETES_CONTEXT is not set to "hidden"
- displays namespace if $OMZ_THEME_AGNOSTER_KUBERNETES_NAMESPACE is not set to "hidden"
