### PR TITLE
chore(z): fix typo

### DIFF
--- a/plugins/z/z.plugin.zsh
+++ b/plugins/z/z.plugin.zsh
@@ -306,7 +306,7 @@ zshz() {
   }
 
   ############################################################
-  # Read the curent datafile contents, update them, "age" them
+  # Read the current datafile contents, update them, "age" them
   # when the total rank gets high enough, and print the new
   # contents to STDOUT.
   #
@@ -931,7 +931,7 @@ add-zsh-hook chpwd _zshz_chpwd
 # Completion
 ############################################################
 
-# Standarized $0 handling
+# Standardized $0 handling
 # https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
 0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
 0="${${(M)0:#/*}:-$PWD/$0}"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x ] The PR title is descriptive.
- [x ] The PR doesn't replicate another PR which is already open.
- [x ] I have read the contribution guide and followed all the instructions.
- [x ] The code follows the code style guide detailed in the wiki.
- [x ] The code is mine or it's from somewhere with an MIT-compatible license.
- [x ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x ] The code is stable and I have tested it myself, to the best of my abilities.
- [x ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
Typos fixed in plugins/z/z.plugin.zsh file:
curent -> current
Standarized -> Standardized
- [...]

## Other comments:

...
