### PR TITLE
Allow nvm plugin to use autoload and lazy together

### DIFF
--- a/plugins/nvm/README.md
+++ b/plugins/nvm/README.md
@@ -58,3 +58,11 @@ zstyle ':omz:plugins:nvm' silent-autoload yes
 ```
 
 Note: _this will not remove regular `nvm` output_
+
+##### autoload with lazy
+
+Lazy and autoload mode can be used concurrently, but when doing so, only the current working directory will
+be searched for an `.nvmrc` file, unlike the usual nvm behaviour of searching all parent directories.
+The expectation is that if you're setting both of these options, this is an acceptable trade-off for the
+combination of lazy automatic loading.  If you need parent-searching for your autoloading, the lazy option
+isn't for you.

--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -61,6 +61,16 @@ fi
 # Autoload nvm when finding a .nvmrc file in the current directory
 # Adapted from: https://github.com/nvm-sh/nvm#zsh
 if zstyle -t ':omz:plugins:nvm' autoload; then
+  # if lazy mode is set, add a simplified nvm_find_nvmrc shim that only looks in the current directory
+  if zstyle -t ':omz:plugins:nvm' lazy; then
+    # This will be overridden with the real one as soon as a .zshrc is detected
+    function nvm_find_nvmrc {
+      if [ -e "${PWD}/.nvmrc" ]; then
+        command printf %s\\n "${PWD}/.nvmrc" 2> /dev/null
+      fi
+    }
+  fi
+
   function load-nvmrc {
     local node_version="$(nvm version)"
     local nvmrc_path="$(nvm_find_nvmrc)"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki. (I think?)
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Just added a simplified version of nvm's nvmrc detection function for the autoload case so lazy and autoload can be used concurrently.  This is needed because normally autoload needs to load nvm to find the nvmrc, so it won't work with lazy.  This allows it to detect an nvmrc in the *current directory only*, to lazily load nvm automatically.

## Other comments:

I'm submitting this as a draft for now mostly just to see if anyone else thinks it's a good idea.  It works very well for my workflow.  My terminals that need a rich prompt and nvm pretty much always open in a directory with an nvmrc.  But it might be confusing for others?  It was motivated initially by the fact that the readme doesn't specify that the two options are mutually exclusive, so I expected them to work together.  But this was throwing errors so I wanted to 'fix' it.  This is how I did it for myself.  If this isn't a good distributable solution, I'll probably do a second PR just to make it more clear in the readme that you have to pick one of those settings (and maybe print a warning or something if they're both turned on anyways?)
