### PR TITLE
fix(ssh-agent): add error message if `~/.ssh` is not found

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -20,6 +20,13 @@ function _start_agent() {
   # start ssh-agent and setup environment
   zstyle -t :omz:plugins:ssh-agent quiet || echo >&2 "Starting ssh-agent ..."
   ssh-agent -s ${lifetime:+-t} ${lifetime} | sed '/^echo/d' >! "$ssh_env_cache"
+  if [[ $? -ne 0 ]]; then
+  mkdir ~/.ssh
+  chmod 700 ~/.ssh
+  echo "You have enabled the ssh-agent which requires ~/.ssh directory to store a cache file."
+  echo "Created ~/.ssh directory to store cache file."
+  return
+  fi
   chmod 600 "$ssh_env_cache"
   . "$ssh_env_cache" > /dev/null
 }

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -13,6 +13,11 @@ function _start_agent() {
     fi
   fi
 
+  if [[ ! -d "$HOME/.ssh" ]]; then
+    echo "[oh-my-zsh] ssh-agent plugin requires ~/.ssh directory"
+    return 1
+  fi
+
   # Set a maximum lifetime for identities added to ssh-agent
   local lifetime
   zstyle -s :omz:plugins:ssh-agent lifetime lifetime
@@ -20,13 +25,6 @@ function _start_agent() {
   # start ssh-agent and setup environment
   zstyle -t :omz:plugins:ssh-agent quiet || echo >&2 "Starting ssh-agent ..."
   ssh-agent -s ${lifetime:+-t} ${lifetime} | sed '/^echo/d' >! "$ssh_env_cache"
-  if [[ $? -ne 0 ]]; then
-  mkdir ~/.ssh
-  chmod 700 ~/.ssh
-  echo "You have enabled the ssh-agent which requires ~/.ssh directory to store a cache file."
-  echo "Created ~/.ssh directory to store cache file."
-  return
-  fi
   chmod 600 "$ssh_env_cache"
   . "$ssh_env_cache" > /dev/null
 }


### PR DESCRIPTION
solves:  #11829


Added the code for ssh-agent plugin to fail gracefully and better handle edge cases.
Before this PR: If the ssh-agent plugin was enabled and the required ~/.ssh directory was not found , the plugin used to respond with an error message which was hard to understand.


Now if the ~/.ssh directory doesn't exist, plugin will respond with understandable error and will automatically create ~/.ssh directory as mentioned in the issue.

Message will be:

You have enabled the ssh-agent which requires ~/.ssh directory to store a cache file. 
Created ~/.ssh directory to store cache file.

This will only be displayed for first time if the directory doesn't existed before.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
Included Code after line 22 in ssh-agent.plugin.zsh file


    if [[ $? -ne 0 ]]; then
    mkdir ~/.ssh
    chmod 700 ~/.ssh
    echo "You have enabled the ssh-agent which requires ~/.ssh directory to store a cache file."
    echo "Created ~/.ssh directory to store cache file."
    return
    fi

Added the code for ssh-agent plugin to fail gracefully and better handle edge cases.
Before this PR: If the ssh-agent plugin was enabled and the required ~/.ssh directory was not found , the plugin used to respond with an error message which was hard to understand.


Now if the ~/.ssh directory doesn't exist, plugin will respond with understandable error and will automatically create ~/.ssh directory as mentioned in the issue.

Message will be:

You have enabled the ssh-agent which requires ~/.ssh directory to store a cache file.
Created ~/.ssh directory to store cache file.

This will only be displayed for first time if the directory doesn't existed before.