### PR TITLE
feat(kubectl): add aliases `kg*n` to list resources by namespace

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -38,12 +38,14 @@ plugins=(... kubectl)
 |         |                                     | **Service management**                                                                           |
 | kgs     | `kubectl get svc`                   | List all services in ps output format                                                            |
 | kgsw    | `kgs --watch`                       | After listing all services, watch for changes                                                    |
+| kgsn    | `kgs -n`                            | List services by namespace. Example: `kgsn kube-system`                                          |
 | kgswide | `kgs -o wide`                       | After listing all services, output in plain-text format with any additional information          |
 | kes     | `kubectl edit svc`                  | Edit services(svc) from the default editor                                                       |
 | kds     | `kubectl describe svc`              | Describe all services in detail                                                                  |
 | kdels   | `kubectl delete svc`                | Delete all services matching passed argument                                                     |
 |         |                                     | **Ingress management**                                                                           |
 | kgi     | `kubectl get ingress`               | List ingress resources in ps output format                                                       |
+| kgin    | `kgi -n`                            | List ingress resources by namespace. Example: `kgin kube-system`                                 |
 | kei     | `kubectl edit ingress`              | Edit ingress resource from the default editor                                                    |
 | kdi     | `kubectl describe ingress`          | Describe ingress resource in detail                                                              |
 | kdeli   | `kubectl delete ingress`            | Delete ingress resources matching passed argument                                                |
@@ -55,15 +57,18 @@ plugins=(... kubectl)
 | kdelns  | `kubectl delete namespace`          | Delete the namespace. WARNING! This deletes everything in the namespace                          |
 |         |                                     | **ConfigMap management**                                                                         |
 | kgcm    | `kubectl get configmaps`            | List the configmaps in ps output format                                                          |
+| kgcmn   | `kgcm -n`                           | List configmaps by namespace. Example: `kgcmn kube-system`                                       |
 | kecm    | `kubectl edit configmap`            | Edit configmap resource from the default editor                                                  |
 | kdcm    | `kubectl describe configmap`        | Describe configmap resource in detail                                                            |
 | kdelcm  | `kubectl delete configmap`          | Delete the configmap                                                                             |
 |         |                                     | **Secret management**                                                                            |
 | kgsec   | `kubectl get secret`                | Get secret for decoding                                                                          |
+| kgsecn  | `kgsec -n`                          | List secrets by namespace. Example: `kgsecn kube-system`                                         |
 | kdsec   | `kubectl describe secret`           | Describe secret resource in detail                                                               |
 | kdelsec | `kubectl delete secret`             | Delete the secret                                                                                |
 |         |                                     | **Deployment management**                                                                        |
 | kgd     | `kubectl get deployment`            | Get the deployment                                                                               |
+| kgdn    | `kgd -n`                            | Get deployments by namspace. Example: `kgdn kube-system`                                         |
 | kgdw    | `kgd --watch`                       | After getting the deployment, watch for changes                                                  |
 | kgdwide | `kgd -o wide`                       | After getting the deployment, output in plain-text format with any additional information        |
 | ked     | `kubectl edit deployment`           | Edit deployment resource from the default editor                                                 |
@@ -74,6 +79,7 @@ plugins=(... kubectl)
 | kres    | `kubectl set env $@ REFRESHED_AT=...` | Recreate all pods in deployment with zero-downtime                                             |
 |         |                                     | **Rollout management**                                                                           |
 | kgrs    | `kubectl get replicaset`            | List all ReplicaSets `rs` created by the deployment                                              |
+| kgrsn   | `kgrs -n`                           | List ReplicaSets by namespace. Example: `kgrsn kube-system`                                      |
 | kdrs    | `kubectl describe replicaset`       | Describe ReplicaSet in detail                                                                    |
 | kers    | `kubectl edit replicaset`           | Edit ReplicaSet from the default editor                                                          |
 | krh     | `kubectl rollout history`           | Check the revisions of this deployment                                                           |
@@ -90,17 +96,20 @@ plugins=(... kubectl)
 | kcp     | `kubectl cp`                        | Copy files and directories to and from containers                                                |
 |         |                                     | **Node management**                                                                              |
 | kgno    | `kubectl get nodes`                 | List the nodes in ps output format                                                               |
+| kgnon   | `kgno -n`                           | List nodes by namespace. Example: `kgnon kube-system`                                            |
 | keno    | `kubectl edit node`                 | Edit nodes resource from the default editor                                                      |
 | kdno    | `kubectl describe node`             | Describe node resource in detail                                                                 |
 | kdelno  | `kubectl delete node`               | Delete the node                                                                                  |
 |         |                                     | **Persistent Volume Claim management**                                                           |
 | kgpvc   | `kubectl get pvc`                   | List all PVCs                                                                                    |
+| kgpvcn  | `kgpvc -n`                          | List PVCs by namespace. Example: `kgpvcn kube-system`                                            |
 | kgpvcw  | `kgpvc --watch`                     | After listing/getting the requested object, watch for changes                                    |
 | kepvc   | `kubectl edit pvc`                  | Edit pvcs from the default editor                                                                |
 | kdpvc   | `kubectl describe pvc`              | Describe all pvcs                                                                                |
 | kdelpvc | `kubectl delete pvc`                | Delete all pvcs matching passed arguments                                                        |
 |         |                                     | **StatefulSets management**                                                                      |
 | kgss    | `kubectl get statefulset`           | List the statefulsets in ps format                                                               |
+| kgssn   | `kgss -n`                           | List statefulsets by namespace. Example: `kgssn kube-system`                                     |
 | kgssw   | `kgss --watch`                      | After getting the list of statefulsets, watch for changes                                        |
 | kgsswide| `kgss -o wide`                      | After getting the statefulsets, output in plain-text format with any additional information      |
 | kess    | `kubectl edit statefulset`          | Edit statefulset resource from the default editor                                                |
