### PR TITLE
fix(macos): print usage for `man-preview` with no args

### DIFF
--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -224,6 +224,8 @@ function quick-look() {
 }
 
 function man-preview() {
+  [[ $# -eq 0 ]] && >&2 echo "Usage: $0 command1 [command2 ...]" && return 1
+
   local page
   for page in "${(@f)"$(man -w $@)"}"; do
     command mandoc -Tpdf $page | open -f -a Preview


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Instead of just running `man` with no argument, which leads to it printing the question `What manual page do you want?`, we now print a usage statement if no arguments are provided.

**Before this change**
```
> man-preview
What manual page do you want?
```
The command then hangs and you need to use Ctrl-C to abort it.

**After this change**
```
> man-preview
Usage: man-preview command1 [command2 ...]
>
```