### PR TITLE
fix(azure): recognize properly linuxbrew

### DIFF
--- a/plugins/azure/azure.plugin.zsh
+++ b/plugins/azure/azure.plugin.zsh
@@ -31,11 +31,9 @@ function _az-homebrew-installed() {
   # check if Homebrew is installed
   (( $+commands[brew] )) || return 1
 
-  # speculatively check default brew prefix
-  if [[ -d /usr/local ]]; then
-    _brew_prefix=/usr/local
-  elif [[ -d /opt/homebrew ]]; then
-    _brew_prefix=/opt/homebrew
+  # if so, we assume it's default way to install brew
+  if [[ ${commands[brew]:t2} == bin/brew ]]; then
+    _brew_prefix="${commands[brew]:h:h}" # remove trailing /bin/brew
   else
     # ok, it is not in the default prefix
     # this call to brew is expensive (about 400 ms), so at least let's make it only once

--- a/plugins/azure/azure.plugin.zsh
+++ b/plugins/azure/azure.plugin.zsh
@@ -1,4 +1,4 @@
-# AZ Get Subscritions
+# AZ Get Subscriptions
 function azgs() {
   az account show --output tsv --query 'name' 2>/dev/null
 }


### PR DESCRIPTION
Closes #11644

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Recognize properly linuxbrew