### PR TITLE
fix(init): avoid overwriting existing aliases

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -159,10 +159,10 @@ _omz_source() {
   zstyle -T ":omz:${context}" aliases || disable_aliases=1
 
   # Back up alias names prior to sourcing
-  local -a aliases_pre galiases_pre
+  local -A aliases_pre galiases_pre
   if (( disable_aliases )); then
-    aliases_pre=("${(@k)aliases}")
-    galiases_pre=("${(@k)galiases}")
+    aliases_pre=("${(@kv)aliases}")
+    galiases_pre=("${(@kv)galiases}")
   fi
 
   # Source file from $ZSH_CUSTOM if it exists, otherwise from $ZSH
@@ -174,10 +174,16 @@ _omz_source() {
 
   # Unset all aliases that don't appear in the backed up list of aliases
   if (( disable_aliases )); then
-    local -a disabled
-    # ${var:|array} gets the list of items in var not in array
-    disabled=("${(@k)aliases:|aliases_pre}" "${(@k)galiases:|galiases_pre}")
-    (( $#disabled == 0 )) || unalias "${(@)disabled}"
+    if (( #aliases_pre )); then
+      aliases=("${(@kv)aliases_pre}")
+    else
+      (( #aliases )) && unalias "${(@k)aliases}"
+    fi
+    if (( #galiases_pre )); then
+      galiases=("${(@kv)galiases_pre}")
+    else
+      (( #galiases )) && unalias "${(@k)galiases}"
+    fi
   fi
 }
 


### PR DESCRIPTION
Fix regression introduced in #11550. If an existing alias was present in the moment of sourcing, and oh-my-zsh aliases were disabled for that file, it'd be overwritten aswell. See #11658.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Fix regression introduced in #11550. If an existing alias was present in the moment of sourcing, and oh-my-zsh aliases were disabled for that file, it'd be overwritten aswell. See #11658.
