### PR TITLE
fix(wd): use `(( ))` instead of `[[ ]]`

### DIFF
--- a/plugins/wd/wd.sh
+++ b/plugins/wd/wd.sh
@@ -396,7 +396,7 @@ fi
 # disable extendedglob for the complete wd execution time
 setopt | grep -q extendedglob
 wd_extglob_is_set=$?
-[[ $wd_extglob_is_set ]] && setopt noextendedglob
+(( ! $wd_extglob_is_set )) && setopt noextendedglob
 
 # load warp points
 typeset -A points
@@ -484,7 +484,7 @@ fi
 # if not, next time warp will pick up variables from this run
 # remember, there's no sub shell
 
-[[ $wd_extglob_is_set ]] && setopt extendedglob
+(( ! $wd_extglob_is_set )) && setopt extendedglob
 
 unset wd_extglob_is_set
 unset wd_warp


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

zsh versions prior to 5.0.6 mark `[[ <num> ]]` as invalid syntax

Closes #12017 