### PR TITLE
Adds the `sail` plugin to be able to use Laravel Sail commands without the need of the sail command

### DIFF
--- a/plugins/sail/LICENSE
+++ b/plugins/sail/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2019 Joshua Bedford
+Copyright (c) 2023 Marc-André Appel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/sail/README.md
+++ b/plugins/sail/README.md
@@ -1,0 +1,40 @@
+# Laravel Sail Oh-My-Zsh plugin
+
+This [OMZ plugin](https://github.com/ohmyzsh/ohmyzsh/wiki/Plugins) adds aliases for typical commands with [Laravel Sail](https://laravel.com/docs/10.x/sail). It will only run within sail-driven project directories.
+
+To use it, add `sail` to the oh-my-zsh plugins array in your `.zshrc` file:
+
+```zsh
+plugins=(... sail)
+```
+
+## Commands
+
+| Alias      | Description     |
+|:----------:|:---------------:|
+| `artisan`  | `sail artisan`  |
+| `composer` | `sail composer` |
+| `node`     | `sail node`     |
+| `npm`      | `sail npm`      |
+| `npx`      | `sail npx`      |
+| `php`      | `sail php`      |
+| `yarn`     | `sail yarn`     |
+
+## How it works
+
+This plugin removes the requirement to type `sail` before a command. It utilizes the sail version of supported commands run within directories where the `sail` command is found in the `vendor/bin` directory.
+
+## Settings
+
+The plugin will utilize the default values. Set the variable(s) below as needed in your .zshrc file to change these default values to match your development environment:
+
+- `SAIL_ZSH_BIN_PATH`: The plugin will check to see if this provided path exists to check for presence of Laravel Sail. By default, the path is `vendor/bin/sail` but this can be changed if needed.
+
+## Authors
+
+- [Marc-André Appel](https://maa.rocks)
+- [https://github.com/marcandreappel/sail-zsh](https://github.com/marcandreappel/sail-zsh)
+
+- Joshua Bedford (Author of the original Lando plugin)
+- URL: [https://github.com/joshuabedford/lando-zsh](https://github.com/joshuabedford/lando-zsh)
+

--- a/plugins/sail/sail.plugin.zsh
+++ b/plugins/sail/sail.plugin.zsh
@@ -1,0 +1,30 @@
+# Laravel Sail ZSH plugin
+#
+# Setting
+: ${SAIL_ZSH_BIN_PATH:="./vendor/bin/sail"}
+
+# Enable multiple commands with sail
+function artisan \
+         composer \
+         node \
+         npm \
+         npx \
+         php \
+         yarn {
+  if checkForSail; then
+    $SAIL_ZSH_BIN_PATH "$0" "$@"
+  else
+    command "$0" "$@"
+  fi
+}
+
+# Check for the file in the current and parent directories.
+checkForSail() {
+  # Check if ./vendor directory exists and if ./vendor/bin/sail file exists.
+  if [ -f $SAIL_ZSH_BIN_PATH ]; then
+    return 0
+  else
+    # Could not find $SAIL_ZSH_BIN_PATH in the current directory
+    return 1
+  fi
+}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds the `sail` plugin to be able to use Laravel Sail commands without the need of the sail command

## Other comments:

No aliases are added.
