### PR TITLE
fix(aws): pass default region to fetch regions

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -202,8 +202,17 @@ function aws_change_access_key() {
 }
 
 function aws_regions() {
+  local -a region
+  if [[ $AWS_DEFAULT_REGION ]];then
+      region="$AWS_DEFAULT_REGION"
+  elif [[ $AWS_REGION ]];then
+      region="$AWS_REGION"
+  else
+      region="us-west-1"
+  fi
+
   if [[ $AWS_DEFAULT_PROFILE || $AWS_PROFILE ]];then
-    aws ec2 describe-regions |grep RegionName | awk -F ':' '{gsub(/"/, "", $2);gsub(/,/, "", $2);gsub(/ /, "", $2);  print $2}'
+    aws ec2 describe-regions --region $region |grep RegionName | awk -F ':' '{gsub(/"/, "", $2);gsub(/,/, "", $2);gsub(/ /, "", $2);  print $2}'
   else
     echo "You must specify a AWS profile."
   fi

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -202,7 +202,7 @@ function aws_change_access_key() {
 }
 
 function aws_regions() {
-  local -a region
+  local region
   if [[ $AWS_DEFAULT_REGION ]];then
       region="$AWS_DEFAULT_REGION"
   elif [[ $AWS_REGION ]];then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Sets a default region for the `aws ec2 describe-regions` call in `aws_regions` to avoid this situation:
```
# asr eu-west-1

You must specify a region. You can also configure your region by running "aws configure".

You must specify a region. You can also configure your region by running "aws configure".
Available regions:
```

## Other comments:

I've used `$AWS_DEFAULT_REGION` and `$AWS_REGION` as regions for the call in case they are set.
I think we could always use any region like `us-west-1` but I can't test if the list is different when using an "exotic" source region.
