### PR TITLE
feat(tmux): add `tds` alias for directory sessions

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -25,6 +25,7 @@ The plugin also supports the following:
 | `tkss`     | tmux kill-session -t       | Terminate named running tmux session                     |
 | `tmux`     | `_zsh_tmux_plugin_run`     | Start a new tmux session                                 |
 | `tmuxconf` | `$EDITOR $ZSH_TMUX_CONFIG` | Open .tmux.conf file with an editor                      |
+| `td`       | `_tmux_directory_session`  | Creates or attaches to a session for the current path    |
 
 ## Configuration Variables
 

--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -25,7 +25,7 @@ The plugin also supports the following:
 | `tkss`     | tmux kill-session -t       | Terminate named running tmux session                     |
 | `tmux`     | `_zsh_tmux_plugin_run`     | Start a new tmux session                                 |
 | `tmuxconf` | `$EDITOR $ZSH_TMUX_CONFIG` | Open .tmux.conf file with an editor                      |
-| `td`       | `_tmux_directory_session`  | Creates or attaches to a session for the current path    |
+| `tds`      | `_tmux_directory_session`  | Creates or attaches to a session for the current path    |
 
 ## Configuration Variables
 

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -108,6 +108,19 @@ compdef _tmux _zsh_tmux_plugin_run
 # Alias tmux to our wrapper function.
 alias tmux=_zsh_tmux_plugin_run
 
+function _tmux_directory_session() {
+  # current directory without leading path
+  local dir=${PWD##*/}
+  # md5 hash for the full working directory path
+  local md5=$(printf '%s' "$PWD" | md5sum | cut -d  ' ' -f 1)
+  # human friendly unique session name for this directory
+  local session_name="${dir}-${md5:0:6}"
+  # create or attach to the session
+  tmux new -As "$session_name"
+}
+
+alias td=_tmux_directory_session
+
 # Autostart if not already in tmux and enabled.
 if [[ -z "$TMUX" && "$ZSH_TMUX_AUTOSTART" == "true" && -z "$INSIDE_EMACS" && -z "$EMACS" && -z "$VIM" && -z "$INTELLIJ_ENVIRONMENT_READER" ]]; then
   # Actually don't autostart if we already did and multiple autostarts are disabled.

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -119,7 +119,7 @@ function _tmux_directory_session() {
   tmux new -As "$session_name"
 }
 
-alias td=_tmux_directory_session
+alias tds=_tmux_directory_session
 
 # Autostart if not already in tmux and enabled.
 if [[ -z "$TMUX" && "$ZSH_TMUX_AUTOSTART" == "true" && -z "$INSIDE_EMACS" && -z "$EMACS" && -z "$VIM" && -z "$INTELLIJ_ENVIRONMENT_READER" ]]; then


### PR DESCRIPTION
The `td` alias will create or attach to a tmux session named for the current working directory.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Created the `td` alias, and the associated `_tmux_directory_session` function that handles the fiddly bits.
- Added documentation to the plugin README

## Other comments:

The use case is when I'm working across several sessions. My tmux sessions are almost always scoped to whatever directory / repo I'm working out of, and doing the `tmux ls` and `tmux -a` dance to determine if I already have a session set up for a project is cumbersome and repetitive. Now I just go into a directory and `td` and it just works. 