### PR TITLE
feat(theme-and-appearance): allow disabling gnu-ls in bsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To learn more, visit [ohmyz.sh](https://ohmyz.sh), follow [@ohmyzsh](https://twi
     - [Manual Installation](#manual-installation)
   - [Installation Problems](#installation-problems)
   - [Custom Plugins and Themes](#custom-plugins-and-themes)
+  - [Disable GNU ls in macOS and freeBSD systems](#disable-gnu-ls)
   - [Skip aliases](#skip-aliases)
 - [Getting Updates](#getting-updates)
   - [Updates verbosity](#updates-verbosity)
@@ -277,6 +278,18 @@ If you want to override any of the default behaviors, just add a new file (endin
 If you have many functions that go well together, you can put them as a `XYZ.plugin.zsh` file in the `custom/plugins/` directory and then enable this plugin.
 
 If you would like to override the functionality of a plugin distributed with Oh My Zsh, create a plugin of the same name in the `custom/plugins/` directory and it will be loaded instead of the one in `plugins/`.
+
+### Disable GNU ls in macOS and freeBSD systems
+
+<a name="disable-gnu-ls"></a>
+
+The default behaviour in Oh My Zsh is to use GNU `ls` even in macOS and freeBSD systems if it's installed (as
+`gls` command) when enabling colorized `ls` in `lib/theme-and-appearance.zsh`. If you want to disable this
+behaviour you can use zstyle-based config before sourcing `oh-my-zsh.sh`:
+
+```zsh
+zstyle ':omz:lib:theme-and-appearance' gnu-ls no
+```
 
 ### Skip aliases
 

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -20,9 +20,24 @@ if command diff --color /dev/null{,} &>/dev/null; then
   }
 fi
 
-
 # Don't set ls coloring if disabled
 [[ "$DISABLE_LS_COLORS" != true ]] || return 0
+
+# Default coloring for BSD-based ls
+export LSCOLORS="Gxfxcxdxbxegedabagacad"
+
+# Default coloring for GNU-based ls
+if [[ -z "$LS_COLORS" ]]; then
+  # Define LS_COLORS via dircolors if available. Otherwise, set a default
+  # equivalent to LSCOLORS (generated via https://geoff.greer.fm/lscolors)
+  if (( $+commands[dircolors] )); then
+    [[ -f "$HOME/.dircolors" ]] \
+      && source <(dircolors -b "$HOME/.dircolors") \
+      || source <(dircolors -b)
+  else
+    export LS_COLORS="di=1;36:ln=35:so=32:pi=33:ex=31:bd=34;46:cd=34;43:su=30;41:sg=30;46:tw=30;42:ow=30;43"
+  fi
+fi
 
 function test-ls-args {
   local cmd="$1"          # ls, gls, colorls, ...
@@ -50,7 +65,7 @@ case "$OSTYPE" in
     test-ls-args ls -G && alias ls='ls -G'
     # Only use GNU ls if installed and there are user defaults for $LS_COLORS,
     # as the default coloring scheme is not very pretty
-    [[ -n "$LS_COLORS" || -f "$HOME/.dircolors" ]] \
+    zstyle -T ':omz:lib:theme-and-appearance' gnu-ls \
       && test-ls-args gls --color \
       && alias ls='gls --color=tty'
     ;;
@@ -64,20 +79,3 @@ case "$OSTYPE" in
 esac
 
 unfunction test-ls-args
-
-
-# Default coloring for BSD-based ls
-export LSCOLORS="Gxfxcxdxbxegedabagacad"
-
-# Default coloring for GNU-based ls
-if [[ -z "$LS_COLORS" ]]; then
-  # Define LS_COLORS via dircolors if available. Otherwise, set a default
-  # equivalent to LSCOLORS (generated via https://geoff.greer.fm/lscolors)
-  if (( $+commands[dircolors] )); then
-    [[ -f "$HOME/.dircolors" ]] \
-      && source <(dircolors -b "$HOME/.dircolors") \
-      || source <(dircolors -b)
-  else
-    export LS_COLORS="di=1;36:ln=35:so=32:pi=33:ex=31:bd=34;46:cd=34;43:su=30;41:sg=30;46:tw=30;42:ow=30;43"
-  fi
-fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Closes #11647 

To disable gnu-ls (`gls`) even if it's installed in freeBSD and macOS you can set it up with:
```zsh
zstyle ':omz:lib:theme-and-appearance' gnu-ls no
```