### PR TITLE
feat(vscode): add `vscp` alias

### DIFF
--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -1,6 +1,7 @@
 # VS Code
 
-This plugin provides useful aliases to simplify the interaction between the command line and VS Code or VSCodium editor.
+This plugin provides useful aliases to simplify the interaction between the command line and VS Code or
+VSCodium editor.
 
 To start using it, add the `vscode` plugin to your `plugins` array in `~/.zshrc`:
 
@@ -14,26 +15,30 @@ This plugin requires to have a flavour of VS Code installed and it's executable 
 
 You can install either:
 
-* VS Code (code)
-* VS Code Insiders (code-insiders)
-* VSCodium (codium)
+- VS Code (code)
+- VS Code Insiders (code-insiders)
+- VSCodium (codium)
 
 ### MacOS
+
 While Linux installations will add the executable to PATH, MacOS users might still have to do this manually:
 
-[For VS Code and VS Code Insiders](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line), open
-the Command Palette via (F1 or ⇧⌘P) and type shell command to find the Shell Command:
+[For VS Code and VS Code Insiders](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line),
+open the Command Palette via (F1 or ⇧⌘P) and type shell command to find the Shell Command:
+
 > Shell Command: Install 'code' command in PATH
 
-[For VSCodium](https://github.com/VSCodium/vscodium/blob/master/DOCS.md#how-do-i-open-vscodium-from-the-terminal), open
-the Command Palette via (F1 or ⇧⌘P) and type shell command to find the Shell Command:
+[For VSCodium](https://github.com/VSCodium/vscodium/blob/master/DOCS.md#how-do-i-open-vscodium-from-the-terminal),
+open the Command Palette via (F1 or ⇧⌘P) and type shell command to find the Shell Command:
+
 > Shell Command: Install 'codium' command in PATH
 
 ## Using multiple flavours
 
-If for any reason, you ever require to use multiple flavours of VS Code i.e. VS Code (stable) and VS Code Insiders, you can
-manually specify the flavour's executable. Add the following line to the .zshrc file (between the `ZSH_THEME` and the `plugins=()` lines).
-This will make the plugin use your manually defined executable.
+If for any reason, you ever require to use multiple flavours of VS Code i.e. VS Code (stable) and VS Code
+Insiders, you can manually specify the flavour's executable. Add the following line to the .zshrc file
+(between the `ZSH_THEME` and the `plugins=()` lines). This will make the plugin use your manually defined
+executable.
 
 ```zsh
 ZSH_THEME=...
@@ -61,6 +66,7 @@ source $ZSH/oh-my-zsh.sh
 | vscr                    | code --reuse-window            | Force to open a file or folder in the last active window.                                                   |
 | vscw                    | code --wait                    | Wait for the files to be closed before returning.                                                           |
 | vscu `dir`              | code --user-data-dir `dir`     | Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code. |
+| vscp `profile`          | code --profile `profile`       | Specifies the profile to open Code with.                                                                    |
 
 ## Extensions aliases
 

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -3,6 +3,7 @@
 #   https://github.com/MarsiBarsi (original author)
 #   https://github.com/babakks
 #   https://github.com/SteelShot
+#   https://github.com/AliSajid
 
 # Verify if any manual user choice of VS Code exists first.
 if [[ -n "$VSCODE" ]] && ! which $VSCODE &>/dev/null; then
@@ -46,3 +47,5 @@ alias vscue="$VSCODE --uninstall-extension"
 alias vscv="$VSCODE --verbose"
 alias vscl="$VSCODE --log"
 alias vscde="$VSCODE --disable-extensions"
+
+alias vscp="$VSCODE --profile"

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -39,6 +39,7 @@ alias vscn="$VSCODE --new-window"
 alias vscr="$VSCODE --reuse-window"
 alias vscw="$VSCODE --wait"
 alias vscu="$VSCODE --user-data-dir"
+alias vscp="$VSCODE --profile"
 
 alias vsced="$VSCODE --extensions-dir"
 alias vscie="$VSCODE --install-extension"
@@ -47,5 +48,3 @@ alias vscue="$VSCODE --uninstall-extension"
 alias vscv="$VSCODE --verbose"
 alias vscl="$VSCODE --log"
 alias vscde="$VSCODE --disable-extensions"
-
-alias vscp="$VSCODE --profile"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added a vscode plugin alias that allows you to open it with a particular profile.

## Other comments:

This functionality is available in the newer VS Code versions and documented [here](https://code.visualstudio.com/docs/editor/profiles). The particular commandline option is given [here](https://code.visualstudio.com/docs/editor/profiles#_command-line).
