### PR TITLE
feat(extract): support `obscpio` format

### DIFF
--- a/plugins/extract/README.md
+++ b/plugins/extract/README.md
@@ -32,6 +32,8 @@ plugins=(... extract)
 | `lrz`             | LRZ archive                          |
 | `lz4`             | LZ4 archive                          |
 | `lzma`            | LZMA archive                         |
+| `obscpio`         | cpio archive used on
+[OBS](https://github.com/openSUSE/obs-service-tar_scm#obscpio)             |
 | `rar`             | WinRAR archive                       |
 | `rpm`             | RPM package                          |
 | `sublime-package` | Sublime Text package                 |

--- a/plugins/extract/README.md
+++ b/plugins/extract/README.md
@@ -1,10 +1,10 @@
 # extract plugin
 
-This plugin defines a function called `extract` that extracts the archive file
-you pass it, and it supports a wide variety of archive filetypes.
+This plugin defines a function called `extract` that extracts the archive file you pass it, and it supports a
+wide variety of archive filetypes.
 
-This way you don't have to know what specific command extracts a file, you just
-do `extract <filename>` and the function takes care of the rest.
+This way you don't have to know what specific command extracts a file, you just do `extract <filename>` and
+the function takes care of the rest.
 
 To use it, add `extract` to the plugins array in your zshrc file:
 
@@ -15,7 +15,7 @@ plugins=(... extract)
 ## Supported file extensions
 
 | Extension         | Description                          |
-|:------------------|:-------------------------------------|
+| :---------------- | :----------------------------------- |
 | `7z`              | 7zip file                            |
 | `Z`               | Z archive (LZW)                      |
 | `apk`             | Android app file                     |
@@ -32,8 +32,7 @@ plugins=(... extract)
 | `lrz`             | LRZ archive                          |
 | `lz4`             | LZ4 archive                          |
 | `lzma`            | LZMA archive                         |
-| `obscpio`         | cpio archive used on
-[OBS](https://github.com/openSUSE/obs-service-tar_scm#obscpio)             |
+| `obscpio`         | cpio archive used on OBS             |
 | `rar`             | WinRAR archive                       |
 | `rpm`             | RPM package                          |
 | `sublime-package` | Sublime Text package                 |
@@ -59,5 +58,5 @@ plugins=(... extract)
 | `zst`             | Zstandard file (zstd)                |
 | `zpaq`            | Zpaq file                            |
 
-See [list of archive formats](https://en.wikipedia.org/wiki/List_of_archive_formats) for
-more information regarding archive formats.
+See [list of archive formats](https://en.wikipedia.org/wiki/List_of_archive_formats) for more information
+regarding archive formats.

--- a/plugins/extract/_extract
+++ b/plugins/extract/_extract
@@ -3,5 +3,5 @@
 
 _arguments \
   '(-r --remove)'{-r,--remove}'[Remove archive.]' \
-  "*::archive file:_files -g '(#i)*.(7z|Z|apk|aar|bz2|cab|cpio|deb|ear|gz|ipa|ipsw|jar|lrz|lz4|lzma|rar|rpm|sublime-package|tar|tar.bz2|tar.gz|tar.lrz|tar.lz|tar.lz4|tar.xz|tar.zma|tar.zst|tbz|tbz2|tgz|tlz|txz|tzst|war|whl|xpi|xz|zip|zst|zpaq)(-.)'" \
+  "*::archive file:_files -g '(#i)*.(7z|Z|apk|aar|bz2|cab|cpio|deb|ear|gz|ipa|ipsw|jar|lrz|lz4|lzma|obscpio|rar|rpm|sublime-package|tar|tar.bz2|tar.gz|tar.lrz|tar.lz|tar.lz4|tar.xz|tar.zma|tar.zst|tbz|tbz2|tgz|tlz|txz|tzst|war|whl|xpi|xz|zip|zst|zpaq)(-.)'" \
     && return 0

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -72,7 +72,7 @@ EOF
         builtin cd -q ..; command rm *.tar.* debian-binary ;;
       (*.zst) unzstd "$file" ;;
       (*.cab) cabextract -d "$extract_dir" "$file" ;;
-      (*.cpio) cpio -idmvF "$file" ;;
+      (*.cpio|*.obscpio) cpio -idmvF "$file" ;;
       (*.zpaq) zpaq x "$file" ;;
       (*)
         echo "extract: '$file' cannot be extracted" >&2


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add support for [obscpio](https://github.com/openSUSE/obs-service-tar_scm#obscpio) archive format

## Other comments:

For extraction purposes an `obscpio` archive is a `cpio` archive.
