### PR TITLE
fix(colored-man-pages): add env GROFF_NO_SGR=1

### DIFF
--- a/plugins/colored-man-pages/colored-man-pages.plugin.zsh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.zsh
@@ -15,7 +15,6 @@ less_termcap[se]="${reset_color}"
 # underlining
 less_termcap[us]="${fg_bold[green]}"
 less_termcap[ue]="${reset_color}"
-export GROFF_NO_SGR=1
 
 # Handle $0 according to the standard:
 # https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
@@ -37,6 +36,7 @@ function colored() {
   # Prefer `less` whenever available, since we specifically configured
   # environment for it.
   environment+=( PAGER="${commands[less]:-$PAGER}" )
+  environment+=( GROFF_NO_SGR=1 )
 
   # See ./nroff script.
   if [[ "$OSTYPE" = solaris* ]]; then

--- a/plugins/colored-man-pages/colored-man-pages.plugin.zsh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.zsh
@@ -15,6 +15,7 @@ less_termcap[se]="${reset_color}"
 # underlining
 less_termcap[us]="${fg_bold[green]}"
 less_termcap[ue]="${reset_color}"
+export GROFF_NO_SGR=1
 
 # Handle $0 according to the standard:
 # https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
The `colored-man-pages` plugin stopped working after this bug see
[this](https://unix.stackexchange.com/questions/746094/why-dont-these-less-termcap-variables-work-on-oracle-linux)
and [this](https://bugzilla.redhat.com/show_bug.cgi?id=1028764)
the fix was just to add
`export GROFF_NO_SGR=1` to the plugin

