### PR TITLE
Fix (docker plugin): use `command docker` to bypass aliases

### DIFF
--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -38,7 +38,7 @@ fi
 
 {
   # `docker completion` is only available from 23.0.0 on
-  local _docker_version=$(docker version --format '{{.Client.Version}}' 2>/dev/null)
+  local _docker_version=$(command docker version --format '{{.Client.Version}}' 2>/dev/null)
   if is-at-least 23.0.0 $_docker_version; then
     # If the completion file doesn't exist yet, we need to autoload it and
     # bind it to `docker`. Otherwise, compinit will have already done that.
@@ -47,6 +47,6 @@ fi
       autoload -Uz _docker
       _comps[docker]=_docker
     fi
-    docker completion zsh >| "$ZSH_CACHE_DIR/completions/_docker"
+    command docker completion zsh >| "$ZSH_CACHE_DIR/completions/_docker"
   fi
 } &|


### PR DESCRIPTION
Use `command docker` to avoid aliases and functions that may be overriding the `docker` command.

Since most docker commands require `sudo` privileges, I added an `alias docker='sudo docker'` to my `.zshrc`. I noticed that if I put the alias before `source $ZSH/oh-my-zsh.sh`, the [docker plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/docker) uses the user-defined alias instead of the actual `docker` command.

By invoking docker with `command docker` instead, aliases and functions are ignored, and the correct behaviour is always observed.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Replaces invocations of docker with `command docker` (not a breaking change) in the plugin

## Other comments:

...
