### PR TITLE
feat(vi-mode): add option to disable clipboard

### DIFF
--- a/plugins/vi-mode/README.md
+++ b/plugins/vi-mode/README.md
@@ -37,6 +37,8 @@ plugins=(... vi-mode)
 - `INSERT_MODE_INDICATOR`: controls the string displayed when the shell is in insert mode.
   See [Mode indicators](#mode-indicators) for details.
 
+- `VI_MODE_DISABLE_CLIPBOARD`: If set, disables clipboard integration on yank/paste
+
 ## Mode indicators
 
 *Normal mode* is indicated with a red `<<<` mark at the right prompt, when it

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -147,17 +147,19 @@ function wrap_clipboard_widgets() {
   done
 }
 
-wrap_clipboard_widgets copy \
-    vi-yank vi-yank-eol vi-yank-whole-line \
-    vi-change vi-change-eol vi-change-whole-line \
-    vi-kill-line vi-kill-eol vi-backward-kill-word \
-    vi-delete vi-delete-char vi-backward-delete-char
+if [[ -z "${VI_MODE_DISABLE_CLIPBOARD:-}" ]]; then
+  wrap_clipboard_widgets copy \
+      vi-yank vi-yank-eol vi-yank-whole-line \
+      vi-change vi-change-eol vi-change-whole-line \
+      vi-kill-line vi-kill-eol vi-backward-kill-word \
+      vi-delete vi-delete-char vi-backward-delete-char
 
-wrap_clipboard_widgets paste \
-    vi-put-{before,after} \
-    put-replace-selection
+  wrap_clipboard_widgets paste \
+      vi-put-{before,after} \
+      put-replace-selection
 
-unfunction wrap_clipboard_widgets
+  unfunction wrap_clipboard_widgets
+fi
 
 # if mode indicator wasn't setup by theme, define default, we'll leave INSERT_MODE_INDICATOR empty by default
 if [[ -z "$MODE_INDICATOR" ]]; then


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds a flag to disable clipboard functionality on yank/paste, thus restoring workflow as before.

## Other comments:

PR #11861 enabled clipboard integration when utilizing yank/paste in vi-mode, but that broke by workflow.  This change adds a flag to disable the newly added functionality, thus restoring workflow as before.

If the environment variable `VI_MODE_DISABLE_CLIPBOARD` is set the newly added functionality is not run.
