### PR TITLE
docs(brew): remove twice written alias from documentation

### DIFF
--- a/plugins/brew/README.md
+++ b/plugins/brew/README.md
@@ -21,7 +21,6 @@ defined for convenience.
 | -------- | --------------------------------------- | ------------------------------------------------------------------- |
 | `bcubc`  | `brew upgrade --cask && brew cleanup`   | Update outdated casks, then run cleanup.                            |
 | `bcubo`  | `brew update && brew outdated --cask`   | Update Homebrew data, then list outdated casks.                     |
-| `bcubc`  | `brew upgrade --cask && brew cleanup`   | Update outdated casks, then run cleanup.                            |
 | `brewp`  | `brew pin`                              | Pin a specified formula so that it's not upgraded.                  |
 | `brews`  | `brew list -1`                          | List installed formulae or the installed files for a given formula. |
 | `brewsp` | `brew list --pinned`                    | List pinned formulae, or show the version of a given formula.       |


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Remove twice written alias from documentation

