### PR TITLE
Added verbose flag to update.sh (issue #11574)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,17 @@ zstyle ':omz:update' frequency 7
 zstyle ':omz:update' frequency 0
 ```
 
+You can also limit the update verbosity with the following settings:
+
+```sh
+# This display the default update prompt
+zstyle ':omz:update' verbosity default
+# This will minimize the update prompt to a few sentences
+zstyle ':omz:update' verbosity minimal
+# This will only render update errors
+zstyle ':omz:update' verbosity silent
+```
+
 ### Manual Updates
 
 If you'd like to update at any point in time (maybe someone just released a new plugin and you don't want to wait a week?) you just need to run:

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -775,11 +775,14 @@ function _omz::theme::use {
 function _omz::update {
   local last_commit=$(builtin cd -q "$ZSH"; git rev-parse HEAD)
 
+  zmodload zsh/zutil
+  zstyle -s ":omz:update" verbose verbose_mode || verbose_mode=default
+
   # Run update script
   if [[ "$1" != --unattended ]]; then
-    ZSH="$ZSH" command zsh -f "$ZSH/tools/upgrade.sh" --interactive || return $?
+    ZSH="$ZSH" command zsh -f "$ZSH/tools/upgrade.sh" --interactive --$verbose_mode || return $?
   else
-    ZSH="$ZSH" command zsh -f "$ZSH/tools/upgrade.sh" || return $?
+    ZSH="$ZSH" command zsh -f "$ZSH/tools/upgrade.sh" --$verbose_mode || return $?
   fi
 
   # Update last updated file

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -10,16 +10,16 @@ case "$ZSH_EVAL_CONTEXT" in
   *:file) echo "error: this file should not be sourced" && return ;;
 esac
 
+# Load user settings so that we can access :omz:update
+source $HOME/.szhrc
+
 # Get user's update verbose preferences
 #
 # Supported update verbose modes:
-# - prompt (default): the user is asked before updating when it's time to update
 # - default: default output
 # - minimal: a minimal output
 # - silent: no output, except for errors
-zstyle -s ':omz:update' verbose verbose_mode || {
-  verbose_mode=prompt
-}
+zstyle -s ':omz:update' verbose verbose_mode || verbose_mode=default
 
 cd "$ZSH"
 
@@ -214,8 +214,9 @@ git checkout -q "$branch" -- || exit 1
 last_commit=$(git rev-parse "$branch")
 
 # Update Oh My Zsh
-if ! [[ "$verbose_mode" = silent ]]
-printf "${BLUE}%s${RESET}\n" "Updating Oh My Zsh"
+# Avoid printing if silent
+if [[ "$verbose_mode" != silent ]]
+  printf "${BLUE}%s${RESET}\n" "Updating Oh My Zsh"
 fi
 if LANG= git pull --quiet --rebase $remote $branch; then
   # Check if it was really updated or not
@@ -232,12 +233,14 @@ if LANG= git pull --quiet --rebase $remote $branch; then
       "$ZSH/tools/changelog.sh" HEAD "$last_commit"
     fi
     
-    if ! [[ "$verbose_mode" = silent ]]
+    # Skip printing if silent
+    if [[ "$verbose_mode" != silent ]]
       printf "${BLUE}%s \`${BOLD}%s${RESET}${BLUE}\`${RESET}\n" "You can see the changelog with" "omz changelog"
     fi
   fi
 
   if [[ "$verbose_mode" = default]]
+    # Only print this if verbose is set to default
     printf '%s         %s__      %s           %s        %s       %s     %s__   %s\n'      $RAINBOW $RESET
     printf '%s  ____  %s/ /_    %s ____ ___  %s__  __  %s ____  %s_____%s/ /_  %s\n'      $RAINBOW $RESET
     printf '%s / __ \\%s/ __ \\  %s / __ `__ \\%s/ / / / %s /_  / %s/ ___/%s __ \\ %s\n'  $RAINBOW $RESET

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -10,9 +10,6 @@ case "$ZSH_EVAL_CONTEXT" in
   *:file) echo "error: this file should not be sourced" && return ;;
 esac
 
-# Load user settings so that we can access :omz:update
-source $HOME/.szhrc
-
 # Get user's update verbose preferences
 #
 # Supported update verbose modes:
@@ -215,7 +212,7 @@ last_commit=$(git rev-parse "$branch")
 
 # Update Oh My Zsh
 # Avoid printing if silent
-if [[ "$verbose_mode" != silent ]]
+if [[ "$verbose_mode" != silent ]]; then
   printf "${BLUE}%s${RESET}\n" "Updating Oh My Zsh"
 fi
 if LANG= git pull --quiet --rebase $remote $branch; then
@@ -234,12 +231,12 @@ if LANG= git pull --quiet --rebase $remote $branch; then
     fi
     
     # Skip printing if silent
-    if [[ "$verbose_mode" != silent ]]
+    if [[ "$verbose_mode" != silent ]]; then
       printf "${BLUE}%s \`${BOLD}%s${RESET}${BLUE}\`${RESET}\n" "You can see the changelog with" "omz changelog"
     fi
   fi
 
-  if [[ "$verbose_mode" = default]]
+  if [[ "$verbose_mode" == default]]; then
     # Only print this if verbose is set to default
     printf '%s         %s__      %s           %s        %s       %s     %s__   %s\n'      $RAINBOW $RESET
     printf '%s  ____  %s/ /_    %s ____ ___  %s__  __  %s ____  %s_____%s/ /_  %s\n'      $RAINBOW $RESET

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -10,6 +10,17 @@ case "$ZSH_EVAL_CONTEXT" in
   *:file) echo "error: this file should not be sourced" && return ;;
 esac
 
