### PR TITLE
fix(rkj-repos): check if `~/.hgrc` exists

### DIFF
--- a/themes/rkj-repos.zsh-theme
+++ b/themes/rkj-repos.zsh-theme
@@ -1,7 +1,7 @@
 # user, host, full path, and time/date on two lines for easier vgrepping
 
 function hg_prompt_info {
-  if (( $+commands[hg] )) && grep -q "prompt" ~/.hgrc; then
+  if (( $+commands[hg] )) && [[ -e ~/.hgrc ]] && grep -q "prompt" ~/.hgrc; then
     hg prompt --angle-brackets "\
 <hg:%{$fg[magenta]%}<branch>%{$reset_color%}><:%{$fg[magenta]%}<bookmark>%{$reset_color%}>\
 </%{$fg[yellow]%}<tags|%{$reset_color%}, %{$fg[yellow]%}>%{$reset_color%}>\


### PR DESCRIPTION
If the `hg` command is available but `~/.hgrc` does not exist, the theme would print `grep: ~/.hgrc: No such file or directory` before every prompt line.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

## Other comments:

Could be also achieved by redirecting grep's stderr to `/dev/null` or adding the `-s` flag. Not sure which approach is best, please comment.
