### PR TITLE
docs: document the off-github installation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Oh My Zsh is installed by running one of the following commands in your terminal
 | **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"`   |
 | **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"` |
 
+Alternatively, the installer is also mirrored outside GitHub. Using this URL instead may be required if you're in a country like India or China, that blocks `raw.githubusercontent.com`:
+
+| Method    | Command                                                                                           |
+| :-------- | :------------------------------------------------------------------------------------------------ |
+| **curl**  | `sh -c "$(curl -fsSL https://install.ohmyz.sh/)"`                                                 |
+| **wget**  | `sh -c "$(wget -O- https://install.ohmyz.sh/)"`                                                   |
+| **fetch** | `sh -c "$(fetch -o - https://install.ohmyz.sh/)"`                                                 |
+
 _Note that any previous `.zshrc` will be renamed to `.zshrc.pre-oh-my-zsh`. After installation, you can move the configuration you want to preserve into the new `.zshrc`._
 
 #### Manual Inspection
@@ -100,6 +108,8 @@ then running it:
 wget https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh
 sh install.sh
 ```
+
+Like with the basic installation, if the above URL times out or otherwise fails, you may have to substitute the URL for `https://install.ohmyz.sh` to be able to get the script.
 
 ## Using Oh My Zsh
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ wget https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh
 sh install.sh
 ```
 
-Like with the basic installation, if the above URL times out or otherwise fails, you may have to substitute the URL for `https://install.ohmyz.sh` to be able to get the script.
+If the above URL times out or otherwise fails, you may have to substitute the URL for `https://install.ohmyz.sh` to be able to get the script.
 
 ## Using Oh My Zsh
 
@@ -229,6 +229,8 @@ the default shell, and it also won't run `zsh` when the installation has finishe
 ```sh
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 ```
+
+If you're in China, India, or another country that blocks `raw.githubusercontent.com`, you may have to substitute the URL for `https://install.ohmyz.sh` for it to install.
 
 #### Installing From A Forked Repository
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

#11467 never documented the alternate installation URL. This PR fixes that, at least for the GitHub README, by including it as an alternative in key places where the GitHub raw URL is mentioned. The website needs to be updated as well, but that's a separate task for later, as it isn't covered by this repo anyway.

