### PR TITLE
docs(git): align markdown table borders

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -34,7 +34,7 @@ plugins=(... git)
 | gbsg                 | git bisect good                                                                                                                                                  |
 | gbsr                 | git bisect reset                                                                                                                                                 |
 | gbss                 | git bisect start                                                                                                                                                 |
-| gbl                  | git blame -w                                                                                                                                                  |
+| gbl                  | git blame -w                                                                                                                                                     |
 | gb                   | git branch                                                                                                                                                       |
 | gba                  | git branch --all                                                                                                                                                 |
 | gbd                  | git branch --delete                                                                                                                                              |


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Correct whitespace to align table borders following change in #11864. This hasn't affected rendering on GitHub, but might on other markdown viewers.

## Other comments:

n/a