### PR TITLE
Update Zsh-z, which now allows setting $ZSHZ_CD

### DIFF
--- a/plugins/z/z.plugin.zsh
+++ b/plugins/z/z.plugin.zsh
@@ -4,7 +4,7 @@
 #
 # https://github.com/agkozak/zsh-z
 #
-# Copyright (c) 2018-2022 Alexandros Kozak
+# Copyright (c) 2018-2023 Alexandros Kozak
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -52,6 +52,7 @@
 #   ZSHZ_CASE -> if `ignore', pattern matching is case-insensitive; if `smart',
 #     pattern matching is case-insensitive only when the pattern is all
 #     lowercase
+#   ZSHZ_CD -> the directory-changing command that is used (default: builtin cd)
 #   ZSHZ_CMD -> name of command (default: z)
 #   ZSHZ_COMPLETION -> completion method (default: 'frecent'; 'legacy' for
 #     alphabetic sorting)
@@ -129,6 +130,7 @@ is-at-least 5.3.0 && ZSHZ[PRINTV]=1
 # Globals:
 #   ZSHZ
 #   ZSHZ_CASE
+#   ZSHZ_CD
 #   ZSHZ_COMPLETION
 #   ZSHZ_DATA
 #   ZSHZ_DEBUG
@@ -149,9 +151,19 @@ zshz() {
   local REPLY
   local -a lines
 
-  # Allow the user to specify the datafile name in $ZSHZ_DATA (default: ~/.z)
+  # Allow the user to specify a custom datafile in $ZSHZ_DATA (or legacy $_Z_DATA)
+  local custom_datafile="${ZSHZ_DATA:-$_Z_DATA}"
+
+  # If a datafile was provided as a standalone file without a directory path
+  # print a warning and exit
+  if [[ -n ${custom_datafile} && ${custom_datafile} != */* ]]; then
+    print "ERROR: You configured a custom Zsh-z datafile (${custom_datafile}), but have not specified its directory." >&2
+    exit
+  fi
+
+  # If the user specified a datafile, use that or default to ~/.z
   # If the datafile is a symlink, it gets dereferenced
-  local datafile=${${ZSHZ_DATA:-${_Z_DATA:-${HOME}/.z}}:A}
+  local datafile=${${custom_datafile:-$HOME/.z}:A}
 
   # If the datafile is a directory, print a warning and exit
   if [[ -d $datafile ]]; then
@@ -161,7 +173,7 @@ zshz() {
 
   # Make sure that the datafile exists before attempting to read it or lock it
   # for writing
-  [[ -f $datafile ]] || touch "$datafile"
+  [[ -f $datafile ]] || { mkdir -p "${datafile:h}" && touch "$datafile" }
 
   # Bail if we don't own the datafile and $ZSHZ_OWNER is not set
   [[ -z ${ZSHZ_OWNER:-${_Z_OWNER}} && -f $datafile && ! -O $datafile ]] &&
@@ -620,7 +632,7 @@ zshz() {
         *)
           # Frecency routine
           (( dx = EPOCHSECONDS - time_field ))
-          rank=$(( 10000 * rank_field * (3.75/((0.0001 * dx + 1) + 0.25)) ))
+          rank=$(( 10000 * rank_field * (3.75/( (0.0001 * dx + 1) + 0.25)) ))
           ;;
       esac
 
@@ -757,6 +769,26 @@ zshz() {
   }
 
   #########################################################
+  # Allow the user to specify directory-changing command
+  # using $ZSHZ_CD (default: builtin cd).
+  #
+  # Globals:
+  #   ZSHZ_CD
+  #
+  # Arguments:
+  #   $* Path
+  #########################################################
+  zshz_cd() {
+    setopt LOCAL_OPTIONS NO_WARN_CREATE_GLOBAL
+
+    if [[ -z $ZSHZ_CD ]]; then
+      builtin cd "$*"
+    else
+      ${=ZSHZ_CD} "$*"
+    fi
+  }
+
+  #########################################################
   # If $ZSHZ_ECHO == 1, display paths as you jump to them.
   # If it is also the case that $ZSHZ_TILDE == 1, display
   # the home directory as a tilde.
@@ -773,7 +805,7 @@ zshz() {
 
   if [[ ${@: -1} == /* ]] && (( ! $+opts[-e] && ! $+opts[-l] )); then
     # cd if possible; echo the new path if $ZSHZ_ECHO == 1
-    [[ -d ${@: -1} ]] && builtin cd ${@: -1} && _zshz_echo && return
+    [[ -d ${@: -1} ]] && zshz_cd ${@: -1} && _zshz_echo && return
   fi
 
   # With option -c, make sure query string matches beginning of matches;
@@ -830,12 +862,12 @@ zshz() {
       print -- "$cd"
     else
       # cd if possible; echo the new path if $ZSHZ_ECHO == 1
-      [[ -d $cd ]] && builtin cd "$cd" && _zshz_echo
+      [[ -d $cd ]] && zshz_cd "$cd" && _zshz_echo
     fi
   else
     # if $req is a valid path, cd to it; echo the new path if $ZSHZ_ECHO == 1
     if ! (( $+opts[-e] || $+opts[-l] )) && [[ -d $req ]]; then
-      builtin cd "$req" && _zshz_echo
+      zshz_cd "$req" && _zshz_echo
     else
       return $ret2
     fi
@@ -900,9 +932,9 @@ add-zsh-hook chpwd _zshz_chpwd
 ############################################################
 
 # Standarized $0 handling
-# (See https://github.com/agkozak/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc)
-0=${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}
-0=${${(M)0:#/*}:-$PWD/$0}
+# https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
 
 (( ${fpath[(ie)${0:A:h}]} <= ${#fpath} )) || fpath=( "${0:A:h}" "${fpath[@]}" )
 


### PR DESCRIPTION
See https://github.com/agkozak/zsh-z#settings:

`ZSHZ_CD` specifies the default directory-changing command (default: builtin cd)

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
