### PR TITLE
fix(gradle): exclude lookup for settings.gradle* files for `gradle` function

### DIFF
--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -6,7 +6,7 @@ function gradle-or-gradlew() {
   # taken from https://github.com/gradle/gradle-completion
   local dir="$PWD" project_root="$PWD"
   while [[ "$dir" != / ]]; do
-    if [[ -f "$dir/settings.gradle" || -f "$dir/settings.gradle.kts" || -f "$dir/gradlew" ]]; then
+    if [[ -x "$dir/gradlew" ]]; then
       project_root="$dir"
       break
     fi


### PR DESCRIPTION
Now `gradle` alias works properly with composite builds inside project

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- removed lookup of `settings.gradle` and `settings.gradle.kts` files to work with composite builds inside project

## Other comments:

Fixes #11916
