### PR TITLE
fix(clipboard): remove clippaste additional newline on wayland

### DIFF
--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -62,7 +62,7 @@ function detect-clipboard() {
     function clippaste() { powershell.exe -noprofile -command Get-Clipboard; }
   elif [ -n "${WAYLAND_DISPLAY:-}" ] && (( ${+commands[wl-copy]} )) && (( ${+commands[wl-paste]} )); then
     function clipcopy() { cat "${1:-/dev/stdin}" | wl-copy &>/dev/null &|; }
-    function clippaste() { wl-paste; }
+    function clippaste() { wl-paste --no-newline; }
   elif [ -n "${DISPLAY:-}" ] && (( ${+commands[xsel]} )); then
     function clipcopy() { cat "${1:-/dev/stdin}" | xsel --clipboard --input; }
     function clippaste() { xsel --clipboard --output; }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The function `clippaste` wont emit an additional new line on Wayland anymore.

`clippaste` Now behaves similarly between Wayland and X11.

## Other comments:

Here are my tests, on X11:

```console
$ echo foobar | xsel --clipboard --input; xsel --clipboard --output; echo END
foobar
END
$ echo -n foobar | xsel --clipboard --input; xsel --clipboard --output; echo END
foobarEND
```
```console
$ echo foobar | xclip -selection clipboard -in &>/dev/null; xclip -out -selection clipboard; echo END
foobar
END
$ echo -n foobar | xclip -selection clipboard -in &>/dev/null; xclip -out -selection clipboard; echo END
foobarEND
```

on Wayland (sway), without and with `wl-paste`'s `--no-newline` option:

```console
$ echo foobar | wl-copy; wl-paste; echo END
foobar

END
$ echo -n foobar | wl-copy; wl-paste; echo END
foobar
END
```
```console
$ echo foobar | wl-copy; wl-paste --no-newline; echo END
foobar
END
$ echo -n foobar | wl-copy; wl-paste --no-newline; echo END
foobarEND
```
(this last block is `clippaste`'s new behavior)

