### PR TITLE
feat(swiftpm): update completion for Swift 5.9

### DIFF
--- a/plugins/swiftpm/README.md
+++ b/plugins/swiftpm/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This plugin provides a few utilities that make you faster on your daily work with the [Swift Package Manager](https://github.com/apple/swift-package-manager), as well as autocompletion for Swift 5.7.
+This plugin provides a few utilities that make you faster on your daily work with the [Swift Package Manager](https://github.com/apple/swift-package-manager), as well as autocompletion for Swift 5.9.
 
 To start using it, add the `swiftpm` plugin to your `plugins` array in `~/.zshrc`:
 

--- a/plugins/swiftpm/_swift
+++ b/plugins/swiftpm/_swift
@@ -57,6 +57,8 @@ _swift_run() {
         '--config-path[Specify the shared configuration directory path]:config-path:_files -/'
         '--security-path[Specify the shared security directory path]:security-path:_files -/'
         '--scratch-path[Specify a custom scratch directory path (default .build)]:scratch-path:_files -/'
+        '--pkg-config-path[Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
+        specify more than one path.]:pkg-config-path:_files -/'
         '--enable-dependency-cache[Use a shared cache when fetching dependencies]'
         '--disable-dependency-cache[Use a shared cache when fetching dependencies]'
         '--enable-build-manifest-caching'
@@ -64,13 +66,18 @@ _swift_run() {
         '--manifest-cache[Caching mode of Package.swift manifests (shared: shared cache, local: package'"'"'s build directory, none: disabled]:manifest-cache:'
         '(--verbose -v)'{--verbose,-v}'[Increase verbosity to include informational output]'
         '(--very-verbose --vv)'{--very-verbose,--vv}'[Increase verbosity to include debug output]'
+        '(--quiet -q)'{--quiet,-q}'[Decrease verbosity to only include error output.]'
         '--disable-sandbox[Disable using the sandbox when executing subprocesses]'
-        '--enable-netrc[Load credentials from a .netrc file]'
-        '--disable-netrc[Load credentials from a .netrc file]'
-        '--netrc-file[Specify the .netrc file path.]:netrc-file:_files'
+        '--netrc[Use netrc file even in cases where other credential stores are preferred]'
+        '--enable-netrc[Load credentials from a netrc file]'
+        '--disable-netrc[Load credentials from a netrc file]'
+        '--netrc-file[Specify the netrc file path]:netrc-file:_files'
         '--enable-keychain[Search credentials in macOS keychain]'
         '--disable-keychain[Search credentials in macOS keychain]'
         '--resolver-fingerprint-checking:resolver-fingerprint-checking:'
+        '--resolver-signing-entity-checking:resolver-signing-entity-checking:'
+        '--enable-signature-validation[Validate signature of a signed package release downloaded from registry]'
+        '--disable-signature-validation[Validate signature of a signed package release downloaded from registry]'
         '--enable-prefetching'
         '--disable-prefetching'
         '(--force-resolved-versions --disable-automatic-resolution --only-use-versions-from-resolved-file)'{--force-resolved-versions,--disable-automatic-resolution,--only-use-versions-from-resolved-file}'[Only use versions from the Package.resolved file and fail resolution if it is out-of-date]'
@@ -78,6 +85,7 @@ _swift_run() {
         '--disable-scm-to-registry-transformation[disable source control to registry transformation]'
         '--use-registry-identity-for-scm[look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins]'
         '--replace-scm-with-registry[look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible]'
+        '--default-registry-url[Default registry URL to use, instead of the registries.json configuration file]:default-registry-url:'
         '(--configuration -c)'{--configuration,-c}'[Build with configuration]:configuration:(debug release)'
         '-Xcc[Pass flag through to all C compiler invocations]:Xcc:'
         '-Xswiftc[Pass flag through to all Swift compiler invocations]:Xswiftc:'
@@ -86,7 +94,7 @@ _swift_run() {
         '--triple:triple:'
         '--sdk:sdk:_files -/'
         '--toolchain:toolchain:_files -/'
-        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:'
+        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:(address thread undefined scudo)'
         '--auto-index-store[Enable or disable indexing-while-building feature]'
         '--enable-index-store[Enable or disable indexing-while-building feature]'
         '--disable-index-store[Enable or disable indexing-while-building feature]'
@@ -94,8 +102,8 @@ _swift_run() {
         '(--jobs -j)'{--jobs,-j}'[The number of jobs to spawn in parallel during the build process]:jobs:'
         '--emit-swift-module-separately'
         '--use-integrated-swift-driver'
+        '--explicit-target-dependency-import-check:explicit-target-dependency-import-check:'
         '--experimental-explicit-module-build'
-        '--print-manifest-job-graph[Write the command graph for the build manifest as a graphviz file]'
         '--build-system:build-system:(native xcode)'
         '--enable-dead-strip[Disable/enable dead code stripping by the linker]'
         '--disable-dead-strip[Disable/enable dead code stripping by the linker]'
@@ -125,6 +133,8 @@ _swift_build() {
         '--config-path[Specify the shared configuration directory path]:config-path:_files -/'
         '--security-path[Specify the shared security directory path]:security-path:_files -/'
         '--scratch-path[Specify a custom scratch directory path (default .build)]:scratch-path:_files -/'
+        '--pkg-config-path[Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
+        specify more than one path.]:pkg-config-path:_files -/'
         '--enable-dependency-cache[Use a shared cache when fetching dependencies]'
         '--disable-dependency-cache[Use a shared cache when fetching dependencies]'
         '--enable-build-manifest-caching'
@@ -132,13 +142,18 @@ _swift_build() {
         '--manifest-cache[Caching mode of Package.swift manifests (shared: shared cache, local: package'"'"'s build directory, none: disabled]:manifest-cache:'
         '(--verbose -v)'{--verbose,-v}'[Increase verbosity to include informational output]'
         '(--very-verbose --vv)'{--very-verbose,--vv}'[Increase verbosity to include debug output]'
+        '(--quiet -q)'{--quiet,-q}'[Decrease verbosity to only include error output.]'
         '--disable-sandbox[Disable using the sandbox when executing subprocesses]'
-        '--enable-netrc[Load credentials from a .netrc file]'
-        '--disable-netrc[Load credentials from a .netrc file]'
-        '--netrc-file[Specify the .netrc file path.]:netrc-file:_files'
+        '--netrc[Use netrc file even in cases where other credential stores are preferred]'
+        '--enable-netrc[Load credentials from a netrc file]'
+        '--disable-netrc[Load credentials from a netrc file]'
+        '--netrc-file[Specify the netrc file path]:netrc-file:_files'
         '--enable-keychain[Search credentials in macOS keychain]'
         '--disable-keychain[Search credentials in macOS keychain]'
         '--resolver-fingerprint-checking:resolver-fingerprint-checking:'
+        '--resolver-signing-entity-checking:resolver-signing-entity-checking:'
+        '--enable-signature-validation[Validate signature of a signed package release downloaded from registry]'
+        '--disable-signature-validation[Validate signature of a signed package release downloaded from registry]'
         '--enable-prefetching'
         '--disable-prefetching'
         '(--force-resolved-versions --disable-automatic-resolution --only-use-versions-from-resolved-file)'{--force-resolved-versions,--disable-automatic-resolution,--only-use-versions-from-resolved-file}'[Only use versions from the Package.resolved file and fail resolution if it is out-of-date]'
@@ -146,6 +161,7 @@ _swift_build() {
         '--disable-scm-to-registry-transformation[disable source control to registry transformation]'
         '--use-registry-identity-for-scm[look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins]'
         '--replace-scm-with-registry[look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible]'
+        '--default-registry-url[Default registry URL to use, instead of the registries.json configuration file]:default-registry-url:'
         '(--configuration -c)'{--configuration,-c}'[Build with configuration]:configuration:(debug release)'
         '-Xcc[Pass flag through to all C compiler invocations]:Xcc:'
         '-Xswiftc[Pass flag through to all Swift compiler invocations]:Xswiftc:'
@@ -154,7 +170,7 @@ _swift_build() {
         '--triple:triple:'
         '--sdk:sdk:_files -/'
         '--toolchain:toolchain:_files -/'
-        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:'
+        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:(address thread undefined scudo)'
         '--auto-index-store[Enable or disable indexing-while-building feature]'
         '--enable-index-store[Enable or disable indexing-while-building feature]'
         '--disable-index-store[Enable or disable indexing-while-building feature]'
@@ -162,8 +178,8 @@ _swift_build() {
         '(--jobs -j)'{--jobs,-j}'[The number of jobs to spawn in parallel during the build process]:jobs:'
         '--emit-swift-module-separately'
         '--use-integrated-swift-driver'
+        '--explicit-target-dependency-import-check:explicit-target-dependency-import-check:'
         '--experimental-explicit-module-build'
-        '--print-manifest-job-graph[Write the command graph for the build manifest as a graphviz file]'
         '--build-system:build-system:(native xcode)'
         '--enable-dead-strip[Disable/enable dead code stripping by the linker]'
         '--disable-dead-strip[Disable/enable dead code stripping by the linker]'
@@ -171,6 +187,7 @@ _swift_build() {
         '--no-static-swift-stdlib[Link Swift stdlib statically]'
         '--build-tests[Build both source and test targets]'
         '--show-bin-path[Print the binary output path]'
+        '--print-manifest-job-graph[Write the command graph for the build manifest as a graphviz file]'
         '--target[Build the specified target]:target:'
         '--product[Build the specified product]:product:'
         '--version[Show the version.]'
@@ -190,6 +207,8 @@ _swift_test() {
         '--config-path[Specify the shared configuration directory path]:config-path:_files -/'
         '--security-path[Specify the shared security directory path]:security-path:_files -/'
         '--scratch-path[Specify a custom scratch directory path (default .build)]:scratch-path:_files -/'
+        '--pkg-config-path[Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
+        specify more than one path.]:pkg-config-path:_files -/'
         '--enable-dependency-cache[Use a shared cache when fetching dependencies]'
         '--disable-dependency-cache[Use a shared cache when fetching dependencies]'
         '--enable-build-manifest-caching'
@@ -197,13 +216,18 @@ _swift_test() {
         '--manifest-cache[Caching mode of Package.swift manifests (shared: shared cache, local: package'"'"'s build directory, none: disabled]:manifest-cache:'
         '(--verbose -v)'{--verbose,-v}'[Increase verbosity to include informational output]'
         '(--very-verbose --vv)'{--very-verbose,--vv}'[Increase verbosity to include debug output]'
+        '(--quiet -q)'{--quiet,-q}'[Decrease verbosity to only include error output.]'
         '--disable-sandbox[Disable using the sandbox when executing subprocesses]'
-        '--enable-netrc[Load credentials from a .netrc file]'
-        '--disable-netrc[Load credentials from a .netrc file]'
-        '--netrc-file[Specify the .netrc file path.]:netrc-file:_files'
+        '--netrc[Use netrc file even in cases where other credential stores are preferred]'
+        '--enable-netrc[Load credentials from a netrc file]'
+        '--disable-netrc[Load credentials from a netrc file]'
+        '--netrc-file[Specify the netrc file path]:netrc-file:_files'
         '--enable-keychain[Search credentials in macOS keychain]'
         '--disable-keychain[Search credentials in macOS keychain]'
         '--resolver-fingerprint-checking:resolver-fingerprint-checking:'
+        '--resolver-signing-entity-checking:resolver-signing-entity-checking:'
+        '--enable-signature-validation[Validate signature of a signed package release downloaded from registry]'
+        '--disable-signature-validation[Validate signature of a signed package release downloaded from registry]'
         '--enable-prefetching'
         '--disable-prefetching'
         '(--force-resolved-versions --disable-automatic-resolution --only-use-versions-from-resolved-file)'{--force-resolved-versions,--disable-automatic-resolution,--only-use-versions-from-resolved-file}'[Only use versions from the Package.resolved file and fail resolution if it is out-of-date]'
@@ -211,6 +235,7 @@ _swift_test() {
         '--disable-scm-to-registry-transformation[disable source control to registry transformation]'
         '--use-registry-identity-for-scm[look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins]'
         '--replace-scm-with-registry[look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible]'
+        '--default-registry-url[Default registry URL to use, instead of the registries.json configuration file]:default-registry-url:'
         '(--configuration -c)'{--configuration,-c}'[Build with configuration]:configuration:(debug release)'
         '-Xcc[Pass flag through to all C compiler invocations]:Xcc:'
         '-Xswiftc[Pass flag through to all Swift compiler invocations]:Xswiftc:'
@@ -219,7 +244,7 @@ _swift_test() {
         '--triple:triple:'
         '--sdk:sdk:_files -/'
         '--toolchain:toolchain:_files -/'
-        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:'
+        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:(address thread undefined scudo)'
         '--auto-index-store[Enable or disable indexing-while-building feature]'
         '--enable-index-store[Enable or disable indexing-while-building feature]'
         '--disable-index-store[Enable or disable indexing-while-building feature]'
@@ -227,27 +252,75 @@ _swift_test() {
         '(--jobs -j)'{--jobs,-j}'[The number of jobs to spawn in parallel during the build process]:jobs:'
         '--emit-swift-module-separately'
         '--use-integrated-swift-driver'
+        '--explicit-target-dependency-import-check:explicit-target-dependency-import-check:'
         '--experimental-explicit-module-build'
-        '--print-manifest-job-graph[Write the command graph for the build manifest as a graphviz file]'
         '--build-system:build-system:(native xcode)'
         '--enable-dead-strip[Disable/enable dead code stripping by the linker]'
         '--disable-dead-strip[Disable/enable dead code stripping by the linker]'
         '--static-swift-stdlib[Link Swift stdlib statically]'
         '--no-static-swift-stdlib[Link Swift stdlib statically]'
         '--skip-build[Skip building the test target]'
+        '--test-product[Test the specified product.]:test-product:'
         '--parallel[Run the tests in parallel.]'
         '--num-workers[Number of tests to execute in parallel.]:num-workers:'
         '(--list-tests -l)'{--list-tests,-l}'[Lists test methods in specifier format]'
-        '--show-codecov-path[Print the path of the exported code coverage JSON file]'
+        '(--show-codecov-path --show-code-coverage-path --show-coverage-path)'{--show-codecov-path,--show-code-coverage-path,--show-coverage-path}'[Print the path of the exported code coverage JSON file]'
         '(-s --specifier)'{-s,--specifier}':specifier:'
         '--filter[Run test cases matching regular expression, Format: <test-target>.<test-case> or <test-target>.<test-case>/<test>]:filter:'
         '--skip[Skip test cases matching regular expression, Example: --skip PerformanceTests]:skip:'
         '--xunit-output[Path where the xUnit xml file should be generated.]:xunit-output:_files -/'
-        '--test-product[Test the specified product.]:test-product:'
         '--enable-testable-imports[Enable or disable testable imports. Enabled by default.]'
         '--disable-testable-imports[Enable or disable testable imports. Enabled by default.]'
         '--enable-code-coverage[Enable code coverage]'
         '--disable-code-coverage[Enable code coverage]'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+        '(-): :->command'
+        '(-)*:: :->arg'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+    case $state in
+        (command)
+            local subcommands
+            subcommands=(
+                'list:Lists test methods in specifier format'
+                'generate-linuxmain:Generate LinuxMain.swift (deprecated)'
+            )
+            _describe "subcommand" subcommands
+            ;;
+        (arg)
+            case ${words[1]} in
+                (list)
+                    _swift_test_list
+                    ;;
+                (generate-linuxmain)
+                    _swift_test_generate-linuxmain
+                    ;;
+            esac
+            ;;
+    esac
+
+    return ret
+}
+
+_swift_test_list() {
+    integer ret=1
+    local -a args
+    args+=(
+        '--skip-build[Skip building the test target]'
+        '--test-product[Test the specified product.]:test-product:'
+        '--version[Show the version.]'
+        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
+    )
+    _arguments -w -s -S $args[@] && ret=0
+
+    return ret
+}
+
+_swift_test_generate-linuxmain() {
+    integer ret=1
+    local -a args
+    args+=(
         '--version[Show the version.]'
         '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
@@ -265,6 +338,8 @@ _swift_package() {
         '--config-path[Specify the shared configuration directory path]:config-path:_files -/'
         '--security-path[Specify the shared security directory path]:security-path:_files -/'
         '--scratch-path[Specify a custom scratch directory path (default .build)]:scratch-path:_files -/'
+        '--pkg-config-path[Specify alternative path to search for pkg-config `.pc` files. Use the option multiple times to
+        specify more than one path.]:pkg-config-path:_files -/'
         '--enable-dependency-cache[Use a shared cache when fetching dependencies]'
         '--disable-dependency-cache[Use a shared cache when fetching dependencies]'
         '--enable-build-manifest-caching'
@@ -272,13 +347,18 @@ _swift_package() {
         '--manifest-cache[Caching mode of Package.swift manifests (shared: shared cache, local: package'"'"'s build directory, none: disabled]:manifest-cache:'
         '(--verbose -v)'{--verbose,-v}'[Increase verbosity to include informational output]'
         '(--very-verbose --vv)'{--very-verbose,--vv}'[Increase verbosity to include debug output]'
+        '(--quiet -q)'{--quiet,-q}'[Decrease verbosity to only include error output.]'
         '--disable-sandbox[Disable using the sandbox when executing subprocesses]'
-        '--enable-netrc[Load credentials from a .netrc file]'
-        '--disable-netrc[Load credentials from a .netrc file]'
-        '--netrc-file[Specify the .netrc file path.]:netrc-file:_files'
+        '--netrc[Use netrc file even in cases where other credential stores are preferred]'
+        '--enable-netrc[Load credentials from a netrc file]'
+        '--disable-netrc[Load credentials from a netrc file]'
+        '--netrc-file[Specify the netrc file path]:netrc-file:_files'
         '--enable-keychain[Search credentials in macOS keychain]'
         '--disable-keychain[Search credentials in macOS keychain]'
         '--resolver-fingerprint-checking:resolver-fingerprint-checking:'
+        '--resolver-signing-entity-checking:resolver-signing-entity-checking:'
+        '--enable-signature-validation[Validate signature of a signed package release downloaded from registry]'
+        '--disable-signature-validation[Validate signature of a signed package release downloaded from registry]'
         '--enable-prefetching'
         '--disable-prefetching'
         '(--force-resolved-versions --disable-automatic-resolution --only-use-versions-from-resolved-file)'{--force-resolved-versions,--disable-automatic-resolution,--only-use-versions-from-resolved-file}'[Only use versions from the Package.resolved file and fail resolution if it is out-of-date]'
@@ -286,6 +366,7 @@ _swift_package() {
         '--disable-scm-to-registry-transformation[disable source control to registry transformation]'
         '--use-registry-identity-for-scm[look up source control dependencies in the registry and use their registry identity when possible to help deduplicate across the two origins]'
         '--replace-scm-with-registry[look up source control dependencies in the registry and use the registry to retrieve them instead of source control when possible]'
+        '--default-registry-url[Default registry URL to use, instead of the registries.json configuration file]:default-registry-url:'
         '(--configuration -c)'{--configuration,-c}'[Build with configuration]:configuration:(debug release)'
         '-Xcc[Pass flag through to all C compiler invocations]:Xcc:'
         '-Xswiftc[Pass flag through to all Swift compiler invocations]:Xswiftc:'
@@ -294,7 +375,7 @@ _swift_package() {
         '--triple:triple:'
         '--sdk:sdk:_files -/'
         '--toolchain:toolchain:_files -/'
-        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:'
+        '--sanitize[Turn on runtime checks for erroneous behavior, possible values: address, thread, undefined, scudo]:sanitize:(address thread undefined scudo)'
         '--auto-index-store[Enable or disable indexing-while-building feature]'
         '--enable-index-store[Enable or disable indexing-while-building feature]'
         '--disable-index-store[Enable or disable indexing-while-building feature]'
@@ -302,8 +383,8 @@ _swift_package() {
         '(--jobs -j)'{--jobs,-j}'[The number of jobs to spawn in parallel during the build process]:jobs:'
         '--emit-swift-module-separately'
         '--use-integrated-swift-driver'
+        '--explicit-target-dependency-import-check:explicit-target-dependency-import-check:'
         '--experimental-explicit-module-build'
-        '--print-manifest-job-graph[Write the command graph for the build manifest as a graphviz file]'
         '--build-system:build-system:(native xcode)'
         '--enable-dead-strip[Disable/enable dead code stripping by the linker]'
         '--disable-dead-strip[Disable/enable dead code stripping by the linker]'
@@ -325,25 +406,19 @@ _swift_package() {
                 'update:Update package dependencies'
                 'describe:Describe the current package'
                 'init:Initialize a new package'
-                '_format:'
                 'diagnose-api-breaking-changes:Diagnose API-breaking changes to Swift modules in a package'
-                'experimental-api-diff:Deprecated - use `swift package diagnose-api-breaking-changes` instead'
                 'dump-symbol-graph:Dump Symbol Graph'
-                'dump-pif:'
                 'dump-package:Print parsed Package.swift as JSON'
                 'edit:Put a package in editable mode'
                 'unedit:Remove a package from editable mode'
                 'config:Manipulate configuration of the package'
                 'resolve:Resolve package dependencies'
-                'fetch:'
                 'show-dependencies:Print the resolved dependency graph'
                 'tools-version:Manipulate tools version of the current package'
-                'generate-xcodeproj:Generates an Xcode project. This command will be deprecated soon.'
                 'compute-checksum:Compute the checksum for a binary artifact.'
                 'archive-source:Create a source archive for the package'
                 'completion-tool:Completion tool (for shell completions)'
                 'plugin:Invoke a command plugin or perform other actions on command plugins'
-                'default-command:'
             )
             _describe "subcommand" subcommands
             ;;
@@ -367,20 +442,11 @@ _swift_package() {
                 (init)
                     _swift_package_init
                     ;;
-                (_format)
-                    _swift_package__format
-                    ;;
                 (diagnose-api-breaking-changes)
                     _swift_package_diagnose-api-breaking-changes
                     ;;
-                (experimental-api-diff)
-                    _swift_package_experimental-api-diff
-                    ;;
                 (dump-symbol-graph)
                     _swift_package_dump-symbol-graph
-                    ;;
-                (dump-pif)
-                    _swift_package_dump-pif
                     ;;
                 (dump-package)
                     _swift_package_dump-package
@@ -397,17 +463,11 @@ _swift_package() {
                 (resolve)
                     _swift_package_resolve
                     ;;
-                (fetch)
-                    _swift_package_fetch
-                    ;;
                 (show-dependencies)
                     _swift_package_show-dependencies
                     ;;
                 (tools-version)
                     _swift_package_tools-version
-                    ;;
-                (generate-xcodeproj)
-                    _swift_package_generate-xcodeproj
                     ;;
                 (compute-checksum)
                     _swift_package_compute-checksum
@@ -420,9 +480,6 @@ _swift_package() {
                     ;;
                 (plugin)
                     _swift_package_plugin
-                    ;;
-                (default-command)
-                    _swift_package_default-command
                     ;;
             esac
             ;;
@@ -498,21 +555,8 @@ _swift_package_init() {
     integer ret=1
     local -a args
     args+=(
-        '--type[Package type: empty | library | executable | system-module | manifest]:type:'
+        '--type[Package type:]:type:'
         '--name[Provide custom package name]:name:'
-        '--version[Show the version.]'
-        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
-    )
-    _arguments -w -s -S $args[@] && ret=0
-
-    return ret
-}
-
-_swift_package__format() {
-    integer ret=1
-    local -a args
-    args+=(
-        ':swift-format-flags:'
         '--version[Show the version.]'
         '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
@@ -539,19 +583,6 @@ _swift_package_diagnose-api-breaking-changes() {
     return ret
 }
 
-_swift_package_experimental-api-diff() {
-    integer ret=1
-    local -a args
-    args+=(
-        ':args:'
-        '--version[Show the version.]'
-        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
-    )
-    _arguments -w -s -S $args[@] && ret=0
-
-    return ret
-}
-
 _swift_package_dump-symbol-graph() {
     integer ret=1
     local -a args
@@ -561,19 +592,8 @@ _swift_package_dump-symbol-graph() {
         '--minimum-access-level[Include symbols with this access level or more. Possible values: private | fileprivate | internal | public | open]:minimum-access-level:(private fileprivate internal public open)'
         '--skip-inherited-docs[Skip emitting doc comments for members inherited through classes or default implementations.]'
         '--include-spi-symbols[Add symbols with SPI information to the symbol graph.]'
-        '--version[Show the version.]'
-        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
-    )
-    _arguments -w -s -S $args[@] && ret=0
-
-    return ret
-}
-
-_swift_package_dump-pif() {
-    integer ret=1
-    local -a args
-    args+=(
-        '--preserve-structure[Preserve the internal structure of PIF]'
+        '--emit-extension-block-symbols[Emit extension block symbols for extensions to external types or directly associate members and conformances with the extended nominal.]'
+        '--omit-extension-block-symbols[Emit extension block symbols for extensions to external types or directly associate members and conformances with the extended nominal.]'
         '--version[Show the version.]'
         '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
@@ -614,7 +634,7 @@ _swift_package_unedit() {
     integer ret=1
     local -a args
     args+=(
-        '--force[Unedit the package even if it has uncommitted and unpushed changes]'
+        '--force[Unedit the package even if it has uncommited and unpushed changes]'
         ':package-name:'
         '--version[Show the version.]'
         '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
@@ -666,9 +686,8 @@ _swift_package_config_set-mirror() {
     integer ret=1
     local -a args
     args+=(
-        '--package-url[The package dependency url]:package-url:'
-        '--original-url[The original url]:original-url:'
-        '--mirror-url[The mirror url]:mirror-url:'
+        '--original[The original url or identity]:original:'
+        '--mirror[The mirror url or identity]:mirror:'
         '--version[Show the version.]'
         '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
@@ -681,9 +700,8 @@ _swift_package_config_unset-mirror() {
     integer ret=1
     local -a args
     args+=(
-        '--package-url[The package dependency url]:package-url:'
-        '--original-url[The original url]:original-url:'
-        '--mirror-url[The mirror url]:mirror-url:'
+        '--original[The original url or identity]:original:'
+        '--mirror[The mirror url or identity]:mirror:'
         '--version[Show the version.]'
         '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
@@ -696,8 +714,7 @@ _swift_package_config_get-mirror() {
     integer ret=1
     local -a args
     args+=(
-        '--package-url[The package dependency url]:package-url:'
-        '--original-url[The original url]:original-url:'
+        '--original[The original url or identity]:original:'
         '--version[Show the version.]'
         '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
@@ -707,22 +724,6 @@ _swift_package_config_get-mirror() {
 }
 
 _swift_package_resolve() {
-    integer ret=1
-    local -a args
-    args+=(
-        '--version[The version to resolve at]:version:'
-        '--branch[The branch to resolve at]:branch:'
-        '--revision[The revision to resolve at]:revision:'
-        ':package-name:'
-        '--version[Show the version.]'
-        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
-    )
-    _arguments -w -s -S $args[@] && ret=0
-
-    return ret
-}
-
-_swift_package_fetch() {
     integer ret=1
     local -a args
     args+=(
@@ -758,25 +759,6 @@ _swift_package_tools-version() {
     args+=(
         '--set-current[Set tools version of package to the current tools version in use]'
         '--set[Set tools version of package to the given value]:set:'
-        '--version[Show the version.]'
-        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
-    )
-    _arguments -w -s -S $args[@] && ret=0
-
-    return ret
-}
-
-_swift_package_generate-xcodeproj() {
-    integer ret=1
-    local -a args
-    args+=(
-        '--xcconfig-overrides[Path to xcconfig file]:xcconfig-overrides:_files'
-        '--output[Path where the Xcode project should be generated]:output:_files -/'
-        '--legacy-scheme-generator[Use the legacy scheme generator]'
-        '--watch[Watch for changes to the Package manifest to regenerate the Xcode project]'
-        '--skip-extra-files[Do not add file references for extra files to the generated Xcode project]'
-        '--enable-code-coverage[Enable code coverage]'
-        '--disable-code-coverage[Enable code coverage]'
         '--version[Show the version.]'
         '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )
@@ -831,23 +813,9 @@ _swift_package_plugin() {
         '--list[List the available command plugins]'
         '--allow-writing-to-package-directory[Allow the plugin to write to the package directory]'
         '--allow-writing-to-directory[Allow the plugin to write to an additional directory]:allow-writing-to-directory:'
+        '--allow-network-connections:allow-network-connections:(none local all docker unixDomainSocket)'
         ':command:'
         ':arguments:'
-        '--version[Show the version.]'
-        '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
-    )
-    _arguments -w -s -S $args[@] && ret=0
-
-    return ret
-}
-
-_swift_package_default-command() {
-    integer ret=1
-    local -a args
-    args+=(
-        '--allow-writing-to-package-directory[Allow the plugin to write to the package directory]'
-        '--allow-writing-to-directory[Allow the plugin to write to an additional directory]:allow-writing-to-directory:'
-        ':remaining:'
         '--version[Show the version.]'
         '(-help -h --help)'{-help,-h,--help}'[Show help information.]'
     )


### PR DESCRIPTION
This PR updates the SwiftPM plugin autocomplete information for Swift 5.9.

Result autocompletion

![Large GIF (560x416)](https://github.com/ohmyzsh/ohmyzsh/assets/4176826/889bba98-bdf3-499a-ae2a-e9daa1b51ec0)

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- `_swift` file was generated by running swift package completion-tool generate-zsh-script with Swift [5.9](https://github.com/apple/swift-package-manager/releases/tag/swift-5.9-RELEASE)