### PR TITLE
fix(gnu-utils): reset ls alias to use GNU-based --color argument

### DIFF
--- a/plugins/gnu-utils/gnu-utils.plugin.zsh
+++ b/plugins/gnu-utils/gnu-utils.plugin.zsh
@@ -61,3 +61,14 @@ __gnu_utils_preexec() {
 
 autoload -Uz add-zsh-hook
 add-zsh-hook preexec __gnu_utils_preexec
+
+# lib/theme-and-appearance.zsh sets the alias for ls not knowing that
+# we'll be using GNU ls. We'll reset this to use GNU ls --color.
+# See https://github.com/ohmyzsh/ohmyzsh/issues/11503
+#
+# The ls alias might look like:
+# - ls='ls -G'
+# - ls='gls --color=tty'
+if [[ -x "${commands[gls]}" && "${aliases[ls]}" = (*-G*|gls*) ]]; then
+  alias ls='ls --color=tty'
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Checks whether `ls` alias looks like `ls -G` or `gls --color=tty` and resets it to `ls --color=tty`.

Fixes #11503
