### PR TITLE
fix(git): move squash-merged branch deletion from `gbda` to `gbds` function

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -250,7 +250,8 @@ receive further support.
 | `git_develop_branch`     | Returns the name of the “development” branch: `dev`, `devel`, `development` if they exist, `develop` otherwise. |
 | `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise.                                   |
 | `grename <old> <new>`    | Renames branch `<old>` to `<new>`, including on the origin remote.                                              |
-| `gbda`                   | Deletes all merged and squash-merged branches                                                                   |
+| `gbda`                   | Deletes all merged branches                                                                   |
+| `gbds`                   | Deletes all squash-merged branches (**Note: performance degrades with number of branches**)                     |
 
 ### Work in Progress (WIP)
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -128,11 +128,13 @@ alias gba='git branch --all'
 alias gbd='git branch --delete'
 alias gbD='git branch --delete --force'
 
-# Copied and modified from James Roeder (jmaroeder) under MIT License
-# https://github.com/jmaroeder/plugin-git/blob/216723ef4f9e8dde399661c39c80bdf73f4076c4/functions/gbda.fish
 function gbda() {
   git branch --no-color --merged | command grep -vE "^([+*]|\s*($(git_main_branch)|$(git_develop_branch))\s*$)" | command xargs git branch --delete 2>/dev/null
+}
 
+# Copied and modified from James Roeder (jmaroeder) under MIT License
+# https://github.com/jmaroeder/plugin-git/blob/216723ef4f9e8dde399661c39c80bdf73f4076c4/functions/gbda.fish
+function gbds() {
   local default_branch=$(git_main_branch)
   (( ! $? )) || default_branch=$(git_develop_branch)
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Move deletion of squash-merged branches into its own function
- This is a slow operation (#11985) and can't be fixed apparently

See https://github.com/ohmyzsh/ohmyzsh/issues/11985#issuecomment-1769049733

Fixes #11985