### PR TITLE
fix(installer): don't use `sudo` when user is in Termux

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -84,6 +84,8 @@ command_exists() {
 user_can_sudo() {
   # Check if sudo is installed
   command_exists sudo || return 1
+  # Having tsu linked to sudo will cause errors.
+  [ ! -L $(command -v sudo) ] || ! [ $(basename $(readlink -f $(command -v sudo))) = tsu ]
   # The following command has 3 parts:
   #
   # 1. Run `sudo` with `-v`. Does the following:

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -84,6 +84,11 @@ command_exists() {
 user_can_sudo() {
   # Check if sudo is installed
   command_exists sudo || return 1
+  # Termux can't run sudo unless the device is rooted. Either way, `chsh` works
+  # without sudo, so we can detect it and exit the function early.
+  case "$PREFIX" in
+  *com.termux*) return 1 ;;
+  esac
   # The following command has 3 parts:
   #
   # 1. Run `sudo` with `-v`. Does the following:
@@ -440,7 +445,7 @@ EOF
   # On systems that don't have a user with passwordless sudo, the user will
   # be prompted for the password either way, so this shouldn't cause any issues.
   #
-  if [ "$termux" != true ] && user_can_sudo; then
+  if user_can_sudo; then
     sudo -k chsh -s "$zsh" "$USER"  # -k forces the password prompt
   else
     chsh -s "$zsh" "$USER"          # run chsh normally

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -84,8 +84,6 @@ command_exists() {
 user_can_sudo() {
   # Check if sudo is installed
   command_exists sudo || return 1
-  # Having tsu linked to sudo will cause errors.
-  [ ! -L $(command -v sudo) ] || ! [ $(basename $(readlink -f $(command -v sudo))) = tsu ]
   # The following command has 3 parts:
   #
   # 1. Run `sudo` with `-v`. Does the following:
@@ -442,7 +440,7 @@ EOF
   # On systems that don't have a user with passwordless sudo, the user will
   # be prompted for the password either way, so this shouldn't cause any issues.
   #
-  if user_can_sudo; then
+  if [ "$termux" != true ] && user_can_sudo; then
     sudo -k chsh -s "$zsh" "$USER"  # -k forces the password prompt
   else
     chsh -s "$zsh" "$USER"          # run chsh normally


### PR DESCRIPTION
Using "sudo -k chsh" in termux will cause an error "env: exec -k: No such file or directory", so it needs to judge

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add a link to determine whether sudo is tsu in install.sh

## Other comments:

...
