### PR TITLE
docs(theme-and-appearance): fix docs on forcing GNU ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ The default behaviour in Oh My Zsh is to use BSD `ls` in macOS and freeBSD syste
 sourcing `oh-my-zsh.sh`:
 
 ```zsh
-zstyle ':omz:lib:theme-and-appearance' gnu-ls no
+zstyle ':omz:lib:theme-and-appearance' gnu-ls yes
 ```
 
 _Note: this is not compatible with `DISABLE_LS_COLORS=true`_


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fix docs on forcing use of GNU `ls`

## Other comments:

Needed after https://github.com/ohmyzsh/ohmyzsh/commit/dcff7a7f0854591ee1b4f25266f292ec1b1904eb as far as I can tell, for mac users who want to nudge OMZ to use GNU ls aliases
