### PR TITLE
feat(aws): add sso logout capabilities

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -16,6 +16,7 @@ plugins=(... aws)
   It also sets `$AWS_EB_PROFILE` to `<profile>` for the Elastic Beanstalk CLI. It sets `$AWS_PROFILE_REGION` for display in `aws_prompt_info`.
   Run `asp` without arguments to clear the profile.
 * `asp [<profile>] login`: If AWS SSO has been configured in your aws profile, it will run the `aws sso login` command following profile selection.
+* `asp [<profile>] logout`: If AWS SSO has been configured in your aws profile, it will run the `aws sso logout` command following profile selection.
 
 * `asr [<region>]`: sets `$AWS_REGION` and `$AWS_DEFAULT_REGION` (legacy) to `<region>`.
   Run `asr` without arguments to clear the profile.

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -30,6 +30,8 @@ function asp() {
 
   if [[ "$2" == "login" ]]; then
     aws sso login
+  elif [[ "$2" == "logout" ]]; then
+    aws sso logout
   fi
 }
 


### PR DESCRIPTION
The aws plugin gives the user the possibility to login into the sso session when using the AWS profile selection. Unfortunately, it is not possible to also logout this way. Naturally, one would think that when one is typing "asp <aws_profile> login" it is also possible to type "asp <aws_profile> logout" but this is currently not the case. This commit adds this possibility and therefore enables the user to login and logout with the plugin without having to use awscli directly.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add aws sso logout possibility for aws plugin

## Other comments:

...
