### PR TITLE
feat(autoenv): macOS compatibility, add more dirs

### DIFF
--- a/plugins/autoenv/autoenv.plugin.zsh
+++ b/plugins/autoenv/autoenv.plugin.zsh
@@ -17,9 +17,13 @@ if ! type autoenv_init >/dev/null; then
       /usr/local/bin
       /usr/share/autoenv-git
       ~/Library/Python/bin
+      .venv/bin
+      venv/bin
+      env/bin
+      .env/bin
     )
     for d ( $install_locations ); do
-      if [[ -e $d/activate.sh ]]; then
+      if [[ -e $d/activate || -e $d/activate.sh ]]; then
         autoenv_dir=$d
         break
       fi
@@ -29,13 +33,13 @@ if ! type autoenv_init >/dev/null; then
   # Look for Homebrew path as a last resort
   if [[ -z "$autoenv_dir" ]] && (( $+commands[brew] )); then
     d=$(brew --prefix)/opt/autoenv
-    if [[ -e $d/activate.sh ]]; then
+    if [[ -e $d/activate || -e $d/activate.sh ]]; then
       autoenv_dir=$d
     fi
   fi
 
   # Complain if autoenv is not installed
-  if [[ -z $autoenv_dir ]]; then 
+  if [[ -z $autoenv_dir ]]; then
     cat <<END >&2
 -------- AUTOENV ---------
 Could not locate autoenv installation.
@@ -46,10 +50,15 @@ END
     return 1
   fi
   # Load autoenv
-  source $autoenv_dir/activate.sh
+  if [[ -e $autoenv_dir/activate ]]; then  # Modificado: Verifica si existe activate
+    source $autoenv_dir/activate
+  else
+    source $autoenv_dir/activate.sh
+  fi
 fi
 }
 [[ $? != 0 ]] && return $?
+
 
 # The use_env call below is a reusable command to activate/create a new Python
 # virtualenv, requiring only a single declarative line of code in your .env files.

--- a/plugins/autoenv/autoenv.plugin.zsh
+++ b/plugins/autoenv/autoenv.plugin.zsh
@@ -50,7 +50,7 @@ END
     return 1
   fi
   # Load autoenv
-  if [[ -e $autoenv_dir/activate ]]; then  # Modificado: Verifica si existe activate
+  if [[ -e $autoenv_dir/activate ]];
     source $autoenv_dir/activate
   else
     source $autoenv_dir/activate.sh
@@ -58,7 +58,6 @@ END
 fi
 }
 [[ $? != 0 ]] && return $?
-
 
 # The use_env call below is a reusable command to activate/create a new Python
 # virtualenv, requiring only a single declarative line of code in your .env files.


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Create a support for `venv`, `env`, `.venv` and `.env` folder.
- Support for `activate.sh` or `activate` files.

## Other comments:

I have come across repositories that document that to create virtual environments they use variations of folders like "env" or "venv", using for example:
```bash
python3 -m venv .venv
```
To support these, add some variations to `$install_locations`.

In mac M1 (I have not checked if it happens in other OS or if it happens by the venv library) the files that are generated do not end in .sh, so I added compatibility by doing `-e $d/activate || -e $d/activate.sh`