### PR TITLE
fix(vi-mode): fix check for prompt redisplay on mode change

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -34,12 +34,25 @@ function _vi-mode-set-cursor-shape-for-keymap() {
   printf $'\e[%d q' "${_shape}"
 }
 
+function _vi-mode-should-reset-prompt() {
+  # If $VI_MODE_RESET_PROMPT_ON_MODE_CHANGE is unset (default), dynamically
+  # check whether we're using the prompt to display vi-mode info
+  if [[ -z "${VI_MODE_RESET_PROMPT_ON_MODE_CHANGE:-}" ]]; then
+    [[ "${PS1} ${RPS1}" = *'$(vi_mode_prompt_info)'* ]]
+    return $?
+  fi
+
+  # If $VI_MODE_RESET_PROMPT_ON_MODE_CHANGE was manually set, let's check
+  # if it was specifically set to true or it was disabled with any other value
+  [[ "${VI_MODE_RESET_PROMPT_ON_MODE_CHANGE}" = true ]]
+}
+
 # Updates editor information when the keymap changes.
 function zle-keymap-select() {
   # update keymap variable for the prompt
   typeset -g VI_KEYMAP=$KEYMAP
 
-  if [[ "${VI_MODE_RESET_PROMPT_ON_MODE_CHANGE:-}" = true ]]; then
+  if _vi-mode-should-reset-prompt; then
     zle reset-prompt
     zle -R
   fi
@@ -50,10 +63,9 @@ zle -N zle-keymap-select
 # These "echoti" statements were originally set in lib/key-bindings.zsh
 # Not sure the best way to extend without overriding.
 function zle-line-init() {
-  local prev_vi_keymap
-  prev_vi_keymap="${VI_KEYMAP:-}"
+  local prev_vi_keymap="${VI_KEYMAP:-}"
   typeset -g VI_KEYMAP=main
-  [[ "$prev_vi_keymap" != 'main' ]] && [[ "${VI_MODE_RESET_PROMPT_ON_MODE_CHANGE:-}" = true ]] && zle reset-prompt
+  [[ "$prev_vi_keymap" != 'main' ]] && _vi-mode-should-reset-prompt && zle reset-prompt
   (( ! ${+terminfo[smkx]} )) || echoti smkx
   _vi-mode-set-cursor-shape-for-keymap "${VI_KEYMAP}"
 }
@@ -129,13 +141,6 @@ if [[ -z "$MODE_INDICATOR" ]]; then
 fi
 
 function vi_mode_prompt_info() {
-  # If we're using the prompt to display mode info, and we haven't explicitly
-  # disabled "reset prompt on mode change", then set it here.
-  #
-  # We do that here instead of the `if` statement below because the user may
-  # set RPS1/RPROMPT to something else in their custom config.
-  : "${VI_MODE_RESET_PROMPT_ON_MODE_CHANGE:=true}"
-
   echo "${${VI_KEYMAP/vicmd/$MODE_INDICATOR}/(main|viins)/$INSERT_MODE_INDICATOR}"
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The previous logic checked $VI_MODE_RESET_PROMPT_ON_MODE_CHANGE, which was changed on the  `vi_mode_prompt_info` function to make sure that we redisplay the prompt on vi mode change only if the vi-mode indicator is shown on the prompt.

This failed because the variable context inside a prompt function did not propagate to the regular variable environment, so the `VI_MODE_RESET_PROMPT_ON_MODE_CHANGE=true` code did not actually change anything and the prompt was never forcibly redisplayed.

This change dynamically checks whether the vi_mode_prompt_info function is added to the prompt segments to figure out whether we must redisplay the prompt.

Fixes #10915