### PR TITLE
feat(mortalscumbag): show toolbox info

### DIFF
--- a/themes/mortalscumbag.zsh-theme
+++ b/themes/mortalscumbag.zsh-theme
@@ -51,8 +51,14 @@ function ssh_connection() {
   fi
 }
 
+function _toolbox_prompt_info() {
+  if typeset -f toolbox_prompt_info > /dev/null; then
+    toolbox_prompt_info
+  fi
+}
+
 local ret_status="%(?:%{$fg_bold[green]%}:%{$fg_bold[red]%})%?%{$reset_color%}"
-PROMPT=$'\n$(ssh_connection)%{$fg_bold[green]%}%n@%m%{$reset_color%}$(my_git_prompt) : %~\n[${ret_status}] %# '
+PROMPT=$'\n$(_toolbox_prompt_info)$(ssh_connection)%{$fg_bold[green]%}%n@%m%{$reset_color%}$(my_git_prompt) : %~\n[${ret_status}] %# '
 
 ZSH_THEME_PROMPT_RETURNCODE_PREFIX="%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_PREFIX=" $fg[white]‹ %{$fg_bold[yellow]%}"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Show the Toolbox icon in mortalscumbag if relevant. This brings the theme in line with the default Fedora Silverblue bash prompt.

## Other comments:

I tested this with and without `toolbox` enabled.

/cc @carlosala