### PR TITLE
feat(fast-gentoo): Add `fast-gentoo` theme, a faster and more responsive `gentoo` theme alternative

### DIFF
--- a/themes/fast-gentoo.zsh-theme
+++ b/themes/fast-gentoo.zsh-theme
@@ -1,0 +1,17 @@
+function prompt_char {
+	if [ $UID -eq 0 ]; then echo "#"; else echo $; fi
+}
+
+git_branch() {
+  local branch=$(git rev-parse --abbrev-ref HEAD 2>&1)
+  if [[ $branch == 'fatal: not a git repository (or any of the parent directories): .git' ]]; then
+    echo "";
+  else
+    echo "(${branch})"
+  fi
+}
+
+PROMPT='%(!.%{$fg_bold[red]%}.%{$fg_bold[green]%}%n@)%m %{$fg_bold[blue]%}%(!.%1~.%~) $(git_branch | xargs) $(prompt_char)%{$reset_color%} '
+
+ZSH_THEME_GIT_PROMPT_PREFIX="("
+ZSH_THEME_GIT_PROMPT_SUFFIX=") "


### PR DESCRIPTION
Add a new theme called `fast-gentoo`, which looks like the `gentoo` theme but is more responsive thanks to using `git rev-parse`.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add new theme called `fast-gentoo` – a faster alternative to the `gentoo` theme.

## Other comments:

I've been using it on Mac and Linux devices for several years and it's been great so far.
