### PR TITLE
feat(deno): add `dt` alias for `deno task`

### DIFF
--- a/plugins/deno/README.md
+++ b/plugins/deno/README.md
@@ -16,5 +16,6 @@ This plugin sets up completion and aliases for [Deno](https://deno.land).
 | drA   | deno run -A         |
 | drw   | deno run --watch    |
 | dru   | deno run --unstable |
+| dt    | deno task           |
 | dts   | deno test           |
 | dup   | deno upgrade        |

--- a/plugins/deno/deno.plugin.zsh
+++ b/plugins/deno/deno.plugin.zsh
@@ -9,6 +9,7 @@ alias drn='deno run'
 alias drA='deno run -A'
 alias drw='deno run --watch'
 alias dru='deno run --unstable'
+alias dt='deno task'
 alias dts='deno test'
 alias dup='deno upgrade'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

* Add a `dt` alias in the Deno plugin to use `deno task`

## Other comments:

Nope. Thanks!
