### PR TITLE
move $ZSH_TMUX_CONFIG from $HOME to $XDG_CONFIG_HOME

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -26,7 +26,7 @@ fi
 # systems without the proper terminfo
 : ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=screen-256color}
 # Set the configuration path
-: ${ZSH_TMUX_CONFIG:=$HOME/.tmux.conf}
+: ${ZSH_TMUX_CONFIG:=${XDG_CONFIG_HOME:=~/.config/tmux.conf}}
 # Set -u option to support unicode
 : ${ZSH_TMUX_UNICODE:=false}
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

use `XDG_CONFIG_HOME` variable with default location `~/.config/tmux.conf` for `ZSH_TMUX_CONFIG`
```
${ZSH_TMUX_CONFIG:=${XDG_CONFIG_HOME:=~/.config/tmux.conf}}
```
