### PR TITLE
fix(rake-fast): make `.rake_tasks` write atomic

### DIFF
--- a/plugins/rake-fast/rake-fast.plugin.zsh
+++ b/plugins/rake-fast/rake-fast.plugin.zsh
@@ -43,14 +43,17 @@ _tasks_changed () {
 }
 
 _rake_generate () {
-  echo "version:$_rake_tasks_version" > .rake_tasks
-
-  rake --silent --tasks --all \
+  local rake_tasks_content="version:$_rake_tasks_version\n"
+  rake_tasks_content+=$(rake --silent --tasks --all \
     | sed "s/^rake //" | sed "s/\:/\\\:/g" \
     | sed "s/\[[^]]*\]//g" \
     | sed "s/ *# /\:/" \
-    | sed "s/\:$//" \
-    >> .rake_tasks
+    | sed "s/\:$//")
+
+  local rake_tasks_file="$(mktemp -t .rake_tasks.XXXXXX)"
+  echo $rake_tasks_content > $rake_tasks_file
+
+  mv $rake_tasks_file .rake_tasks
 }
 
 _rake () {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- The sequence of steps when generating `.rake_tasks` file has been changed
  - a variable with the contents of this file is created
  - the variable is written to a temporary file
  - the temporary file is moved to the location of the final `.rake_tasks` file.

## Other comments:

This ensures that the `.rake_tasks` file is not corrupted if a process terminates prematurely or if multiple processes run in parallel. This is useful in particular when used in conjunction with the [marlonrichert/zsh-autocomplete](https://github.com/marlonrichert/zsh-autocomplete) plugin, which, while typing, runs an autocomplete command every time a key is pressed, causing the file to become corrupted.