### PR TITLE
feat(plugins/command-not-found): added command_not_found_handler func…

### DIFF
--- a/plugins/command-not-found/README.md
+++ b/plugins/command-not-found/README.md
@@ -30,5 +30,5 @@ It works out of the box with the command-not-found packages for:
 - [NixOS](https://github.com/NixOS/nixpkgs/tree/master/nixos/modules/programs/command-not-found)
 - [Termux](https://github.com/termux/command-not-found)
 - [SUSE](https://www.unix.com/man-page/suse/1/command-not-found/)
-
+- [linux (Homebrew)] 
 You can add support for other platforms by submitting a Pull Request.

--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -67,3 +67,20 @@ if [[ -x /usr/bin/command-not-found ]]; then
     /usr/bin/command-not-found "$1"
   }
 fi
+
+
+if [[ -e /etc/os-release || "$OSTYPE" == "linux-gnu"]]; then
+  source /etc/os-release
+  brew_installation_directory=$(brew --prefix)
+  if [[[ "$ID" = "ubuntu" || "$ID" = "centos" || "$ID" = "fedora" || "$ID" = "debian" || "$ID" == "opensuse"] && [ -d "$brew_installation_directory" ]] || [["$OSTYPE" == "linux-gnu" && -d "$brew_installation_directory"]]]; then
+    # Check if $brew_installation_directory is set and contains the handler script
+    if [[ -n $brew_installation_directory && -x "$brew_installation_directory/Library/Taps/homebrew/homebrew-command-not-found/handler.sh" ]]; then
+      command_not_found_handler() {
+        "$brew_installation_directory/Library/Taps/homebrew/homebrew-command-not-found/handler.sh" -- "$1"
+        return $?
+      }
+    fi
+  else
+     #Unknown or unsupported Linux distribution.
+  fi
+fi


### PR DESCRIPTION
command_not_found handler addition for homebrew installations on linux platforms (linuxbrew)
fixes: #11151
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x ] The PR title is descriptive.
- [ x] The PR doesn't replicate another PR which is already open.
- [ x] I have read the contribution guide and followed all the instructions.
- [ x] The code follows the code style guide detailed in the wiki.
- [ x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x] The code is stable and I have tested it myself, to the best of my abilities.
- [ x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added command_not_found_handler for brew installed linux platforms

Since there are so many different linux OSes, it seems difficult to come up with a generic script to identify current running os environment which would work well for identifying all linux oses. This solution attempts to consider most standard linux OSes with the use of /etc/os-release and $OSTYPE. This solution leaves room for appendment of support for more linux OSes which would require other than standard approach to identify the os environment.

## Important Note
An Alternate approach worth considering.

Considering homebrew is currently only available for macos and linux platforms (linuxbrew) and leveraging the seemingly less probability of homebrew starting to support windows natively other than WSL, a  solution which can potentially make the script more generic and less code is provided below for team to go through.

```
brew_installation_directory=$(brew --prefix)
if [[ "$OSTYPE" != "darwin"* && -d "$brew_installation_directory"]]; then
  # Check if $brew_installation_directory is set and contains the handler script
  if [[ -n $brew_installation_directory && -x "$brew_installation_directory/Library/Taps/homebrew/homebrew-command-not-found/handler.sh" ]]; then
    command_not_found_handler() {
      "$brew_installation_directory/Library/Taps/homebrew/homebrew-command-not-found/handler.sh" -- "$1"
      return $?
    }
  fi
fi
```
