### PR TITLE
Added glc and glca commands for simple workflow working with dangling branches etc

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -230,6 +230,8 @@ alias glola="git log --graph --pretty='%Cred%h%Creset -%C(auto)%d%Creset %s %Cgr
 alias glog='git log --oneline --decorate --graph'
 alias gloga='git log --oneline --decorate --graph --all'
 alias glp="_git_log_prettily"
+alias glc="git log --all --graph --simplify-by-decoration --pretty='format:%C(auto)%d - %s'"
+alias glca="git log --all --graph --simplify-by-decoration --pretty='format:%C(blue)%h %C(green)%as %C(yellow)%al%C(auto)%d - %s'"
 
 alias gm='git merge'
 alias gmom='git merge origin/$(git_main_branch)'


### PR DESCRIPTION
feat(git): add aliases *glc* and *glca* for working with compact history, showing branch endpoints.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Intruduction of new aliases, glc and glca. Powerful utility to see all dangling branches. Helpful when cleaning up a repo.
- Workflow:
```
glc
# Investigate repository. IF more information is needed:
glca
# Do maintenance on the repository. Repeat as needed
```

## Other comments:

...
