### PR TITLE
fix(lib): use `$BROWSER` in `open_command` if set

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -30,6 +30,13 @@ function open_command() {
               ;;
   esac
 
+  # If a URL is passed, $BROWSER might be set to a local browser within SSH.
+  # See https://github.com/ohmyzsh/ohmyzsh/issues/11098
+  if [[ -n "$BROWSER" && "$1" = (http|https)://* ]]; then
+    "$BROWSER" "$@"
+    return
+  fi
+
   ${=open_cmd} "$@" &>/dev/null
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- If a URL is passed to `open_command`, use `$BROWSER` when set. This will fix the case when the user is in a SSH session and `$BROWSER` is set to a local browser.

Fixes #11098