### PR TITLE
fix(gcloud): source `path.zsh.inc` always

### DIFF
--- a/plugins/gcloud/gcloud.plugin.zsh
+++ b/plugins/gcloud/gcloud.plugin.zsh
@@ -29,11 +29,9 @@ if [[ -z "${CLOUDSDK_HOME}" ]]; then
 fi
 
 if (( ${+CLOUDSDK_HOME} )); then
-  # Only source this if gcloud isn't already on the path
-  if (( ! $+commands[gcloud] )); then
-    if [[ -f "${CLOUDSDK_HOME}/path.zsh.inc" ]]; then
-      source "${CLOUDSDK_HOME}/path.zsh.inc"
-    fi
+  # Source path file
+  if [[ -f "${CLOUDSDK_HOME}/path.zsh.inc" ]]; then
+    source "${CLOUDSDK_HOME}/path.zsh.inc"
   fi
 
   # Look for completion file in different paths


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

This PR removes the condition that checks if `gcloud` command is already available before sourcing the path file.

## Why:

If gcloud SDK was installed with brew, the binary is already symlinked in the folder `/opt/homebrew/bin` which is by default in the PATH. This means that the condition is never verified and therefore, the file never sourced. This causes an issue when you need to connect on GKE clusters for instance. You would need to use the `gke-gcloud-auth-plugin` binary which won't be available because not in the PATH.