### PR TITLE
feat(web-search): add `youtube` alias

### DIFF
--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -25,6 +25,7 @@ function web_search() {
     archive         "https://web.archive.org/web/*/"
     scholar         "https://scholar.google.com/scholar?q="
     ask             "https://www.ask.com/web?q="
+    youtube         "https://www.youtube.com/results?search_query="
   )
 
   # check whether the search engine is supported
@@ -66,11 +67,12 @@ alias wolframalpha='web_search wolframalpha'
 alias archive='web_search archive'
 alias scholar='web_search scholar'
 alias ask='web_search ask'
+alias youtube='web_search youtube'
 
 #add your own !bang searches here
 alias wiki='web_search duckduckgo \!w'
 alias news='web_search duckduckgo \!n'
-alias youtube='web_search duckduckgo \!yt'
+#alias youtube='web_search duckduckgo \!yt'
 alias map='web_search duckduckgo \!m'
 alias image='web_search duckduckgo \!i'
 alias ducky='web_search duckduckgo \!'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- added `alias` for `youtube` instead of the duckduckgo `!bang` search

## Other comments:

!bang search for youtube using duckduckgo takes some time due to the `redirection` from duckduckgo to youtube also this makes  use of duckduckgo without the user concern which does not affect anything but still people might not like it.

with this change people can search youtube results using their primary search engine without any redirection or delay

![Screenshot from 2023-08-30 14-57-28](https://github.com/ohmyzsh/ohmyzsh/assets/119417646/09739097-d127-44aa-85ff-17be8f91e8ab)
![Screenshot from 2023-08-30 14-58-52](https://github.com/ohmyzsh/ohmyzsh/assets/119417646/47881b89-c0be-4ad4-9e06-26c7cc0918a4)

also allowing user to use duckduckgo !bang search by using
![Screenshot from 2023-08-30 19-19-38](https://github.com/ohmyzsh/ohmyzsh/assets/119417646/7e241b99-4e1c-448a-9bb2-80fecd4d0b7f)
