### PR TITLE
fix(git): restore showing patch in `gsts`

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -185,7 +185,7 @@ plugins=(... git)
 | `gstp`                 | `git stash pop`                                                                                                                                                     |
 | `gsta`                 | On Git >= 2.13: `git stash push`                                                                                                                                    |
 | `gsta`                 | On Git < 2.13: `git stash save`                                                                                                                                     |
-| `gsts`                 | `git stash show`                                                                                                                                                    |
+| `gsts`                 | `git stash show --patch`                                                                                                                                            |
 | `gst`                  | `git status`                                                                                                                                                        |
 | `gss`                  | `git status --short`                                                                                                                                                |
 | `gsb`                  | `git status --short -b`                                                                                                                                             |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -349,7 +349,7 @@ alias gstp='git stash pop'
 is-at-least 2.13 "$git_version" \
   && alias gsta='git stash push' \
   || alias gsta='git stash save'
-alias gsts='git stash show'
+alias gsts='git stash show --patch'
 alias gst='git status'
 alias gss='git status --short'
 alias gsb='git status --short --branch'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Follow up to #11897 after discussion. The removed `--text` option was forcing showing the patch, this PR adds the `--patch` option ([from `git diff`](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt--p)) to show the patch, without forcing binary files to be shown. Although `stash.showPatch` can be configured to enable this by default, the alias showed the patch previously and folks may not be aware of the option.

## Other comments:

Thanks @MarijnS95 for reporting.
