### PR TITLE
Add dsh command to docker plugin

### DIFF
--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -41,38 +41,39 @@ zstyle ':omz:plugins:docker' legacy-completion yes
 
 ## Aliases
 
-| Alias   | Command                       | Description                                                                              |
-| :------ | :---------------------------- | :--------------------------------------------------------------------------------------- |
-| dbl     | `docker build`                | Build an image from a Dockerfile                                                         |
-| dcin    | `docker container inspect`    | Display detailed information on one or more containers                                   |
-| dcls    | `docker container ls`         | List all the running docker containers                                                   |
-| dclsa   | `docker container ls -a`      | List all running and stopped containers                                                  |
-| dib     | `docker image build`          | Build an image from a Dockerfile (same as docker build)                                  |
-| dii     | `docker image inspect`        | Display detailed information on one or more images                                       |
-| dils    | `docker image ls`             | List docker images                                                                       |
-| dipu    | `docker image push`           | Push an image or repository to a remote registry                                         |
-| dirm    | `docker image rm`             | Remove one or more images                                                                |
-| dit     | `docker image tag`            | Add a name and tag to a particular image                                                 |
-| dlo     | `docker container logs`       | Fetch the logs of a docker container                                                     |
-| dnc     | `docker network create`       | Create a new network                                                                     |
-| dncn    | `docker network connect`      | Connect a container to a network                                                         |
-| dndcn   | `docker network disconnect`   | Disconnect a container from a network                                                    |
-| dni     | `docker network inspect`      | Return information about one or more networks                                            |
-| dnls    | `docker network ls`           | List all networks the engine daemon knows about, including those spanning multiple hosts |
-| dnrm    | `docker network rm`           | Remove one or more networks                                                              |
-| dpo     | `docker container port`       | List port mappings or a specific mapping for the container                               |
-| dpu     | `docker pull`                 | Pull an image or a repository from a registry                                            |
-| dr      | `docker container run`        | Create a new container and start it using the specified command                          |
-| drit    | `docker container run -it`    | Create a new container and start it in an interactive shell                              |
-| drm     | `docker container rm`         | Remove the specified container(s)                                                        |
-| drm!    | `docker container rm -f`      | Force the removal of a running container (uses SIGKILL)                                  |
-| dst     | `docker container start`      | Start one or more stopped containers                                                     |
-| drs     | `docker container restart`    | Restart one or more containers                                                           |
-| dsta    | `docker stop $(docker ps -q)` | Stop all running containers                                                              |
-| dstp    | `docker container stop`       | Stop one or more running containers                                                      |
-| dtop    | `docker top`                  | Display the running processes of a container                                             |
-| dvi     | `docker volume inspect`       | Display detailed information about one or more volumes                                   |
-| dvls    | `docker volume ls`            | List all the volumes known to docker                                                     |
-| dvprune | `docker volume prune`         | Cleanup dangling volumes                                                                 |
-| dxc     | `docker container exec`       | Run a new command in a running container                                                 |
-| dxcit   | `docker container exec -it`   | Run a new command in a running container in an interactive shell                         |
+| Alias                 | Command                       | Description                                                                              |
+| :-------------------- | :---------------------------- | :--------------------------------------------------------------------------------------- |
+| dbl                   | `docker build`                | Build an image from a Dockerfile                                                         |
+| dcin                  | `docker container inspect`    | Display detailed information on one or more containers                                   |
+| dcls                  | `docker container ls`         | List all the running docker containers                                                   |
+| dclsa                 | `docker container ls -a`      | List all running and stopped containers                                                  |
+| dib                   | `docker image build`          | Build an image from a Dockerfile (same as docker build)                                  |
+| dii                   | `docker image inspect`        | Display detailed information on one or more images                                       |
+| dils                  | `docker image ls`             | List docker images                                                                       |
+| dipu                  | `docker image push`           | Push an image or repository to a remote registry                                         |
+| dirm                  | `docker image rm`             | Remove one or more images                                                                |
+| dit                   | `docker image tag`            | Add a name and tag to a particular image                                                 |
+| dlo                   | `docker container logs`       | Fetch the logs of a docker container                                                     |
+| dnc                   | `docker network create`       | Create a new network                                                                     |
+| dncn                  | `docker network connect`      | Connect a container to a network                                                         |
+| dndcn                 | `docker network disconnect`   | Disconnect a container from a network                                                    |
+| dni                   | `docker network inspect`      | Return information about one or more networks                                            |
+| dnls                  | `docker network ls`           | List all networks the engine daemon knows about, including those spanning multiple hosts |
+| dnrm                  | `docker network rm`           | Remove one or more networks                                                              |
+| dpo                   | `docker container port`       | List port mappings or a specific mapping for the container                               |
+| dpu                   | `docker pull`                 | Pull an image or a repository from a registry                                            |
+| dr                    | `docker container run`        | Create a new container and start it using the specified command                          |
+| drit                  | `docker container run -it`    | Create a new container and start it in an interactive shell                              |
+| drm                   | `docker container rm`         | Remove the specified container(s)                                                        |
+| drm!                  | `docker container rm -f`      | Force the removal of a running container (uses SIGKILL)                                  |
+| dst                   | `docker container start`      | Start one or more stopped containers                                                     |
+| drs                   | `docker container restart`    | Restart one or more containers                                                           |
+| dsta                  | `docker stop $(docker ps -q)` | Stop all running containers                                                              |
+| dstp                  | `docker container stop`       | Stop one or more running containers                                                      |
+| dtop                  | `docker top`                  | Display the running processes of a container                                             |
+| dvi                   | `docker volume inspect`       | Display detailed information about one or more volumes                                   |
+| dvls                  | `docker volume ls`            | List all the volumes known to docker                                                     |
+| dvprune               | `docker volume prune`         | Cleanup dangling volumes                                                                 |
+| dxc                   | `docker container exec`       | Run a new command in a running container                                                 |
+| dxcit                 | `docker container exec -it`   | Run a new command in a running container in an interactive shell                         |
+| dsh <containername>   | `docker container exec -it $1 /bin/bash`   | Enter an interactive bash shell by container name                           |

