### PR TITLE
feat(vi-mode): copy to clipboard when using `vi-change*` and `vi-yank*` widgets

### DIFF
--- a/plugins/vi-mode/README.md
+++ b/plugins/vi-mode/README.md
@@ -144,10 +144,16 @@ NOTE: this used to be bound to `v`. That is now the default (`visual-mode`).
 - `c{motion}`   : Delete {motion} text and start insert
 - `cc`          : Delete line and start insert
 - `C`           : Delete to the end of the line and start insert
+- `P`           : Insert the contents of the clipboard before the cursor
+- `p`           : Insert the contents of the clipboard after the cursor
 - `r{char}`     : Replace the character under the cursor with {char}
 - `R`           : Enter replace mode: Each character replaces existing one
 - `x`           : Delete `count` characters under and after the cursor
 - `X`           : Delete `count` characters before the cursor
+
+NOTE: delete/kill commands (`dd`, `D`, `c{motion}`, `C`, `x`,`X`) and yank commands
+(`y`, `Y`) will copy to the clipboard. Contents can then be put back using paste commands
+(`P`, `p`).
 
 ## Known issues
 

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -147,8 +147,15 @@ function wrap_clipboard_widgets() {
   done
 }
 
-wrap_clipboard_widgets copy vi-yank vi-yank-eol vi-backward-kill-word vi-change-whole-line vi-delete vi-delete-char
-wrap_clipboard_widgets paste vi-put-{before,after}
+wrap_clipboard_widgets copy \
+    vi-yank vi-yank-eol vi-yank-whole-line \
+    vi-change vi-change-eol vi-change-whole-line \
+    vi-kill-line vi-kill-eol vi-backward-kill-word \
+    vi-delete vi-delete-char vi-backward-delete-char
+
+wrap_clipboard_widgets paste \
+    vi-put-{before,after}
+
 unfunction wrap_clipboard_widgets
 
 # if mode indicator wasn't setup by theme, define default, we'll leave INSERT_MODE_INDICATOR empty by default


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

This makes it possible to kill/yank to the clipboard  using `c{motion}`, `C`, `dd`, `d`, `x` and `X` when editing a line and put it back using `p` or `P`.

## Other comments:

This was already partially supported, although some of the `vi-yank`, `vi-change` and `vi-delete` widgets were missing.
