### PR TITLE
fix: Use "hook" instead of "export" in `direnv` plugin

### DIFF
--- a/plugins/direnv/direnv.plugin.zsh
+++ b/plugins/direnv/direnv.plugin.zsh
@@ -3,7 +3,7 @@ command -v direnv &>/dev/null || return
 
 _direnv_hook() {
   trap -- '' SIGINT;
-  eval "$(direnv export zsh)";
+  eval "$(direnv hook zsh)";
   trap - SIGINT;
 }
 typeset -ag precmd_functions;


### PR DESCRIPTION
Based on here:
https://github.com/direnv/direnv/blob/master/docs/hook.md#zsh

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fix `direnv` plugin hook installation