+# Get user's update verbose preferences
+#
+# Supported update verbose modes:
+# - prompt (default): the user is asked before updating when it's time to update
+# - default: default output
+# - minimal: a minimal output
+# - silent: no output, except for errors
+zstyle -s ':omz:update' verbose verbose_mode || {
+  verbose_mode=prompt
+}
+
 cd "$ZSH"
 
 # Use colors, but only if connected to a terminal
@@ -203,7 +214,9 @@ git checkout -q "$branch" -- || exit 1
 last_commit=$(git rev-parse "$branch")
 
 # Update Oh My Zsh
+if ! [[ "$verbose_mode" = silent ]]
 printf "${BLUE}%s${RESET}\n" "Updating Oh My Zsh"
+fi
 if LANG= git pull --quiet --rebase $remote $branch; then
   # Check if it was really updated or not
   if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]; then
@@ -218,21 +231,25 @@ if LANG= git pull --quiet --rebase $remote $branch; then
     if [[ "$1" = --interactive ]]; then
       "$ZSH/tools/changelog.sh" HEAD "$last_commit"
     fi
-
-    printf "${BLUE}%s \`${BOLD}%s${RESET}${BLUE}\`${RESET}\n" "You can see the changelog with" "omz changelog"
+    
+    if ! [[ "$verbose_mode" = silent ]]
+      printf "${BLUE}%s \`${BOLD}%s${RESET}${BLUE}\`${RESET}\n" "You can see the changelog with" "omz changelog"
+    fi
   fi
 
-  printf '%s         %s__      %s           %s        %s       %s     %s__   %s\n'      $RAINBOW $RESET
-  printf '%s  ____  %s/ /_    %s ____ ___  %s__  __  %s ____  %s_____%s/ /_  %s\n'      $RAINBOW $RESET
-  printf '%s / __ \\%s/ __ \\  %s / __ `__ \\%s/ / / / %s /_  / %s/ ___/%s __ \\ %s\n'  $RAINBOW $RESET
-  printf '%s/ /_/ /%s / / / %s / / / / / /%s /_/ / %s   / /_%s(__  )%s / / / %s\n'      $RAINBOW $RESET
-  printf '%s\\____/%s_/ /_/ %s /_/ /_/ /_/%s\\__, / %s   /___/%s____/%s_/ /_/  %s\n'    $RAINBOW $RESET
-  printf '%s    %s        %s           %s /____/ %s       %s     %s          %s\n'      $RAINBOW $RESET
-  printf '\n'
-  printf "${BLUE}%s${RESET}\n\n" "$message"
-  printf "${BLUE}${BOLD}%s %s${RESET}\n" "To keep up with the latest news and updates, follow us on Twitter:" "$(fmt_link @ohmyzsh https://twitter.com/ohmyzsh)"
-  printf "${BLUE}${BOLD}%s %s${RESET}\n" "Want to get involved in the community? Join our Discord:" "$(fmt_link "Discord server" https://discord.gg/ohmyzsh)"
-  printf "${BLUE}${BOLD}%s %s${RESET}\n" "Get your Oh My Zsh swag at:" "$(fmt_link "Planet Argon Shop" https://shop.planetargon.com/collections/oh-my-zsh)"
+  if [[ "$verbose_mode" = default]]
+    printf '%s         %s__      %s           %s        %s       %s     %s__   %s\n'      $RAINBOW $RESET
+    printf '%s  ____  %s/ /_    %s ____ ___  %s__  __  %s ____  %s_____%s/ /_  %s\n'      $RAINBOW $RESET
+    printf '%s / __ \\%s/ __ \\  %s / __ `__ \\%s/ / / / %s /_  / %s/ ___/%s __ \\ %s\n'  $RAINBOW $RESET
+    printf '%s/ /_/ /%s / / / %s / / / / / /%s /_/ / %s   / /_%s(__  )%s / / / %s\n'      $RAINBOW $RESET
+    printf '%s\\____/%s_/ /_/ %s /_/ /_/ /_/%s\\__, / %s   /___/%s____/%s_/ /_/  %s\n'    $RAINBOW $RESET
+    printf '%s    %s        %s           %s /____/ %s       %s     %s          %s\n'      $RAINBOW $RESET
+    printf '\n'
+    printf "${BLUE}%s${RESET}\n\n" "$message"
+    printf "${BLUE}${BOLD}%s %s${RESET}\n" "To keep up with the latest news and updates, follow us on Twitter:" "$(fmt_link @ohmyzsh https://twitter.com/ohmyzsh)"
+    printf "${BLUE}${BOLD}%s %s${RESET}\n" "Want to get involved in the community? Join our Discord:" "$(fmt_link "Discord server" https://discord.gg/ohmyzsh)"
+    printf "${BLUE}${BOLD}%s %s${RESET}\n" "Get your Oh My Zsh swag at:" "$(fmt_link "Planet Argon Shop" https://shop.planetargon.com/collections/oh-my-zsh)"
+  fi
 else
   ret=$?
   printf "${RED}%s${RESET}\n" 'There was an error updating. Try again later?'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Sources settings from $HOME/.zshrc to read :omz:update verbose
- Sets verbose_mode to default if not set
- Dependant text rendering based on verbose_mode

## Other comments:
- .zshrc probably should have a mention of :omz:update verbose if implemented
- docs probably should have a mention of :omz:update verbose if implemented
...
