### PR TITLE
feat(rake-fast): show task descriptions in autocomplete

### DIFF
--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -1,5 +1,28 @@
+# The version of the format of .rake_tasks. If the output of _rake_generate
+# changes, incrementing this number will force it to regenerate
+_rake_tasks_version=2
+
 _rake_does_task_list_need_generating () {
-  [[ ! -f .rake_tasks ]] || [[ Rakefile -nt .rake_tasks ]] || { _is_rails_app && _tasks_changed }
+  _rake_tasks_missing || _rake_tasks_version_changed || _rakefile_has_changes || { _is_rails_app && _tasks_changed }
+}
+
+_rake_tasks_missing () {
+  [[ ! -f .rake_tasks ]]
+}
+
+_rake_tasks_version_changed () {
+  local -a file_version
+  file_version=`head -n 1 .rake_tasks | sed "s/^version\://"`
+
+  if ! [[ $file_version =~ '^[0-9]*$' ]]; then
+    return true
+  fi
+
+  [[ $file_version -ne $_rake_tasks_version ]]
+}
+
+_rakefile_has_changes () {
+  [[ Rakefile -nt .rake_tasks ]]
 }
 
 _is_rails_app () {
@@ -20,7 +43,14 @@ _tasks_changed () {
 }
 
 _rake_generate () {
-  rake --silent --tasks | cut -d " " -f 2 | sed 's/\[.*\]//g' > .rake_tasks
+  echo "version:$_rake_tasks_version" > .rake_tasks
+
+  rake --silent --tasks --all \
+    | sed "s/^rake //" | sed "s/\:/\\\:/g" \
+    | sed "s/\[[^]]*\]//g" \
+    | sed "s/ *# /\:/" \
+    | sed "s/\:$//" \
+    >> .rake_tasks
 }
 
 _rake () {
@@ -29,7 +59,10 @@ _rake () {
       echo "\nGenerating .rake_tasks..." >&2
       _rake_generate
     fi
-    compadd $(cat .rake_tasks)
+    local -a rake_options
+    rake_options=("${(@f)$(cat .rake_tasks)}")
+    shift rake_options
+    _describe 'rake tasks' rake_options
   fi
 }
 compdef _rake rake


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x] The PR title is descriptive.
- [ x] The PR doesn't replicate another PR which is already open.
- [ x] I have read the contribution guide and followed all the instructions.
- [ x] The code follows the code style guide detailed in the wiki.
- [ x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added rake task descriptions in the autocomplete list
- Added version control to the .rake_tasks file. If the `_rake_tasks_version` changes, it will force .rake_tasks to regenerate. This is necessary because the file format has changed
- The list of completions now shows all tasks, not just those that have a description

## Other comments:
Based on https://github.com/ohmyzsh/ohmyzsh/pull/4720, errors fixed (see PR comments)
