### PR TITLE
feat(web-search): add `deepL`

### DIFF
--- a/plugins/web-search/README.md
+++ b/plugins/web-search/README.md
@@ -45,6 +45,7 @@ Available search contexts are:
 | `scholar`             | `https://scholar.google.com/scholar?q=`         |
 | `ask`                 | `https://www.ask.com/web?q=`                    |
 | `youtube`             | `https://www.youtube.com/results?search_query=` |
+| `deepl`               | `https://www.deepl.com/translator#auto/auto/`   |
 
 Also there are aliases for bang-searching DuckDuckGo:
 

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -26,6 +26,7 @@ function web_search() {
     scholar         "https://scholar.google.com/scholar?q="
     ask             "https://www.ask.com/web?q="
     youtube         "https://www.youtube.com/results?search_query="
+    deepl           "https://www.deepl.com/translator#auto/auto/"
   )
 
   # check whether the search engine is supported
@@ -68,6 +69,7 @@ alias archive='web_search archive'
 alias scholar='web_search scholar'
 alias ask='web_search ask'
 alias youtube='web_search youtube'
+alias deepl='web_search deepl'
 
 #add your own !bang searches here
 alias wiki='web_search duckduckgo \!w'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- added alias for DeepL URL: `https://www.deepl.com/translator#auto/auto/`

## Other comments:

I discovered that when I input a specific string into the URLs of DeepL, they automatically translate it for me.
I often use web-search.plugin and frequently use DeepL as well. Therefore, thinking it would be convenient to be able to translate from web-search.plugin to DeepL, I sent a request.

DeepL automatically translates text when you add a string after `https://www.deepl.com/translator#auto/auto/`.
 For example, like this:
[https://www.deepl.com/translator#auto/auto/こんにちは世界](https://www.deepl.com/translator#auto/auto/こんにちは世界)