### PR TITLE
fix(docker): only generate completion for docker >23

### DIFF
--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -1,13 +1,3 @@
-# If the completion file doesn't exist yet, we need to autoload it and
-# bind it to `docker`. Otherwise, compinit will have already done that.
-if [[ ! -f "$ZSH_CACHE_DIR/completions/_docker" ]]; then
-  typeset -g -A _comps
-  autoload -Uz _docker
-  _comps[docker]=_docker
-fi
-
-docker completion zsh >| "$ZSH_CACHE_DIR/completions/_docker" &|
-
 alias dbl='docker build'
 alias dcin='docker container inspect'
 alias dcls='docker container ls'
@@ -41,3 +31,22 @@ alias dvls='docker volume ls'
 alias dvprune='docker volume prune'
 alias dxc='docker container exec'
 alias dxcit='docker container exec -it'
+
+if (( ! $+commands[docker] )); then
+  return
+fi
+
+{
+  # `docker completion` is only available from 23.0.0 on
+  local _docker_version=$(docker version --format '{{.Client.Version}}' 2>/dev/null)
+  if is-at-least 23.0.0 $_docker_version; then
+    # If the completion file doesn't exist yet, we need to autoload it and
+    # bind it to `docker`. Otherwise, compinit will have already done that.
+    if [[ ! -f "$ZSH_CACHE_DIR/completions/_docker" ]]; then
+      typeset -g -A _comps
+      autoload -Uz _docker
+      _comps[docker]=_docker
+    fi
+    docker completion zsh >| "$ZSH_CACHE_DIR/completions/_docker"
+  fi
+} &|


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
