### PR TITLE
feat(dnf): use `dnf5` if available

### DIFF
--- a/plugins/dnf/README.md
+++ b/plugins/dnf/README.md
@@ -10,6 +10,9 @@ To use it, add `dnf` to the plugins array in your zshrc file:
 plugins=(... dnf)
 ```
 
+Classic `dnf` is getting superseded by `dnf5`; this plugin detects the presence
+of `dnf5` and uses it as drop-in alternative to the slower `dnf`.
+
 ## Aliases
 
 | Alias | Command                 | Description              |

--- a/plugins/dnf/dnf.plugin.zsh
+++ b/plugins/dnf/dnf.plugin.zsh
@@ -1,15 +1,19 @@
 ## Aliases
+local dnfprog="dnf"
 
-alias dnfl="dnf list"                       # List packages
-alias dnfli="dnf list installed"            # List installed packages
-alias dnfgl="dnf grouplist"                 # List package groups
-alias dnfmc="dnf makecache"                 # Generate metadata cache
-alias dnfp="dnf info"                       # Show package information
-alias dnfs="dnf search"                     # Search package
+# Prefer dnf5 if installed
+command -v dnf5 > /dev/null && dnfprog=dnf5
 
-alias dnfu="sudo dnf upgrade"               # Upgrade package
-alias dnfi="sudo dnf install"               # Install package
-alias dnfgi="sudo dnf groupinstall"         # Install package group
-alias dnfr="sudo dnf remove"                # Remove package
-alias dnfgr="sudo dnf groupremove"          # Remove package group
-alias dnfc="sudo dnf clean all"             # Clean cache
+alias dnfl="${dnfprog} list"                       # List packages
+alias dnfli="${dnfprog} list installed"            # List installed packages
+alias dnfgl="${dnfprog} grouplist"                 # List package groups
+alias dnfmc="${dnfprog} makecache"                 # Generate metadata cache
+alias dnfp="${dnfprog} info"                       # Show package information
+alias dnfs="${dnfprog} search"                     # Search package
+
+alias dnfu="sudo ${dnfprog} upgrade"               # Upgrade package
+alias dnfi="sudo ${dnfprog} install"               # Install package
+alias dnfgi="sudo ${dnfprog} groupinstall"         # Install package group
+alias dnfr="sudo ${dnfprog} remove"                # Remove package
+alias dnfgr="sudo ${dnfprog} groupremove"          # Remove package group
+alias dnfc="sudo ${dnfprog} clean all"             # Clean cache


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fedora 39 or 40 moves from classic dnf to dnf5, which makes dependency
solving, package cache updates etc. faster. It's desirable to use it now
if available.


## Other comments:

No new aliases were added.
