### PR TITLE
Added rtx plugin (asdf replacement)

### DIFF
--- a/plugins/rtx/README.md
+++ b/plugins/rtx/README.md
@@ -25,6 +25,6 @@ See the [rtx readme](https://github.com/jdx/rtx#table-of-contents) for informati
 ```
 rtx install node         Install the current version specified in .tool-versions/.rtx.toml
 rtx use -g node@system   Use system node as global default
-rtx install node@20.0.0  //Install a specific version number
+rtx install node@20.0.0  Install a specific version number
 rtx use -g node@20       Use node-20.x as global default
 ```

--- a/plugins/rtx/README.md
+++ b/plugins/rtx/README.md
@@ -8,8 +8,9 @@ Adds integration with [rtx](https://github.com/jdx/rtx), a runtime executor comp
 1. [Download & install rtx](https://github.com/jdx/rtx#installation) by running the following:
 
   ```
-  curl https://rtx.pub/rtx-latest-macos-arm64 > /usr/local/bin/rtx
+  curl https://rtx.pub/install.sh | sh
   ```
+
 
 2. [Enable rtx](https://github.com/jdx/rtx#quickstart) by adding it to your `plugins` definition in `~/.zshrc`.
 

--- a/plugins/rtx/README.md
+++ b/plugins/rtx/README.md
@@ -1,0 +1,29 @@
+## rtx
+
+
+Adds integration with [rtx](https://github.com/jdx/rtx), a runtime executor compatible with npm,  nodenv, pyenv, etc. rtx is written in rust and is very fast. 20x-200x faster than asdf. With that being said, rtx is compatible with asdf plugins and .tool-versions files. It can be used as a drop-in replacement.
+
+### Installation
+
+1. [Download & install rtx](https://github.com/jdx/rtx#installation) by running the following:
+
+  ```
+  curl https://rtx.pub/rtx-latest-macos-arm64 > /usr/local/bin/rtx
+  ```
+
+2. [Enable rtx](https://github.com/jdx/rtx#quickstart) by adding it to your `plugins` definition in `~/.zshrc`.
+
+  ```
+  plugins=(rtx)
+  ```
+
+### Usage
+
+See the [rtx readme](https://github.com/jdx/rtx#table-of-contents) for information on how to use rtx. Here are a few examples:
+
+```
+rtx install node         Install the current version specified in .tool-versions/.rtx.toml
+rtx use -g node@system   Use system node as global default
+rtx install node@20.0.0  //Install a specific version number
+rtx use -g node@20       Use node-20.x as global default
+```

--- a/plugins/rtx/rtx.plugin.zsh
+++ b/plugins/rtx/rtx.plugin.zsh
@@ -1,0 +1,30 @@
+# Find where rtx should be installed
+RTX_DIR="${RTX_DIR:-$HOME/.rtx}"
+RTX_COMPLETIONS="$RTX_DIR/completions"
+
+if [[ ! -f "$RTX_DIR/rtx.sh" || ! -f "$RTX_COMPLETIONS/_rtx" ]]; then
+  # If not found, check for archlinux/AUR package (/opt/rtx-vm/)
+  if [[ -f "/opt/rtx-vm/rtx.sh" ]]; then
+    RTX_DIR="/opt/rtx-vm"
+    RTX_COMPLETIONS="$RTX_DIR"
+  # If not found, check for Homebrew package
+  elif (( $+commands[brew] )); then
+    _RTX_PREFIX="$(brew --prefix rtx)"
+    RTX_DIR="${_RTX_PREFIX}/libexec"
+    RTX_COMPLETIONS="${_RTX_PREFIX}/share/zsh/site-functions"
+    unset _RTX_PREFIX
+  else
+    return
+  fi
+fi
+
+# Load command
+if [[ -f "$RTX_DIR/rtx.sh" ]]; then
+  source "$RTX_DIR/rtx.sh"
+  # Load completions
+  if [[ -f "$RTX_COMPLETIONS/_rtx" ]]; then
+    fpath+=("$RTX_COMPLETIONS")
+    autoload -Uz _rtx
+    compdef _rtx rtx # compdef is already loaded before loading plugins
+  fi
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
Added a plugin for rtx, which is faster asdf as it is written in rust. Solves #11700.
- [...]

## Other comments:
I would like to add aliases to both rtx and asdf based on use cases of users. An example would be
```alias install = "rtx install"```
...
