### PR TITLE
Feat(agnoster) Add terraform workspace name prompt support. Plugins terraform-workspace-prompt)

### DIFF
--- a/plugins/terraform-workspace-prompt/README.md
+++ b/plugins/terraform-workspace-prompt/README.md
@@ -1,0 +1,90 @@
+# Terraform plugin to display workspace in prompt
+
+Plugin for Terraform from Hashicorp, an infrastructure as code tool that allows for multi-cloud support, modularity, 
+and the ability to plan and apply changes, making it easier to manage and provision infrastructure resources.
+
+## Features:
+- Completion for `terraform`
+- aliases
+- prompt function
+- Support for agnoster template
+
+## Structure:
+```sh
+.
+├── README.md
+├── plugins
+    ├── _terraform
+    └── terraform-workspace.plugin.zsh
+```
+
+## Requirements
+* [zsh](http://www.zsh.org/)
+* [Terraform](https://terraform.io/)
+* [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh)
+* [terraform-workspace plugin](https://github.com/ocontant/terraform-workspace)
+* [terraform-workspace themes](https://github.com/ocontant/terraform-agnoster)
+
+# Installation:
+## Manual
+1. Clone the repository to your localspace
+   - `git clone https://github.com/ocontant/terraform-workspace.git`
+2. Copy the plugins folder to ~/.oh-my-zsh/custom/plugins/terraform-workspace
+   - `cp -r plugins/terraform-workspace ~/.oh-my-zsh/custom/plugins/terraform-workspace`
+3. Copy the themes folder to ~/.oh-my-zsh/custom/themes/agnoster
+   - `cp -r themes/agnoster ~/.oh-my-zsh/custom/themes/agnoster`
+4. Add the plugin `terraform-workspace` to your plugins array section of your `~/.zshrc` file
+    - `plugins=(... terraform-workspace)`
+5. Add the theme `terraform-agnoster` to your theme section of your `~/.zshrc` file
+
+## With Antigen
+1. Install Antigen:
+   - `curl -L git.io/antigen > ~/antigen.zsh`
+2. Add antigen requirements to your `~/.zshrc` file
+```sh
+  source ~/antigen.zsh 
+  # Load Antigen configurations 
+  antigen init ~/.antigenrc
+```
+3. Create the file ~/.antigenrc and add the following content (I included my favorite bundle, feel free to add/remove):
+```sh
+  # Load oh-my-zsh library
+  antigen use oh-my-zsh
+
+  # Load bundles from the default repo (oh-my-zsh)
+  antigen bundle git
+  antigen bundle command-not-found
+  antigen bundle docker
+
+  # Load bundles from external repos
+  antigen bundle zsh-users/zsh-completions
+  antigen bundle zsh-users/zsh-autosuggestions
+  antigen bundle zsh-users/zsh-syntax-highlighting
+  antigen bundle zsh-users/zsh-history-substring-search
+  
+  # Load the terraform plugins and theme
+  antigen bundle ocontant/terraform-workspace
+  antigen theme ocontant/terraform-agnoster
+
+  # Tell Antigen that you're done.
+  antigen apply
+```
+4. Add the theme `terraform-agnoster` to your theme section of your `~/.zshrc` file
+5. Add the plugin `terraform-workspace` to your plugins array section of your `~/.zshrc` file
+    - `plugins=(... terraform-workspace)`
+
+
+# Prompt function
+## If you don't want to use oh-my-zsh agnoster theme, you can use this prompt to display the current Terraform workspace in your prompt.
+
+1. Create a bloc in your `~/.zshrc` file:
+```sh
+# Terraform prompt
+## Create 2 variables (feel free to customize the colors)
+ZSH_THEME_TF_PROMPT_PREFIX="%{$fg[white]%}"
+ZSH_THEME_TF_PROMPT_SUFFIX="%{$reset_color%}"
+
+## Add the current Terraform workspace in your prompt by adding `"TF: ${__TERRAFORM_WORKSPACE_CACHE:gs/%/%%}"` to your `PROMPT` or `RPROMPT` variable.
+## Example:
+PROMPT="${PROMPT}>${ZSH_THEME_TF_PROMPT_PREFIX-[}${__TERRAFORM_WORKSPACE_CACHE:gs/%/%%}${ZSH_THEME_TF_PROMPT_SUFFIX-]}"
+```

--- a/plugins/terraform-workspace-prompt/_terraform
+++ b/plugins/terraform-workspace-prompt/_terraform
@@ -1,0 +1,411 @@
+#compdef terraform
+
+local -a _terraform_cmds opt_args
+_terraform_cmds=(
+    'apply:Builds or changes infrastructure'
+    'console:Interactive console for Terraform interpolations'
+    'destroy:Destroy Terraform-managed infrastructure'
+    'fmt:Rewrites config files to canonical format'
+    'force-unlock:Manually unlock the terraform state'
+    'get:Download and install modules for the configuration'
+    'graph:Create a visual graph of Terraform resources'
+    'import:Import existing infrastructure into Terraform'
+    'init:Initialize a Terraform working directory'
+    'login:Obtain and save credentials for a remote host'
+    'logout:Remove locally-stored credentials for a remote host'
+    'output:Read an output from a state file'
+    'plan:Generate and show an execution plan'
+    'providers:Prints a tree of the providers used in the configuration'
+    'refresh:Update local state file against real resources'
+    'show:Inspect Terraform state or plan'
+    'state:Advanced state management'
+    'taint:Manually mark a resource for recreation'
+    'untaint:Manually unmark a resource as tainted'
+    'validate:Validates the Terraform files'
+    'version:Prints the Terraform version'
+    'workspace:Workspace management'
+    '0.12upgrade:Rewrites pre-0.12 module source code for v0.12'
+    '0.13upgrade:Rewrites pre-0.13 module source code for v0.13'
+)
+
+__012upgrade() {
+  _arguments \
+    '-yes[Skip the initial introduction messages and interactive confirmation. This can be used to run this command in batch from a script.]' \
+    '-force[ Override the heuristic that attempts to detect if a configuration is already written for v0.12 or later.  Some of the transformations made by this command are not idempotent, so re-running against the same module may change the meanings expressions in the module.]'
+}
+
+__013upgrade() {
+  _arguments \
+    '-yes[Skip the initial introduction messages and interactive confirmation. This can be used to run this command in batch from a script.]'
+}
+
+__apply() {
+    _arguments \
+        '-auto-approve[Skip interactive approval of plan before applying.]' \
+        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
+        '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
+        '-lock-timeout=[(0s) Duration to retry a state lock.]' \
+        '-input=[(true) Ask for input for variables if not directly set.]' \
+        '-no-color[If specified, output will be colorless.]' \
+        '-parallelism=[(10) Limit the number of parallel resource operations.]' \
+        '-refresh=[(true) Update state prior to checking for differences. This has no effect if a plan file is given to apply.]' \
+        '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]:statefile:_files -g "*.tfstate"' \
+        '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -g "*.tfstate"' \
+        '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
+}
+
+__console() {
+    _arguments \
+        '-state=[(terraform.tfstate) Path to read state.]' \
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
+}
+
+__destroy() {
+    _arguments \
+        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
+        '-auto-approve[Skip interactive approval before destroying.]' \
+        '-force[Deprecated: same as auto-approve.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
+        '-lock-timeout=[(0s) Duration to retry a state lock.]' \
+        '-no-color[If specified, output will contain no color.]' \
+        '-parallelism=[(10) Limit the number of concurrent operations.]' \
+        '-refresh=[(true) Update state prior to checking for differences. This has no effect if a plan file is given to apply.]' \
+        '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]:statefile:_files -g "*.tfstate"' \
+        '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -g "*.tfstate"' \
+        '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
+}
+
+__fmt() {
+    _arguments \
+        '-list=[(true) List files whose formatting differs (always false if using STDIN)]' \
+        '-write=[(true) Write result to source file instead of STDOUT (always false if using STDIN or -check)]' \
+        '-diff=[(false) Display diffs of formatting changes]' \
+        '-check=[(false) Check if the input is formatted. Exit status will be 0 if all input is properly formatted and non-zero otherwise.]' \
+        '-recursive=[(false) Also process files in subdirectories. By default, only the given directory (or current directory) is processed.]'
+}
+
+__force_unlock() {
+    _arguments \
+        "-force[Don't ask for input for unlock confirmation.]"
+}
+
+__get() {
+    _arguments \
+        '-update=[(false) If true, modules already downloaded will be checked for updates and updated if necessary.]' \
+        '-no-color[Disable text coloring in the output.]'
+}
+
+__graph() {
+    _arguments \
+        '-draw-cycles[Highlight any cycles in the graph with colored edges. This helps when diagnosing cycle errors.]' \
+        '-type=[(plan) Type of graph to output. Can be: plan, plan-destroy, apply, validate, input, refresh.]'
+}
+
+__import() {
+    _arguments \
+        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
+        '-config=[(path) Path to a directory of Terraform configuration files to use to configure the provider. Defaults to pwd. If no config files are present, they must be provided via the input prompts or env vars.]' \
+        '-allow-missing-config[Allow import when no resource configuration block exists.]' \
+        '-input=[(true) Ask for input for variables if not directly set.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
+        '-lock-timeout=[(0s) Duration to retry a state lock.]' \
+        '-no-color[If specified, output will contain no color.]' \
+        '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -g "*.tfstate"' \
+        '-state-out=[(PATH) Path to the destination state file to write to. If this is not specified, the source state file will be used. This can be a new or existing path.]:statefile:_files -g "*.tfstate"' \
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times. This is only useful with the "-config" flag.]' \
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
+}
+
+__init() {
+    _arguments \
+        '-backend=[(true) Configure the backend for this configuration.]' \
+        '-backend-config=[This can be either a path to an HCL file with key/value assignments (same format as terraform.tfvars) or a 'key=value' format. This is merged with what is in the configuration file. This can be specified multiple times. The backend type must be in the configuration itself.]' \
+        '-force-copy[Suppress prompts about copying state data. This is equivalent to providing a "yes" to all confirmation prompts.]' \
+        '-from-module=[(SOURCE) Copy the contents of the given module into the target directory before initialization.]' \
+        '-get=[(true) Download any modules for this configuration.]' \
+        '-get-plugins=[(true) Download any missing plugins for this configuration.]' \
+        '-input=[(true) Ask for input if necessary. If false, will error if input was required.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
+        '-lock-timeout=[(0s) Duration to retry a state lock.]' \
+        '-no-color[If specified, output will contain no color.]' \
+        '-plugin-dir[Directory containing plugin binaries. This overrides all default search paths for plugins, and prevents the automatic installation of plugins. This flag can be used multiple times.]:plugin_dir:_files -/' \
+        '-reconfigure[Reconfigure the backend, ignoring any saved configuration.]' \
+        '-upgrade=[(false) If installing modules (-get) or plugins (-get-plugins), ignore previously-downloaded objects and install the latest version allowed within configured constraints.]' \
+        '-verify-plugins=[(true) Verify the authenticity and integrity of automatically downloaded plugins.]'
+}
+
+__login() {
+    _arguments \
+
+}
+
+__logout() {
+    _arguments \
+
+}
+
+__output() {
+    _arguments \
+        '-state=[(path) Path to the state file to read. Defaults to "terraform.tfstate".]:statefile:_files -g "*.tfstate"' \
+        '-no-color[If specified, output will contain no color.]' \
+        '-json[If specified, machine readable output will be printed in JSON format]'
+}
+
+__plan() {
+    _arguments \
+        '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
+        '-destroy[If set, a plan will be generated to destroy all resources managed by the given configuration and state.]' \
+        '-detailed-exitcode[() Return detailed exit codes when the command exits. This will change the meaning of exit codes to: 0 - Succeeded, diff is empty (no changes); 1 - Errored, 2 - Succeeded; there is a diff]' \
+        '-input=[(true) Ask for input for variables if not directly set.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
+        '-lock-timeout=[(0s) Duration to retry a state lock.]' \
+        '-no-color[() If specified, output will contain no color.]' \
+        '-out=[(path) Write a plan file to the given path. This can be used as input to the "apply" command.]' \
+        '-parallelism=[(10) Limit the number of concurrent operations.]' \
+        '-refresh=[(true) Update state prior to checking for differences.]' \
+        '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]:statefile:_files -g "*.tfstate"' \
+        '*-target=[(resource) Resource to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
+}
+
+__providers() {
+    local -a __providers_cmds
+    __providers_cmds=(
+      'mirror:Mirrors the provider plugins needed for the current configuration'
+      'schema:Prints the schemas of the providers used in the configuration'
+    )
+    _describe -t providers "providers commands" __providers_cmds
+
+}
+
+__providers_mirror() {
+    _arguments \
+      '-platform=[(os_arch) Choose which target platform to build a mirror for.]' \
+      "*:target_dir:_files -/"
+}
+
+__providers_schema() {
+    _arguments \
+      '-json[]' \
+      '::'
+}
+
+__refresh() {
+    _arguments \
+        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]::backupfile:_files -g "*.backup"' \
+        '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
+        '-input=[(true) Ask for input for variables if not directly set.]' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
+        '-lock-timeout=[(0s) Duration to retry a state lock.]' \
+        '-no-color[If specified, output will not contain any color.]' \
+        '-state=[(path) Path to read and save state (unless state-out is specified). Defaults to "terraform.tfstate".]:statefile:_files -g "*.tfstate"' \
+        '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -g "*.tfstate"' \
+        '*-target=[(resource) A Resource Address to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__statelist' \
+        '*-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
+        '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
+}
+
+__show() {
+    _arguments \
+        '-json[If specified, output the Terraform plan or state in a machine-readable form.]' \
+        '-no-color[If specified, output will not contain any color.]'
+}
+
+__state() {
+    local -a __state_cmds
+    __state_cmds=(
+      'list:List resources in the state'
+      'mv:Move an item in the state'
+      'pull:Pull current state and output to stdout'
+      'push:Update remote state from a local state file'
+      'replace-provider:Replace provider for resources in the Terraform state'
+      'rm:Remove instances from the state' 
+      'show:Show a resource in the state'
+    )
+    _describe -t state "state commands" __state_cmds
+}
+
+__state_list() {
+  _arguments \
+    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default, Terraform will consult the state of the currently-selected workspace.]' \
+    '-id=[(id) Filters the results to include only instances whose resource types have an attribute named id whose value equals the given id string.]' \
+    "*:address:__statelist" 
+}
+
+__state_mv() {
+  _arguments \
+    "-dry-run[If set, prints out what would've been moved but doesn't actually move anything.]" \
+    '-backup=[(PATH) Path where Terraform should write the backup for the original state. This can"t be disabled. If not set, Terraform will write it to the same path as the statefile with a ".backup" extension.]:backupfile:_files -g "*.backup"' \
+    '-backup-out=[(PATH) Path where Terraform should write the backup for the destination state. This can"t be disabled. If not set, Terraform will write it to the same path as the destination state file with a backup extension. This only needs to be specified if -state-out is set to a different path than -state.]:backupfile:_files -g "*.backup"' \
+    "-lock=[(true) Lock the state files when locking is supported.]:lock:(true false)" \
+    "-lock-timeout=[(0s) Duration to retry a state lock.]" \
+    '-state=[(path) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -g "*.tfstate"' \
+    '-state-out=[(path) Path to the destination state file to write to. If this isn"t specified, the source state file will be used. This can be a new or existing path.]:statefile:_files -g "*.tfstate"' \
+    "::" \
+    ":source:__statelist" \
+    ":destination: " 
+}
+
+__state_push() {
+  _arguments \
+    "-force[Write the state even if lineages don't match or the remote serial is higher.]" \
+    '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
+    "-lock-timeout=[(0s) Duration to retry a state lock.]" \
+    "::" \
+    ":destination:_files"
+}
+
+__state_replace_provider() {
+  _arguments \
+    '-auto-approve[Skip interactive approval.]' \
+    '-backup=[(PATH) Path where Terraform should write the backup for the state file. This can"t be disabled. If not set, Terraform will write it to the same path as the state file with a ".backup" extension.]:backupfile:_files -g "*.backup"' \
+    "-lock=[(true) Lock the state files when locking is supported.]:lock:(true false)" \
+    "-lock-timeout=[(0s) Duration to retry a state lock.]" \
+    '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -g "*.tfstate"' \
+    ":from_provider_fqn:" \
+    ":to_provider_fqn:"
+}
+
+__state_rm() {
+  _arguments \
+    "-dry-run[If set, prints out what would've been removed but doesn't actually remove anything.]" \
+    '-backup=[(PATH) Path where Terraform should write the backup for the original state.]::backupfile:_files -g "*.backup"' \
+    "-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)" \
+    "-lock-timeout=[(0s) Duration to retry a state lock.]" \
+    '-state=[(PATH) Path to the state file to update. Defaults to the current workspace state.]:statefile:_files -g "*.tfstate"' \
+    "*:address:__statelist" 
+}
+
+
+__state_show() {
+  _arguments \
+    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]:statefile:_files -g "*.tfstate"' \
+    "*:address:__statelist" 
+}
+
+__statelist() {
+  compadd $(terraform state list $opt_args[-state])
+}
+
+__taint() {
+    _arguments \
+        '-allow-missing[If specified, the command will succeed (exit code 0) even if the resource is missing.]' \
+        '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
+        '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
+        '-lock-timeout=[(0s) Duration to retry a state lock.]' \
+        '-module=[(path)  The module path where the resource lives. By default this will be root. Child modules can be specified by names. Ex. "consul" or "consul.vpc" (nested modules).]' \
+        '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]:statefile:_files -g "*.tfstate"' \
+        '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]:statefile:_files -g "*.tfstate"' \
+        "*:address:__statelist" 
+}
+
+__untaint() {
+    _arguments \
+    '-allow-missing[If specified, the command will succeed (exit code 0) even if the resource is missing.]' \
+    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
+    '-lock=[(true) Lock the state file when locking is supported.]:lock:(true false)' \
+    '-lock-timeout=[(0s) Duration to retry a state lock.]' \
+    '-module=[(path)  The module path where the resource lives. By default this will be root. Child modules can be specified by names. Ex. "consul" or "consul.vpc" (nested modules).]' \
+    '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]:statefile:_files -g "*.tfstate"' \
+    '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]:statefile:_files -g "*.tfstate"'
+}
+
+__validate() {
+    _arguments \
+    '-no-color[If specified, output will not contain any color.]' \
+    '-json[Produce output in a machine-readable JSON format, suitable for use in text editor integrations and other automated systems.]' \
+    ':dir:_files -/'
+}
+
+__version() {
+    _arguments \
+    '-json[Output the version information as a JSON object.]'
+}
+
+__workspace() {
+    local -a __workspace_cmds
+    __workspace_cmds=(
+        'delete:Delete a workspace'
+        'list:List Workspaces'
+        'new:Create a new workspace'
+        'select:Select a workspace'
+        'show:Show the name of the current workspace'
+    )
+    _describe -t workspace "workspace commands" __workspace_cmds
+}
+
+_arguments '*:: :->command'
+
+if (( CURRENT == 1 )); then
+  _describe -t commands "terraform command" _terraform_cmds
+  return
+fi
+
+local -a _command_args
+case "$words[1]" in
+  0.12upgrade)
+    __012upgrade ;;
+  0.13upgrade)
+    __013upgrade ;;
+  apply)
+    __apply ;;
+  console)
+    __console;;
+  destroy)
+    __destroy ;;
+  fmt)
+    __fmt;;
+  force-unlock)
+    __force_unlock;;
+  get)
+    __get ;;
+  graph)
+    __graph ;;
+  import)
+    __import;;
+  init)
+    __init ;;
+  login)
+    __login ;;
+  logout)
+    __logout ;;
+  output)
+    __output ;;
+  plan)
+    __plan ;;
+  providers)
+    test $CURRENT -lt 3 && __providers
+    [[ $words[2] = "mirror" ]] && __providers_mirror
+    [[ $words[2] = "schema" ]] && __providers_schema
+    ;;
+  refresh)
+    __refresh ;;
+  show)
+    __show ;;
+  state)
+    test $CURRENT -lt 3 && __state
+    [[ $words[2] = "list" ]] && __state_list
+    [[ $words[2] = "mv" ]] && __state_mv
+    [[ $words[2] = "push" ]] && __state_push
+    [[ $words[2] = "replace-provider" ]] && __state_replace_provider
+    [[ $words[2] = "rm" ]] && __state_rm
+    [[ $words[2] = "show" ]] && __state_show
+    ;;
+  taint)
+    __taint ;;
+  untaint)
+    __untaint ;;
+  validate)
+    __validate ;;
+  version)
+    __version ;;
+  workspace)
+    test $CURRENT -lt 3 && __workspace ;;
+esac

