### PR TITLE
Add toolbox run (tbr) to Toolbox plugin

### DIFF
--- a/plugins/toolbox/README.md
+++ b/plugins/toolbox/README.md
@@ -22,4 +22,5 @@ RPROMPT='$(toolbox_prompt_info)'
 
 | Alias | Command              | Description                            |
 |-------|----------------------|----------------------------------------|
-| tb    | `toolbox enter`      | Enters the toolbox environment         |
+| tbe   | `toolbox enter`      | Enters the toolbox environment         |
+| tbr   | `toolbox run`        | Run a command in an existing toolbox   |

--- a/plugins/toolbox/toolbox.plugin.zsh
+++ b/plugins/toolbox/toolbox.plugin.zsh
@@ -2,5 +2,5 @@ function toolbox_prompt_info() {
   [[ -f /run/.toolboxenv ]] && echo "⬢"
 }
 
-alias tb="toolbox enter"
-alias tr="toolbox run"
+alias tbe="toolbox enter"
+alias tbr="toolbox run"

--- a/plugins/toolbox/toolbox.plugin.zsh
+++ b/plugins/toolbox/toolbox.plugin.zsh
@@ -3,3 +3,4 @@ function toolbox_prompt_info() {
 }
 
 alias tb="toolbox enter"
+alias tr="toolbox run"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `tbr` to allow run `toolbox run`.
- Change `te` to `tbe` to have them in sync.

## Other comments:

I'm thinking of adding more commands, but I'm still new to Toolbox.
