### PR TITLE
feat(git-auto-fetch): fetch also submodules

### DIFF
--- a/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
+++ b/plugins/git-auto-fetch/git-auto-fetch.plugin.zsh
@@ -29,7 +29,7 @@ function git-fetch-all {
     date -R &>! "$gitdir/FETCH_LOG"
     GIT_SSH_COMMAND="command ssh -o BatchMode=yes" \
     GIT_TERMINAL_PROMPT=0 \
-      command git fetch --all 2>/dev/null &>> "$gitdir/FETCH_LOG"
+      command git fetch --all --recurse-submodules=yes 2>/dev/null &>> "$gitdir/FETCH_LOG"
   ) &|
 }
 


### PR DESCRIPTION
This PR enhances the git-auto-fetch plugin to support recursive fetching of submodules in a monorepo setup, without affecting its behavior in regular repositories.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Enabled recursive submodule fetching in git-auto-fetch script.
