### PR TITLE
docs(gas): update gas plugin URL

### DIFF
--- a/plugins/gas/README.md
+++ b/plugins/gas/README.md
@@ -1,6 +1,6 @@
 # Gas plugin
 
-This plugin adds autocompletion for the [gas](http://walle.github.com/gas) command,
+This plugin adds autocompletion for the [gas](http://ramblingsby.me/gas/) command,
 a utility to manage Git authors.
 
 To use it, add `gas` to the plugins array of your zshrc file:


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Changed the link for the `gas` plugin to the current URL

## Other comments:

The previous url was a GitHub page hosted at http://walle.github.com/gas. The error message that appears says that github.com links no longer work for GitHub pages and to use github.io instead. After changing the URL to github.io, it redirected to this new link.
