### PR TITLE
docker: avoid `docker version` subcommand.

### DIFF
--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -38,7 +38,7 @@ fi
 
 {
   # `docker completion` is only available from 23.0.0 on
-  local _docker_version=$(command docker version --format '{{.Client.Version}}' 2>/dev/null)
+  local _docker_version=${${(s:,:z)"$(docker --version)"}[3]}
   if is-at-least 23.0.0 $_docker_version; then
     # If the completion file doesn't exist yet, we need to autoload it and
     # bind it to `docker`. Otherwise, compinit will have already done that.


### PR DESCRIPTION
`docker version` subcommand is able to return both docker client and docker daemon information.  To get a daemon version, it connects to a possibly remote daemon.  If the remote daemon is not accessible, the client waits for some time, until it gets interrupted by timeout.

As a result we can have a docker client running in background. When zsh session is rather short, a terminal application (iTerm2) starts asking if that background docker process should be stopped.

On the other hand, to get a docker client version only, we can use `docker --version` instead. It does not connect to a daemon.

relates to #11754

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
