### PR TITLE
fix(lib): patch `omz_urlencode` to not encode UTF-8 chars in Termux

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -182,6 +182,8 @@ function omz_urlencode() {
   fi
 
   # Use LC_CTYPE=C to process text byte-by-byte
+  # Note that this doesn't work in Termux, as it only has UTF-8 locale.
+  # Characters will be processed as UTF-8, which is fine for URLs.
   local i byte ord LC_ALL=C
   export LC_ALL
   local reserved=';/?:@&=+$,'
@@ -206,6 +208,9 @@ function omz_urlencode() {
     else
       if [[ "$byte" == " " && -n $spaces_as_plus ]]; then
         url_str+="+"
+      elif [[ "$PREFIX" = *com.termux* ]]; then
+        # Termux does not have non-UTF8 locales, so just send the UTF-8 character directly
+        url_str+="$byte"
       else
         ord=$(( [##16] #byte ))
         url_str+="%$ord"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Termux only has a single UTF-8 locale, so byte-by-byte encoding is not possible. This PR effectively bypasses that so that the resulting URL has the UTF-8 characters directly, which is [already possible in URLs](https://stackoverflow.com/a/913653).

Fixes #12061