### PR TITLE
Jadjay lxd plugin enhancement

### DIFF
--- a/plugins/lxd/lxd.plugin.zsh
+++ b/plugins/lxd/lxd.plugin.zsh
@@ -9,7 +9,7 @@ _lxc_get_global_flags () {
 }
 
 _lxc_get_command_list () {
-    echo "___command"
+    
     $_comp_command1 -h              | _lxc_get_commands
     $_comp_command1 -h              | _lxc_get_global_flags
 }
@@ -22,24 +22,24 @@ _lxc_get_subcommand_list () {
 
     case ${words[2]} in
             alias|cluster|image|operation|profile|project|remote|storage|warning)
-                    echo "___subco_alias"
+                    
                     ${words[1]} ${words[2]} list -f csv | cut -d, -f1
                     ;;
             list)
-                    echo "___subco_list"
+                    
                     ${words[1]} ${words[2]} -cn -fcsv ${words[3]}
                     ;;
             exec)
-                    echo "___subco_exec"
+                    
                     echo "--"
                     ${words[1]} list -cn -fcsv ${words[3]}
                     ;;
             network)
-                    echo "___subco_autre"
+                    
                     ${words[1]} ${words[2]} list -fcsv  | cut -d, -f1
                     ;;
             *)
-                    echo "___subco_autre"
+                    
                     ${words[1]} list -cn -fcsv  ${words[3]}
                     ;;
      esac
@@ -49,12 +49,12 @@ _lxc_get_subcommand_list () {
 _lxc_get_element_list () {
     case ${words[2]} in
             exec)
-                    echo "___subco_exec2"
+                    
                     echo "--"
                     $_comp_command1 ${words[2]} -h | _lxc_get_flags
             ;;
             *)
-                echo "___subco_autre2"
+                
                 $_comp_command1 ${words[2]} ${words[3]} -h | _lxc_get_flags
                 $_comp_command1 ${words[2]} ${words[3]} -h | _lxc_get_commands
             ;;

--- a/plugins/lxd/lxd.plugin.zsh
+++ b/plugins/lxd/lxd.plugin.zsh
@@ -1,9 +1,64 @@
-_lxc_get_command_list () {
-    $_comp_command1 | sed "1,/Available Commands/d" | awk '/^[ \t]*[a-z]+/ { print $1 }'
+_lxc_get_commands () {
+            sed '/Available Commands/,/Flags/!d' | awk '/^[ \t]/{ print $1 }'
+}
+_lxc_get_flags () {
+            sed '/^Flags/,/^Global Flags/!d'     | awk '/^[ \t]*--/ { print $1 }/^[ \t]*-.,/ { print $1 $2 }' | sed 's/,/ /'
+}
+_lxc_get_global_flags () {
+            sed '/^Global Flags/,$!d'     | awk '/^[ \t]*--/ { print $1 }/^[ \t]*-.,/ { print $1 $2 }' | sed 's/,/ /'
 }
 
+_lxc_get_command_list () {
+    echo "___command"
+    $_comp_command1 -h              | _lxc_get_commands
+    $_comp_command1 -h              | _lxc_get_global_flags
+}
+
+
 _lxc_get_subcommand_list () {
-    $_comp_command1 ${words[2]} | sed "1,/Available Commands/d" | awk '/^[ \t]*[a-z]+/ { print $1 }'
+
+    $_comp_command1 ${words[2]} -h | _lxc_get_flags
+    $_comp_command1 ${words[2]} -h | _lxc_get_commands
+
+    case ${words[2]} in
+            alias|cluster|image|operation|profile|project|remote|storage|warning)
+                    echo "___subco_alias"
+                    ${words[1]} ${words[2]} list -f csv | cut -d, -f1
+                    ;;
+            list)
+                    echo "___subco_list"
+                    ${words[1]} ${words[2]} -cn -fcsv ${words[3]}
+                    ;;
+            exec)
+                    echo "___subco_exec"
+                    echo "--"
+                    ${words[1]} list -cn -fcsv ${words[3]}
+                    ;;
+            network)
+                    echo "___subco_autre"
+                    ${words[1]} ${words[2]} list -fcsv  | cut -d, -f1
+                    ;;
+            *)
+                    echo "___subco_autre"
+                    ${words[1]} list -cn -fcsv  ${words[3]}
+                    ;;
+     esac
+
+}
+
+_lxc_get_element_list () {
+    case ${words[2]} in
+            exec)
+                    echo "___subco_exec2"
+                    echo "--"
+                    $_comp_command1 ${words[2]} -h | _lxc_get_flags
+            ;;
+            *)
+                echo "___subco_autre2"
+                $_comp_command1 ${words[2]} ${words[3]} -h | _lxc_get_flags
+                $_comp_command1 ${words[2]} ${words[3]} -h | _lxc_get_commands
+            ;;
+    esac
 }
 
 _lxc () {
@@ -11,16 +66,20 @@ _lxc () {
   typeset -A opt_args
   _arguments \
     '1: :->command'\
+    '2: :->subcommand'\
     '*: :->args'
 
   case $state in
     command)
       compadd $(_lxc_get_command_list)
       ;;
+    subcommand)
+      compadd $(_lxc_get_subcommand_list)
+      ;;
     *)
-        compadd $(_lxc_get_subcommand_list)
+        compadd $(_lxc_get_element_list)
       ;;
   esac
 }
 
-compdef _lxc lxc
+compdef _lxc lxc lxd


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add elements listing
- Add instance listing
- Separate Flags, Global Flags, Commands
- Delete debug logs

## Other comments:

This avoid errors while using lxd autocompletion : 

Like this one : 

```shell
$ lxc image lis[TAB]
```
```shell
$ lxc image lisUsage:
  lxc image [flags]
  lxc image [command]

Available Commands:
  alias          Manage image aliases
  copy           Copy images between servers
  delete         Delete
(...)
```