--- a/plugins/terraform-workspace-prompt/terraform-workspace.plugin.zsh
+++ b/plugins/terraform-workspace-prompt/terraform-workspace.plugin.zsh
@@ -1,0 +1,35 @@
+# Global variables to cache the last known .terraform directory and its corresponding workspace name
+__TERRAFORM_WORKSPACE_CACHE=""
+__TERRAFORM_DIRECTORY_CACHE=""
+
+# Function to find the .terraform directory in the current or any parent directory
+__find_terraform_directory() {
+  local current_dir="$PWD"
+  while [[ "$current_dir" != "/" ]]; do
+    if [[ -d "${current_dir}/.terraform" ]]; then
+      echo "${current_dir}/.terraform"
+      return
+    fi
+    current_dir="$(dirname "$current_dir")"
+  done
+}
+
+# Function to update the Terraform workspace prompt based on the current working directory, utilizing the global cache variables
+__update_terraform_workspace_prompt() {
+  local terraform_dir="$(__find_terraform_directory)"
+  if [[ -n "$terraform_dir" && "$terraform_dir" != "$__TERRAFORM_DIRECTORY_CACHE" ]]; then
+    __TERRAFORM_DIRECTORY_CACHE="$terraform_dir"
+    local workspace="$(terraform -chdir="$(dirname "${terraform_dir%/}")" workspace show 2>/dev/null)"
+    __TERRAFORM_WORKSPACE_CACHE="$workspace"
+  elif [[ -z "$terraform_dir" ]]; then
+    __TERRAFORM_DIRECTORY_CACHE=""
+    __TERRAFORM_WORKSPACE_CACHE=""
+  fi
+}
+
+# Hooks to call the update function when the working directory changes or before each prompt is displayed
+autoload -Uz add-zsh-hook
+add-zsh-hook chpwd __update_terraform_workspace_prompt
+add-zsh-hook precmd __update_terraform_workspace_prompt
+
+complete -o nospace -C $(which terraform) terraform

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -252,12 +252,21 @@ prompt_aws() {
   esac
 }
 
+# Terraform Workspace:
+# - display current Terraform workspace name
+# - displays black on yellow
+prompt_terraform-workspace() {
+  [[ -z "$__TERRAFORM_WORKSPACE_CACHE" ]] && return
+  prompt_segment yellow black "TF: ${__TERRAFORM_WORKSPACE_CACHE:gs/%/%%}"
+}
+
 ## Main prompt
 build_prompt() {
   RETVAL=$?
   prompt_status
   prompt_virtualenv
   prompt_aws
+  prompt_terraform-workspace
   prompt_context
   prompt_dir
   prompt_git


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add support to display terraform workspace name in Agnoster theme prompt.
- The change is designed to support the plugin terraform-workspace-prompt

## Other comments:
There is currently no plugin that support to easily and aesthetically display terraform workspace in zsh prompt, using agnoster theme prompt engine. 

I added a terraform prompt logic, to uniformely support terraform workspace name to be displayed in the agnoster prompt.

I'm currently using this code via /.oh-my-zsh/custom/... structure.

Dependency: 
- [terraform-workspace-prompt](https://github.com/ocontant/terraform-workspace)
  - ohmyzsh PR: Plugins: terraform-workspace-prompt
  
  

If you find this contribution useful, feel free to merge. 

Best Regards,

