### PR TITLE
fix(archlinux): yaorph cmd now removes orphans

### DIFF
--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -173,7 +173,7 @@ if (( $+commands[yay] )); then
   alias yaloc='yay -Qi'
   alias yalocs='yay -Qs'
   alias yalst='yay -Qe'
-  alias yaorph='yay -Qtd'
+  alias yaorph='yay -Qtdq | yay -Rns -'
   alias yainsd='yay -S --asdeps'
   alias yamir='yay -Syy'
   alias yaupd="yay -Sy"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- The `yaorph` command for yay only listed orphans, it did not remove them. This changes the command from `yay -Qtd` to `yay -Qtdq | yay -Rns -`

## Other comments:

none, this is a very minor tweak
