### PR TITLE
feat(directories): re-assign duplicate alias

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -39,7 +39,7 @@ function d () {
 compdef _dirs d
 
 # List directory contents
-alias lsa='ls -lah'
+alias lsa='ls -Ah'
 alias l='ls -lah'
 alias ll='ls -lh'
 alias la='ls -lAh'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Re-assign the `lsa` alias

## Other comments:

The `lsa` alias pointed to the same command as the `l` alias.

After the changes, the two aliases would work like this:

![image](https://user-images.githubusercontent.com/25194985/220903925-06d7d9c0-525c-42c2-9a11-12c24abdcf57.png)
