### PR TITLE
feat(adwnode): Add plugin

### DIFF
--- a/plugins/adwnode/LICENSE
+++ b/plugins/adwnode/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023-present Adrian Wojdat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/adwnode/README.md
+++ b/plugins/adwnode/README.md
@@ -1,0 +1,14 @@
+# NodeJs - Scripts autocomplete
+
+<p align="center"><img src="https://drive.google.com/uc?id=183iJtqEywucyUWWJYv_PTg-Tb2bKlZLN" alt="NodeJs Autocompleter"></p>
+
+## Instalation
+To use it, add `adwnode` to the plugins array in your .zshrc file:
+
+```shell
+plugins=(... adwnode)
+```
+
+## Usage
+Just start typing `yarn` or `npm run` inside NodeJs app directory and double press tab key to start autocompleter.
+<p align="center"><img src="https://drive.google.com/uc?id=1kQFPM2i4MzuICihUMSiKGRo14nQwr5rS" alt="NodeJs Autocompleter"></p>

--- a/plugins/adwnode/_adwnode
+++ b/plugins/adwnode/_adwnode
@@ -1,0 +1,17 @@
+_load_nodejs_scripts() {
+  local read_package_json_scripts_command="try { Object.keys(require('./package.json').scripts).join('\n').replace(/:/g, '\\\:') } catch {''}"
+  nodejs_scripts=("${(@f)$(node -pe ${read_package_json_scripts_command} | sort)}")
+}
+
+_adwnode() {
+  if command -v node >/dev/null 2>&1; then
+    if [ -f ./package.json ]; then
+      _load_nodejs_scripts
+
+      
+      if [[ ! ${#nodejs_scripts[@]} -eq 0 ]]; then
+        _describe '' nodejs_scripts
+      fi
+    fi
+  fi
+}

--- a/plugins/adwnode/adwnode.plugin.zsh
+++ b/plugins/adwnode/adwnode.plugin.zsh
@@ -1,0 +1,3 @@
+autoload -Uz _adwnode
+compdef _adwnode yarn
+compdef _adwnode npm run


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added NodeJs autocompleter for scripts in package.json

## Other comments:
`adwnode` is a plugin that provides auto-completion for scripts defined in a package.json file. This plugin makes it easier to run scripts that are defined in the scripts field of a project's package.json file without having to remember the exact name of the script.

### Demo 
<p align="center"><img src="https://drive.google.com/uc?id=183iJtqEywucyUWWJYv_PTg-Tb2bKlZLN" alt="NodeJs Autocompleter"></p>

<p align="center"><img src="https://drive.google.com/uc?id=1kQFPM2i4MzuICihUMSiKGRo14nQwr5rS" alt="NodeJs Autocompleter"></p>
