### PR TITLE
fix(cli): execute as expected if `ksh_arrays` is set

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -11,7 +11,7 @@ function omz {
 
   # Subcommand functions start with _ so that they don't
   # appear as completion entries when looking for `omz`
-  (( $+functions[_omz::$command] )) || {
+  (( ${+functions[_omz::$command]} )) || {
     _omz::help
     return 1
   }


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- omz cli: Don’t fail with “bad output format specification” in shells with -o ksh_arrays