### PR TITLE
chore(postgres): fix typo

### DIFF
--- a/plugins/postgres/README.md
+++ b/plugins/postgres/README.md
@@ -19,4 +19,4 @@ plugins=(... postgres)
 | stoppost    | `pg_ctl -D /usr/local/var/postgres stop -s -m fast`                             | Stop postgres server                                        |
 | restartpost | `stoppost && sleep 1 && startpost`                                              | Restart (calls stop, then start)                            |
 | reloadpost  | `pg_ctl reload -D /usr/local/var/postgres -s`                                   | Reload postgres configuration (some setting require restart)|
-| statuspost  | `pg_ctl status -D /usr/local/var/postgres -s`                                   | Check startus of postgres server (running, stopped)         |
+| statuspost  | `pg_ctl status -D /usr/local/var/postgres -s`                                   | Check status of postgres server (running, stopped)          |


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x ] The PR title is descriptive.
- [x ] The PR doesn't replicate another PR which is already open.
- [x ] I have read the contribution guide and followed all the instructions.
- [x ] The code follows the code style guide detailed in the wiki.
- [x ] The code is mine or it's from somewhere with an MIT-compatible license.
- [x ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x ] The code is stable and I have tested it myself, to the best of my abilities.
- [x ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Typo Fixed in plugins/postgres/README.md file:
startus -> status
- [...]

## Other comments:

...
