### PR TITLE
fix typo

### DIFF
--- a/plugins/aliases/README.md
+++ b/plugins/aliases/README.md
@@ -17,7 +17,7 @@ Requirements: Python needs to be installed.
 
 - `als`: show all aliases by group
 
-- `als -h/--help`: print help mesage
+- `als -h/--help`: print help message
 
 - `als <keyword(s)>`: filter and highlight aliases by `<keyword>`
 


### PR DESCRIPTION
line 20 convert 'mesage' to 'message'

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Corrected a typo in the readme file. "Message" was written as 'mesage'

## Other comments:

...
