### PR TITLE
Added Alias for npm install-test as npmIt

### DIFF
--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -73,6 +73,9 @@ alias npmSe="npm search"
 # Run npm run dev
 alias npmrd="npm run dev"
 
+# Adding npm install-test
+alias npmIt="npm install-test"
+
 npm_toggle_install_uninstall() {
   # Look up to the previous 2 history commands
   local line


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- This corresponds to https://github.com/ohmyzsh/ohmyzsh/issues/10890.
- Added alias npmIt="npm install-test" to the npm.plugin.zsh file.

## Other comments:
Yes there was already a PR for this but there was confusion with that as that was changing some things on README.md as well which is not required here. So, this is a fresh PR to resolve the issue.

Thanks.
...
