### PR TITLE
fix(aliases): clarify how to pass in keywords to `acs`

### DIFF
--- a/plugins/aliases/README.md
+++ b/plugins/aliases/README.md
@@ -19,7 +19,7 @@ Requirements: Python needs to be installed.
 
 - `acs -h/--help`: print help mesage
 
-- `acs <keyword>`: filter aliases by `<keyword>` and highlight
+- `acs <keyword(s)>`: filter and highlight aliases by `<keyword>`
 
 - `acs -g <group>/--group <group>`: show only aliases for group `<group>`. Multiple uses of the flag show all groups
 

--- a/plugins/aliases/cheatsheet.py
+++ b/plugins/aliases/cheatsheet.py
@@ -51,9 +51,9 @@ def pretty_print(cheatsheet, wfilter, group_list=None, groups_only=False):
             continue
         aliases = cheatsheet.get(key)
         if not wfilter:
-            pretty_print_group(key, aliases, wfilter, groups_only)
+            pretty_print_group(key, aliases, only_groupname=groups_only)
         else:
-            pretty_print_group(key, [ alias for alias in aliases if alias[0].find(wfilter)>-1 or alias[1].find(wfilter)>-1], wfilter)
+            pretty_print_group(key, [ alias for alias in aliases if wfilter in alias[0] or wfilter in alias[1] ], wfilter)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Pretty print aliases.")
@@ -64,5 +64,5 @@ if __name__ == '__main__':
 
     lines = sys.stdin.readlines()
     group_list = args.group_list or None
-    wfilter = " ".join(args.filter) or None
+    wfilter = " ".join(args.filter[1:]) if args.filter else None
     pretty_print(cheatsheet(lines), wfilter, group_list, args.groups_only)

--- a/plugins/aliases/cheatsheet.py
+++ b/plugins/aliases/cheatsheet.py
@@ -56,7 +56,7 @@ def pretty_print(cheatsheet, wfilter, group_list=None, groups_only=False):
             pretty_print_group(key, [ alias for alias in aliases if wfilter in alias[0] or wfilter in alias[1] ], wfilter)
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Pretty print aliases.")
+    parser = argparse.ArgumentParser(description="Pretty print aliases.", prog="acs")
     parser.add_argument('filter', nargs="*", metavar="<keyword>", help="search aliases matching keywords")
     parser.add_argument('-g', '--group', dest="group_list", action='append', help="only print aliases in given groups")
     parser.add_argument('--groups', dest='groups_only', action='store_true', help="only print alias groups")

--- a/plugins/aliases/cheatsheet.py
+++ b/plugins/aliases/cheatsheet.py
@@ -57,7 +57,7 @@ def pretty_print(cheatsheet, wfilter, group_list=None, groups_only=False):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Pretty print aliases.")
-    parser.add_argument('filter', nargs="*", help="search aliases matching string")
+    parser.add_argument('filter', nargs="*", metavar="<keyword>", help="search aliases matching keywords")
     parser.add_argument('-g', '--group', dest="group_list", action='append', help="only print aliases in given groups")
     parser.add_argument('--groups', dest='groups_only', action='store_true', help="only print alias groups")
     args = parser.parse_args()


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The plugin `aliases` offers a `filter` argument to filter all available aliases, but it does not work. 

For example, `acs filter a` should only list all aliases containing `a`, but this command produces no output before this PR. 

