### PR TITLE
feat(lib/spectrum): add `FX[dim]` and `FX[no-dim]` formats

### DIFF
--- a/lib/spectrum.zsh
+++ b/lib/spectrum.zsh
@@ -7,6 +7,7 @@ typeset -AHg FX FG BG
 FX=(
   reset     "%{[00m%}"
   bold      "%{[01m%}" no-bold      "%{[22m%}"
+  dim       "%{[02m%}" no-dim       "%{[22m%}"
   italic    "%{[03m%}" no-italic    "%{[23m%}"
   underline "%{[04m%}" no-underline "%{[24m%}"
   blink     "%{[05m%}" no-blink     "%{[25m%}"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add the "dim" formatting option that has been missing in the FX helper in `lib/spectrum.zsh`

## Other comments:

The _dim_ option is listed for example [here](https://misc.flogisoft.com/bash/tip_colors_and_formatting).
