### PR TITLE
fix(dirhistory): run properly if `ksh_arrays` is set

### DIFF
--- a/plugins/dirhistory/dirhistory.plugin.zsh
+++ b/plugins/dirhistory/dirhistory.plugin.zsh
@@ -19,15 +19,17 @@ export DIRHISTORY_SIZE=30
 # Returns the element if the array was not empty,
 # otherwise returns empty string.
 function pop_past() {
-  typeset -g $1="${dirhistory_past[$#dirhistory_past]}"
+  setopt localoptions no_ksh_arrays
   if [[ $#dirhistory_past -gt 0 ]]; then
+    typeset -g $1="${dirhistory_past[$#dirhistory_past]}"
     dirhistory_past[$#dirhistory_past]=()
   fi
 }
 
 function pop_future() {
-  typeset -g $1="${dirhistory_future[$#dirhistory_future]}"
+  setopt localoptions no_ksh_arrays
   if [[ $#dirhistory_future -gt 0 ]]; then
+    typeset -g $1="${dirhistory_future[$#dirhistory_future]}"
     dirhistory_future[$#dirhistory_future]=()
   fi
 }
@@ -35,6 +37,7 @@ function pop_future() {
 # Push a new element onto the end of dirhistory_past. If the size of the array
 # is >= DIRHISTORY_SIZE, the array is shifted
 function push_past() {
+  setopt localoptions no_ksh_arrays
   if [[ $#dirhistory_past -ge $DIRHISTORY_SIZE ]]; then
     shift dirhistory_past
   fi
@@ -44,6 +47,7 @@ function push_past() {
 }
 
 function push_future() {
+  setopt localoptions no_ksh_arrays
   if [[ $#dirhistory_future -ge $DIRHISTORY_SIZE ]]; then
     shift dirhistory_future
   fi


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- dirhistory plugin: Don’t fail with “parameter not set” errors on navigation in shells with -o ksh_arrays