### PR TITLE
chore(brew): remove duplicated alias

### DIFF
--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -36,7 +36,6 @@ fi
 
 alias bcubc='brew upgrade --cask && brew cleanup'
 alias bcubo='brew update && brew outdated --cask'
-alias bcubc='brew upgrade --cask && brew cleanup'
 alias brewp='brew pin'
 alias brewsp='brew list --pinned'
 alias bubc='brew upgrade && brew cleanup'


### PR DESCRIPTION
## Standards checklist:

Using the tool proposed in https://github.com/ohmyzsh/ohmyzsh/pull/10859, I could find this duplicate which is easy to fix

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
