### PR TITLE
Fixing slowness in large GIT repo (#12088)

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -37,6 +37,13 @@ function git_prompt_info() {
 function parse_git_dirty() {
   local STATUS
   local -a FLAGS
+
+  # The process of checking whether the directory is dirty in a large GIT project is extremely slow.
+  # To enhance user experience, we are bypassing this step altogether.
+  gitdir=$(__git_prompt_git rev-parse --git-dir)
+  size=$(du -s "$gitdir" | cut -f1)
+  [ "$size" -gt 102400 ] && return
+
   FLAGS=('--porcelain')
   if [[ "$(__git_prompt_git config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
     if [[ "${DISABLE_UNTRACKED_FILES_DIRTY:-}" == "true" ]]; then


### PR DESCRIPTION
Every time you press Enter, we actually execute a git status command to check if the current directory is dirty. In large Git repositories, this process can be particularly slow. Therefore, before executing this command, we check if the repository is larger than 100MB and skip the command if it is.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
