### PR TITLE
feat(half-life): add virtualenv prompt

### DIFF
--- a/themes/half-life.zsh-theme
+++ b/themes/half-life.zsh-theme
@@ -89,5 +89,9 @@ ZSH_THEME_RUBY_PROMPT_PREFIX="with%F{red} "
 ZSH_THEME_RUBY_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_RVM_PROMPT_OPTIONS="v g"
 
+# virtualenv prompt settings
+ZSH_THEME_VIRTUALENV_PREFIX=" with%F{red} "
+ZSH_THEME_VIRTUALENV_SUFFIX="%{$reset_color%}"
+
 setopt prompt_subst
-PROMPT="${purple}%n%{$reset_color%} in ${limegreen}%~%{$reset_color%}\$(ruby_prompt_info)\$vcs_info_msg_0_${orange} λ%{$reset_color%} "
+PROMPT="${purple}%n%{$reset_color%} in ${limegreen}%~%{$reset_color%}\$(virtualenv_prompt_info)\$(ruby_prompt_info)\$vcs_info_msg_0_${orange} λ%{$reset_color%} "


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added virtualenv prompt info to half-life theme
