### PR TITLE
feat(termsupport): configurable terminal title patterns & cmdline truncate

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -38,11 +38,15 @@ function title {
   esac
 }
 
-ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD
-ZSH_THEME_TERM_TITLE_IDLE="%n@%m:%~"
+# Allow overriding these settings, but fallback to defaults if unset
+ZSH_THEME_TERM_TITLE_CMDLINE_TRUNCATE="${ZSH_THEME_TERM_TITLE_CMDLINE_TRUNCATE:-100}"
+ZSH_THEME_TERM_TAB_TITLE_IDLE="${ZSH_THEME_TERM_TAB_TITLE_IDLE:-%15<..<%~%<<}" #15 char left truncated PWD
+ZSH_THEME_TERM_TITLE_IDLE="${ZSH_THEME_TERM_TITLE_IDLE:-%n@%m:%~}"
 # Avoid duplication of directory in terminals with independent dir display
 if [[ "$TERM_PROGRAM" == Apple_Terminal ]]; then
-  ZSH_THEME_TERM_TITLE_IDLE="%n@%m"
+  # Use user-specified setting if set, else use ZSH_THEME_TERM_TITLE_IDLE
+  # and remove ':%~' (e.g. default: "%n@%m")
+  ZSH_THEME_TERM_TITLE_IDLE="${ZSH_THEME_TERM_TITLE_IDLE_SHORT:-${ZSH_THEME_TERM_TITLE_IDLE//:%~/}}"
 fi
 
 # Runs before showing the prompt
@@ -99,7 +103,7 @@ function omz_termsupport_preexec {
   local CMD="${1[(wr)^(*=*|sudo|ssh|mosh|rake|-*)]:gs/%/%%}"
   local LINE="${2:gs/%/%%}"
 
-  title "$CMD" "%100>...>${LINE}%<<"
+  title "$CMD" "%${ZSH_THEME_TERM_TITLE_CMDLINE_TRUNCATE}>...>${LINE}%<<"
 }
 
 autoload -Uz add-zsh-hook

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -40,6 +40,20 @@ ZSH_THEME="robbyrussell"
 # Uncomment the following line to disable auto-setting terminal title.
 # DISABLE_AUTO_TITLE="true"
 
+# Uncomment the following to override default terminal title command truncation
+# char limit
+# ZSH_THEME_TERM_TITLE_CMDLINE_TRUNCATE="50"
+
+# Uncomment the following to override idle terminal title
+# ZSH_THEME_TERM_TITLE_IDLE="%n@%m:%90<..<%~%<<"
+
+# Uncomment the following to override idle terminal tab title
+# ZSH_THEME_TERM_TAB_TITLE_IDLE="%50<..<%~%<<"
+
+# Uncomment the following to override idle terminal tab title for terminals with
+# independent dir display (e.g. Apple_Terminal)
+# ZSH_THEME_TERM_TITLE_IDLE_SHORT='%n@%m'
+
 # Uncomment the following line to enable command auto-correction.
 # ENABLE_CORRECTION="true"
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [N/A] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Configurable terminal title patterns & cmdline truncation

## Other comments:

Allow user to set environment variables to override default terminal title patterns, and command line truncation char limit.  Fallback to original defaults if any are unset.
