### PR TITLE
feat(aws): add creds expiration timer

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -195,6 +195,50 @@ function aws_change_access_key() {
   aws --no-cli-pager iam list-access-keys
 }
 
+calculate_time_difference() {
+  # Check if both arguments are provided
+  if [[ $# -lt 2 ]]; then
+    echo "Error: Two arguments are required."
+    return 1
+  fi
+
+  # Assign the arguments to variables
+  local time1=$1
+  local time2=$2
+
+  # Convert times to Unix timestamps
+  local timestamp1=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$time1" +"%s")
+  local timestamp2=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$time2" +"%s")
+
+  # Calculate the difference in seconds
+  diff_seconds=$((timestamp2 - timestamp1))
+
+  # Convert the difference to HH:MM:SS format
+  local hours=$((diff_seconds / 3600))
+  local minutes=$(( (diff_seconds / 60) % 60 ))
+  local seconds=$((diff_seconds % 60))
+
+  # Place diff in time_diff
+  time_diff="${hours}:${minutes}:${seconds}"
+}
+
+function tte() {
+  # calculates and displays time until current AWS creds expire
+
+  cachedir=$HOME/.aws/sso/cache
+  current_cache_file="$cachedir/$(ls -tU $cachedir | head -n1)"  
+  expiration_time=$(jq -r .expiresAt $current_cache_file)
+  current_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  calculate_time_difference $current_time $expiration_time
+  if [[ $diff_seconds -le 0 ]];then
+    echo "Creds have expired. Run `aws sso login` to renew."
+    return 1
+  else
+    echo "Time remaining: $time_diff"
+  fi
+}
+
+
 function aws_regions() {
   if [[ $AWS_DEFAULT_PROFILE || $AWS_PROFILE ]];then
     aws ec2 describe-regions |grep RegionName | awk -F ':' '{gsub(/"/, "", $2);gsub(/,/, "", $2);gsub(/ /, "", $2);  print $2}'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds a function `tte` to display "time til expiration" -- the time in hrs:min:sec until AWS creds expire. Returns 1 if creds are expired.

## Other comments:

...
