### PR TITLE
fix(init): exit gracefully if on non-zsh emulation mode

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -1,14 +1,14 @@
+# ANSI formatting function (\033[<code>m)
+# 0: reset, 1: bold, 4: underline, 22: no bold, 24: no underline, 31: red, 33: yellow
+omz_f() {
+  [ $# -gt 0 ] || return
+  IFS=";" printf "\033[%sm" $*
+}
+# If stdout is not a terminal ignore all formatting
+[ -t 1 ] || omz_f() { :; }
+
 # Protect against non-zsh execution of Oh My Zsh (use POSIX syntax here)
 [ -n "$ZSH_VERSION" ] || {
-  # ANSI formatting function (\033[<code>m)
-  # 0: reset, 1: bold, 4: underline, 22: no bold, 24: no underline, 31: red, 33: yellow
-  omz_f() {
-    [ $# -gt 0 ] || return
-    IFS=";" printf "\033[%sm" $*
-  }
-  # If stdout is not a terminal ignore all formatting
-  [ -t 1 ] || omz_f() { :; }
-
   omz_ptree() {
     # Get process tree of the current process
     pid=$$; pids="$pid"
@@ -37,6 +37,15 @@
 
   return 1
 }
+
+# Check if in emulation mode, if so early return
+# https://github.com/ohmyzsh/ohmyzsh/issues/11686
+[[ "$(emulate)" = zsh ]] || {
+  printf "$(omz_f 1 31)Error:$(omz_f 22) Oh My Zsh can't be loaded in \`$(emulate)\` emulation mode.$(omz_f 0)\n" >&2
+  return 1
+}
+
+unset -f omz_f
 
 # If ZSH is not defined, use the current script's directory.
 [[ -z "$ZSH" ]] && export ZSH="${${(%):-%x}:a:h}"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Skips loading Oh My Zsh if current zsh is in non-zsh emulation mode

## Other comments:

Fixes #11686
