### PR TITLE
chore(zsh-navigation-tools): fix typo

### DIFF
--- a/plugins/zsh-navigation-tools/n-list
+++ b/plugins/zsh-navigation-tools/n-list
@@ -467,7 +467,7 @@ while (( 1 )); do
     elif [ -n "$keypad" ]; then
         final_key="$keypad"
     else
-        _nlist_status_msg "Inproper input detected"
+        _nlist_status_msg "Improper input detected"
         zcurses refresh main inner
     fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x ] The PR title is descriptive.
- [x ] The PR doesn't replicate another PR which is already open.
- [x ] I have read the contribution guide and followed all the instructions.
- [x ] The code follows the code style guide detailed in the wiki.
- [x ] The code is mine or it's from somewhere with an MIT-compatible license.
- [x ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x ] The code is stable and I have tested it myself, to the best of my abilities.
- [x ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
Corrected a typo in plugins/zsh-navigation-tools/n-list in line number 470. fixed 'Inproper' to 'Improper'
- [...]

## Other comments:

...
