### PR TITLE
feat(bgnotify): add option to disable terminal bell

### DIFF
--- a/plugins/bgnotify/README.md
+++ b/plugins/bgnotify/README.md
@@ -35,12 +35,14 @@ Just add bgnotify to your plugins list in your `.zshrc`
 
 One can configure a few things:
 
+- `bgnotify_bell` enabled or disables the terminal bell (default true)
 - `bgnotify_threshold` sets the notification threshold time (default 6 seconds)
 - `function bgnotify_formatted` lets you change the notification. You can for instance customize the message and pass in an icon.
 
 Use these by adding a function definition before the your call to source. Example:
 
 ```sh
+bgnotify_bell=false   ## disable terminal bell
 bgnotify_threshold=4  ## set your own notification threshold
 
 function bgnotify_formatted {

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -27,7 +27,7 @@ function bgnotify_end {
     # check if Terminal app is not active
     [[ $(bgnotify_appid) != "$bgnotify_termid" ]] || return
 
-    printf '\a' # beep sound
+    [[ $bgnotify_bell = true ]] && printf '\a' # beep sound
     bgnotify_formatted "$exit_status" "$bgnotify_lastcmd" "$elapsed"
   } always {
     bgnotify_timestamp=0
@@ -99,6 +99,9 @@ function bgnotify {
 }
 
 ## Defaults
+
+# enable terminal bell on notify by default
+bgnotify_bell=${bgnotify_bell:-true}
 
 # notify if command took longer than 5s by default
 bgnotify_threshold=${bgnotify_threshold:-5}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `bgnotify_bell` option to disable the terminal bell to just show a silent notification.