### PR TITLE
feat(bureau): ignore hidden git repos

### DIFF
--- a/themes/bureau.zsh-theme
+++ b/themes/bureau.zsh-theme
@@ -67,6 +67,12 @@ bureau_git_status() {
 }
 
 bureau_git_prompt() {
+  # ignore non git folders and hidden repos (adapted from lib/git.zsh)
+  if ! command git rev-parse --git-dir &> /dev/null \
+     || [[ "$(command git config --get oh-my-zsh.hide-info 2>/dev/null)" == 1 ]]; then
+    return
+  fi
+
   # check git information
   local gitinfo=$(bureau_git_info)
   if [[ -z "$gitinfo" ]]; then


### PR DESCRIPTION
The git_prompt_info() function in lib/git.zsh ignores git repos which contains a specific config key, allowing to effectively "hide" them from the prompt. Unfortunately, the bureau theme doesn't use the library function to build its prompt.

This commit modifies the specific prompt generation function in the bureau theme in order to achieve the same behaviour.

Fixes #11706

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add support for hiding git repos with oh-my-zsh.hidden-info set to 1 as in lib/git.zsh

## Other comments:


