### PR TITLE
Also recurse git submodules when "taking" a git repo

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -58,7 +58,7 @@ function takeurl() {
 }
 
 function takegit() {
-  git clone "$1"
+  git clone --recurse-submodules "$1"
   cd "$(basename ${1%%.git})"
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [z] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `--recurse-submodules` to `takegit` function, therefore to `take` function

## Other comments:

Searched `takegit`:
- https://github.com/ohmyzsh/ohmyzsh/issues?q=is%3Aissue+is%3Aopen+%22takegit%22
- https://github.com/ohmyzsh/ohmyzsh/pull/2029

No one was complaining about the fact that if you have a submodule(s) in your git repo then the convenient `take` function is still missing one step :) I think this is a terrific default, if you need more detailed control then you could simply use `git`