### PR TITLE
feat(kubectl): add `kgdsa` alias

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -162,6 +162,7 @@ alias kdelsa="kubectl delete sa"
 
 # DaemonSet management.
 alias kgds='kubectl get daemonset'
+alias kgdsa='kubectl get daemonset --all-namespaces'
 alias kgdsw='kgds --watch'
 alias keds='kubectl edit daemonset'
 alias kdds='kubectl describe daemonset'


### PR DESCRIPTION
Add an alias to list all daemonset

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Only adding one alias to get all DS

## Other comments:

...