--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -41,39 +41,39 @@ zstyle ':omz:plugins:docker' legacy-completion yes
 
 ## Aliases
 
-| Alias                 | Command                       | Description                                                                              |
-| :-------------------- | :---------------------------- | :--------------------------------------------------------------------------------------- |
-| dbl                   | `docker build`                | Build an image from a Dockerfile                                                         |
-| dcin                  | `docker container inspect`    | Display detailed information on one or more containers                                   |
-| dcls                  | `docker container ls`         | List all the running docker containers                                                   |
-| dclsa                 | `docker container ls -a`      | List all running and stopped containers                                                  |
-| dib                   | `docker image build`          | Build an image from a Dockerfile (same as docker build)                                  |
-| dii                   | `docker image inspect`        | Display detailed information on one or more images                                       |
-| dils                  | `docker image ls`             | List docker images                                                                       |
-| dipu                  | `docker image push`           | Push an image or repository to a remote registry                                         |
-| dirm                  | `docker image rm`             | Remove one or more images                                                                |
-| dit                   | `docker image tag`            | Add a name and tag to a particular image                                                 |
-| dlo                   | `docker container logs`       | Fetch the logs of a docker container                                                     |
-| dnc                   | `docker network create`       | Create a new network                                                                     |
-| dncn                  | `docker network connect`      | Connect a container to a network                                                         |
-| dndcn                 | `docker network disconnect`   | Disconnect a container from a network                                                    |
-| dni                   | `docker network inspect`      | Return information about one or more networks                                            |
-| dnls                  | `docker network ls`           | List all networks the engine daemon knows about, including those spanning multiple hosts |
-| dnrm                  | `docker network rm`           | Remove one or more networks                                                              |
-| dpo                   | `docker container port`       | List port mappings or a specific mapping for the container                               |
-| dpu                   | `docker pull`                 | Pull an image or a repository from a registry                                            |
-| dr                    | `docker container run`        | Create a new container and start it using the specified command                          |
-| drit                  | `docker container run -it`    | Create a new container and start it in an interactive shell                              |
-| drm                   | `docker container rm`         | Remove the specified container(s)                                                        |
-| drm!                  | `docker container rm -f`      | Force the removal of a running container (uses SIGKILL)                                  |
-| dst                   | `docker container start`      | Start one or more stopped containers                                                     |
-| drs                   | `docker container restart`    | Restart one or more containers                                                           |
-| dsta                  | `docker stop $(docker ps -q)` | Stop all running containers                                                              |
-| dstp                  | `docker container stop`       | Stop one or more running containers                                                      |
-| dtop                  | `docker top`                  | Display the running processes of a container                                             |
-| dvi                   | `docker volume inspect`       | Display detailed information about one or more volumes                                   |
-| dvls                  | `docker volume ls`            | List all the volumes known to docker                                                     |
-| dvprune               | `docker volume prune`         | Cleanup dangling volumes                                                                 |
-| dxc                   | `docker container exec`       | Run a new command in a running container                                                 |
-| dxcit                 | `docker container exec -it`   | Run a new command in a running container in an interactive shell                         |
-| dsh <containername>   | `docker container exec -it $1 /bin/bash`   | Enter an interactive bash shell by container name                           |
+| Alias                 | Command                                   | Description                                                                              |
+| :-------------------- | :---------------------------------------- | :--------------------------------------------------------------------------------------- |
+| dbl                   | `docker build`                            | Build an image from a Dockerfile                                                         |
+| dcin                  | `docker container inspect`                | Display detailed information on one or more containers                                   |
+| dcls                  | `docker container ls`                     | List all the running docker containers                                                   |
+| dclsa                 | `docker container ls -a`                  | List all running and stopped containers                                                  |
+| dib                   | `docker image build`                      | Build an image from a Dockerfile (same as docker build)                                  |
+| dii                   | `docker image inspect`                    | Display detailed information on one or more images                                       |
+| dils                  | `docker image ls`                         | List docker images                                                                       |
+| dipu                  | `docker image push`                       | Push an image or repository to a remote registry                                         |
+| dirm                  | `docker image rm`                         | Remove one or more images                                                                |
+| dit                   | `docker image tag`                        | Add a name and tag to a particular image                                                 |
+| dlo                   | `docker container logs`                   | Fetch the logs of a docker container                                                     |
+| dnc                   | `docker network create`                   | Create a new network                                                                     |
+| dncn                  | `docker network connect`                  | Connect a container to a network                                                         |
+| dndcn                 | `docker network disconnect`               | Disconnect a container from a network                                                    |
+| dni                   | `docker network inspect`                  | Return information about one or more networks                                            |
+| dnls                  | `docker network ls`                       | List all networks the engine daemon knows about, including those spanning multiple hosts |
+| dnrm                  | `docker network rm`                       | Remove one or more networks                                                              |
+| dpo                   | `docker container port`                   | List port mappings or a specific mapping for the container                               |
+| dpu                   | `docker pull`                             | Pull an image or a repository from a registry                                            |
+| dr                    | `docker container run`                    | Create a new container and start it using the specified command                          |
+| drit                  | `docker container run -it`                | Create a new container and start it in an interactive shell                              |
+| drm                   | `docker container rm`                     | Remove the specified container(s)                                                        |
+| drm!                  | `docker container rm -f`                  | Force the removal of a running container (uses SIGKILL)                                  |
+| dst                   | `docker container start`                  | Start one or more stopped containers                                                     |
+| drs                   | `docker container restart`                | Restart one or more containers                                                           |
+| dsta                  | `docker stop $(docker ps -q)`             | Stop all running containers                                                              |
+| dstp                  | `docker container stop`                   | Stop one or more running containers                                                      |
+| dtop                  | `docker top`                              | Display the running processes of a container                                             |
+| dvi                   | `docker volume inspect`                   | Display detailed information about one or more volumes                                   |
+| dvls                  | `docker volume ls`                        | List all the volumes known to docker                                                     |
+| dvprune               | `docker volume prune`                     | Cleanup dangling volumes                                                                 |
+| dxc                   | `docker container exec`                   | Run a new command in a running container                                                 |
+| dxcit                 | `docker container exec -it`               | Run a new command in a running container in an interactive shell                         |
+| dsh <containername>   | `docker container exec -it $1 /bin/bash`  | Enter an interactive bash shell by container name                                        |

