### PR TITLE
feat(gcloud): add asdf installation dir

### DIFF
--- a/plugins/gcloud/gcloud.plugin.zsh
+++ b/plugins/gcloud/gcloud.plugin.zsh
@@ -17,6 +17,7 @@ if [[ -z "${CLOUDSDK_HOME}" ]]; then
     "/opt/google-cloud-sdk"
     "/opt/google-cloud-cli"
     "/opt/local/libexec/google-cloud-sdk"
+    "$HOME/.asdf/installs/gcloud/*/"
   )
 
   for gcloud_sdk_location in $search_locations; do


### PR DESCRIPTION
I have added the path `"$HOME/.asdf/installs/gcloud/*/"` to the `search_locations` array. This is specifically for cases where the **Google Cloud SDK** is installed using the **ASDF Version Manager**.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

### `gcloud.plugin.zsh:20`
- Added `$HOME/.asdf/installs/gcloud/*/` to the `search_locations` array. 