### PR TITLE
fix(michelebologna): use blue instead of white

### DIFF
--- a/themes/michelebologna.zsh-theme
+++ b/themes/michelebologna.zsh-theme
@@ -29,14 +29,13 @@ local cyan="%{$fg_bold[cyan]%}"
 local yellow="%{$fg_bold[yellow]%}"
 local blue="%{$fg_bold[blue]%}"
 local magenta="%{$fg_bold[magenta]%}"
-local white="%{$fg_bold[white]%}"
 local reset="%{$reset_color%}"
 
 local -a color_array
-color_array=($green $red $cyan $yellow $blue $magenta $white)
+color_array=($green $red $cyan $yellow $blue $magenta)
 
-local username_color=$white
-local hostname_color=$color_array[$[((#HOST))%7+1]] # choose hostname color based on first character
+local username_color=$blue
+local hostname_color=$color_array[$[((#HOST))%6+1]] # choose hostname color based on first character
 local current_dir_color=$blue
 
 local username="%n"
@@ -66,10 +65,10 @@ function michelebologna_git_prompt {
   local out=$(git_prompt_info)$(git_prompt_status)$(git_remote_status)
   [[ -n $out ]] || return
   printf " %s(%s%s%s)%s" \
-    "%{$fg_bold[white]%}" \
+    "%{$fg_bold[blue]%}" \
     "%{$fg_bold[green]%}" \
     "$out" \
-    "%{$fg_bold[white]%}" \
+    "%{$fg_bold[blue]%}" \
     "%{$reset_color%}"
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- change white to blue

## Other comments:

Fixes issue #11809
