### PR TITLE
fix(termsupport): match foot* extra shipped terminfo files

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -17,7 +17,7 @@ function title {
   : ${2=$1}
 
   case "$TERM" in
-    cygwin|xterm*|putty*|rxvt*|konsole*|ansi|mlterm*|alacritty|st*|foot|contour*)
+    cygwin|xterm*|putty*|rxvt*|konsole*|ansi|mlterm*|alacritty|st*|foot*|contour*)
       print -Pn "\e]2;${2:q}\a" # set window name
       print -Pn "\e]1;${1:q}\a" # set tab name
       ;;


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [N/A] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- fix(termsupport): match foot* extra shipped terminfo files

## Other comments:

- `foot` terminal ships `foot-extra` and/or `foot-extra-direct` terminfo files on many distros.
  - `TERM` is set accordingly (e.g. `TERM=foot-extra`),
    and would not otherwise match simply "`foot`",
    therefore disabling OMZ's features when in fact they are supported.
  - Reference:
    - https://codeberg.org/dnkl/foot/wiki\#foot-s-terminfo-vs-ncurses-terminfo
