### PR TITLE
fix(bgnotify): make it work with `set -e`

### DIFF
--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -21,11 +21,11 @@ function bgnotify_end {
     local elapsed=$(( EPOCHSECONDS - bgnotify_timestamp ))
 
     # check time elapsed
-    [[ $bgnotify_timestamp -gt 0 ]] || return
-    [[ $elapsed -ge $bgnotify_threshold ]] || return
+    [[ $bgnotify_timestamp -gt 0 ]] || return 0
+    [[ $elapsed -ge $bgnotify_threshold ]] || return 0
 
     # check if Terminal app is not active
-    [[ $(bgnotify_appid) != "$bgnotify_termid" ]] || return
+    [[ $(bgnotify_appid) != "$bgnotify_termid" ]] || return 0
 
     [[ $bgnotify_bell = true ]] && printf '\a' # beep sound
     bgnotify_formatted "$exit_status" "$bgnotify_lastcmd" "$elapsed"


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
fixes: #12097 When running with bgnotify plugin, set -e will terminate zsh immediately 

- Added return 0 instead of return

## Other comments:
- Attributed the code change to the original author @ipChrisLee on the commit