### PR TITLE
add support to `take' for taking remote iso

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -55,11 +55,17 @@ function takegit() {
   cd "$(basename ${1%%.git})"
 }
 
+function takeiso() {
+  curl -L "$1" -O .
+}
+
 function take() {
   if [[ $1 =~ ^(https?|ftp).*\.(tar\.(gz|bz2|xz)|tgz)$ ]]; then
     takeurl "$1"
   elif [[ $1 =~ ^([A-Za-z0-9]\+@|https?|git|ssh|ftps?|rsync).*\.git/?$ ]]; then
     takegit "$1"
+  elif [[ $1 =~ ^(https?|ftp).*\.(iso)$ ]]; then
+    takeiso "$1"
   else
     takedir "$@"
   fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add the support of remote `.iso` file.
