### PR TITLE
feat(rails): add `rta` alias

### DIFF
--- a/plugins/rails/README.md
+++ b/plugins/rails/README.md
@@ -47,6 +47,7 @@ plugins=(... rails)
 | `rsp`   | `rails server --port`            | Launch a web server and specify the listening port     |
 | `rsts`  | `rails stats`                    | Print code statistics                                  |
 | `rt`    | `rails test`                     | Run Rails tests                                        |
+| `rta`   | `rails test:all`                 | Runs all Rails tests, including system tests           |
 | `ru`    | `rails runner`                   | Run Ruby code in the context of Rails                  |
 
 ### Foreman

--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -75,6 +75,7 @@ alias rsd='rails server --debugger'
 alias rsp='rails server --port'
 alias rsts='rails stats'
 alias rt='rails test'
+alias rta='rails test:all'
 alias ru='rails runner'
 
 # Foreman aliases


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add alias `rta` for `rails test:all`, following the `rt` 'convention' 

## Other comments:

`rails test` only run a subset of all tests, running the whole suite tests are a common task
