### PR TITLE
fix(yarn): output completion entries in UTF-8

### DIFF
--- a/plugins/yarn/_yarn
+++ b/plugins/yarn/_yarn
@@ -144,7 +144,7 @@ _yarn_scripts() {
   fi
 
   if [[ -n $packageJson ]]; then
-    scripts=("${(@f)$(cat ${packageJson} | perl -0777 -MJSON::PP -n -E '%r=%{decode_json($_)->{scripts}}; do{$k=$_;($e=$k)=~s/:/\\:/g; printf "$e:$r{$k}\n"} for sort keys %r')}")
+    scripts=("${(@f)$(cat ${packageJson} | perl -0777 -MJSON::PP -n -E 'binmode(STDOUT, ":encoding(UTF-8)"); %r=%{decode_json($_)->{scripts}}; do{$k=$_;($e=$k)=~s/:/\\:/g; printf "$e:$r{$k}\n"} for sort keys %r')}")
   fi
 
   commands=('env' $scripts $binaries)


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes `yarn run ...` completions with UTF-8 chars in scripts. This is especially useful if there are emojis in the scripts.

## Other comments:

Before the fix:

<img width="1412" alt="image" src="https://github.com/ohmyzsh/ohmyzsh/assets/326935/0ed619e7-ed94-48d4-9882-125fb93fbfce">


After the fix:

<img width="1407" alt="image" src="https://github.com/ohmyzsh/ohmyzsh/assets/326935/7ddebdcd-3ae6-41ec-973f-788a1a32e5e7">
