### PR TITLE
feat(plugins): Add nala plugin

### DIFF
--- a/plugins/nala/README.md
+++ b/plugins/nala/README.md
@@ -1,0 +1,53 @@
+# Nala plugin
+
+This plugin adds aliases for [Nala](https://gitlab.com/volian/nala).
+It is inspired by the [Ubuntu plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/ubuntu) and is intended for users of that plugin, which is why many of the aliases are in the format `ng*` instead of just `n*`.
+
+To use it, add `nala` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... nala)
+```
+
+## Aliases
+
+| Alias | Command                                 | Description                                              |
+|-------|-----------------------------------------|----------------------------------------------------------|
+| nge   | `sudo nala`                             | Run nala with sudo                                       |
+| ngli  | `sudo nala list --installed`            | List the installed packages                              |
+| nglu  | `sudo nala list --upgradable`           | List the installed packages that can be upgraded         |
+| ngc   | `sudo nala clean`                       | Clear out the local archive of downloaded package files. |
+| ngf   | `sudo nala fetch`                       | Fetch fast mirrors to speed up downloads.                |
+| ngi   | `sudo nala install`                     | Install packages.                                        |
+| ngp   | `sudo nala purge`                       | Purge packages                                           |
+| ngr   | `sudo nala remove`                      | Remove packages                                          |
+| ngsh  | `sudo nala show`                        | Show package details                                     |
+| ngu   | `sudo nala update`                      | Update package list                                      |
+| ngug  | `sudo nala upgrade`                     | Update package list and upgrade the system               |
+| ngap  | `sudo nala autopurge`                   | Autopurge packages that are no longer needed             |
+| ngar  | `sudo nala autoremove`                  | Autoremove packages that are no longer needed            |
+| ngs   | `sudo nala search`                      | Search package names and descriptions                    |
+| ngh   | `sudo nala history`                     | Show transaction history                                 |
+| nghi  | `sudo nala history info`                | Show information about a specific transaction            |
+| nghr  | `sudo nala history redo`                | Redo the specified transaction                           |
+| nghu  | `sudo nala history undo`                | Undo the specified transaction                           |
+
+
+## Functions
+
+| Function | Usage                                 | Description                                                                         |
+|----------|---------------------------------------|-------------------------------------------------------------------------------------|
+| nar      | `nar ppa:xxxxxx/xxxxxx [packagename]` | apt-add-repository with automatic install/upgrade of the desired package using nala |
+
+## Author:
+- [@james-horrocks](https://github.com/james-horrocks)
+
+## Ubuntu Plugin Authors:
+
+- [@AlexBio](https://github.com/AlexBio)
+- [@dbb](https://github.com/dbb)
+- [@Mappleconfusers](https://github.com/Mappleconfusers)
+- [@trinaldi](https://github.com/trinaldi)
+- [Nicolas Jonas](https://nextgenthemes.com)
+- [@loctauxphilippe](https://github.com/loctauxphilippe)
+- [@HaraldNordgren](https://github.com/HaraldNordgren)

--- a/plugins/nala/nala.plugin.zsh
+++ b/plugins/nala/nala.plugin.zsh
@@ -1,0 +1,43 @@
+#List all installed packages
+alias ngli='nala list --installed'
+
+# List available updates only
+alias nglu='nala list --upgradable'
+
+# superuser operations ######################################################
+alias nge="sudo nala"
+alias ngc="sudo nala clean"
+alias ngf="sudo nala fetch"
+alias ngi="sudo nala install"
+alias ngp="sudo nala purge"
+alias ngr="sudo nala remove"
+alias ngsh="sudo nala show"
+alias ngu="sudo nala update"
+alias ngug="sudo nala upgrade"
+alias ngap="sudo nala autopurge"
+alias ngar="sudo nala autoremove"
+alias ngs="sudo nala search"
+
+alias ngh="sudo nala history"
+alias nghi="sudo nala history info"
+alias nghr="sudo nala history redo"
+alias nghu="sudo nala history undo"
+
+# apt-add-repository with automatic install/upgrade of the desired package
+# Usage: aar ppa:xxxxxx/xxxxxx [packagename]
+# If packagename is not given as 2nd argument the function will ask for it and guess the default by taking
+# the part after the / from the ppa name which is sometimes the right name for the package you want to install
+function nar() {
+	if [ -n "$2" ]; then
+		PACKAGE=$2
+	else
+		read "PACKAGE?Type in the package name to install/upgrade with this ppa [${1##*/}]: "
+	fi
+
+	if [ -z "$PACKAGE" ]; then
+		PACKAGE=${1##*/}
+	fi
+
+	sudo apt-add-repository $1 && sudo nala update
+	sudo nala install $PACKAGE
+}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added new plugin under `plugins/nala/nala.plugin.zsh`

## Use case

Nala provides a user friendly wrapper around `apt` on Debian based distros.

I couldn't say exactly how many people use Nala but it has featured on [itsfoss.com](https://itsfoss.com/nala) and [omgubuntu.co.uk](https://www.omgubuntu.co.uk/2023/01/install-nala-on-ubuntu). 
It is also installable from official repos in Debian and Ubuntu.

## Other comments:

I haven't tested the `nar` function as I didn't have a repository to test it on, but it's almost an exact copy of the `aar` function from the **[Ubuntu plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/ubuntu)** so it *should* work
