### PR TITLE
fix(af-magic): fix number of dashes caused by python_venv checking logic

### DIFF
--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -6,7 +6,8 @@
 # dashed separator size
 function afmagic_dashes {
   # check either virtualenv or condaenv variables
-  local python_env="${VIRTUAL_ENV:-$CONDA_DEFAULT_ENV}"
+  local python_env_dir="${VIRTUAL_ENV:-$CONDA_DEFAULT_ENV}"
+  local python_env="${python_env_dir##*/}"
 
   # if there is a python virtual environment and it is displayed in
   # the prompt, account for it when returning the number of dashes


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- fix number of dashes in af-magic theme. 

## Other comments:

The latest release of `af-magic` theme seems to have a problem on my zsh, I found #11495.

https://github.com/ohmyzsh/ohmyzsh/blob/8c50d1fa4a87b159080f8f3c70294669807fc7e2/themes/af-magic.zsh-theme#L9-L17

`python_env` is the **path** of Python venv like `/path/of/venv` and `PS1` contains the **name** of Python venv folder like `(venv)`. 

So line 13 is always false, therefore dashes will exceeds one line. Besides, line 14 minus too much and  dashes cannot fill one line.

![image](https://user-images.githubusercontent.com/17383312/220815324-89cc9ffc-23b3-4603-902d-9596efd15354.png)
