### PR TITLE
Update vi-mode plugin doc to prevent overriden settings

### DIFF
--- a/plugins/vi-mode/README.md
+++ b/plugins/vi-mode/README.md
@@ -8,6 +8,9 @@ To use it, add `vi-mode` to the plugins array in your zshrc file:
 plugins=(... vi-mode)
 ```
 
+NOTE: The following settings should be added after `source $ZSH/oh-my-zsh.sh`
+so the plugin doesn't override them.
+
 ## Settings
 
 - `VI_MODE_RESET_PROMPT_ON_MODE_CHANGE`: controls whether the prompt is redrawn when


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add basic comment to document how to configure settings for vi-mode plugin

## Other comments:

- I had some problems configuring settings for vi-mode plugin until I realized the plugin was overriding them. It may be due to me being a noob using oh-my-zsh but this quick note would have saved me some time 😃
