### PR TITLE
feat(systemd): add alias for --failed commands

### DIFF
--- a/plugins/systemd/README.md
+++ b/plugins/systemd/README.md
@@ -12,6 +12,7 @@ plugins=(... systemd)
 
 | Alias                  | Command                            | Description                                                      |
 |:-----------------------|:-----------------------------------|:-----------------------------------------------------------------|
+| `sc-failed`            | `systemctl --failed`               | List failed systemd units                                        |
 | `sc-list-units`        | `systemctl list-units`             | List all units systemd has in memory                             |
 | `sc-is-active`         | `systemctl is-active`              | Show whether a unit is active                                    |
 | `sc-status`            | `systemctl status`                 | Show terse runtime status information about one or more units    |

--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -93,6 +93,9 @@ alias scu-enable-now="scu-enable --now"
 alias scu-disable-now="scu-disable --now"
 alias scu-mask-now="scu-mask --now"
 
+# --failed commands
+alias scu-failed='systemctl --user --failed'
+alias sc-failed='systemctl --failed'
 
 function systemd_prompt_info {
   local unit


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Adds `alias sc-failed=systemctl --failed` to list failed systemd units

