### PR TITLE
fix(ruby): add missing `-run` in `rserver` alias

### DIFF
--- a/plugins/ruby/ruby.plugin.zsh
+++ b/plugins/ruby/ruby.plugin.zsh
@@ -23,4 +23,4 @@ alias gel="gem lock"
 alias geo="gem open"
 alias geoe="gem open -e"
 alias rrun="ruby -e"
-alias rserver="ruby -e httpd . -p 8080" # requires webrick
+alias rserver="ruby -run -e httpd . -p 8080" # requires webrick


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
