### PR TITLE
sudo plugin fix `sudo -e` issue: #12149

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -67,7 +67,7 @@ sudo-command-line() {
 
     # If sudo -e is not ok or $EDITOR is not set, just toggle the sudo prefix on and off
     test -z "$EDITOR" || __sudo_e_ok "${(z)LBUFFER}"
-    if [[ $? -ne 0 || -z "$EDITOR" ]]; then
+    if [[ "$?" -ne 0 ]]; then
       case "$BUFFER" in
         sudo\ -e\ *) __sudo-replace-buffer "sudo -e" "" ;;
         sudo\ *) __sudo-replace-buffer "sudo" "" ;;

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -29,7 +29,7 @@ __sudo_e_ok() {
     [[ "$(id -u)" -eq "$(ls -ldn "$dir" | awk '{print $3}')" ]] && return 1
     local owner=( $(ls -ldn "$dir" | awk '{print $4}') )
     for grp in "${groups[@]}"; do
-      [[ "$grp" == "$owner" ]] && return 1
+      [[ "$grp" -eq "$owner" ]] && return 1
     done
   done
   return 0

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -66,7 +66,7 @@ sudo-command-line() {
     local EDITOR=${SUDO_EDITOR:-${VISUAL:-$EDITOR}}
 
     # If sudo -e is not ok or $EDITOR is not set, just toggle the sudo prefix on and off
-    __sudo_e_ok "${(z)LBUFFER}"
+    test -z "$EDITOR" || __sudo_e_ok "${(z)LBUFFER}"
     if [[ $? -ne 0 || -z "$EDITOR" ]]; then
       case "$BUFFER" in
         sudo\ -e\ *) __sudo-replace-buffer "sudo -e" "" ;;

--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -21,7 +21,7 @@ __sudo_e_ok() {
   shift
   local file grp groups=( $(id -G) )
   for file in "$@"; do
-    # Dirs and symlinks are not allowed, now is a non-existent parent
+    # Dirs and symlinks are not allowed, nor is a non-existent parent
     [[ -d "$file" || -L "$file" ]] && return 1
     local dir="$(dirname -- "$file")"
     [[ ! -d "$dir" ]] && return 1


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes #12149

## Other comments:

Tested with the following tests (each subsequent line is the result of double tapping escape while the previous line is loaded):

---

### Should use `sudo -e`

Existing file:
```zsh
vim /etc/hosts
sudo -e /etc/hosts
/usr/bin/vim /etc/hosts
sudo -e /etc/hosts
/usr/bin/vim /etc/hosts
```

Non-existent file:
```zsh
vim /foo
sudo -e /foo
/usr/bin/vim /foo
sudo -e /foo
/usr/bin/vim /foo
```

Both of the above:
```zsh
vim /foo
sudo -e /foo
/usr/bin/vim /foo
sudo -e /foo
/usr/bin/vim /foo
```

---

### Should use `sudo $EDITOR`

Symlink
```zsh
vim /my_symlink
sudo vim /my_symlink
vim /my_symlink
```

Dir
```zsh
vim /var
sudo vim /var
vim /var
```

User owned dir
```zsh
vim ~/a
sudo vim ~/a
vim ~/a
```

Group owned dir
```zsh
vim ~/b
sudo vim ~/b
vim ~/b
```

All of the above
```zsh
vim /my_symlink /var ~/a ~/b
sudo vim /my_symlink /var ~/a ~/b
vim /my_symlink /var ~/a ~/b
```