### PR TITLE
extract: fixes and other improvements

### DIFF
--- a/plugins/extract/README.md
+++ b/plugins/extract/README.md
@@ -25,6 +25,7 @@ plugins=(... extract)
 | `cpio`            | Cpio archive                         |
 | `deb`             | Debian package                       |
 | `ear`             | Enterprise Application aRchive       |
+| `exe`             | Windows executable file              |
 | `gz`              | Gzip file                            |
 | `ipa`             | iOS app package                      |
 | `ipsw`            | iOS firmware file                    |
@@ -52,9 +53,11 @@ plugins=(... extract)
 | `txz`             | Tarball with lzma2 compression       |
 | `tzst`            | Tarball with zstd compression        |
 | `war`             | Web Application archive (Java-based) |
+| `whl`             | Python wheel file                    |
 | `xpi`             | Mozilla XPI module file              |
 | `xz`              | LZMA2 archive                        |
 | `zip`             | Zip archive                          |
+| `zlib`            | zlib archive                         |
 | `zst`             | Zstandard file (zstd)                |
 | `zpaq`            | Zpaq file                            |
 

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -83,9 +83,10 @@ EOF
         builtin cd -q ../data; extract ../data.tar.*
         builtin cd -q ..; command rm *.tar.* debian-binary ;;
       (*.zst) unzstd "$full_path" ;;
-      (*.cab) cabextract "$full_path" ;;
+      (*.cab|*.exe) cabextract "$full_path" ;;
       (*.cpio|*.obscpio) cpio -idmvF "$full_path" ;;
       (*.zpaq) zpaq x "$full_path" ;;
+      (*.zlib) zlib-flate -uncompress < "$full_path" > "${file:r}" ;;
       (*)
         echo "extract: '$file' cannot be extracted" >&2
         success=1 ;;


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Extract files to random directory to minimize chance of name conflicts
- Only move single extracted directory if current directory does not contain a file or directory of the same name, i.e. to prevent:
	```sh
	touch file
	gzip file
	extract file.gz # error here
	```
- Add support for `.whl` (already there), `.zlib` and `.exe` files.

Fixes #11642
Fixes #11085