### PR TITLE
feat(history-substring-search): update to upstream

### DIFF
--- a/plugins/history-substring-search/README.md
+++ b/plugins/history-substring-search/README.md
@@ -23,7 +23,15 @@ Install
 Using the [Homebrew]( https://brew.sh ) package manager:
 
     brew install zsh-history-substring-search
-    echo 'source /usr/local/share/zsh-history-substring-search/zsh-history-substring-search.zsh' >> ~/.zshrc
+    echo 'source $(brew --prefix)/share/zsh-history-substring-search/zsh-history-substring-search.zsh' >> ~/.zshrc
+
+Using [Fig](https://fig.io):
+
+Fig adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `zsh-history-substring-search` in just one click.
+
+<a href="https://fig.io/plugins/other/zsh-history-substring-search" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 Using [Oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh):
 
@@ -33,24 +41,63 @@ Using [Oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh):
 
 2. Activate the plugin in `~/.zshrc`:
 
-        plugins=( [plugins...] history-substring-search)
+        plugins=( [plugins...] zsh-history-substring-search)
 
-3. Source `~/.zshrc`  to take changes into account:
+3. Run `exec zsh`  to take changes into account:
 
-        source ~/.zshrc
+        exec zsh
+
+Using [zplug](https://github.com/zplug/zplug):
+
+1. Add this repo to `~/.zshrc`:
+
+        zplug "zsh-users/zsh-history-substring-search", as: plugin
+
+Using [antigen](https://github.com/zsh-users/antigen):
+
+1. Add the `antigen bundle` command just before `antigen apply`, like this:
+
+``` 
+antigen bundle zsh-users/zsh-history-substring-search
+antigen apply
+```
+ 
+2. Then, **after** `antigen apply`, add the key binding configurations, like this:
+ 
+```
+# zsh-history-substring-search configuration
+bindkey '^[[A' history-substring-search-up # or '\eOA'
+bindkey '^[[B' history-substring-search-down # or '\eOB'
+HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE=1
+```
+
+Using [Zinit](https://github.com/zdharma-continuum/zinit):
+
+1. Use the `Oh-my-zsh` Zinit snippet in `~/.zshrc`:
+
+        zinit snippet OMZ::plugins/git/git.plugin.zsh`
+
+2. Load the plugin in `~/.zshrc`:
+
+        zinit load 'zsh-users/zsh-history-substring-search
+        zinit ice wait atload'_history_substring_search_config'
+
+3. Run `exec zsh` to take changes into account:
+
+        exec zsh
 
 Usage
 ------------------------------------------------------------------------------
 
 1.  Load this script into your interactive ZSH session:
 
-        % source zsh-history-substring-search.zsh
+        source zsh-history-substring-search.zsh
 
     If you want to use [zsh-syntax-highlighting][6] along with this script,
     then make sure that you load it *before* you load this script:
 
-        % source zsh-syntax-highlighting.zsh
-        % source zsh-history-substring-search.zsh
+        source zsh-syntax-highlighting.zsh
+        source zsh-history-substring-search.zsh
 
 2.  Bind keyboard shortcuts to this script's functions.
 
@@ -72,6 +119,10 @@ Usage
 
           bindkey "$terminfo[kcuu1]" history-substring-search-up
           bindkey "$terminfo[kcud1]" history-substring-search-down
+
+      Users have also observed that `[OA` and `[OB` are correct values, 
+      _even if_ these were not the observed values. If you are having trouble
+      with the observed values, give these a try.
 
       You might also want to bind the Control-P/N keys for use in EMACS mode:
 
@@ -115,7 +166,7 @@ Configuration
 ------------------------------------------------------------------------------
 
 This script defines the following global variables. You may override their
-default values only after having loaded this script into your ZSH session.
+default values.
 
 * `HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND` is a global variable that defines
   how the query should be highlighted inside a matching command. Its default
@@ -141,6 +192,12 @@ default values only after having loaded this script into your ZSH session.
   value, causes this script to perform a fuzzy search by words, matching in
   given order e.g. `ab c` will match `*ab*c*`
 
+* `HISTORY_SUBSTRING_SEARCH_PREFIXED` is a global variable that defines how
+  the command history will be searched for your query. If set to a non-empty
+  value, your query will be matched against the start of each history entry.
+  For example, if this variable is empty, `ls` will match `ls -l` and `echo
+  ls`; if it is non-empty, `ls` will only match `ls -l`.
+
 * `HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE` is a global variable that defines
   whether all search results returned are _unique_. If set to a non-empty
   value, then only unique search results are presented. This behaviour is off
@@ -154,6 +211,9 @@ default values only after having loaded this script into your ZSH session.
   search result appeared twice as you cycled through them. If you wish to
   receive globally unique search results only once, then use this
   configuration variable, or use `setopt HIST_IGNORE_ALL_DUPS`.
+
+* `HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_TIMEOUT` is a global variable that
+  defines a timeout in seconds for clearing the search highlight.
 
 
 History
@@ -187,8 +247,8 @@ https://github.com/zsh-users/zsh-history-substring-search.
 
 This downstream copy was last updated from the following upstream commit:
 
-  SHA:          0f80b8eb3368b46e5e573c1d91ae69eb095db3fb
-  Commit date:  2019-05-12 17:35:54 -0700
+  SHA:          8dd05bfcc12b0cd1ee9ea64be725b3d9f713cf64
+  Commit date:  2023-11-23 12:12:14 +0200
 
 Everything above this section is a copy of the original upstream's README, so things
 may differ slightly when you're using this inside OMZ. In particular, you do not

--- a/plugins/history-substring-search/history-substring-search.plugin.zsh
+++ b/plugins/history-substring-search/history-substring-search.plugin.zsh
@@ -1,9 +1,5 @@
-# Handle $0 according to the standard:
-# https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
-0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
-0="${${(M)0:#/*}:-$PWD/$0}"
-
-source ${0:A:h}/history-substring-search.zsh
+0=${(%):-%N}
+source ${0:A:h}/zsh-history-substring-search.zsh
 
 
 # Bind terminal-specific up and down keys


### PR DESCRIPTION
Updates OMZ's copy to commit 8dd05bfcc12b0cd1ee9ea64be725b3d9f713cf64 from zsh-users/zsh-history-substring-search

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- ran `ohmyzsh/plugins/history-substring-search/update-from-upstream.zsh` and created PR from changes

## Other comments:
- Fixed #11925 
