### PR TITLE
fix(jump): even spacing between marks

### DIFF
--- a/plugins/jump/jump.plugin.zsh
+++ b/plugins/jump/jump.plugin.zsh
@@ -35,12 +35,11 @@ marks() {
 			max=${#link:t}
 		fi
 	done
-	local printf_markname_template="$(printf -- "%%%us " "$max")"
+	local printf_markname_template="$(printf -- "%%%us" "$max")"
 	for link in $MARKPATH/{,.}*(@N); do
-		local markname="$fg[cyan]${link:t}$reset_color"
+		local markname="$fg[cyan]$(printf -- "$printf_markname_template" "${link:t}")$reset_color"
 		local markpath="$fg[blue]$(readlink $link)$reset_color"
-		printf -- "$printf_markname_template" "$markname"
-		printf -- "-> %s\n" "$markpath"
+		printf -- "%s -> %s\n" "$markname" "$markpath"
 	done
 }
 


### PR DESCRIPTION
Previously in 3c3766fdf5f64daa4a4e96bee56487314ebcd642, the applied patch did not account for the characters that would be consumed by colour coding.

Fix this by using `printf` on the inner mark name, which does not yet have colour coding.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.