### PR TITLE
Check if cmd is available in current lando dir.

### DIFF
--- a/plugins/lando/lando.plugin.zsh
+++ b/plugins/lando/lando.plugin.zsh
@@ -11,7 +11,7 @@ function artisan \
          php \
          wp \
          yarn {
-  if checkForLandoFile; then
+  if [ checkForLandoFile ] && [ lando "$0" > /dev/null 2>&1 ]; then
     lando "$0" "$@"
   else
     command "$0" "$@"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added a check before executing the command within lando to see if the command exists in lando.

## Other comments:

The initial issue was the command would always execute inside the Lando container(s), even if it didn't exist. Example: running `npm` would execute `lando npm` when I didn't have Node installed in that lando container(s).

I'm not super familiar with shell scripting, so if there is a better way for this conditional, please let me know. 😄 
