### PR TITLE
fix(sublime): pass user's env to `sst`

### DIFF
--- a/plugins/sublime/sublime.plugin.zsh
+++ b/plugins/sublime/sublime.plugin.zsh
@@ -4,7 +4,7 @@ alias st=subl
 alias stt='subl .'
 
 # Define sst only if sudo exists
-(( $+commands[sudo] )) && alias sst='sudo subl'
+(( $+commands[sudo] )) && alias sst='sudo -EH subl'
 
 alias stp=find_project
 alias stn=create_project
@@ -62,7 +62,7 @@ alias stn=create_project
   for _sublime_path in $_sublime_paths; do
     if [[ -a $_sublime_path ]]; then
       alias subl="'$_sublime_path'"
-      (( $+commands[sudo] )) && alias sst="sudo '$_sublime_path'"
+      (( $+commands[sudo] )) && alias sst="sudo -EH '$_sublime_path'"
       break
     fi
   done


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Changed the alias `sst` from `sudo subl` to `sudo -EH subl`

## Other comments:

On some (all ?) wayland environnements, like Hyprland,  `sudo subl` is not able to open a new window (although it can open files in an already open window). This fix allow it to work.