### PR TITLE
ci(dependencies): pass app token properly

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -8,19 +8,22 @@ jobs:
   check:
     name: Check for updates
     runs-on: ubuntu-latest
+    if: github.repository == 'ohmyzsh/ohmyzsh'
     steps:
       - name: Checkout
-        if: github.repository == 'ohmyzsh/ohmyzsh'
         uses: actions/checkout@v4
       - name: Authenticate as @ohmyzsh
+        id: generate_token
         uses: ohmyzsh/github-app-token@v2
         with:
           app_id: ${{ secrets.OHMYZSH_APP_ID }}
           private_key: ${{ secrets.OHMYZSH_APP_PRIVATE_KEY }}
       - name: Process dependencies
         env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          TMP_DIR: ${{ env.RUNNER_TEMP }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GIT_APP_NAME: ohmyzsh[bot]
+          GIT_APP_EMAIL: 54982679+ohmyzsh[bot]@users.noreply.github.com
+          TMP_DIR: ${{ runner.temp }}
         run: |
-          gh auth login --with-token <<< "${GITHUB_TOKEN}"
+          pip install -r .github/workflows/dependencies/requirements.txt
           python3 .github/workflows/dependencies/updater.py

--- a/.github/workflows/dependencies/requirements.txt
+++ b/.github/workflows/dependencies/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML~=6.0.1
+requests~=2.31.0

--- a/.github/workflows/dependencies/updater.py
+++ b/.github/workflows/dependencies/updater.py
@@ -302,8 +302,8 @@ class Git:
 
   @staticmethod
   def add_and_commit(scope: str, version: str):
-    user_name = "ohmyzsh"
-    user_email = "bot@ohmyz.sh"
+    user_name = os.environ.get("GIT_APP_NAME")
+    user_email = os.environ.get("GIT_APP_EMAIL")
 
     # Add all files to git staging
     CommandRunner.run_or_fail(["git", "add", "-A", "-v"], stage="AddFiles")

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -15,9 +15,15 @@ jobs:
     name: Add to project
     runs-on: ubuntu-latest
     if: github.repository == 'ohmyzsh/ohmyzsh'
-    env:
-      GITHUB_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:
+      - name: Authenticate as @ohmyzsh
+        id: generate_token
+        uses: ohmyzsh/github-app-token@v2
+        with:
+          app_id: ${{ secrets.OHMYZSH_APP_ID }}
+          private_key: ${{ secrets.OHMYZSH_APP_PRIVATE_KEY }}
+      - name: Store app token
+        run: echo "GH_TOKEN=${{ steps.generate_token.outputs.token }}" >> "$GITHUB_ENV"
       - name: Read project data
         env:
           ORGANIZATION: ohmyzsh


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Bugfixes of #12109:

- Pass `GH_TOKEN` properly.
- Author commits as the bot (displayed correctly on Github UI)
- Use bot token as well for `project.yml` workflow
- Fix `tmp` dir