### PR TITLE
Add support for detecting Contour terminal in title() function

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -17,7 +17,7 @@ function title {
   : ${2=$1}
 
   case "$TERM" in
-    cygwin|xterm*|putty*|rxvt*|konsole*|ansi|mlterm*|alacritty|st*|foot)
+    cygwin|xterm*|putty*|rxvt*|konsole*|ansi|mlterm*|alacritty|st*|foot|contour*)
       print -Pn "\e]2;${2:q}\a" # set window name
       print -Pn "\e]1;${1:q}\a" # set tab name
       ;;


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Contour Terminal is is supporting OSC 1 and OSC 2 as well as host programmable statusline, which can be controlled via terminfo entries `tsl` / `fsl` / `dsl`. OMZ seems to use `tsl`/`fsl` to fallback-set the window title, and that is heavily confusing. So this change ensures OSC 1 + OSC 2 logic is used, to streamline this change with most TEs.

## Other comments:

I personally think that the host programmable statusline is a bad start to simply show that string is probably not the best choice to begin with. Despired having rare support for it. :)