### PR TITLE
fix(extract): remove extraction file extension for tar

### DIFF
--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -30,6 +30,11 @@ EOF
     local file="$1" full_path="${1:A}"
     local extract_dir="${1:t:r}"
 
+    # Remove the .tar extension if the file name is .tar.*
+    if [[ $extract_dir =~ '\.tar$' ]]; then
+      extract_dir="${extract_dir:r}"
+    fi
+
     # If there's a file or directory with the same name as the archive
     # add a random string to the end of the extract directory
     if [[ -e "$extract_dir" ]]; then


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Currently, when extracting files with extensions .tar.* (such as xxx.tar.gz or xxx.tar.bz2), the output directory name incorrectly becomes xxx.tar. This patch corrects this issue by removing the .tar extension from the directory name, ensuring the output directory accurately reflects the original file's name.