### PR TITLE
fix: make grc plugin work on darwin-arm64

### DIFF
--- a/plugins/grc/grc.plugin.zsh
+++ b/plugins/grc/grc.plugin.zsh
@@ -2,8 +2,9 @@
 
 # common grc.zsh paths
 files=(
-  /etc/grc.zsh            # default
-  /usr/local/etc/grc.zsh  # homebrew
+  /etc/grc.zsh               # default
+  /usr/local/etc/grc.zsh     # homebrew darwin-x64
+  /opt/homebrew/etc/grc.zsh  # homebrew darwin-arm64
 )
 
 # verify the file is readable and source it


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
