### PR TITLE
feat(archlinux): unify `upgrade` function

### DIFF
--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -180,15 +180,17 @@ fi
 
 # Check Arch Linux PGP Keyring before System Upgrade to prevent failure.
 function upgrade() {
-  echo ":: Checking Arch Linux PGP Keyring..."
+  echo "[oh-my-zsh] Checking Arch Linux PGP Keyring"
   local installedver="$(sudo pacman -Qi archlinux-keyring | grep -Po '(?<=Version         : ).*')"
   local currentver="$(sudo pacman -Si archlinux-keyring | grep -Po '(?<=Version         : ).*')"
   if [ $installedver != $currentver ]; then
-    echo -e " Arch Linux PGP Keyring is out of date.\n Updating before full system upgrade."
-	sudo pacman -Sy --needed --noconfirm archlinux-keyring
+    echo "[oh-my-zsh] Arch Linux PGP Keyring is out of date."
+    echo "[oh-my-zsh] Updating before full system upgrade."
+    sudo pacman -Syu --needed --noconfirm archlinux-keyring
   else
-    echo -e " Arch Linux PGP Keyring is up to date.\n Proceeding with full system upgrade."
+    echo "[oh-my-zsh] Arch Linux PGP Keyring is up to date."
   fi
+  echo "[oh-mh-zsh] Proceeding with full system upgrade."
   if (( $+commands[yay] )); then
     yay -Syu
   elif (( $+commands[trizen] )); then

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -23,7 +23,6 @@ alias pacfiles='pacman -F'
 alias pacls='pacman -Ql'
 alias pacown='pacman -Qo'
 alias pacupd="sudo pacman -Sy"
-alias upgrade='sudo pacman -Syu'
 
 function paclist() {
   # Based on https://bbs.archlinux.org/viewtopic.php?id=93683
@@ -109,7 +108,6 @@ if (( $+commands[aura] )); then
   alias auupd="sudo aura -Sy"
   alias auupg='sudo sh -c "aura -Syu              && aura -Au"'
   alias ausu='sudo sh -c "aura -Syu --no-confirm && aura -Au --no-confirm"'
-  alias upgrade='sudo aura -Syu'
 
   # extra bonus specially for aura
   alias auown="aura -Qqo"
@@ -136,7 +134,6 @@ if (( $+commands[pacaur] )); then
   alias painsd='pacaur -S --asdeps'
   alias pamir='pacaur -Syy'
   alias paupd="pacaur -Sy"
-  alias upgrade='pacaur -Syu'
 fi
 
 if (( $+commands[trizen] )); then
@@ -158,7 +155,6 @@ if (( $+commands[trizen] )); then
   alias trinsd='trizen -S --asdeps'
   alias trmir='trizen -Syy'
   alias trupd="trizen -Sy"
-  alias upgrade='trizen -Syu'
 fi
 
 if (( $+commands[yay] )); then
@@ -180,5 +176,28 @@ if (( $+commands[yay] )); then
   alias yainsd='yay -S --asdeps'
   alias yamir='yay -Syy'
   alias yaupd="yay -Sy"
-  alias upgrade='yay -Syu'
 fi
+
+# Check Arch Linux PGP Keyring before System Upgrade to prevent failure.
+function upgrade() {
+  echo ":: Checking Arch Linux PGP Keyring..."
+  local installedver="$(sudo pacman -Qi archlinux-keyring | grep -Po '(?<=Version         : ).*')"
+  local currentver="$(sudo pacman -Si archlinux-keyring | grep -Po '(?<=Version         : ).*')"
+  if [ $installedver != $currentver ]; then
+    echo -e " Arch Linux PGP Keyring is out of date.\n Updating before full system upgrade."
+	sudo pacman -Sy --needed --noconfirm archlinux-keyring
+  else
+    echo -e " Arch Linux PGP Keyring is up to date.\n Proceeding with full system upgrade."
+  fi
+  if (( $+commands[yay] )); then
+    yay -Syu
+  elif (( $+commands[trizen] )); then
+    trizen -Syu
+  elif (( $+commands[pacaur] )); then
+    pacaur -Syu
+  elif (( $+commands[aura] )); then
+    sudo aura -Syu
+  else
+    sudo pacman -Syu
+  fi
+}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Arch Linux PLugin: Unifies the Upgrade aliases into a single function which is capable of cleanly handling an out of date Arch Linux PGP Keyring to prevent failure before handing off the system upgrade to pacman or an AUR helper.

## Other comments:

...
