### PR TITLE
Update directory aliases to use cd command

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -5,10 +5,10 @@ setopt pushd_ignore_dups
 setopt pushdminus
 
 
-alias -g ...='../..'
-alias -g ....='../../..'
-alias -g .....='../../../..'
-alias -g ......='../../../../..'
+alias -g ...='cd ../..'
+alias -g ....='cd ../../..'
+alias -g .....='cd ../../../..'
+alias -g ......='cd ../../../../..'
 
 alias -- -='cd -'
 alias 1='cd -1'


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- Use the `cd` command inside the `...`, `....`, etc aliases

## Other comments:

Ever since #11550 has shipped, my `...` aliases (which I used to override) have broken.
```
[user:~]$ ...
zsh: permission denied: ../..
```
The new behavior of actually unaliasing the aliases, rather than just [bouncing out early](https://github.com/ohmyzsh/ohmyzsh/blob/277f38212aef31a6baba2cf1a0a355af611be5e0/lib/directories.zsh#L12) means that my overrides no longer work. There is likely somewhere downstream I could move my aliases in my network of dotfiles, but I actually do like a lot of the directory aliases and I see no reason we can't just use the `cd` command in them rather than relying on some other shell shortcut.
