### PR TITLE
feat(podman): add plugin

### DIFF
--- a/plugins/podman/README.md
+++ b/plugins/podman/README.md
@@ -1,0 +1,47 @@
+# Podman plugin
+
+This plugin adds auto-completion and aliases for [podman](https://podman.io/).
+
+To use it add `podman` to the plugins array in your zshrc file.
+
+```zsh
+plugins=(... podman)
+```
+
+## Aliases
+
+| Alias   | Command                                       | Description                                                                              |
+| :------ | :-------------------------------------------- | :--------------------------------------------------------------------------------------- |
+| pbl     | `podman build`                                | Build an image from a Dockerfile                                                         |
+| pcin    | `podman container inspect`                    | Display detailed information on one or more containers                                   |
+| pcls    | `podman container ls`                         | List all the running podman containers                                                   |
+| pclsa   | `podman container ls --all`                   | List all running and stopped containers                                                  |
+| pib     | `podman image build`                          | Build an image from a Dockerfile (same as podman build)                                  |
+| pii     | `podman image inspect`                        | Display detailed information on one or more images                                       |
+| pils    | `podman image ls`                             | List podman images                                                                       |
+| pipu    | `podman image push`                           | Push an image or repository to a remote registry                                         |
+| pirm    | `podman image rm`                             | Remove one or more images                                                                |
+| pit     | `podman image tag`                            | Add a name and tag to a particular image                                                 |
+| plo     | `podman container logs`                       | Fetch the logs of a podman container                                                     |
+| pnc     | `podman network create`                       | Create a new network                                                                     |
+| pncn    | `podman network connect`                      | Connect a container to a network                                                         |
+| pndcn   | `podman network disconnect`                   | Disconnect a container from a network                                                    |
+| pni     | `podman network inspect`                      | Return information about one or more networks                                            |
+| pnls    | `podman network ls`                           | List all networks the engine daemon knows about, including those spanning multiple hosts |
+| pnrm    | `podman network rm`                           | Remove one or more networks                                                              |
+| ppo     | `podman container port`                       | List port mappings or a specific mapping for the container                               |
+| ppu     | `podman pull`                                 | Pull an image or a repository from a registry                                            |
+| pr      | `podman container run`                        | Create a new container and start it using the specified command                          |
+| prit    | `podman container run --interactive --tty`    | Create a new container and start it in an interactive shell                              |
+| prm     | `podman container rm`                         | Remove the specified container(s)                                                        |
+| prm!    | `podman container rm --force`                 | Force the removal of a running container (uses SIGKILL)                                  |
+| pst     | `podman container start`                      | Start one or more stopped containers                                                     |
+| prs     | `podman container restart`                    | Restart one or more containers                                                           |
+| psta    | `podman stop $(podman ps -q)`                 | Stop all running containers                                                              |
+| pstp    | `podman container stop`                       | Stop one or more running containers                                                      |
+| ptop    | `podman top`                                  | Display the running processes of a container                                             |
+| pvi     | `podman volume inspect`                       | Display detailed information about one or more volumes                                   |
+| pvls    | `podman volume ls`                            | List all the volumes known to podman                                                     |
+| pvprune | `podman volume prune`                         | Cleanup dangling volumes                                                                 |
+| pxc     | `podman container exec`                       | Run a new command in a running container                                                 |
+| pxcit   | `podman container exec --interactive --tty`   | Run a new command in a running container in an interactive shell                         |

--- a/plugins/podman/podman.plugin.zsh
+++ b/plugins/podman/podman.plugin.zsh
@@ -1,0 +1,47 @@
+if (( ! $+commands[podman] )); then
+  return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `podman`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_podman" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _podman
+  _comps[podman]=_podman
+fi
+
+podman completion zsh 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_podman" &|
+
+alias pbl='podman build'
+alias pcin='podman container inspect'
+alias pcls='podman container ls'
+alias pclsa='podman container ls --all'
+alias pib='podman image build'
+alias pii='podman image inspect'
+alias pils='podman image ls'
+alias pipu='podman image push'
+alias pirm='podman image rm'
+alias pit='podman image tag'
+alias plo='podman container logs'
+alias pnc='podman network create'
+alias pncn='podman network connect'
+alias pndcn='podman network disconnect'
+alias pni='podman network inspect'
+alias pnls='podman network ls'
+alias pnrm='podman network rm'
+alias ppo='podman container port'
+alias ppu='podman pull'
+alias pr='podman container run'
+alias prit='podman container run --interactive --tty'
+alias prm='podman container rm'
+alias 'prm!'='podman container rm --force'
+alias pst='podman container start'
+alias prs='podman container restart'
+alias psta='podman stop $(podman ps --quiet)'
+alias pstp='podman container stop'
+alias ptop='podman top'
+alias pvi='podman volume inspect'
+alias pvls='podman volume ls'
+alias pvprune='podman volume prune'
+alias pxc='podman container exec'
+alias pxcit='podman container exec --interactive --tty'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
- Adding aliases for `podman` based on the aliases of the `docker` puglin
- Added an automated loading mechanism for the auto completion script, inspired by the `argocd` and `fluxcd` plugin.

## Other comments:

This is the third try to add a plugin for podman, to provide automatic code completion and a set of useful aliases. The prior PRs were:

* #9275
* #11438

It is based on the aliases of docker that are available for docker, as podman is often promoted with its cli compatibility, so that in 95% `alias docker=podman` would also do the trick.

It should fix #9721 and #7489 by 50%.  