### PR TITLE
fix: Quote ruby prompt

### DIFF
--- a/lib/prompt_info_functions.zsh
+++ b/lib/prompt_info_functions.zsh
@@ -40,5 +40,5 @@ ZSH_THEME_RVM_PROMPT_OPTIONS="i v g"
 # use this to enable users to see their ruby version, no matter which
 # version management system they use
 function ruby_prompt_info() {
-  echo $(rvm_prompt_info || rbenv_prompt_info || chruby_prompt_info)
+  echo "$(rvm_prompt_info || rbenv_prompt_info || chruby_prompt_info)"
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- quotes the call in the `ruby_prompt_info` to preserve leading spaces

## Other comments:

<img width="850" alt="Screenshot 2024-02-03 at 09 54 37" src="https://github.com/ohmyzsh/ohmyzsh/assets/32030464/9d7310fb-33af-412c-8f68-2f796e805c87">
