### PR TITLE
fix(direnv): unbreak and simplify direnv support

### DIFF
--- a/plugins/direnv/direnv.plugin.zsh
+++ b/plugins/direnv/direnv.plugin.zsh
@@ -1,16 +1,5 @@
 # Don't continue if direnv is not found
 command -v direnv &>/dev/null || return
 
-_direnv_hook() {
-  trap -- '' SIGINT;
-  eval "$(direnv hook zsh)";
-  trap - SIGINT;
-}
-typeset -ag precmd_functions;
-if [[ -z ${precmd_functions[(r)_direnv_hook]} ]]; then
-  precmd_functions=( _direnv_hook ${precmd_functions[@]} )
-fi
-typeset -ag chpwd_functions;
-if [[ -z ${chpwd_functions[(r)_direnv_hook]} ]]; then
-  chpwd_functions=( _direnv_hook ${chpwd_functions[@]} )
-fi
+eval "$(direnv hook zsh)"
+


### PR DESCRIPTION
To install direnv in zsh, one should `eval "$(direnv hook zsh)"`. Previously, ohmyzsh included the code generated by direnv hook, which included a `direnv export zsh` call that PR #12000 erroneously replaced: `direnv hook` at that place was correct. Now, direnv is only being initialized after the first command executed and doesn't work for the first command issued after the shell has started.

This commit simplifies and fixes the code by just using the recommended official way to install `direnv` in zsh:

https://github.com/direnv/direnv/blob/master/docs/hook.md#zsh

The result is about the same as with the working version before, but with less code and automatically receiving updates to direnv's zsh integration.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
