### PR TITLE
feat(kubectl): Alias for applying with Kustomize

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -21,6 +21,9 @@ alias kca='_kca(){ kubectl "$@" --all-namespaces;  unset -f _kca; }; _kca'
 # Apply a YML file
 alias kaf='kubectl apply -f'
 
+# Apply a directory with Kustomize
+alias kak='kubectl apply -k'
+
 # Drop into an interactive terminal on a container
 alias keti='kubectl exec -t -i'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Kustomize is native in kubectl and is the second method to apply manifests. All users could now apply a full directory.

Use case: Kustomize is the recommended way to install argocd if you want it to be self managed https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#manage-argo-cd-using-argo-cd

## Other comments:

...
