### PR TITLE
fix(git): remove `--text` from `gsts`

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -183,7 +183,7 @@ plugins=(... git)
 | `gstp`                 | `git stash pop`                                                                                                                                                     |
 | `gsta`                 | On Git >= 2.13: `git stash push`                                                                                                                                    |
 | `gsta`                 | On Git < 2.13: `git stash save`                                                                                                                                     |
-| `gsts`                 | `git stash show --text`                                                                                                                                             |
+| `gsts`                 | `git stash show`                                                                                                                                                    |
 | `gst`                  | `git status`                                                                                                                                                        |
 | `gss`                  | `git status --short`                                                                                                                                                |
 | `gsb`                  | `git status --short -b`                                                                                                                                             |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -331,7 +331,7 @@ alias gstp='git stash pop'
 is-at-least 2.13 "$git_version" \
   && alias gsta='git stash push' \
   || alias gsta='git stash save'
-alias gsts='git stash show --text'
+alias gsts='git stash show'
 alias gst='git status'
 alias gss='git status --short'
 alias gsb='git status --short --branch'


### PR DESCRIPTION
⚠️ This PR builds on top of #11895, which should be merged first

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Remove the [`--text` diff option](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt--a) from the `gsts` alias for `git stash show`. `--text` forces treating binary files as text, causing their contents to be output and potentially breaking terminal rendering.

For example, here's what `git stash show` outputs with and without `--text` for a PNG file.

First, without:

```
$ git stash show
 donut.png | Bin 0 -> 238137 bytes
 1 file changed, 0 insertions(+), 0 deletions(-)
```

Plain stat details, and no attempt to represent the binary file. (Representation can be added by setting up a textconv filter.)

Second, with `--text`:

```
$ git stash show --text
diff --git donut.png donut.png
new file mode 100644
index 0000000..be8dd81
--- /dev/null
+++ donut.png
@@ -0,0 +1,938 @@
+<89>PNG^M
+^Z
...
```

The output continues with the remainder of the PNG's bytes. This is never useful behaviour since even if you could read the binary data, it isn't well displayed. On some terminal setups, random bytes can break rendering.

## Other comments:

The `--text` option was included with the creation of the alias, way back in #1864, without any discussion.
