### PR TITLE
refactor(bgnotify): Getting appid using awk instead of jq

### DIFF
--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -59,13 +59,39 @@ function bgnotify_formatted {
   fi
 }
 
+function find_sway_appid {
+  # output is "app_id,container id", for instance "Alacritty,1694"
+  swaymsg -t get_tree | awk '
+    BEGIN { Id = ""; Appid = ""; FocusNesting = -1; Nesting = 0 }
+    {
+      # Enter a block
+      if ($0 ~ /.*{$/) Nesting++
+
+      # Exit a block. If Nesting is now less than FocusNesting, we have the data we are looking for
+      if ($0 ~ /^[[:blank:]]*}.*/) { Nesting--; if (FocusNesting > 0 && Nesting < FocusNesting) exit 0 }
+
+      # Save the Id, it is potentially what we are looking for
+      if ($0 ~ /^[[:blank:]]*"id": [0-9]*,$/)    { sub(/^[[:blank:]]*"id": /, "");      sub(/,$/,  ""); Id = $0 }
+
+      # Save the Appid, it is potentially what we are looking for
+      if ($0 ~ /^[[:blank:]]*"app_id": ".*",$/)  { sub(/^[[:blank:]]*"app_id": "/, ""); sub(/",$/, ""); Appid = $0 }
+
+      # Window is focused, this nesting block contains the Id and Appid we want!
+      if ($0 ~ /^[[:blank:]]*"focused": true,$/) { FocusNesting = Nesting }
+    }
+    END {
+      if (Appid != "" && Id != "" && FocusNesting != -1) print Appid "," Id
+      else print ""
+    }'
+}
+
 function bgnotify_appid {
   if (( ${+commands[osascript]} )); then
     # output is "app ID, window ID" (com.googlecode.iterm2, 116)
     osascript -e 'tell application (path to frontmost application as text) to get the {id, id of front window}' 2>/dev/null
-  elif [[ -n $WAYLAND_DISPLAY ]] && (( ${+commands[swaymsg]} )) && (( ${+commands[jq]} )); then # wayland+sway
-    # output is "app_id, container id" (Alacritty, 1694)
-    swaymsg -t get_tree | jq '.. | select(.type?) | select(.focused==true) | {app_id, id} | join(", ")'
+  elif [[ -n $WAYLAND_DISPLAY ]] && (( ${+commands[swaymsg]} )); then # wayland+sway
+    local app_id=$(find_sway_appid)
+    [[ -n "$app_id" ]] && echo "$app_id" || echo $EPOCHSECONDS
   elif [[ -z $WAYLAND_DISPLAY ]] && [[ -n $DISPLAY ]] && (( ${+commands[xprop]} )); then
     xprop -root _NET_ACTIVE_WINDOW 2>/dev/null | cut -d' ' -f5
   else
@@ -73,19 +99,23 @@ function bgnotify_appid {
   fi
 }
 
+function find_term_id {
+  local term_id="${bgnotify_termid%%,*}" # remove window id
+  if [[ -z "$term_id" ]]; then
+    case "$TERM_PROGRAM" in
+      iTerm.app) term_id='com.googlecode.iterm2' ;;
+      Apple_Terminal) term_id='com.apple.terminal' ;;
+    esac
+  fi
+  echo "$term_id"
+}
+
 function bgnotify {
   local title="$1"
   local message="$2"
   local icon="$3"
   if (( ${+commands[terminal-notifier]} )); then # macOS
-    local term_id="${bgnotify_termid%%,*}" # remove window id
-    if [[ -z "$term_id" ]]; then
-      case "$TERM_PROGRAM" in
-      iTerm.app) term_id='com.googlecode.iterm2' ;;
-      Apple_Terminal) term_id='com.apple.terminal' ;;
-      esac
-    fi
-
+    local term_id=$(find_term_id)
     terminal-notifier -message "$message" -title "$title" ${=icon:+-appIcon "$icon"} ${=term_id:+-activate "$term_id" -sender "$term_id"} &>/dev/null
   elif (( ${+commands[growlnotify]} )); then # macOS growl
     growlnotify -m "$title" "$message"

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -71,13 +71,13 @@ function find_sway_appid {
       if ($0 ~ /^[[:blank:]]*}.*/) { Nesting--; if (FocusNesting > 0 && Nesting < FocusNesting) exit 0 }
 
       # Save the Id, it is potentially what we are looking for
-      if ($0 ~ /^[[:blank:]]*"id": [0-9]*,$/)    { sub(/^[[:blank:]]*"id": /, "");      sub(/,$/,  ""); Id = $0 }
+      if ($0 ~ /^[[:blank:]]*"id": [0-9]*,?$/)    { sub(/^[[:blank:]]*"id": /, "");      sub(/,$/,  ""); Id = $0 }
 
       # Save the Appid, it is potentially what we are looking for
-      if ($0 ~ /^[[:blank:]]*"app_id": ".*",$/)  { sub(/^[[:blank:]]*"app_id": "/, ""); sub(/",$/, ""); Appid = $0 }
+      if ($0 ~ /^[[:blank:]]*"app_id": ".*",?$/)  { sub(/^[[:blank:]]*"app_id": "/, ""); sub(/",$/, ""); Appid = $0 }
 
       # Window is focused, this nesting block contains the Id and Appid we want!
-      if ($0 ~ /^[[:blank:]]*"focused": true,$/) { FocusNesting = Nesting }
+      if ($0 ~ /^[[:blank:]]*"focused": true,?$/) { FocusNesting = Nesting }
     }
     END {
       if (Appid != "" && Id != "" && FocusNesting != -1) print Appid "," Id


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] ~~If the code introduces new aliases, I provide a valid use case for all plugin users down below.~~ (No new aliases)

## Changes:

The idea of bgnotify is that a user can start a long running command, switch window and do something else, and get a system notification when the command is done. If the user has not switched windows, the user should not get the system notification - the plugin does not want to spam when it is already obvious that the command finished. To know if a notification should be displayed, bgnotify gets the appid of the currently focused window.

In the excellent work by @bretello in #12045, the `appid, id` of the currently focused window is retrieved from `swaymsg` for users of Wayland+Sway. The relevant parts from `swaymsg` are then extracted using `jq`, which is definitely the right tool for the job. The issue however, is that `jq` is not part of the standard tools on Linux or Mac, and I believe we could cater to a wider audience by not using `jq`.

This PR is my attempt at extracting the same data using `awk` instead (`awk` being [installed by default on every modern full-fledged Unix](https://unix.stackexchange.com/a/82411)). This is not nearly as neat and pretty as the original solution using `jq` (again, `jq` is the right tool for the job), but as stated, it can be expected to work for far more users.

**I am fine with this PR being rejected.** In my mind, we're choosing between a neater and more maintainable solution by keeping `jq`, versus catering to more users by using `awk`.


Attached is output from `swaymsg -t get_tree`, if anyone wants to poke around with my awk-script: [output.json](https://github.com/ohmyzsh/ohmyzsh/files/13463939/output.json)