### PR TITLE
feat(hitchhiker): clean up refs to magic string

### DIFF
--- a/plugins/hitchhiker/fortunes/hitchhiker
+++ b/plugins/hitchhiker/fortunes/hitchhiker
@@ -194,31 +194,31 @@ ARTHUR	It probably seems a terrible thing to say, but you 	know what I sometimes
 
 - One of the more preferable pieces of advice contained in the Guide.
 %
-"His eyes seemed to be popping out of his head. He wasn't certain if this was because they were trying to see more clearly, or if they simply wanted to leave at this point."QUOTEHERESTRINGMAGIC1234- Arthur trying to see who had diverted him from going to a party.
+"His eyes seemed to be popping out of his head. He wasn't certain if this was because they were trying to see more clearly, or if they simply wanted to leave at this point." - Arthur trying to see who had diverted him from going to a party.
 %
-"Arthur yawed wildly as his skin tried to jump one way and his skeleton the other, whilst his brain tried to work out which of his ears it most wanted to crawl out of. `Bet you weren't expecting to see me again,' said the monster, which Arthur couldn't help thinking was a strange remark for it to make, seeing as he had never met the creature before. He could tell that he hadn't met the creature before from the simple fact that he was able to sleep at nights."QUOTEHERESTRINGMAGIC1234- Arthur discovering who had diverted him from going to a party.
+"Arthur yawed wildly as his skin tried to jump one way and his skeleton the other, whilst his brain tried to work out which of his ears it most wanted to crawl out of. `Bet you weren't expecting to see me again,' said the monster, which Arthur couldn't help thinking was a strange remark for it to make, seeing as he had never met the creature before. He could tell that he hadn't met the creature before from the simple fact that he was able to sleep at nights." - Arthur discovering who had diverted him from going to a party.
 %
-"`That young girl is one of the least benightedly unintelligent organic life forms it has been my profound lack of pleasure not to be able to avoid meeting.'"QUOTEHERESTRINGMAGIC1234- Marvin's first ever compliment about anybody.
+"`That young girl is one of the least benightedly unintelligent organic life forms it has been my profound lack of pleasure not to be able to avoid meeting.'" - Marvin's first ever compliment about anybody.
 %
-"Arthur hoped and prayed that there wasn't an afterlife. Then he realised there was a contradiction there and merely hoped that there wasn't an afterlife."QUOTEHERESTRINGMAGIC1234- Arthur realising that he's in a certain death situation with a supernova bomb that is shaped like a cricket ball.
+"Arthur hoped and prayed that there wasn't an afterlife. Then he realised there was a contradiction there and merely hoped that there wasn't an afterlife." - Arthur realising that he's in a certain death situation with a supernova bomb that is shaped like a cricket ball.
 %
-"`Credit?' he said. `Aaaargggh...' These two words are usually coupled together in the Old Pink Dog Bar."QUOTEHERESTRINGMAGIC1234- Ford in a spot of bother.
+"`Credit?' he said. `Aaaargggh...' These two words are usually coupled together in the Old Pink Dog Bar." - Ford in a spot of bother.
 %
-"`...we might as well start with where your hand is now.' Arthur said, `So which way do I go?' `Down,' said Fenchurch, `on this occasion.' He moved his hand. `Down,' she said, `is in fact the other way.' `Oh yes.'"QUOTEHERESTRINGMAGIC1234- Arthur trying to discover which part of Fenchurch is wrong.
+"`...we might as well start with where your hand is now.' Arthur said, `So which way do I go?' `Down,' said Fenchurch, `on this occasion.' He moved his hand. `Down,' she said, `is in fact the other way.' `Oh yes.'" - Arthur trying to discover which part of Fenchurch is wrong.
 %
-"There was a point to this story, but it has temporarily escaped the chronicler's mind."QUOTEHERESTRINGMAGIC1234- This line perhaps best sums up the whole book.
+"There was a point to this story, but it has temporarily escaped the chronicler's mind." - This line perhaps best sums up the whole book.
 %
