### PR TITLE
feat(dotenv): var to enable recusrive .env sourcing

### DIFF
--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -78,6 +78,15 @@ change.
 NOTE: if a directory is found in both the allowed and disallowed lists, the disallowed list
 takes preference, _i.e._ the .env file will never be sourced.
 
+### ZSH_DOTENV_RECURSIVE, ZSH_DOTENV_ROOT
+Set `ZSH_DOTENV_RECURSIVE=true` in your zshrc file to enable recursive search for the `ZSH_DOTENV_FILE` up to
+`ZSH_DOTENV_ROOT` (default `$HOME`) and source from `$ZSH_DOTENV_ROOT` to `$PWD`.
+
+```zsh
+# in ~/.zshrc, before Oh My Zsh is sourced:
+ZSH_DOTENV_RECURSIVE=true
+ZSH_DOTENV_ROOT=/path/to/root
+```
 ## Version Control
 
 **It's strongly recommended to add `.env` file to `.gitignore`**, because usually it contains sensitive information such as your credentials, secret keys, passwords etc. You don't want to commit this file, it's supposed to be local only.


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add an option to do a recursive source of .env, from a configured ROOT directory to the current working directory, enabling ENVs overwriting
- ENVs added
  - `ZSH_DOTENV_RECURSIVE`: Default `false`, if `true` enables recursive sourcing 
  -  `ZSH_DOTENV_ROOT`: Default `$HOME`, the root directory to starting sourcing from

## Other comments:
My use case: I need to install a python library from a private repository in more than one os my repositories so, instead off heaving multiples `.env` to define `GH_USERNAME` and `GH_TOKEN` I can have only one.

@mcornella 