### PR TITLE
feat(npm): add alias for `npm run build`

### DIFF
--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -30,6 +30,7 @@ plugins=(... npm)
 | `npmi`  | `npm info`                   | Run npm info                                                    |
 | `npmSe` | `npm search`                 | Run npm search                                                  |
 | `npmrd` | `npm run dev`                | Run npm run dev                                                 |
+| `npmrb` | `npm run build`              | Run npm run build                                               |
 
 ## `npm install` / `npm uninstall` toggle
 

--- a/plugins/npm/npm.plugin.zsh
+++ b/plugins/npm/npm.plugin.zsh
@@ -73,6 +73,9 @@ alias npmSe="npm search"
 # Run npm run dev
 alias npmrd="npm run dev"
 
+# Run npm run build
+alias npmrb="npm run build"
+
 npm_toggle_install_uninstall() {
   # Look up to the previous 2 history commands
   local line


### PR DESCRIPTION
This is my first ever attempt at open source contribution, and it is intended for the HacktoberFest. (although I only added 2 lines, I'm not sure if it qualifies) Anyway, enjoy your alias!

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- added requested alias for `npm run build` as `npmrb`

## Other comments:

I did not test this. (I am not sure how to test a different branch of zsh)
