### PR TITLE
Tweak exit code to avoid exiting scripts using "omz update"

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -281,5 +281,8 @@ case "$resetAutoStash" in
   *) git config rebase.autoStash "$resetAutoStash" ;;
 esac
 
-# Exit with `1` if the update failed
-exit $ret
+# Let script exit without exit command if update succeeds to allow ease of external automated updates
+if [ "$ret" -ne 0 ]; then
+    # Exit with exit code if the update failed
+    exit $ret
+fi


### PR DESCRIPTION
Tweak exit code to avoid exiting scripts using "omz update" on successful exit

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ X] The PR title is descriptive.
- [ X] The PR doesn't replicate another PR which is already open.
- [ X] I have read the contribution guide and followed all the instructions.
- [ X] The code follows the code style guide detailed in the wiki.
- [ X] The code is mine or it's from somewhere with an MIT-compatible license.
- [ X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ X] The code is stable and I have tested it myself, to the best of my abilities.
- [ X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add an if statement to check exit code prior to running "exit" and skip if exit code is 0

## Other comments:

This is helpful as if someone runs `omz update ; reboot` on successful update the exit commands stops the continuation of the command
