### PR TITLE
feat(git): add alias gdh for `git diff HEAD`

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -69,6 +69,7 @@ plugins=(... git)
 | gdca                 | git diff --cached                                                                                                                                                                        |
 | gdcw                 | git diff --cached --word-diff                                                                                                                                                            |
 | gdct                 | git describe --tags $(git rev-list --tags --max-count=1)                                                                                                                                 |
+| gdh                  | git diff HEAD                                                                                                                                                                            |
 | gds                  | git diff --staged                                                                                                                                                                        |
 | gdt                  | git diff-tree --no-commit-id --name-only -r                                                                                                                                              |
 | gdnolock             | git diff $@ ":(exclude)package-lock.json" ":(exclude)\*.lock"                                                                                                                            |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -132,6 +132,7 @@ alias gcss='git commit --gpg-sign --signoff'
 alias gcssm='git commit --gpg-sign --signoff --message'
 
 alias gd='git diff'
+alias gdh='git diff HEAD'
 alias gdca='git diff --cached'
 alias gdcw='git diff --cached --word-diff'
 alias gdct='git describe --tags $(git rev-list --tags --max-count=1)'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `gdh` alias to git plugin for `git diff HEAD`

## Other comments:

- Common use case is to quickly check all changes (staged & not staged) that have made of same file before add
- For example: check merge result of resolve conflicts before add

