### PR TITLE
fix(juju): add `public-address` fallback to `jaddr`

### DIFF
--- a/plugins/juju/juju.plugin.zsh
+++ b/plugins/juju/juju.plugin.zsh
@@ -98,7 +98,7 @@ jaddr() {
   elif [[ $# -eq 2 ]]; then
     # Get unit address
     juju status "$1/$2" --format=json \
-      | jq -r ".applications.\"$1\".units.\"$1/$2\".address"
+      | jq -r ".applications.\"$1\".units.\"$1/$2\" | .address // .\"public-address\""
   else
     echo "Invalid number of arguments."
     echo "Usage:   jaddr <app-name> [<unit-number>]"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- The helper function `jaddr` is not working correctly. This might be because of the newer Juju versions (I'm using 3.3, for example). As I checked, the `address` field is now missing in the JSON data returned by `juju status` command. I've added a second fallback that reads the `public-address` field, as well.

## Other comments:

- In jq, `//` is called *Alternative* operator. The jq's man page explains:
  > A filter of the form a // b produces the same results as a, if a produces results other than false and null. Otherwise, a // b produces the same results as b.
