### PR TITLE
feat(git): add `gunwipall` function

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -254,6 +254,7 @@ These features allow to pause a branch development and switch to another one (_"
 | work_in_progress | Echoes a warning if the current branch is a wip |
 | gwip             | Commit wip branch                               |
 | gunwip           | Uncommit wip branch                             |
+| gunwipall        | Uncommit `--wip--` commits recursively          |
 
 ### Deprecated functions
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -30,15 +30,14 @@ function work_in_progress() {
 # Same as `gunwip` but recursive
 # "Unwips" all recent `--wip--` commits in loop until there is no left
 function gunwipall() {
-  commit=$(git rev-parse HEAD)
   while true; do
-    commit_message=$(git show -s --format="%s" "$commit")
-    if [[ $commit_message == *"--wip--"* ]]; then
-      git reset "$commit~1"
+    commit_message=$(git rev-list --max-count=1 --format="%s" HEAD)
+    if [[ $commit_message =~ "--wip--" ]]; then
+      git reset "HEAD~1"
+      (( $? )) && return 1
     else
       break
     fi
-    commit="$commit~1"
   done
 }
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -27,6 +27,21 @@ function work_in_progress() {
   command git -c log.showSignature=false log -n 1 2>/dev/null | grep -q -- "--wip--" && echo "WIP!!"
 }
 
+# Same as `gunwip` but recursive
+# "Unwips" all recent `--wip--` commits in loop until there is no left
+function gunwipall() {
+  commit=$(git rev-parse HEAD)
+  while true; do
+    commit_message=$(git show -s --format="%s" "$commit")
+    if [[ $commit_message == *"--wip--"* ]]; then
+      git reset "$commit~1"
+    else
+      break
+    fi
+    commit="$commit~1"
+  done
+}
+
 # Check if main exists and use instead of master
 function git_main_branch() {
   command git rev-parse --git-dir &>/dev/null || return


### PR DESCRIPTION
Same as `gunwip` but recursive

fix: #11721

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

-  add `gunwipall` function, which is same as `gunwip` but recursive
