### PR TITLE
chore(gitignore): use new API endpoint from TopTal

### DIFF
--- a/plugins/gitignore/README.md
+++ b/plugins/gitignore/README.md
@@ -1,6 +1,6 @@
 # gitignore
 
-This plugin enables you the use of [gitignore.io](https://www.gitignore.io/) from the command line. You need an active internet connection.
+This plugin enables you the use of [gitignore.io](https://www.toptal.com/developers/gitignore) from the command line. You need an active internet connection.
 
 To use it, add `gitignore` to the plugins array in your zshrc file:
 

--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -1,7 +1,7 @@
-function gi() { curl -fLw '\n' https://www.gitignore.io/api/"${(j:,:)@}" }
+function gi() { curl -fLw '\n' https://www.toptal.com/developers/gitignore/api/"${(j:,:)@}" }
 
 _gitignoreio_get_command_list() {
-  curl -sfL https://www.gitignore.io/api/list | tr "," "\n"
+  curl -sfL https://www.toptal.com/developers/gitignore/api/list | tr "," "\n"
 }
 
 _gitignoreio () {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- **N/A** If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Updates API endpoints of `gitignore` plugin to use new TopTal.com endpoints. As [stated in their documentation](https://docs.gitignore.io/use/advanced-command-line#oh-my-zsh). Current endpoints still work but return a 301 Moved Permanently status code so by using new ones we save 1 HTTP request per each request :P 

## Other comments:

...
