### PR TITLE
feat(git-commit): add `wip` kind

### DIFF
--- a/plugins/git-commit/README.md
+++ b/plugins/git-commit/README.md
@@ -29,8 +29,9 @@ Where `type` is one of the following:
 - `rev`
 - `style`
 - `test`
+- `wip`
 
-> NOTE: the alias for `revert` type is `rev`, as otherwise it conflicts with the git command of the same name.  
+> NOTE: the alias for `revert` type is `rev`, as otherwise it conflicts with the git command of the same name.
 > It will still generate a commit message in the format `revert: <message>`
 
 ## Examples
@@ -38,5 +39,6 @@ Where `type` is one of the following:
 | Git alias                                     | Command                                              |
 | --------------------------------------------- | ---------------------------------------------------- |
 | `git style "remove trailing whitespace"`      | `git commit -m "style: remove trailing whitespace"`  |
+| `git wip "work in progress"`                  | `git commit -m "work in progress"`                   |
 | `git fix -s "router" "correct redirect link"` | `git commit -m "fix(router): correct redirect link"` |
 | `git rev -s "api" "rollback v2"`              | `git commit -m "revert(api): rollback v2"`           |

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -11,6 +11,7 @@ _git_commit_aliases=(
   'revert'
   'style'
   'test'
+  'wip'
 )
 
 local alias type


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added new type for commit

## Other comments:

- I noticed that you are following the ["Conventional Commits"](https://www.conventionalcommits.org) exactly but this new implementation might be interesting.
