### PR TITLE
docs(pyenv): warn about pyenv init

### DIFF
--- a/plugins/pyenv/README.md
+++ b/plugins/pyenv/README.md
@@ -10,6 +10,14 @@ To use it, add `pyenv` to the plugins array in your zshrc file:
 plugins=(... pyenv)
 ```
 
+If you receive a `Found pyenv, but it is badly configured.` error on startup, you may need to ensure that `pyenv` is initialized before the oh-my-zsh pyenv plugin is loaded. This can be achived by adding the following earlier in the `.zshrc` file than the `plugins=(...)` line:
+
+```zsh
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init --path)"
+```
+
 ## Settings
 
 - `ZSH_PYENV_QUIET`: if set to `true`, the plugin will not print any messages if it


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x] The PR title is descriptive.
- [ x] The PR doesn't replicate another PR which is already open.
- [ x] I have read the contribution guide and followed all the instructions.
- [ x] The code follows the code style guide detailed in the wiki.
- [ x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x] The code is stable and I have tested it myself, to the best of my abilities.
- [ x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add a warning/instruction to the Pyenv plugin README.md in order to help deal with the confusing issue when using the plugin. Solution based on: https://github.com/pyenv/pyenv/issues/2041#issuecomment-990253001

## Other comments:
When you add the Pyenv plugin to the `~/.zshrc` file and restart the terminal, you can get a message about pyenv being badlye configured. Even after following all the suggested advice, it can often still appear. This is due to the installation instructions being unclear, and often simply appending the needed commands to the end of the `~/.zshrc` file. However, this can be cleared up by running the necessary commands AFTER the plugin is initialized.

There is no mention of this requirement anywhere outside of that one comment thread, and adding a simple suggestion would go a long way to helping new installs. I would prefer that the requirement for it being before the plugins are initialized not be a requirement, but I would not know how to make that fix.