--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -32,6 +32,8 @@ alias dvprune='docker volume prune'
 alias dxc='docker container exec'
 alias dxcit='docker container exec -it'
 
+function dsh() { docker container exec -it $1 /bin/bash;}
+
 if (( ! $+commands[docker] )); then
   return
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add dsh command to docker plugin

## Other comments:

## Valid use cases

Creating an alias like the `dsh()` function you provided can offer several benefits, especially in scenarios where you frequently work with Docker containers. Here are the pros of using such an alias:

1. **Simplified Access**: The alias simplifies the process of accessing the shell of a specific Docker container. Instead of typing the full `docker exec` command with the container ID or name, you can use a concise and memorable alias (`dsh`) followed by the container name.

2. **Increased Productivity**: The alias saves time and keystrokes, which can enhance productivity, especially when you need to access Docker containers frequently. It streamlines the workflow for developers and system administrators.

3. **Ease of Use**: For users who are not familiar with the intricacies of Docker commands, having an easy-to-use alias abstracts away the complexity. This makes it more accessible to team members who might not be Docker experts.

4. **Consistency**: By using a standardized alias across team members and projects, you establish consistency in your workflow. Everyone can use the same alias, ensuring that the process of accessing Docker containers remains uniform.

5. **Reduced Typographical Errors**: The alias reduces the chance of typographical errors when executing `docker exec` commands manually. This is especially helpful when dealing with long container IDs or complex container names.

6. **Scripting and Automation**: If you have scripts that need to interact with Docker containers, using an alias in your scripts simplifies the code and makes it more readable. This can lead to cleaner, more maintainable automation scripts.

7. **Learning and Teaching**: For educational purposes, having a simplified alias can aid in teaching Docker concepts. It allows learners to focus on the core ideas without getting bogged down by the specific syntax of Docker commands.

8. **Customization**: The alias can be easily modified or extended to include additional functionality, such as running specific commands within the container context. This flexibility allows users to tailor the alias to their specific needs.

In summary, the `dsh()` alias provides a more user-friendly and efficient way to interact with Docker containers, offering simplicity, consistency, and productivity benefits for both individual developers and teams working with Dockerized applications.
