### PR TITLE
fix(aws): set the divider to an empty string when it is not provided

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -229,7 +229,7 @@ function aws_prompt_info() {
   fi
 
   if [[ -n $AWS_REGION ]]; then
-    [[ -n $AWS_PROFILE ]] && _aws_to_show+="${ZSH_THEME_AWS_DIVIDER=' '}"
+    [[ -n $AWS_PROFILE ]] && _aws_to_show+="${ZSH_THEME_AWS_DIVIDER=''}"
     _aws_to_show+="${ZSH_THEME_AWS_REGION_PREFIX="<region:"}${region}${ZSH_THEME_AWS_REGION_SUFFIX=">"}"
   fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
- Last week's push changed the default divider view, and now everyone sees an annoying ' ' between the role and the region. To fix this issue, I set the default divider to an empty string character, which removes the unwanted character.

### before changes:
<img width="304" alt="Screenshot 2023-04-27 at 12 18 06" src="https://user-images.githubusercontent.com/102148617/234818024-efb4e20d-9f22-4e68-9c22-e69d03483253.png">

### after changes:
<img width="275" alt="Screenshot 2023-04-27 at 12 19 35" src="https://user-images.githubusercontent.com/102148617/234818474-3d66eac4-2299-473c-964e-d8073aee8fef.png">
