### PR TITLE
fix(core): Use full path to env in functions.zsh

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -5,7 +5,7 @@ function zsh_stats() {
 }
 
 function uninstall_oh_my_zsh() {
-  env ZSH="$ZSH" sh "$ZSH/tools/uninstall.sh"
+  /usr/bin/env ZSH="$ZSH" sh "$ZSH/tools/uninstall.sh"
 }
 
 function upgrade_oh_my_zsh() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Replace bare 'env' with '/usr/bin/env', in `uninstall_oh_my_zsh()`

## Other comments:

I have a shell alias for `env`, in my interactive shell environment. So, with just a bare `env` called in the `uninstall_oh_my_zsh()` function, re-executions of my `.zshrc` would report a parse error:

```sh
$ . ~/.zshrc                       
/.../lib/functions.zsh:8: parse error near `ZSH="$ZSH"'
```

It's safer to use `/usr/bin/env` there, same as in the various shebang lines for the executable scripts.
