### PR TITLE
Terraform: Include auto-approve aliases

### DIFF
--- a/plugins/terraform/README.md
+++ b/plugins/terraform/README.md
@@ -15,17 +15,19 @@ plugins=(... terraform)
 
 ## Aliases
 
-| Alias | Command              |
-| ----- | -------------------- |
-| `tf`  | `terraform`          |
-| `tfa` | `terraform apply`    |
-| `tfc` | `terraform console`  |
-| `tfd` | `terraform destroy`  |
-| `tff` | `terraform fmt`      |
-| `tfi` | `terraform init`     |
-| `tfo` | `terraform output`   |
-| `tfp` | `terraform plan`     |
-| `tfv` | `terraform validate` |
+| Alias  | Command                           |
+| -------| --------------------------------- |
+| `tf`   | `terraform`                       |
+| `tfa`  | `terraform apply`                 |
+| `tfa!` | `terraform apply -auto-approve`   |
+| `tfc`  | `terraform console`               |
+| `tfd`  | `terraform destroy`               |
+| `tfd!` | `terraform destroy -auto-approve` |
+| `tff`  | `terraform fmt`                   |
+| `tfi`  | `terraform init`                  |
+| `tfo`  | `terraform output`                |
+| `tfp`  | `terraform plan`                  |
+| `tfv`  | `terraform validate`              |
 
 ## Prompt function
 

--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -10,8 +10,10 @@ function tf_prompt_info() {
 
 alias tf='terraform'
 alias tfa='terraform apply'
+alias tfa!='terraform apply -auto-approve'
 alias tfc='terraform console'
 alias tfd='terraform destroy'
+alias tfd!='terraform destroy -auto-approve'
 alias tff='terraform fmt'
 alias tfi='terraform init'
 alias tfo='terraform output'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- When applying or deleting a terraform configuration with `tfa` or `tfd` you can now append `!` to the existing aliases to auto-approve the changes.

