### PR TITLE
docs(ssh-agent): Add macOS and Powerline10k specific advice

### DIFF
--- a/plugins/ssh-agent/README.md
+++ b/plugins/ssh-agent/README.md
@@ -99,6 +99,33 @@ ssh-add -K -c -a /run/user/1000/ssh-auth <identities>
 
 For valid `ssh-add` arguments run `ssh-add --help` or `man ssh-add`.
 
+### Powerline 10k specific settings
+
+Powerline10k has an instant prompt setting that doesn't like when this plugin
+writes to the console. Consider using the following settings if you're using
+p10k (documented above):
+
+```
+zstyle :omz:plugins:ssh-agent quiet yes
+zstyle :omz:plugins:ssh-agent lazy yes
+```
+
+### macOS specific settings
+
+macOS supports using passphrases stored in the keychain when adding identities
+to the ssh-agent.
+
+```
+ssh-add --apple-use-keychain ~/.ssh/id_rsa ...
+```
+
+
+This plugin can be configured to use the keychain when loading using the following:
+
+```
+zstyle :omz:plugins:ssh-agent ssh-add-args --apple-load-keychain
+```
+
 ## Credits
 
 Based on code from Joseph M. Reagle: https://www.cygwin.com/ml/cygwin/2001-06/msg00537.html


### PR DESCRIPTION
The combination of p10k instant prompt, and macOS leads to a short but annnoying doc-dive.
Hopefully this helps others avoid the same.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- docs for ssh-agent

## Other comments:

...
