### PR TITLE
fix(misc): only set PAGER if `less` or `more` are available

### DIFF
--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -19,8 +19,13 @@ setopt multios              # enable redirect to multiple streams: echo >file1 >
 setopt long_list_jobs       # show long list format job notifications
 setopt interactivecomments  # recognize comments
 
-env_default 'PAGER' 'less'
-env_default 'LESS' '-R'
+# define pager dependant on what is available (less or more)
+if (( ${+commands[less]} )); then
+  env_default 'PAGER' 'less'
+  env_default 'LESS' '-R'
+elif (( ${+commands[more]} )); then
+  env_default 'PAGER' 'more'
+fi
 
 ## super user alias
 alias _='sudo '


### PR DESCRIPTION
Simple detection of `less` or `more`, and set PAGER to whatever is available.

Fixes #12049 

## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Other comments:

I did not touch the line in https://github.com/ohmyzsh/ohmyzsh/blob/master/lib/cli.zsh#L392 as I can't be certain that the pager is already set when hitting the code. Seemed over-engineering to have the same detection there again.
