### PR TITLE
fix(git): `gunwipall` now only resets once

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -254,7 +254,7 @@ These features allow to pause a branch development and switch to another one (_"
 | work_in_progress | Echoes a warning if the current branch is a wip |
 | gwip             | Commit wip branch                               |
 | gunwip           | Uncommit wip branch                             |
-| gunwipall        | Uncommit `--wip--` commits recursively          |
+| gunwipall        | Uncommit all recent `--wip--` commits           |
 
 ### Deprecated functions
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -27,18 +27,14 @@ function work_in_progress() {
   command git -c log.showSignature=false log -n 1 2>/dev/null | grep -q -- "--wip--" && echo "WIP!!"
 }
 
-# Same as `gunwip` but recursive
-# "Unwips" all recent `--wip--` commits in loop until there is no left
+# Similar to `gunwip` but recursive "Unwips" all recent `--wip--` commits not just the last one
 function gunwipall() {
-  while true; do
-    commit_message=$(git rev-list --max-count=1 --format="%s" HEAD)
-    if [[ $commit_message =~ "--wip--" ]]; then
-      git reset "HEAD~1"
-      (( $? )) && return 1
-    else
-      break
-    fi
-  done
+  commit=$(git rev-list --grep='--wip--' --invert-grep --max-count=1 HEAD)
+  
+  # Check if a commit without "--wip--" was found and it's not the same as HEAD
+  if [[ "$commit" != "$(git rev-parse HEAD)" ]]; then
+    git reset $commit || return 1
+  fi
 }
 
 # Check if main exists and use instead of master

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -29,11 +29,11 @@ function work_in_progress() {
 
 # Similar to `gunwip` but recursive "Unwips" all recent `--wip--` commits not just the last one
 function gunwipall() {
-  commit=$(git rev-list --grep='--wip--' --invert-grep --max-count=1 HEAD)
+  local _commit=$(git log --grep='--wip--' --invert-grep --max-count=1 --format=format:%H)
   
   # Check if a commit without "--wip--" was found and it's not the same as HEAD
-  if [[ "$commit" != "$(git rev-parse HEAD)" ]]; then
-    git reset $commit || return 1
+  if [[ "$_commit" != "$(git rev-parse HEAD)" ]]; then
+    git reset $_commit || return 1
   fi
 }
 


### PR DESCRIPTION
fix: #11750

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

-  improve `gunwipall` function to produce 1 reflog record instead of many.
 

## Other comments:

Solution was provided by @anastygnome in #11750. I've tested it and it seems to work as expected
