### PR TITLE
feat(git): add aliases to pull from upstream with `--rebase` and `--autostash`

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -284,7 +284,11 @@ function ggl() {
 compdef _git ggl=git-checkout
 
 alias gluc='git pull upstream $(git_current_branch)'
+alias glucra='git pull upstream $(git_current_branch) --rebase --autostash'
+alias glucrav='git pull upstream $(git_current_branch) --rebase --autostash -v'
 alias glum='git pull upstream $(git_main_branch)'
+alias glumra='git pull upstream $(git_main_branch) --rebase --autostash'
+alias glumrav='git pull upstream $(git_main_branch) --rebase --autostash -v'
 alias gp='git push'
 alias gpd='git push --dry-run'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add new alias analogous to the currently `gluc` and `glum`

## Other comments:

Currently we have alias to pull from upstream to our current/main branch
but if you have changes in the branch you may need to stash
first those changes and then pull.

Having alias with `--rebase` and `--autostash` flags let you pull code with a single command.

When you use `gluc`/`glum` you need to have a clean branch in order to succesfully.

Replacing `gluc` with `glucra`/`glucrav` and  `glum` with `glumra`/`glumrav` lets you pull remote branches even when you have a minor change in your local branch.

Instead of doing `gsta && glum && gstp` you just need to do `glumra`.

Inpired by `gupav` now `gprav`.