@@ -119,11 +128,13 @@ plugins=(... kubectl)
 | kdelds  | `kubectl delete daemonset`          | Delete all DaemonSets matching passed argument                                                   |
 |         |                                     | **CronJob management**                                                                           |
 | kgcj    | `kubectl get cronjob`               | List all CronJobs in ps output format                                                            |
+| kgcjn   | `kgcj -n`                           | List CronJobs by namespace. Example: `kgcjn kube-system`                                         |
 | kecj    | `kubectl edit cronjob`              | Edit CronJob from the default editor                                                             |
 | kdcj    | `kubectl describe cronjob`          | Describe a CronJob in details                                                                    |
 | kdelcj  | `kubectl delete cronjob`            | Delete the CronJob                                                                               |
 |         |                                     | **Job management**                                                                               |
 | kgj     | `kubectl get job`                   | List all Job in ps output format                                                                 |
+| kgjn    | `kgj -n`                            | List Jobs by namespace. Example: `kgjn kube-system`                                              |
 | kej     | `kubectl edit job`                  | Edit a Job in details                                                                            |
 | kdj     | `kubectl describe job`              | Describe the Job                                                                                 |
 | kdelj   | `kubectl delete job`                | Delete the Job                                                                                   |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -56,6 +56,7 @@ alias kgpn='kgp -n'
 # Service management.
 alias kgs='kubectl get svc'
 alias kgsa='kubectl get svc --all-namespaces'
+alias kgsn='kgs -n'
 alias kgsw='kgs --watch'
 alias kgswide='kgs -o wide'
 alias kes='kubectl edit svc'
@@ -65,6 +66,7 @@ alias kdels='kubectl delete svc'
 # Ingress management
 alias kgi='kubectl get ingress'
 alias kgia='kubectl get ingress --all-namespaces'
+alias kgin='kgi -n'
 alias kei='kubectl edit ingress'
 alias kdi='kubectl describe ingress'
 alias kdeli='kubectl delete ingress'
@@ -79,6 +81,7 @@ alias kcn='kubectl config set-context --current --namespace'
 # ConfigMap management
 alias kgcm='kubectl get configmaps'
 alias kgcma='kubectl get configmaps --all-namespaces'
+alias kgcmn='kgcm -n'
 alias kecm='kubectl edit configmap'
 alias kdcm='kubectl describe configmap'
 alias kdelcm='kubectl delete configmap'
@@ -86,12 +89,14 @@ alias kdelcm='kubectl delete configmap'
 # Secret management
 alias kgsec='kubectl get secret'
 alias kgseca='kubectl get secret --all-namespaces'
+alias kgsecn='kgsec -n'
 alias kdsec='kubectl describe secret'
 alias kdelsec='kubectl delete secret'
 
 # Deployment management.
 alias kgd='kubectl get deployment'
 alias kgda='kubectl get deployment --all-namespaces'
+alias kgdn='kgd -n'
 alias kgdw='kgd --watch'
 alias kgdwide='kgd -o wide'
 alias ked='kubectl edit deployment'
@@ -106,6 +111,7 @@ function kres(){
 
 # Rollout management.
 alias kgrs='kubectl get replicaset'
+alias kgrsn='kgrs -n'
 alias kdrs='kubectl describe replicaset'
 alias kers='kubectl edit replicaset'
 alias krh='kubectl rollout history'
@@ -114,6 +120,7 @@ alias kru='kubectl rollout undo'
 # Statefulset management.
 alias kgss='kubectl get statefulset'
 alias kgssa='kubectl get statefulset --all-namespaces'
+alias kgssn='kgss -n'
 alias kgssw='kgss --watch'
 alias kgsswide='kgss -o wide'
 alias kess='kubectl edit statefulset'
@@ -144,6 +151,7 @@ alias kcp='kubectl cp'
 
 # Node Management
 alias kgno='kubectl get nodes'
+alias kgnon='kgno -n'
 alias keno='kubectl edit node'
 alias kdno='kubectl describe node'
 alias kdelno='kubectl delete node'
@@ -151,6 +159,7 @@ alias kdelno='kubectl delete node'
 # PVC management.
 alias kgpvc='kubectl get pvc'
 alias kgpvca='kubectl get pvc --all-namespaces'
+alias kgpvcn='kgpvc -n'
 alias kgpvcw='kgpvc --watch'
 alias kepvc='kubectl edit pvc'
 alias kdpvc='kubectl describe pvc'
@@ -169,12 +178,14 @@ alias kdelds='kubectl delete daemonset'
 
 # CronJob management.
 alias kgcj='kubectl get cronjob'
+alias kgcjn='kgcj -n'
 alias kecj='kubectl edit cronjob'
 alias kdcj='kubectl describe cronjob'
 alias kdelcj='kubectl delete cronjob'
 
 # Job management.
 alias kgj='kubectl get job'
+alias kgjn='kgj -n'
 alias kej='kubectl edit job'
 alias kdj='kubectl describe job'
 alias kdelj='kubectl delete job'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

This PR adds new alias to list all resources within a namespace passed as a parameter, for example:

```
kgsn <namespace> # list services by namespace
kgin <namespace> # list ingress by namespace
kgcmn <namespace> # list configMaps by namespace
kgsecn <namespace> # list secrets by namespace
kgdn <namespace> # list deployments by namespace
kgrsn <namespace> # list replicaset by namespace
kgnon <namespace> # list nodes by namespace
kgpvcn <namespace> # list pvc by namespace
kgcjn <namespace> # list cronjobs by namespace
kgjn <namespace> # list jobs by namespace
```