### PR TITLE
feat(rvm): add `rb32` alias

### DIFF
--- a/plugins/rvm/README.md
+++ b/plugins/rvm/README.md
@@ -24,6 +24,7 @@ plugins=(... rvm)
 | `rb27`       | `rvm use ruby-2.7`   |
 | `rb30`       | `rvm use ruby-3.0`   |
 | `rb31`       | `rvm use ruby-3.1`   |
+| `rb32`       | `rvm use ruby-3.2`   |
 | `rvm-update` | `rvm get head`       |
 | `gems`       | `gem list`           |
 | `rvms`       | `rvm gemset`         |

--- a/plugins/rvm/rvm.plugin.zsh
+++ b/plugins/rvm/rvm.plugin.zsh
@@ -27,6 +27,7 @@ rubies=(
   27  'ruby-2.7'
   30  'ruby-3.0'
   31  'ruby-3.1'
+  32  'ruby-3.2'
 )
 
 for v in ${(k)rubies}; do


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Ruby 3.2 added to RVM plugin
