### PR TITLE
fix(battery-plugin): add support for OpenBSD

### DIFF
--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -13,6 +13,10 @@
 # Author: Avneet Singh (kalsi-avneet)     #
 # Modified to add support for Android     #
 ###########################################
+# Author: Not Pua (im-notpua)             #
+# Modified to add support for OpenBSD     #
+###########################################
+
 
 if [[ "$OSTYPE" = darwin* ]]; then
   function battery_is_charging() {
@@ -139,6 +143,46 @@ elif [[ "$OSTYPE" = linux-android ]] && (( ${+commands[termux-battery-status]} )
       echo "%{$fg[$color]%}${battery_pct}%%%{$reset_color%}"
     fi
   }
+elif [[ "$OSTYPE" = openbsd* ]]; then
+  function battery_is_charging() {
+    [[ $(apm -b) -eq 3 ]]
+  }
+  function battery_pct() {
+    apm -l
+  }
+  function battery_pct_remaining() {
+    if ! battery_is_charging; then
+      battery_pct
+    else
+      echo "External Power"
+    fi
+  }
+  function battery_time_remaining() {
+    local remaining_time
+    remaining_time=$(apm -m)
+    if [[ $remaining_time -ge 0 ]]; then
+      ((hour = $remaining_time / 60 ))
+      ((minute = $remaining_time % 60 ))
+      printf %02d:%02d $hour $minute
+    fi
+  }
+  function battery_pct_prompt() {
+    local battery_pct color
+    battery_pct=$(battery_pct_remaining)
+    if battery_is_charging; then
+      echo "∞"
+    else
+      if [[ $battery_pct -gt 50 ]]; then
+        color='green'
+      elif [[ $battery_pct -gt 20 ]]; then
+        color='yellow'
+      else
+        color='red'
+      fi
+      echo "%{$fg[$color]%}${battery_pct}%%%{$reset_color%}"
+    fi
+  }
+
 elif [[ "$OSTYPE" = linux*  ]]; then
   function battery_is_charging() {
     if (( $+commands[acpitool] )); then


### PR DESCRIPTION
Fixes #11857 

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Uses the built-in `apm` ([OpenBSD manual](https://man.openbsd.org/apm.8)) command to fetch the battery status and details and adds OpenBSD support.

## Other comments:
I am a bit confused about the `battery_level_gauge` function. It seems like the main function doing most work but the [README](https://github.com/ohmyzsh/ohmyzsh/tree/ccce2e1cfdf5b9680f691a402e288d9cf6ce272a/plugins/battery) just recommends the usage of `battery_pct_prompt` function which only shows the percentage.

Other than that, this is a very useful plugin.