### PR TITLE
feat(changelog): provide links in changelog

### DIFF
--- a/tools/changelog.sh
+++ b/tools/changelog.sh
@@ -157,6 +157,89 @@ function parse-commit {
   fi
 }
 
+################################
+# SUPPORTS HYPERLINKS FUNCTION #
+################################
+
+# The code for checking if a terminal supports hyperlinks is copied from install.sh
+
+# The [ -t 1 ] check only works when the function is not called from
+# a subshell (like in `$(...)` or `(...)`, so this hack redefines the
+# function at the top level to always return false when stdout is not
+# a tty.
+if [ -t 1 ]; then
+  is_tty() {
+    true
+  }
+else
+  is_tty() {
+    false
+  }
+fi
+
+# This function uses the logic from supports-hyperlinks[1][2], which is
+# made by Kat Marchán (@zkat) and licensed under the Apache License 2.0.
+# [1] https://github.com/zkat/supports-hyperlinks
+# [2] https://crates.io/crates/supports-hyperlinks
+#
+# Copyright (c) 2021 Kat Marchán
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+supports_hyperlinks() {
+  # $FORCE_HYPERLINK must be set and be non-zero (this acts as a logic bypass)
+  if [ -n "$FORCE_HYPERLINK" ]; then
+    [ "$FORCE_HYPERLINK" != 0 ]
+    return $?
+  fi
+
+  # If stdout is not a tty, it doesn't support hyperlinks
+  is_tty || return 1
+
+  # DomTerm terminal emulator (domterm.org)
+  if [ -n "$DOMTERM" ]; then
+    return 0
+  fi
+
+  # VTE-based terminals above v0.50 (Gnome Terminal, Guake, ROXTerm, etc)
+  if [ -n "$VTE_VERSION" ]; then
+    [ $VTE_VERSION -ge 5000 ]
+    return $?
+  fi
+
+  # If $TERM_PROGRAM is set, these terminals support hyperlinks
+  case "$TERM_PROGRAM" in
+  Hyper|iTerm.app|terminology|WezTerm) return 0 ;;
+  esac
+
+  # kitty supports hyperlinks
+  if [ "$TERM" = xterm-kitty ]; then
+    return 0
+  fi
+
+  # Windows Terminal also supports hyperlinks
+  if [ -n "$WT_SESSION" ]; then
+    return 0
+  fi
+
+  # Konsole supports hyperlinks, but it's an opt-in setting that can't be detected
+  # https://github.com/ohmyzsh/ohmyzsh/issues/10964
+  # if [ -n "$KONSOLE_VERSION" ]; then
+  #   return 0
+  # fi
+
+  return 1
+}
+
 #############################
 # RELEASE CHANGELOG DISPLAY #
 #############################
@@ -208,7 +291,13 @@ function display-release {
     local hash="${1:-$hash}"
     case "$output" in
     raw) printf '%s' "$hash" ;;
-    text) printf '\e[33m%s\e[0m' "$hash" ;; # red
+    text)
+      local text="\e[33m$hash\e[0m"; # red
+      if supports_hyperlinks; then
+        printf "\e]8;;%s\a%s\e]8;;\a" "https://github.com/ohmyzsh/ohmyzsh/commit/$hash" $text;
+      else
+        echo $text;
+      fi ;;
     md) printf '[`%s`](https://github.com/ohmyzsh/ohmyzsh/commit/%s)' "$hash" "$hash" ;;
     esac
   }
@@ -272,7 +361,12 @@ function display-release {
     case "$output" in
     raw) printf '%s' "$subject" ;;
     # In text mode, highlight (#<issue>) and dim text between `backticks`
-    text) sed -E $'s|#([0-9]+)|\e[32m#\\1\e[0m|g;s|`([^`]+)`|`\e[2m\\1\e[0m`|g' <<< "$subject" ;;
+    text)
+      if supports_hyperlinks; then
+        sed -E $'s|#([0-9]+)|\e]8;;https://github.com/ohmyzsh/ohmyzsh/issues/\\1\a\e[32m#\\1\e[0m\e]8;;\a|g' <<< "$subject"
+      else
+        sed -E $'s|#([0-9]+)|\e[32m#\\1\e[0m|g;s|`([^`]+)`|`\e[2m\\1\e[0m`|g' <<< "$subject"
+      fi ;;
     # In markdown mode, link to (#<issue>) issues
     md) sed -E 's|#([0-9]+)|[#\1](https://github.com/ohmyzsh/ohmyzsh/issues/\1)|g' <<< "$subject" ;;
     esac


### PR DESCRIPTION
For terminals that support it, links are now provided for commit hash and issue references.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- For terminals which support it, references to issues/prs and commit hashes are now hyperlinks.

## Other comments:

I started this work before #11545 was opened - there's a comment in there that implies that a change like this might already be in the works but I figured I may as well finish it up and offer it anyway.

This is my first contribution here, so it's possible I've missed some step - please let me know if there's anything I can do to improve both in terms of the process and code.

~~The logic for the condition used to set `supports_uris` is [taken from symfony/console](https://github.com/symfony/console/blob/75d4749d9620a8fa21a2d2847800a84b5c4e7682/Formatter/OutputFormatterStyle.php#L85-L90), which has to similarly determine whether a given terminal supports hyper links.~~
~~Personally I think this is a sufficiently small amount of code which had to be transformed enough to consider it now new code - but in case you disagree, you can [refer to their license](https://github.com/symfony/console/blob/6.2/LICENSE) and decide whether it is MIT compatible (I am not a lawyer so I cannot make that determination myself).~~
~~EDIT: Okay well github can just outright tell me it's an MIT license, that works too 😅~~"
EDIT2: See comments - we're not using that logic anymore.

@mcornella in https://github.com/ohmyzsh/ohmyzsh/issues/11545#issuecomment-1458236908 you said the following about hyperlink support:
> We are already testing for that feature on a variety of terminals in the installer and updater, so it isn't difficult to adapt the terminal changelog to add suport for that. If the terminal doesn't support this, it isn't feasible to add links as they'd be fully visible in the terminal output.

Given that, I suspect you'll have an opinion about the suitability of this PR. I'll be happy to amend it as required, especially if you have anything else you'd like in that conditional statement.

Fixes #11545