### PR TITLE
feat(extract): always extract files into its own folder

### DIFF
--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -29,61 +29,75 @@ EOF
     local success=0
     local extract_dir="${1:t:r}"
     local file="$1" full_path="${1:A}"
+
+    # Create an extraction directory based on the file name
+    command mkdir -p "$extract_dir"
+    builtin cd -q "$extract_dir"
+
     case "${file:l}" in
       (*.tar.gz|*.tgz)
-        (( $+commands[pigz] )) && { tar -I pigz -xvf "$file" } || tar zxvf "$file" ;;
+        (( $+commands[pigz] )) && { tar -I pigz -xvf "$full_path" } || tar zxvf "$full_path" ;;
       (*.tar.bz2|*.tbz|*.tbz2)
-        (( $+commands[pbzip2] )) && { tar -I pbzip2 -xvf "$file" } || tar xvjf "$file" ;;
+        (( $+commands[pbzip2] )) && { tar -I pbzip2 -xvf "$full_path" } || tar xvjf "$full_path" ;;
       (*.tar.xz|*.txz)
-        (( $+commands[pixz] )) && { tar -I pixz -xvf "$file" } || {
+        (( $+commands[pixz] )) && { tar -I pixz -xvf "$full_path" } || {
         tar --xz --help &> /dev/null \
-        && tar --xz -xvf "$file" \
-        || xzcat "$file" | tar xvf - } ;;
+        && tar --xz -xvf "$full_path" \
+        || xzcat "$full_path" | tar xvf - } ;;
       (*.tar.zma|*.tlz)
         tar --lzma --help &> /dev/null \
-        && tar --lzma -xvf "$file" \
-        || lzcat "$file" | tar xvf - ;;
+        && tar --lzma -xvf "$full_path" \
+        || lzcat "$full_path" | tar xvf - ;;
       (*.tar.zst|*.tzst)
         tar --zstd --help &> /dev/null \
-        && tar --zstd -xvf "$file" \
-        || zstdcat "$file" | tar xvf - ;;
-      (*.tar) tar xvf "$file" ;;
-      (*.tar.lz) (( $+commands[lzip] )) && tar xvf "$file" ;;
-      (*.tar.lz4) lz4 -c -d "$file" | tar xvf - ;;
-      (*.tar.lrz) (( $+commands[lrzuntar] )) && lrzuntar "$file" ;;
-      (*.gz) (( $+commands[pigz] )) && pigz -dk "$file" || gunzip -k "$file" ;;
-      (*.bz2) bunzip2 "$file" ;;
-      (*.xz) unxz "$file" ;;
-      (*.lrz) (( $+commands[lrunzip] )) && lrunzip "$file" ;;
-      (*.lz4) lz4 -d "$file" ;;
-      (*.lzma) unlzma "$file" ;;
-      (*.z) uncompress "$file" ;;
-      (*.zip|*.war|*.jar|*.ear|*.sublime-package|*.ipa|*.ipsw|*.xpi|*.apk|*.aar|*.whl) unzip "$file" -d "$extract_dir" ;;
-      (*.rar) unrar x -ad "$file" ;;
+        && tar --zstd -xvf "$full_path" \
+        || zstdcat "$full_path" | tar xvf - ;;
+      (*.tar) tar xvf "$full_path" ;;
+      (*.tar.lz) (( $+commands[lzip] )) && tar xvf "$full_path" ;;
+      (*.tar.lz4) lz4 -c -d "$full_path" | tar xvf - ;;
+      (*.tar.lrz) (( $+commands[lrzuntar] )) && lrzuntar "$full_path" ;;
+      (*.gz) (( $+commands[pigz] )) && pigz -dk "$full_path" || gunzip -k "$full_path" ;;
+      (*.bz2) bunzip2 "$full_path" ;;
+      (*.xz) unxz "$full_path" ;;
+      (*.lrz) (( $+commands[lrunzip] )) && lrunzip "$full_path" ;;
+      (*.lz4) lz4 -d "$full_path" ;;
+      (*.lzma) unlzma "$full_path" ;;
+      (*.z) uncompress "$full_path" ;;
+      (*.zip|*.war|*.jar|*.ear|*.sublime-package|*.ipa|*.ipsw|*.xpi|*.apk|*.aar|*.whl) unzip "$full_path" ;;
+      (*.rar) unrar x -ad "$full_path" ;;
       (*.rpm)
-        command mkdir -p "$extract_dir" && builtin cd -q "$extract_dir" \
-        && rpm2cpio "$full_path" | cpio --quiet -id ;;
-      (*.7z) 7za x "$file" ;;
+        rpm2cpio "$full_path" | cpio --quiet -id ;;
+      (*.7z) 7za x "$full_path" ;;
       (*.deb)
-        command mkdir -p "$extract_dir/control" "$extract_dir/data"
-        builtin cd -q "$extract_dir"; ar vx "$full_path" > /dev/null
+        command mkdir -p "control" "data"
+        ar vx "$full_path" > /dev/null
         builtin cd -q control; extract ../control.tar.*
         builtin cd -q ../data; extract ../data.tar.*
         builtin cd -q ..; command rm *.tar.* debian-binary ;;
-      (*.zst) unzstd "$file" ;;
-      (*.cab) cabextract -d "$extract_dir" "$file" ;;
-      (*.cpio|*.obscpio) cpio -idmvF "$file" ;;
-      (*.zpaq) zpaq x "$file" ;;
+      (*.zst) unzstd "$full_path" ;;
+      (*.cab) cabextract "$full_path" ;;
+      (*.cpio|*.obscpio) cpio -idmvF "$full_path" ;;
+      (*.zpaq) zpaq x "$full_path" ;;
       (*)
         echo "extract: '$file' cannot be extracted" >&2
         success=1 ;;
     esac
 
     (( success = success > 0 ? success : $? ))
-    (( success == 0 && remove_archive == 0 )) && rm "$full_path"
+    (( success == 0 && remove_archive == 0 )) && command rm "$full_path"
     shift
 
-    # Go back to original working directory in case we ran cd previously
+    # Go back to original working directory
+    # and remove extraction directory if there was an error
     builtin cd -q "$pwd"
+    (( success > 0 )) && command rm -r "$extract_dir"
+
+    # If content of extract dir is a single directory, move its contents up
+    # Glob flags: N: no error if directory is empty, Y2: at most 2 files
+    local content=("${extract_dir}"/*(NY2))
+    if [[ ${#content} -eq 1 && -d "${content[1]}" ]]; then
+      command mv -f "${content[1]}" .
+      command rmdir "$extract_dir"
+    fi
   done
 }

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -93,8 +93,12 @@ EOF
     (( success > 0 )) && command rm -r "$extract_dir"
 
     # If content of extract dir is a single directory, move its contents up
-    # Glob flags: N: no error if directory is empty, Y2: at most 2 files
-    local content=("${extract_dir}"/*(NY2))
+    # Glob flags:
+    # - D: include files starting with .
+    # - N: no error if directory is empty
+    # - Y2: at most give 2 files
+    local -a content
+    content=("${extract_dir}"/*(DNY2))
     if [[ ${#content} -eq 1 && -d "${content[1]}" ]]; then
       command mv -f "${content[1]}" .
       command rmdir "$extract_dir"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Creates a folder based on file name and extracts the contents from within this folder
- Remove the folder if there was an error
- If the only content in the extraction folder is one folder, move the folder up and remove the created extraction folder

Fixes #11537
