### PR TITLE
feat(brew): support nonstandard install locations

### DIFF
--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -7,6 +7,12 @@ if (( ! $+commands[brew] )); then
     BREW_LOCATION="/home/linuxbrew/.linuxbrew/bin/brew"
   elif [[ -x "$HOME/.linuxbrew/bin/brew" ]]; then
     BREW_LOCATION="$HOME/.linuxbrew/bin/brew"
+  # Check if BREW_LOCATION was already set and executable
+  elif [[ -n "$BREW_LOCATION" ]]; then
+    if [[ ! -x "$BREW_LOCATION" ]]; then
+      echo "Warning: BREW_LOCATION was set to $BREW_LOCATION but that is not executable"
+      unset BREW_LOCATION
+    fi
   else
     return
   fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Allows BREW_LOCATION to be passed in to the plugin. Checks that BREW_LOCATION is executable.

## Other comments:

@voronkovich 