### PR TITLE
fix(extract): extraction to directory for single-file .gz

### DIFF
--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -64,7 +64,7 @@ EOF
       (*.tar.lz) (( $+commands[lzip] )) && tar xvf "$full_path" ;;
       (*.tar.lz4) lz4 -c -d "$full_path" | tar xvf - ;;
       (*.tar.lrz) (( $+commands[lrzuntar] )) && lrzuntar "$full_path" ;;
-      (*.gz) (( $+commands[pigz] )) && pigz -dk "$full_path" || gunzip -k "$full_path" ;;
+      (*.gz) (( $+commands[pigz] )) && pigz -cdk "$full_path" > "${file:t:r}" || gunzip -ck "$full_path" > "${file:t:r}" ;;
       (*.bz2) bunzip2 "$full_path" ;;
       (*.xz) unxz "$full_path" ;;
       (*.lrz) (( $+commands[lrunzip] )) && lrunzip "$full_path" ;;
@@ -106,19 +106,19 @@ EOF
     # - Y2: at most give 2 files
     local -a content
     content=("${extract_dir}"/*(DNY2))
-    if [[ ${#content} -eq 1 && -d "${content[1]}" ]]; then
-      # The extracted folder (${content[1]}) may have the same name as $extract_dir
+    if [[ ${#content} -eq 1 && -e "${content[1]}" ]]; then
+      # The extracted file/folder (${content[1]}) may have the same name as $extract_dir
       # If so, we need to rename it to avoid conflicts in a 3-step process
       #
-      # 1. Move and rename the extracted folder to a temporary random name
+      # 1. Move and rename the extracted file/folder to a temporary random name
       # 2. Delete the empty folder
-      # 3. Rename the extracted folder to the original name
+      # 3. Rename the extracted file/folder to the original name
       if [[ "${content[1]:t}" == "$extract_dir" ]]; then
         # =(:) gives /tmp/zsh<random>, with :t it gives zsh<random>
-        local tmp_dir==(:); tmp_dir="${tmp_dir:t}"
-        command mv "${content[1]}" "$tmp_dir" \
+        local tmp_name==(:); tmp_name="${tmp_name:t}"
+        command mv "${content[1]}" "$tmp_name" \
         && command rmdir "$extract_dir" \
-        && command mv "$tmp_dir" "$extract_dir"
+        && command mv "$tmp_name" "$extract_dir"
       # Otherwise, if the extracted folder name already exists in the current
       # directory (because of a previous file / folder), keep the extract_dir
       elif [[ ! -e "${content[1]:t}" ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Changes `pigz` and `gunzip` commands to extract single-file `.gz` archives
- Makes sure to also move single-file extract outputs

## Other comments:

Fixes #11642