### PR TITLE
feat(macos): update spotify plugin to upstream

### DIFF
--- a/plugins/macos/spotify
+++ b/plugins/macos/spotify
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+function spotify() {
 # Copyright (c) 2012--2023 Harish Narayanan <mail@harishnarayanan.org>
 #
 # Contains numerous helpful contributions from Jorge Colindres, Thomas
@@ -150,11 +151,11 @@ if [ $# = 0 ]; then
 else
 	if [ ! -d /Applications/Spotify.app ] && [ ! -d $HOME/Applications/Spotify.app ]; then
 		echo "The Spotify application must be installed."
-		exit 1
+		return 1
 	fi
 
     if [ $(osascript -e 'application "Spotify" is running') = "false" ]; then
-        osascript -e 'tell application "Spotify" to activate' || exit 1
+        osascript -e 'tell application "Spotify" to activate' || return 1
         sleep 2
     fi
 fi
@@ -172,12 +173,12 @@ while [ $# -gt 0 ]; do
                 if [ -z "${CLIENT_ID}" ]; then
                     cecho "Invalid Client ID, please update ${USER_CONFIG_FILE}";
                     showAPIHelp;
-                    exit 1;
+                    return 1;
                 fi
                 if [ -z "${CLIENT_SECRET}" ]; then
                     cecho "Invalid Client Secret, please update ${USER_CONFIG_FILE}";
                     showAPIHelp;
-                    exit 1;
+                    return 1;
                 fi
                 SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
                 SPOTIFY_PLAY_URI="";
@@ -196,7 +197,7 @@ while [ $# -gt 0 ]; do
                         cecho "Autorization failed, please check ${USER_CONFG_FILE}"
                         cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
                         showAPIHelp
-                        exit 1
+                        return 1
                     fi
                     SPOTIFY_ACCESS_TOKEN=$( \
                         printf "${SPOTIFY_TOKEN_RESPONSE_DATA}" \
@@ -308,7 +309,7 @@ while [ $# -gt 0 ]; do
 
         "quit"    ) cecho "Quitting Spotify.";
             osascript -e 'tell application "Spotify" to quit';
-            exit 0 ;;
+            break ;;
 
         "next"    ) cecho "Going to next track." ;
             osascript -e 'tell application "Spotify" to next track';
@@ -359,7 +360,7 @@ while [ $# -gt 0 ]; do
                 echo "  vol down                     # Decreases the volume by $VOL_INCREMENT%.";
                 echo "  vol [amount]                 # Sets the volume to an amount between 0 and 100.";
                 echo "  vol                          # Shows the current Spotify volume.";
-                exit 1;
+                return 1;
             fi
 
             osascript -e "tell application \"Spotify\" to set sound volume to $newvol";
@@ -471,7 +472,8 @@ while [ $# -gt 0 ]; do
             break ;;
         * )
             showHelp;
-            exit 1;
+            return 1;
 
     esac
 done
+}

--- a/plugins/macos/spotify
+++ b/plugins/macos/spotify
@@ -194,7 +194,7 @@ while [ $# -gt 0 ]; do
                             -d "grant_type=client_credentials" \
                     )
                     if ! [[ "${SPOTIFY_TOKEN_RESPONSE_DATA}" =~ "access_token" ]]; then
-                        cecho "Autorization failed, please check ${USER_CONFG_FILE}"
+                        cecho "Authorization failed, please check ${USER_CONFG_FILE}"
                         cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
                         showAPIHelp
                         return 1

--- a/plugins/macos/spotify
+++ b/plugins/macos/spotify
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-function spotify() {
-# Copyright (c) 2012--2019 Harish Narayanan <mail@harishnarayanan.org>
+# Copyright (c) 2012--2023 Harish Narayanan <mail@harishnarayanan.org>
 #
 # Contains numerous helpful contributions from Jorge Colindres, Thomas
 # Pritchard, iLan Epstein, Gabriele Bonetti, Sean Heller, Eric Martin
@@ -34,6 +33,9 @@ if ! [[ -f "${USER_CONFIG_FILE}" ]]; then
     echo -e "${USER_CONFIG_DEFAULTS}" > "${USER_CONFIG_FILE}";
 fi
 source "${USER_CONFIG_FILE}";
+
+# Set the percent change in volume for vol up and vol down
+VOL_INCREMENT=10
 
 showAPIHelp() {
     echo;
@@ -148,11 +150,11 @@ if [ $# = 0 ]; then
 else
 	if [ ! -d /Applications/Spotify.app ] && [ ! -d $HOME/Applications/Spotify.app ]; then
 		echo "The Spotify application must be installed."
-		return 1
+		exit 1
 	fi
 
     if [ $(osascript -e 'application "Spotify" is running') = "false" ]; then
-        osascript -e 'tell application "Spotify" to activate' || return 1
+        osascript -e 'tell application "Spotify" to activate' || exit 1
         sleep 2
     fi
 fi
@@ -170,12 +172,12 @@ while [ $# -gt 0 ]; do
                 if [ -z "${CLIENT_ID}" ]; then
                     cecho "Invalid Client ID, please update ${USER_CONFIG_FILE}";
                     showAPIHelp;
-                    return 1
+                    exit 1;
                 fi
                 if [ -z "${CLIENT_SECRET}" ]; then
                     cecho "Invalid Client Secret, please update ${USER_CONFIG_FILE}";
                     showAPIHelp;
-                    return 1
+                    exit 1;
                 fi
                 SHPOTIFY_CREDENTIALS=$(printf "${CLIENT_ID}:${CLIENT_SECRET}" | base64 | tr -d "\n"|tr -d '\r');
                 SPOTIFY_PLAY_URI="";
@@ -191,14 +193,14 @@ while [ $# -gt 0 ]; do
                             -d "grant_type=client_credentials" \
                     )
                     if ! [[ "${SPOTIFY_TOKEN_RESPONSE_DATA}" =~ "access_token" ]]; then
-                        cecho "Authorization failed, please check ${USER_CONFG_FILE}"
+                        cecho "Autorization failed, please check ${USER_CONFG_FILE}"
                         cecho "${SPOTIFY_TOKEN_RESPONSE_DATA}"
                         showAPIHelp
-                        return 1
+                        exit 1
                     fi
                     SPOTIFY_ACCESS_TOKEN=$( \
                         printf "${SPOTIFY_TOKEN_RESPONSE_DATA}" \
-                        | grep -E -o '"access_token":".*",' \
+                        | command grep -E -o '"access_token":".*",' \
                         | sed 's/"access_token"://g' \
                         | sed 's/"//g' \
                         | sed 's/,.*//g' \
@@ -219,9 +221,8 @@ while [ $# -gt 0 ]; do
                             -H "Accept: application/json" \
                             --data-urlencode "q=$Q" \
                             -d "type=$type&limit=1&offset=0" \
-                        | grep -E -o "spotify:$type:[a-zA-Z0-9]+" -m 1
+                        | command grep -E -o "spotify:$type:[a-zA-Z0-9]+" -m 1
                     )
-                    echo "play uri: ${SPOTIFY_PLAY_URI}"
                 }
 
                 case $2 in
@@ -235,11 +236,11 @@ while [ $# -gt 0 ]; do
 
                         results=$( \
                             curl -s -G $SPOTIFY_SEARCH_API --data-urlencode "q=$Q" -d "type=playlist&limit=10&offset=0" -H "Accept: application/json" -H "Authorization: Bearer ${SPOTIFY_ACCESS_TOKEN}" \
-                            | grep -E -o "spotify:playlist:[a-zA-Z0-9]+" -m 10 \
+                            | command grep -E -o "spotify:playlist:[a-zA-Z0-9]+" -m 10 \
                         )
 
                         count=$( \
-                            echo "$results" | grep -c "spotify:playlist" \
+                            echo "$results" | command grep -c "spotify:playlist" \
                         )
 
                         if [ "$count" -gt 0 ]; then
@@ -307,7 +308,7 @@ while [ $# -gt 0 ]; do
 
         "quit"    ) cecho "Quitting Spotify.";
             osascript -e 'tell application "Spotify" to quit';
-            break ;;
+            exit 0 ;;
 
         "next"    ) cecho "Going to next track." ;
             osascript -e 'tell application "Spotify" to next track';
@@ -333,16 +334,16 @@ while [ $# -gt 0 ]; do
                 cecho "Current Spotify volume level is $vol.";
                 break ;
             elif [ "$2" = "up" ]; then
-                if [ $vol -le 90 ]; then
-                    newvol=$(( vol+10 ));
+              if [ $vol -le $(( 100-$VOL_INCREMENT )) ]; then
+                    newvol=$(( vol+$VOL_INCREMENT ));
                     cecho "Increasing Spotify volume to $newvol.";
                 else
                     newvol=100;
                     cecho "Spotify volume level is at max.";
                 fi
             elif [ "$2" = "down" ]; then
-                if [ $vol -ge 10 ]; then
-                    newvol=$(( vol-10 ));
+                if [ $vol -ge $(( $VOL_INCREMENT )) ]; then
+                    newvol=$(( vol-$VOL_INCREMENT ));
                     cecho "Reducing Spotify volume to $newvol.";
                 else
                     newvol=0;
@@ -354,11 +355,11 @@ while [ $# -gt 0 ]; do
             else
                 echo "Improper use of 'vol' command"
                 echo "The 'vol' command should be used as follows:"
-                echo "  vol up                       # Increases the volume by 10%.";
-                echo "  vol down                     # Decreases the volume by 10%.";
+                echo "  vol up                       # Increases the volume by $VOL_INCREMENT%.";
+                echo "  vol down                     # Decreases the volume by $VOL_INCREMENT%.";
                 echo "  vol [amount]                 # Sets the volume to an amount between 0 and 100.";
                 echo "  vol                          # Shows the current Spotify volume.";
-                return 1
+                exit 1;
             fi
 
             osascript -e "tell application \"Spotify\" to set sound volume to $newvol";
@@ -468,11 +469,9 @@ while [ $# -gt 0 ]; do
         "help" )
             showHelp;
             break ;;
-
         * )
             showHelp;
-            return 1 ;;
+            exit 1;
 
     esac
 done
-}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

This script is a copy/paste from https://github.com/hnarayanan/shpotify (the plugin's acknowledgements list it as such). The upstream script has been updated since this plugin was created, this PR pulls in those changes to this plugin.

## Other comments:

I noticed the version bundled in this plugin does not work with the latest version of Spotify, however the upstream does. Hopefully this will resolve that discrepancy.

I can't tell who (if anyone) is an active maintainer of this plugin so I'm not sure who to `@`, apologies for that.
