### PR TITLE
Set 'py' as alias to 'python3' only if 'py' is not installed

### DIFF
--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -1,5 +1,5 @@
-# python command
-alias py='python3'
+# set python command if 'py' not installed
+which py > /dev/null || alias py='python3'
 
 # Find python file
 alias pyfind='find . -name "*.py"'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

This prevents the python plugin from setting `alias py="python3"` if [`py`](https://github.com/brettcannon/python-launcher) (or anything else with that name) is installed.

- [...]

## Other comments:

...
