### PR TITLE
fix(aliases): correct grouping of aliases by `acs`

### DIFF
--- a/plugins/aliases/cheatsheet.py
+++ b/plugins/aliases/cheatsheet.py
@@ -15,6 +15,7 @@ def parse(line):
 
 def cheatsheet(lines):
     exps = [ parse(line) for line in lines ]
+    exps.sort(key=lambda exp:exp[2])
     cheatsheet = {'_default': []}
     for key, group in itertools.groupby(exps, lambda exp:exp[2]):
         group_list = [ item for item in group ]


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- The itertools.groupby function operates by grouping together *contiguous* items that have the same key. Since the `exps` list is unordered with respect to the 3rd element (i.e., they key for the group), this results in chunking together of items with the same key only if it is fortunate enough to be immediately before or immediately after another expression with the same key. Without sorting the list of `exps`, numerous expressions get put into a bin of one when they should be included in a larger group, which results in erroneously putting these expressions into the "_default" group.
- Aliases that previously showed up in the "_default" group when invoking `acs`, even though other aliases existed with the same base command, are now categorized correctly. The "_default" group now only shows aliases that truly do not share a base command with other aliases.

## Other comments:

As an example, enable the `web_search` plugin and notice that before this change, the command `acs web_search` results in the following:
```
[_default]
	bing = web_search bing
	brs = web_search brave
	ddg = web_search duckduckgo
	ducky = web_search duckduckgo \!
	ecosia = web_search ecosia
	image = web_search duckduckgo \!i
	map = web_search duckduckgo \!m
	news = web_search duckduckgo \!n
	qwant = web_search qwant
	scholar = web_search scholar

[web_search]
	archive = web_search archive
	ask = web_search ask
	baidu = web_search baidu
	github = web_search github
	givero = web_search givero
	goodreads = web_search goodreads
	google = web_search google
	sp = web_search startpage
	stackoverflow = web_search stackoverflow
	wiki = web_search duckduckgo \!w
	wolframalpha = web_search wolframalpha
	yahoo = web_search yahoo
	yandex = web_search yandex
	youtube = web_search duckduckgo \!yt
```
And after the change in this commit, `acs web_search` yields the correct result:
```
[web_search]
	archive = web_search archive
	ask = web_search ask
	baidu = web_search baidu
	bing = web_search bing
	brs = web_search brave
	ddg = web_search duckduckgo
	ducky = web_search duckduckgo \!
	ecosia = web_search ecosia
	github = web_search github
	givero = web_search givero
	goodreads = web_search goodreads
	google = web_search google
	image = web_search duckduckgo \!i
	map = web_search duckduckgo \!m
	news = web_search duckduckgo \!n
	qwant = web_search qwant
	scholar = web_search scholar
	sp = web_search startpage
	stackoverflow = web_search stackoverflow
	wiki = web_search duckduckgo \!w
	wolframalpha = web_search wolframalpha
	yahoo = web_search yahoo
	yandex = web_search yandex
	youtube = web_search duckduckgo \!yt
```
