### PR TITLE
fix(termsupport): don't report current working directory in SSH sessions

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -121,8 +121,8 @@ fi
 #
 # As of May 2021 mlterm, PuTTY, rxvt, screen, termux & xterm simply ignore the unknown OSC.
 
-# Don't define the function if we're inside Emacs
-if [[ -n "$INSIDE_EMACS" ]]; then
+# Don't define the function if we're inside Emacs or in an SSH session (#11696)
+if [[ -n "$INSIDE_EMACS" || -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
   return
 fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Skip initializing `omz_termsupport_cwd` if [in a SSH session](https://unix.stackexchange.com/a/9607/487474).

Fixes #11696
