### PR TITLE
feat(aws): set region when AWS_REGION is not set

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -12,7 +12,7 @@ plugins=(... aws)
 ## Plugin commands
 
 * `asp [<profile>]`: sets `$AWS_PROFILE` and `$AWS_DEFAULT_PROFILE` (legacy) to `<profile>`.
-  It also sets `$AWS_EB_PROFILE` to `<profile>` for the Elastic Beanstalk CLI.
+  It also sets `$AWS_EB_PROFILE` to `<profile>` for the Elastic Beanstalk CLI. It sets `$AWS_PROFILE_REGION` for display in `aws_prompt_info`. 
   Run `asp` without arguments to clear the profile.
 * `asp [<profile>] login`: If AWS SSO has been configured in your aws profile, it will run the `aws sso login` command following profile selection. 
 

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -196,9 +196,15 @@ compctl -K _aws_profiles asp acp aws_change_access_key
 
 # AWS prompt
 function aws_prompt_info() {
-  if [[ -z $AWS_REGION && -z $AWS_PROFILE ]];then return; fi
-  region=${AWS_REGION:-${AWS_DEFAULT_REGION:-$AWS_PROFILE_REGION}}
-  echo "${ZSH_THEME_AWS_PROFILE_PREFIX:=<aws:}${AWS_PROFILE}${ZSH_THEME_AWS_PROFILE_SUFFIX:=>} ${ZSH_THEME_AWS_REGION_PREFIX:=<region:}${region}${ZSH_THEME_AWS_REGION_SUFFIX:=>}"
+  local _aws_to_show
+  if [[ -n $AWS_PROFILE ]];then
+    _aws_to_show+="${ZSH_THEME_AWS_PROFILE_PREFIX:=<aws:}${AWS_PROFILE}${ZSH_THEME_AWS_PROFILE_SUFFIX:=>}"
+  fi
+  if [[ -n $AWS_REGION ]]; then
+    [[ -n $AWS_PROFILE ]] && _aws_to_show+=" "
+    _aws_to_show+="${ZSH_THEME_AWS_REGION_PREFIX:=<region:}${region}${ZSH_THEME_AWS_REGION_SUFFIX:=>}"
+  fi
+  echo "$_aws_to_show"
 }
 
 if [[ "$SHOW_AWS_PROMPT" != false && "$RPROMPT" != *'$(aws_prompt_info)'* ]]; then

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -9,7 +9,7 @@ function agr() {
 # AWS profile selection
 function asp() {
   if [[ -z "$1" ]]; then
-    unset AWS_DEFAULT_PROFILE AWS_PROFILE AWS_EB_PROFILE
+    unset AWS_DEFAULT_PROFILE AWS_PROFILE AWS_EB_PROFILE AWS_PROFILE_REGION
     echo AWS profile cleared.
     return
   fi
@@ -25,6 +25,8 @@ function asp() {
   export AWS_DEFAULT_PROFILE=$1
   export AWS_PROFILE=$1
   export AWS_EB_PROFILE=$1
+
+  export AWS_PROFILE_REGION=$(aws configure get region)
 
   if [[ "$2" == "login" ]]; then
     aws sso login
@@ -195,7 +197,8 @@ compctl -K _aws_profiles asp acp aws_change_access_key
 # AWS prompt
 function aws_prompt_info() {
   if [[ -z $AWS_REGION && -z $AWS_PROFILE ]];then return; fi
-  echo "${ZSH_THEME_AWS_PROFILE_PREFIX:=<aws:}${AWS_PROFILE}${ZSH_THEME_AWS_PROFILE_SUFFIX:=>} ${ZSH_THEME_AWS_REGION_PREFIX:=<region:}${AWS_REGION}${ZSH_THEME_AWS_REGION_SUFFIX:=>}"
+  region=${AWS_REGION:-${AWS_DEFAULT_REGION:-$AWS_PROFILE_REGION}}
+  echo "${ZSH_THEME_AWS_PROFILE_PREFIX:=<aws:}${AWS_PROFILE}${ZSH_THEME_AWS_PROFILE_SUFFIX:=>} ${ZSH_THEME_AWS_REGION_PREFIX:=<region:}${region}${ZSH_THEME_AWS_REGION_SUFFIX:=>}"
 }
 
 if [[ "$SHOW_AWS_PROMPT" != false && "$RPROMPT" != *'$(aws_prompt_info)'* ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- display region from `$AWS_DEFAULT_REGION` if `$AWS_REGION` is not set
- display region from selected profile returned from `aws configure get region`
- cache `aws configure get region` within `$AWS_PROFILE_REGION`

## Other comments:

...
