### PR TITLE
Feat(npm): Add npmRD alias for "npm run dev"

### DIFF
--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -29,6 +29,7 @@ plugins=(... npm)
 | `npmI`  | `npm init`                   | Run npm init                                                    |
 | `npmi`  | `npm info`                   | Run npm info                                                    |
 | `npmSe` | `npm search`                 | Run npm search                                                  |
+| `npmRD` | `npm run dev`                | Run npm run dev                                                 |
 
 ## `npm install` / `npm uninstall` toggle
 

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -70,6 +70,9 @@ alias npmi="npm info"
 # Run npm search
 alias npmSe="npm search"
 
+# Run npm run dev
+alias npmRD="npm run dev"
+
 npm_toggle_install_uninstall() {
   # Look up to the previous 2 history commands
   local line


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add an npmRD alias in the npm plugin to use `npm run dev`

## Other comments:

Many developers use `npm run dev` to test their code. If an alias for `npm test` exists, then `npm run dev` should also exist.
