### PR TITLE
fix(jira): support identifiers delimited with a hyphen

### DIFF
--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -81,7 +81,7 @@ function jira() {
       # Strip suffixes starting with _
       issue_arg=(${(s:_:)issue_arg})
       # If there is only one part, it means that there is a different delimiter. Try with -
-      if [[ ${#issue_arg[@]} = 1 ]]; then
+      if [[ ${#issue_arg[@]} = 1 && ${issue_arg} == *-* ]]; then
         issue_arg=(${(s:-:)issue_arg})
         issue_arg="${issue_arg[1]}-${issue_arg[2]}"
       else

--- a/plugins/jira/jira.plugin.zsh
+++ b/plugins/jira/jira.plugin.zsh
@@ -80,7 +80,13 @@ function jira() {
       issue_arg=${issue_arg##*/}
       # Strip suffixes starting with _
       issue_arg=(${(s:_:)issue_arg})
-      issue_arg=${issue_arg[1]}
+      # If there is only one part, it means that there is a different delimiter. Try with -
+      if [[ ${#issue_arg[@]} = 1 ]]; then
+        issue_arg=(${(s:-:)issue_arg})
+        issue_arg="${issue_arg[1]}-${issue_arg[2]}"
+      else
+        issue_arg=${issue_arg[1]}
+      fi
       if [[ "${issue_arg:l}" = ${jira_prefix:l}* ]]; then
         issue="${issue_arg}"
       else


### PR DESCRIPTION
Our git uses branch names like feature/PROJECT-1234-some-description-of-the-branch. Using "jira branch" does not work here, since it does not detect the PROJECT-1234 tag, but uses the full branch name.
This fix first checks if there is more than one part, then splits it with "-" if there is only one part (that contains a "-").

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

When using "jira branch", the code splitted the branch name on underscore delimiter. The PR now adds support for branch names delimited with a hyphen

## Other comments: