### PR TITLE
feat(gswo): alias to return to old branch

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -53,6 +53,19 @@ function git_develop_branch() {
   echo develop
 }
 
+function git_old_branch() {
+  command git rev-parse --git-dir &>/dev/null || return
+  local branches=($(git branch | cut -c 3-))
+  if [[ ${#branches[@]} -le 1 ]]; then
+    echo $(git_main_branch)
+    return 0
+  fi
+  local current_branch=$(git rev-parse --abbrev-ref HEAD)
+  local old_branch=$(git reflog | grep $current_branch | awk '{print $6}' | head -1)
+  echo $old_branch
+  return 0
+}
+
 #
 # Aliases
 # (sorted alphabetically)
@@ -305,6 +318,7 @@ alias gsw='git switch'
 alias gswc='git switch --create'
 alias gswm='git switch $(git_main_branch)'
 alias gswd='git switch $(git_develop_branch)'
+alias gswo='git switch $(git_old_branch)'
 
 alias gts='git tag --sign'
 alias gtv='git tag | sort -V'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [x] Added a new plugin with aliases and functions to switch with the last accessed branch.

## Other comments:

![alias-to-return-to-old-branch](https://user-images.githubusercontent.com/72097727/227286190-fec5dbb9-e0e5-4ec8-8097-2ef069ee6b64.gif)
