### PR TITLE
refactor(init): rename variable

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -187,12 +187,12 @@ _omz_source() {
   fi
 }
 
-# Load all of the config files in ~/oh-my-zsh that end in .zsh
+# Load all of the lib files in ~/oh-my-zsh/lib that end in .zsh
 # TIP: Add files you don't want in git to .gitignore
-for config_file ("$ZSH"/lib/*.zsh); do
-  _omz_source "lib/${config_file:t}"
+for lib_file ("$ZSH"/lib/*.zsh); do
+  _omz_source "lib/${lib_file:t}"
 done
-unset custom_config_file
+unset lib_file
 
 # Load all of the plugins that were defined in ~/.zshrc
 for plugin ($plugins); do


### PR DESCRIPTION
The variable `custom_config_file` is no longer exist, so `unset` it does nothing. Instead, this patch rename the variable from `config_file` to `lib_file`, and unset it immediately.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Rename the variable from `config_file` to `lib_file`
  - This increased readability by distinguish between the variable for Oh My Zsh lib file and the variable for custom configuration.
  - This solved the problem of `unset` a variable that no longer exist.

## Other comments:

...
