### PR TITLE
fix(firewalld): remove ` (default)` from the end of zone string

### DIFF
--- a/plugins/firewalld/firewalld.plugin.zsh
+++ b/plugins/firewalld/firewalld.plugin.zsh
@@ -9,7 +9,7 @@ function fwl () {
   zones=("${(@f)$(sudo firewall-cmd --get-active-zones | grep -v 'interfaces\|sources')}")
 
   for i in $zones; do
-    sudo firewall-cmd --zone $i --list-all
+    sudo firewall-cmd --zone ${i/ \(default\)} --list-all
   done
 
   echo 'Direct Rules:'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- fix `Error: INVALID_ZONE: public (default)` when using `fwl` with `firewall-cmd` version `2.0.1`

## Other comments:

In `firewall-cmd` version `2.0.1`, command `firewall-cmd --get-active-zones` output like this.

```
public (default)
  interfaces: wlp0s20f3
trusted
  sources: 127.0.0.1
```

Just remove ` (default)` from the end of zone string. This fix won't affect any zone string without ` (default)`.