### PR TITLE
Adding in nextjs search functionality. And add in DDG lucky feature.

### DIFF
--- a/plugins/frontend-search/README.md
+++ b/plugins/frontend-search/README.md
@@ -66,7 +66,16 @@ If you want to have another context, open an Issue and tell us!
 
 ## Fallback search behaviour
 
-The plugin will use Google as a fallback if the docs site for a search context does not have a search function. You can set the fallback search engine to DuckDuckGo by setting  `FRONTEND_SEARCH_FALLBACK='duckduckgo'` in your `~/.zshrc` file before Oh My Zsh is sourced.
+The plugin will use Google as a fallback if the docs site for a search context does not have a search
+function. You can set the fallback search engine to DuckDuckGo by setting
+`FRONTEND_SEARCH_FALLBACK='duckduckgo'` in your `~/.zshrc` file before Oh My Zsh is sourced.
+
+## DuckDuckGo Lucky Search
+
+Enable DuckDuckGo's "ducky" (lucky) search feature to automatically access the top search result. This feature
+is optimized for DuckDuckGo, as Google redirects to an intermediate page. The FRONTEND_SEARCH_FALLBACK_LUCKY
+environment variable triggers the use of DuckDuckGo's lucky search, rendering the FRONTEND_SEARCH_FALLBACK
+setting unnecessary in this context.
 
 ## Author
 

--- a/plugins/frontend-search/README.md
+++ b/plugins/frontend-search/README.md
@@ -60,6 +60,7 @@ Available search contexts are:
 | typescript    | `https://google.com/search?as_sitesearch=www.typescriptlang.org/docs&as_q=` |
 | unheap        | `http://www.unheap.com/?s=`                                                 |
 | vuejs         | `https://www.google.com/search?as_sitesearch=vuejs.org&as_q=`               |
+| nextjs        | `https://www.google.com/search?as_sitesearch=nextjs.org&as_q=`              |
 
 If you want to have another context, open an Issue and tell us!
 

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -27,6 +27,7 @@ alias stackoverflow='frontend stackoverflow'
 alias typescript='frontend typescript'
 alias unheap='frontend unheap'
 alias vuejs='frontend vuejs'
+alias nextjs='frontend nextjs'
 
 function _frontend_fallback() {
   case "$FRONTEND_SEARCH_FALLBACK" in
@@ -70,6 +71,7 @@ function frontend() {
     typescript     $(_frontend_fallback 'www.typescriptlang.org/docs')
     unheap         'http://www.unheap.com/?s='
     vuejs          $(_frontend_fallback 'vuejs.org')
+    nextjs         $(_frontend_fallback 'nextjs.org')
   )
 
   # show help for command list
@@ -81,7 +83,7 @@ function frontend() {
     print -P ""
     print -P "  angular, angularjs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow, packagephobia"
     print -P "  dartlang, emberjs, fontello, flowtype, github, html5please, jestjs, jquery, lodash,"
-    print -P "  mdn, npmjs, nodejs, qunit, reactjs, smacss, stackoverflow, unheap, vuejs, bundlephobia"
+    print -P "  mdn, npmjs, nodejs, qunit, reactjs, smacss, stackoverflow, unheap, vuejs, bundlephobia, nextjs"
     print -P ""
     print -P "For example: frontend npmjs mocha (or just: npmjs mocha)."
     print -P ""
@@ -96,7 +98,7 @@ function frontend() {
     echo ""
     echo "  angular, angularjs, bem, bootsnipp, caniuse, codepen, compassdoc, cssflow, packagephobia"
     echo "  dartlang, emberjs, fontello, github, html5please, jest, jquery, lodash,"
-    echo "  mdn, npmjs, nodejs, qunit, reactjs, smacss, stackoverflow, unheap, vuejs, bundlephobia"
+    echo "  mdn, npmjs, nodejs, qunit, reactjs, smacss, stackoverflow, unheap, vuejs, bundlephobia, nextjs"
     echo ""
     return 1
   fi

--- a/plugins/frontend-search/frontend-search.plugin.zsh
+++ b/plugins/frontend-search/frontend-search.plugin.zsh
@@ -30,10 +30,16 @@ alias vuejs='frontend vuejs'
 alias nextjs='frontend nextjs'
 
 function _frontend_fallback() {
-  case "$FRONTEND_SEARCH_FALLBACK" in
-    duckduckgo) echo "https://duckduckgo.com/?sites=$1&q=" ;;
-    *) echo "https://google.com/search?as_sitesearch=$1&as_q=" ;;
-  esac
+  if [[ "$FRONTEND_SEARCH_FALLBACK_LUCKY" == "true" ]]; then
+    case true in
+      *) echo "https://duckduckgo.com/?q=!ducky+site%3A$1+" ;;
+    esac
+  else
+    case "$FRONTEND_SEARCH_FALLBACK" in
+      duckduckgo) echo "https://duckduckgo.com/?sites=$1&q=" ;;
+      *) echo "https://google.com/search?as_sitesearch=$1&as_q=" ;;
+    esac
+  fi
 }
 
 function frontend() {


### PR DESCRIPTION
Adding in nextjs search functionality. Also added in lucky feature the top result from DDO automatically added for things tha the fallback search provider..

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add nextjs search option for frontend-search plugin.
- Add FRONTEND_SEARCH_FALLBACK_LUCKY env variable which allows the plugin to automatically open the top DuckDuckGo search result for context's that use the fallback search url.

## Other comments:
I can break this up into two separate PRs if that makes more sense. But since the lucky ("ducky") feature is completely opt-in, and doesn't change the default behavior of the plugin, I thought it might be okay to do it in one.
