### PR TITLE
change l alias to ls -lAh

### DIFF
--- a/lib/directories.zsh
+++ b/lib/directories.zsh
@@ -35,6 +35,6 @@ compdef _dirs d
 
 # List directory contents
 alias lsa='ls -lah'
-alias l='ls -lah'
+alias l='ls -lAh'
 alias ll='ls -lh'
 alias la='ls -lAh'


### PR DESCRIPTION
## Standards checklist:
- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
Changed alias 
`l = ls -lha`
to 
`l = ls -lhA`
so that we do not see the ./ and ../

## Other comments:
I think that if users do not feel like writing more than one letter, they do need need to see the implied ./ and ../.

At least I do.