### PR TITLE
Add the node-bin plugin

### DIFF
--- a/plugins/node-bin/README.md
+++ b/plugins/node-bin/README.md
@@ -1,0 +1,10 @@
+# nodenv plugin
+
+This plugin adds `node_modules/.bin` to your path. It does so recursively up the ancestor tree,
+meaning it also  works for subdirectories and monorepos.
+
+To use it, add `node-bin` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... node-bin)
+```

--- a/plugins/node-bin/node-bin.plugin.zsh
+++ b/plugins/node-bin/node-bin.plugin.zsh
@@ -1,0 +1,16 @@
+# Add local ancestor node_modules/.bin folders to the path.
+_nodeBin() {
+  path=( ${path[@]:#*node_modules*} )
+  local p="$(pwd)"
+  while [[ "$p" != '/' ]]; do
+    if [[ -d "$p/node_modules/.bin" ]]; then
+      path+=("$p/node_modules/.bin")
+    fi
+    p="$(dirname "$p")"
+  done
+  typeset -U path
+}
+
+autoload -U add-zsh-hook
+add-zsh-hook chpwd _nodeBin
+_nodeBin


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

This plugin adds `node_modules/.bin` to your path. It does so recursively up the ancestor tree, meaning it also  works for subdirectories and monorepos.

## Other comments:

The `node_modules/.bin` paths are appended, not prepended. This means system executables take precedence over local node modules.

Fixes #10924
