### PR TITLE
Revert breaking changes to debian and ubuntu plugin

### DIFF
--- a/plugins/aliases/README.md
+++ b/plugins/aliases/README.md
@@ -15,14 +15,14 @@ Requirements: Python needs to be installed.
 
 ## Usage
 
-- `acs`: show all aliases by group
+- `als`: show all aliases by group
 
-- `acs -h/--help`: print help mesage
+- `als -h/--help`: print help mesage
 
-- `acs <keyword(s)>`: filter and highlight aliases by `<keyword>`
+- `als <keyword(s)>`: filter and highlight aliases by `<keyword>`
 
-- `acs -g <group>/--group <group>`: show only aliases for group `<group>`. Multiple uses of the flag show all groups
+- `als -g <group>/--group <group>`: show only aliases for group `<group>`. Multiple uses of the flag show all groups
 
-- `acs --groups`: show only group names
+- `als --groups`: show only group names
 
   ![screenshot](https://cloud.githubusercontent.com/assets/3602957/11581913/cb54fb8a-9a82-11e5-846b-5a67f67ad9ad.png)

--- a/plugins/aliases/aliases.plugin.zsh
+++ b/plugins/aliases/aliases.plugin.zsh
@@ -4,7 +4,7 @@
 0="${${(M)0:#/*}:-$PWD/$0}"
 
 eval '
-  function acs(){
+  function als(){
     (( $+commands[python3] )) || {
       echo "[error] No python executable detected"
       return

--- a/plugins/debian/README.md
+++ b/plugins/debian/README.md
@@ -21,7 +21,7 @@ Set `$apt_pref` and `$apt_upgr` to whatever command you want (before sourcing Oh
 | ------ | ---------------------------------------------------------------------- | ---------------------------------------------------------- |
 | `age`  | `apt-get`                                                              | Command line tool for handling packages                    |
 | `api`  | `aptitude`                                                             | Same functionality as `apt-get`, provides extra options    |
-| `acse` | `apt-cache search`                                                     | Command line tool for searching apt software package cache |
+| `acs`  | `apt-cache search`                                                     | Command line tool for searching apt software package cache |
 | `aps`  | `aptitude search`                                                      | Searches installed packages using aptitude                 |
 | `as`   | `aptitude -F '* %p -> %d \n(%v/%V)' --no-gui --disable-columns search` | Print searched packages using a custom format              |
 | `afs`  | `apt-file search --regexp`                                             | Search file in packages                                    |

--- a/plugins/debian/debian.plugin.zsh
+++ b/plugins/debian/debian.plugin.zsh
@@ -26,7 +26,7 @@ alias age='apt-get'
 alias api='aptitude'
 
 # Some self-explanatory aliases
-alias acse="apt-cache search"
+alias acs="apt-cache search"
 alias aps='aptitude search'
 alias as="aptitude -F '* %p -> %d \n(%v/%V)' --no-gui --disable-columns search"
 

--- a/plugins/ubuntu/README.md
+++ b/plugins/ubuntu/README.md
@@ -15,7 +15,7 @@ Commands that use `$APT` will use `apt` if installed or defer to `apt-get` other
 | Alias   | Command                                                                  | Description                                                                                       |
 |---------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | age     | `sudo $APT`                                                              | Run apt-get with sudo                                                                             |
-| acse    | `apt-cache search`                                                       | Search the apt-cache with the specified criteria                                                  |
+| acs     | `apt-cache search`                                                       | Search the apt-cache with the specified criteria                                                  |
 | acsp    | `apt-cache showpkg`                                                      | Shows information about the listed packages                                                       |
 | acp     | `apt-cache policy`                                                       | Display the package source priorities                                                             |
 | afs     | `apt-file search --regexp`                                               | Perform a regular expression apt-file search                                                      |

--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -1,6 +1,6 @@
 (( $+commands[apt] )) && APT=apt || APT=apt-get
 
-alias acse='apt-cache search'
+alias acs='apt-cache search'
 
 alias afs='apt-file search --regexp'
 


### PR DESCRIPTION
Give new aliases plugin a more suitable alias
Fixes #11311 by reverting the broken solution

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Revert breaking changes to debian and ubuntu plugin
- Give the new aliases plugin a more suitable alias
- Fixes #11311 by reverting the broken solution

## Other comments:
- Debian and Ubuntu are deployed on millions of computers across the planet.  apt is used on all of them.  The aliases plugin is not.  This PR reverts the breaking change to fundamental OS functionality for minor functionality.
- Take it or leave it.  This shouldn't get bogged down in policy debate, and I'm not interested in policy debate.  Fix millions of computers or not.
...
