### PR TITLE
feat(terraform): add terraform version prompt

### DIFF
--- a/plugins/terraform/README.md
+++ b/plugins/terraform/README.md
@@ -1,7 +1,7 @@
 # Terraform plugin
 
-Plugin for Terraform, a tool from Hashicorp for managing infrastructure safely and efficiently.
-It adds completion for `terraform`, as well as aliases and a prompt function.
+Plugin for Terraform, a tool from Hashicorp for managing infrastructure safely and efficiently. It adds
+completion for `terraform`, as well as aliases and a prompt function.
 
 To use it, add `terraform` to the plugins array of your `~/.zshrc` file:
 
@@ -11,7 +11,7 @@ plugins=(... terraform)
 
 ## Requirements
 
-* [Terraform](https://terraform.io/)
+- [Terraform](https://terraform.io/)
 
 ## Aliases
 
@@ -29,11 +29,12 @@ plugins=(... terraform)
 
 ## Prompt function
 
-You can add the current Terraform workspace in your prompt by adding `$(tf_prompt_info)`
-to your `PROMPT` or `RPROMPT` variable.
+You can add the current Terraform workspace in your prompt by adding `$(tf_prompt_info)`,
+`$(tf_version_prompt_info)` to your `PROMPT` or `RPROMPT` variable.
 
 ```sh
 RPROMPT='$(tf_prompt_info)'
+RPROMPT='$(tf_version_prompt_info)'
 ```
 
 You can also specify the PREFIX and SUFFIX for the workspace with the following variables:
@@ -41,4 +42,6 @@ You can also specify the PREFIX and SUFFIX for the workspace with the following 
 ```sh
 ZSH_THEME_TF_PROMPT_PREFIX="%{$fg[white]%}"
 ZSH_THEME_TF_PROMPT_SUFFIX="%{$reset_color%}"
+ZSH_THEME_TF_VERSION_PROMPT_PREFIX="%{$fg[white]%}"
+ZSH_THEME_TF_VERSION_PROMPT_SUFFIX="%{$reset_color%}"
 ```

--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -8,6 +8,13 @@ function tf_prompt_info() {
   echo "${ZSH_THEME_TF_PROMPT_PREFIX-[}${workspace:gs/%/%%}${ZSH_THEME_TF_PROMPT_SUFFIX-]}"
 }
 
+function tf_version_prompt_info() {
+    local terraform_version
+    terraform_version=$(terraform --version | head -n 1 | cut -d ' ' -f 2)
+    echo "${ZSH_THEME_TF_VERSION_PROMPT_PREFIX-[}${terraform_version:gs/%/%%}${ZSH_THEME_TF_VERSION_PROMPT_SUFFIX-]}"
+}
+
+
 alias tf='terraform'
 alias tfa='terraform apply'
 alias tfc='terraform console'


### PR DESCRIPTION

- resolves #11811 

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

-  I added a function called `tf_version_prompt_info` to the zsh file to specify the terraform version and also added an introduction to that function in the `Prompt function` section to the README file.


## Other comments:

@roeniss He taught me shell script grammar while also giving me a very valuable opportunity to contribute to ohmyzsh. He is a very thoughtful software engineer and a man full of love. I am very grateful that he gave me this precious opportunity. ♥︎
