### PR TITLE
feat(aws): allow more customisation in prompt function

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -57,6 +57,8 @@ the current `$AWS_PROFILE` and `$AWS_REGION`. It uses four variables to control 
 
 * ZSH_THEME_AWS_REGION_SUFFIX: sets the suffix of the AWS_REGION. Defaults to `>`.
 
+* ZSH_THEME_AWS_DIVIDER: sets the divider between ZSH_THEME_AWS_PROFILE_SUFFIX and ZSH_THEME_AWS_REGION_PREFIX. Defaults to ` ` (single space).
+
 ## Configuration
 
 [Configuration and credential file settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) by AWS

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -203,9 +203,8 @@ function aws_prompt_info() {
     _aws_to_show+="${ZSH_THEME_AWS_PROFILE_PREFIX="<aws:"}${AWS_PROFILE}${ZSH_THEME_AWS_PROFILE_SUFFIX=">"}"
   fi
 
-  _aws_to_show+="${ZSH_THEME_AWS_DIVIDER=' '}"
-
   if [[ -n $AWS_REGION ]]; then
+    [[ -n $AWS_PROFILE ]] && _aws_to_show+="${ZSH_THEME_AWS_DIVIDER=' '}"
     _aws_to_show+="${ZSH_THEME_AWS_REGION_PREFIX="<region:"}${region}${ZSH_THEME_AWS_REGION_SUFFIX=">"}"
   fi
 

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -200,28 +200,13 @@ function aws_prompt_info() {
   local region="${AWS_REGION:-${AWS_DEFAULT_REGION:-$AWS_PROFILE_REGION}}"
 
   if [[ -n $AWS_PROFILE ]];then
-    if [[ -z ${ZSH_THEME_AWS_PROFILE_PREFIX+x} ]]; then # empty string is evaluated as false (ref : https://stackoverflow.com/a/13864829/8556340)
-      ZSH_THEME_AWS_PROFILE_PREFIX="<aws:"
-    fi
-    if [[ -z ${ZSH_THEME_AWS_PROFILE_SUFFIX+x} ]]; then
-      ZSH_THEME_AWS_PROFILE_SUFFIX=">"
-    fi
-    _aws_to_show+="${ZSH_THEME_AWS_PROFILE_PREFIX}${AWS_PROFILE}${ZSH_THEME_AWS_PROFILE_SUFFIX}"
+    _aws_to_show+="${ZSH_THEME_AWS_PROFILE_PREFIX="<aws:"}${AWS_PROFILE}${ZSH_THEME_AWS_PROFILE_SUFFIX=">"}"
   fi
 
-  if [[ -z ${ZSH_THEME_AWS_DIVIDER+x} ]]; then
-    ZSH_THEME_AWS_DIVIDER=" "
-  fi
-  _aws_to_show+="${ZSH_THEME_AWS_DIVIDER}"
+  _aws_to_show+="${ZSH_THEME_AWS_DIVIDER=' '}"
 
   if [[ -n $AWS_REGION ]]; then
-    if [[ -z ${ZSH_THEME_AWS_REGION_PREFIX+x} ]];then
-      ZSH_THEME_AWS_REGION_PREFIX="<region:"
-    fi
-    if [[ -z ${ZSH_THEME_AWS_REGION_SUFFIX+x} ]];then
-      ZSH_THEME_AWS_REGION_SUFFIX=">"
-    fi
-    _aws_to_show+="${ZSH_THEME_AWS_REGION_PREFIX}${region}${ZSH_THEME_AWS_REGION_SUFFIX}"
+    _aws_to_show+="${ZSH_THEME_AWS_REGION_PREFIX="<region:"}${region}${ZSH_THEME_AWS_REGION_SUFFIX=">"}"
   fi
 
   echo "$_aws_to_show"

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -198,13 +198,32 @@ compctl -K _aws_profiles asp acp aws_change_access_key
 function aws_prompt_info() {
   local _aws_to_show
   local region="${AWS_REGION:-${AWS_DEFAULT_REGION:-$AWS_PROFILE_REGION}}"
+
   if [[ -n $AWS_PROFILE ]];then
-    _aws_to_show+="${ZSH_THEME_AWS_PROFILE_PREFIX:=<aws:}${AWS_PROFILE}${ZSH_THEME_AWS_PROFILE_SUFFIX:=>}"
+    if [[ -z ${ZSH_THEME_AWS_PROFILE_PREFIX+x} ]]; then # empty string is evaluated as false (ref : https://stackoverflow.com/a/13864829/8556340)
+      ZSH_THEME_AWS_PROFILE_PREFIX="<aws:"
+    fi
+    if [[ -z ${ZSH_THEME_AWS_PROFILE_SUFFIX+x} ]]; then
+      ZSH_THEME_AWS_PROFILE_SUFFIX=">"
+    fi
+    _aws_to_show+="${ZSH_THEME_AWS_PROFILE_PREFIX}${AWS_PROFILE}${ZSH_THEME_AWS_PROFILE_SUFFIX}"
   fi
+
+  if [[ -z ${ZSH_THEME_AWS_DIVIDER+x} ]]; then
+    ZSH_THEME_AWS_DIVIDER=" "
+  fi
+  _aws_to_show+="${ZSH_THEME_AWS_DIVIDER}"
+
   if [[ -n $AWS_REGION ]]; then
-    [[ -n $AWS_PROFILE ]] && _aws_to_show+=" "
-    _aws_to_show+="${ZSH_THEME_AWS_REGION_PREFIX:=<region:}${region}${ZSH_THEME_AWS_REGION_SUFFIX:=>}"
+    if [[ -z ${ZSH_THEME_AWS_REGION_PREFIX+x} ]];then
+      ZSH_THEME_AWS_REGION_PREFIX="<region:"
+    fi
+    if [[ -z ${ZSH_THEME_AWS_REGION_SUFFIX+x} ]];then
+      ZSH_THEME_AWS_REGION_SUFFIX=">"
+    fi
+    _aws_to_show+="${ZSH_THEME_AWS_REGION_PREFIX}${region}${ZSH_THEME_AWS_REGION_SUFFIX}"
   fi
+
   echo "$_aws_to_show"
 }
 


### PR DESCRIPTION
resolves #11618

tl;dr : `$(aws_prompt_info)` now can be `admin|us-east-1`


## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes

- feature 1: allow empty string for variables
  - e.g., `ZSH_THEME_AWS_PROFILE_PREFIX` can be an empty string (`""`)
- feature 2: add a divider variable instead of a single space

## Other comments:

Slight worry for the second feature: Before this commit, the divider (a single space) i visible only when AWS_PROFILE and AWS_REGION were set. But this PR, for straightforward usage, makes it always visible.