-"The last time anybody made a list of the top hundred character attributes of New Yorkers, common sense snuck in at number 79. .... When it's fall in New York, the air smells as if someone's been frying goats in it, and if you are keen to breathe the best plan is to open a window and stick your head in a building."QUOTEHERESTRINGMAGIC1234- Nuff said??
+"The last time anybody made a list of the top hundred character attributes of New Yorkers, common sense snuck in at number 79. .... When it's fall in New York, the air smells as if someone's been frying goats in it, and if you are keen to breathe the best plan is to open a window and stick your head in a building." - Nuff said??
 %
-"`What's been happening here?' he demanded. `Oh just the nicest things, sir, just the nicest things. can I sit on your lap please?'" "`Colin, I am going to abandon you to your fate.' `I'm so happy.'" "`It will be very, very nasty for you, and that's just too bad. Got it?' `I gurgle with pleasure.'"QUOTEHERESTRINGMAGIC1234- Ford and Colin the robot.
+"`What's been happening here?' he demanded. `Oh just the nicest things, sir, just the nicest things. can I sit on your lap please?'" "`Colin, I am going to abandon you to your fate.' `I'm so happy.'" "`It will be very, very nasty for you, and that's just too bad. Got it?' `I gurgle with pleasure.'" - Ford and Colin the robot.
 %
-"What the hell, he thought, you're only young once, and threw himself out of the window. That would at least keep the element of surprise on his side."QUOTEHERESTRINGMAGIC1234- Ford outwitting a Vogon with a rocket launcher by going into another certain death situation.
+"What the hell, he thought, you're only young once, and threw himself out of the window. That would at least keep the element of surprise on his side." - Ford outwitting a Vogon with a rocket launcher by going into another certain death situation.
 %
-"The major difference between a thing that might go wrong and a thing that cannot possibly go wrong is that when a thing that cannot possibly go wrong goes wrong it usually turns out to be impossible to get at or repair."QUOTEHERESTRINGMAGIC1234- One of the laws of computers and programming revealed.
+"The major difference between a thing that might go wrong and a thing that cannot possibly go wrong is that when a thing that cannot possibly go wrong goes wrong it usually turns out to be impossible to get at or repair." - One of the laws of computers and programming revealed.
 %
-"`You know they've reintroduced the death penalty for insurance company directors?' `Really?' said Arthur. `No I didn't. For what offence?' Trillian frowned. `What do you mean, offence?' `I see.'"QUOTEHERESTRINGMAGIC1234- Evidence that there will be some justice in the Universe eventually.
+"`You know they've reintroduced the death penalty for insurance company directors?' `Really?' said Arthur. `No I didn't. For what offence?' Trillian frowned. `What do you mean, offence?' `I see.'" - Evidence that there will be some justice in the Universe eventually.
 %
-"`She hit me on the head with the rock again.' `I think I can confirm that that was my daughter.' `Sweet kid.' `You have to get to know her,' said Arthur. `She eases up does she?' `No,' said Arthur, `but you get a better sense of when to duck.'"QUOTEHERESTRINGMAGIC1234- Ford and Arthur on Random.
+"`She hit me on the head with the rock again.' `I think I can confirm that that was my daughter.' `Sweet kid.' `You have to get to know her,' said Arthur. `She eases up does she?' `No,' said Arthur, `but you get a better sense of when to duck.'" - Ford and Arthur on Random.
 %
 "Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun. "
 %


### PR DESCRIPTION
Replace instances of QUOTEHERESTRINGMAGIC1234 with a space. Looks like someone was doing some string processing and failed to substitute these 13 instances back out.

Tagging @luizpericolo who submitted this fortune database in the first place and perhaps can remember why.


## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [n/a] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [n/a] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Replace instances of QUOTEHERESTRINGMAGIC1234 with a space 

## Other comments:

None :)
