### PR TITLE
fix(kubectx): k8s contexts with spaces

### DIFF
--- a/plugins/kubectx/kubectx.plugin.zsh
+++ b/plugins/kubectx/kubectx.plugin.zsh
@@ -9,5 +9,5 @@ function kubectx_prompt_info() {
 
   # use value in associative array if it exists
   # otherwise fall back to the context name
-  echo "${kubectx_mapping[$current_ctx]:-${current_ctx:gs/%/%%}}"
+  echo "${kubectx_mapping[\"$current_ctx\"]:-${current_ctx:gs/%/%%}}"
 }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fix the problem: When Kubernetes context contains spaces, custom names are not working.
