### PR TITLE
feat(bun): add plugin

### DIFF
--- a/plugins/bun/README.md
+++ b/plugins/bun/README.md
@@ -1,0 +1,3 @@
+# Bun Plugin
+
+This plugin sets up completion for [Bun](https://bun.sh).

--- a/plugins/bun/README.md
+++ b/plugins/bun/README.md
@@ -1,3 +1,20 @@
 # Bun Plugin
 
 This plugin sets up completion for [Bun](https://bun.sh).
+
+To use it, add `bun` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... bun)
+```
+
+This plugin does not add any aliases.
+
+## Cache
+
+This plugin caches the completion script and is automatically updated when the
+plugin is loaded, which is usually when you start up a new terminal emulator.
+
+The cache is stored at:
+
+- `$ZSH_CACHE_DIR/completions/_bun_` completions script

--- a/plugins/bun/bun.plugin.zsh
+++ b/plugins/bun/bun.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_bun" ]]; then
   _comps[bun]=_bun
 fi
 
-bun completions zsh >| "$ZSH_CACHE_DIR/completions/_bun" &|
+bun completions >| "$ZSH_CACHE_DIR/completions/_bun" &|

--- a/plugins/bun/bun.plugin.zsh
+++ b/plugins/bun/bun.plugin.zsh
@@ -1,0 +1,14 @@
+# If Bun is not found, don't do the rest of the script
+if (( ! $+commands[bun] )); then
+  return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `bun`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_bun" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _bun
+  _comps[bun]=_bun
+fi
+
+bun completions zsh >| "$ZSH_CACHE_DIR/completions/_bun" &|


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds `bun` completions. the autocompletion file is autogenerated using `bun completions`
