### PR TITLE
fix(updater): disable `nounset` to avoid warnings

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env zsh
+set +u # disable nounset
 
 local ret=0 # exit code
 


### PR DESCRIPTION
Fixes #11838

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

