### PR TITLE
fix(grc): source grc.zsh on gentoo

### DIFF
--- a/plugins/grc/grc.plugin.zsh
+++ b/plugins/grc/grc.plugin.zsh
@@ -3,9 +3,9 @@
 # common grc.zsh paths
 files=(
   /etc/grc.zsh               # default
-  /usr/share/grc/grc.zsh     # Gentoo Linux (app-misc/grc)
   /usr/local/etc/grc.zsh     # homebrew darwin-x64
   /opt/homebrew/etc/grc.zsh  # homebrew darwin-arm64
+  /usr/share/grc/grc.zsh     # Gentoo Linux (app-misc/grc)
 )
 
 # verify the file is readable and source it

--- a/plugins/grc/grc.plugin.zsh
+++ b/plugins/grc/grc.plugin.zsh
@@ -3,6 +3,7 @@
 # common grc.zsh paths
 files=(
   /etc/grc.zsh               # default
+  /usr/share/grc/grc.zsh     # Gentoo Linux (app-misc/grc)
   /usr/local/etc/grc.zsh     # homebrew darwin-x64
   /opt/homebrew/etc/grc.zsh  # homebrew darwin-arm64
 )


### PR DESCRIPTION
Closes #12048

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added file `/usr/share/grc/grc.zsh` to the list of files that (could) get sourced - which is provided by Gentoo Linux package app-misc/grc.