### PR TITLE
fix(changelog): use longer hashes for commits

### DIFF
--- a/tools/changelog.sh
+++ b/tools/changelog.sh
@@ -292,16 +292,17 @@ function display-release {
   function fmt:hash {
     #* Uses $hash from outer scope
     local hash="${1:-$hash}"
+    local short_hash="${hash:0:7}" # 7 characters sha, top level sha is 12 characters
     case "$output" in
-    raw) printf '%s' "$hash" ;;
+    raw) printf '%s' "$short_hash" ;;
     text)
-      local text="\e[33m$hash\e[0m"; # red
+      local text="\e[33m$short_hash\e[0m"; # red
       if supports_hyperlinks; then
         printf "\e]8;;%s\a%s\e]8;;\a" "https://github.com/ohmyzsh/ohmyzsh/commit/$hash" $text;
       else
         echo $text;
       fi ;;
-    md) printf '[`%s`](https://github.com/ohmyzsh/ohmyzsh/commit/%s)' "$hash" "$hash" ;;
+    md) printf '[`%s`](https://github.com/ohmyzsh/ohmyzsh/commit/%s)' "$short_hash" "$hash" ;;
     esac
   }
 
@@ -512,13 +513,13 @@ function main {
   # Git log options
   # -z:             commits are delimited by null bytes
   # --format:       [7-char hash]<field sep>[ref names]<field sep>[subject]<field sep>[body]
-  # --abbrev=7:     force commit hashes to be 7 characters long
+  # --abbrev=7:     force commit hashes to be 12 characters long
   # --no-merges:    merge commits are omitted
   # --first-parent: commits from merged branches are omitted
   local SEP="0mZmAgIcSeP"
   local -a raw_commits
   raw_commits=(${(0)"$(command git -c log.showSignature=false log -z \
-    --format="%h${SEP}%D${SEP}%s${SEP}%b" --abbrev=7 \
+    --format="%h${SEP}%D${SEP}%s${SEP}%b" --abbrev=12 \
     --no-merges --first-parent $range)"})
 
   local raw_commit


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
Fixed 404 for changelog commit URLs. `omz changelog` was using 7 letter short sha for GitHub commit URLs. Since the repo has grown bigger in number of commits, we may need to update it to use 12 letter short sha instead. This is a good number for the future as well.

#### The bug
Following is the changelog from running `omz changelog` for the the recent update:
```
master

Features:

 - 48ccc7b [dotnet]          Update completion script (#12028)
 - 346bd1c [frontend-search] Add `I am lucky` option
 - c37df3e [frontend-search] Add nextjs

Bug fixes:

 - 1ae0515 [lib]             Patch `omz_urlencode` to not encode UTF-8 chars in Termux (#12076)
```

The output above links to 346bd1c for `[frontend-search] Add I am lucky option` the URL generated is https://github.com/ohmyzsh/ohmyzsh/commit/346bd1c `https://github.com/ohmyzsh/ohmyzsh/commit/346bd1c` which lands to a Github 404 page.

#### The fix
- This MR updates the short sha length to `12` characters instead of the previous `7` characters. 
- It also retains the output to use 7 characters whenever the commit sha is displayed as a string to reduce the length of the characters printed on the screen. 
- It retains the long cha of 12 characters length whenever the changelog has to print a direct URL to GitHub commit.
- New URL example: https://github.com/ohmyzsh/ohmyzsh/commit/346bd1cd53e1 `https://github.com/ohmyzsh/ohmyzsh/commit/346bd1cd53e1`

## Other comments:
n/a
