### PR TITLE
update to replace current dir in prompt with git repo name, when in a git dir.

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -217,7 +217,13 @@ prompt_hg() {
 
 # Dir: current working directory
 prompt_dir() {
-  prompt_segment blue $CURRENT_FG '%~'
+  if $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
+    gn=`git rev-parse --show-toplevel`
+    bn=`basename $gn`
+    prompt_segment blue $CURRENT_FG $bn
+  else
+    prompt_segment blue $CURRENT_FG '%~'
+  fi
 }
 
 # Virtualenv: current working virtualenv


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The existing prompt has this format:
`user_id@hostname ~<current_dir_from_user_root> > main >`
Current dir can get long. Since we mostly care about what repo I'm working on for current shell, I replaced the current dir with the repo name instead when I'm in a git repo dir.
I found that's been working well for me.
`user_id@hostname ~<repo_name> > main >`

This PR doesn't change the prompt behavior when in a non-git dir.


## Other comments:

...
