### PR TITLE
feat(web-search): add programming packages search

### DIFF
--- a/plugins/web-search/README.md
+++ b/plugins/web-search/README.md
@@ -46,6 +46,10 @@ Available search contexts are:
 | `ask`                 | `https://www.ask.com/web?q=`                    |
 | `youtube`             | `https://www.youtube.com/results?search_query=` |
 | `deepl`               | `https://www.deepl.com/translator#auto/auto/`   |
+| `dockerhub`           | `https://hub.docker.com/search?q=`              |
+| `npmpkg`              | `https://www.npmjs.com/search?q=`               |
+| `packagist`           | `https://packagist.org/?query=`                 |
+| `gopkg`               | `https://pkg.go.dev/search?m=package&q=`        |
 
 Also there are aliases for bang-searching DuckDuckGo:
 

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -27,6 +27,10 @@ function web_search() {
     ask             "https://www.ask.com/web?q="
     youtube         "https://www.youtube.com/results?search_query="
     deepl           "https://www.deepl.com/translator#auto/auto/"
+    dockerhub       "https://hub.docker.com/search?q="
+    npmpkg          "https://www.npmjs.com/search?q="
+    packagist       "https://packagist.org/?query="
+    gopkg           "https://pkg.go.dev/search?m=package&q="
   )
 
   # check whether the search engine is supported
@@ -75,6 +79,10 @@ alias scholar='web_search scholar'
 alias ask='web_search ask'
 alias youtube='web_search youtube'
 alias deepl='web_search deepl'
+alias dockerhub='web_search dockerhub'
+alias npmpkg='web_search npmpkg'
+alias packagist='web_search packagist'
+alias gopkg='web_search gopkg'
 
 #add your own !bang searches here
 alias wiki='web_search duckduckgo \!w'


### PR DESCRIPTION
## Changes:

- Add search engine `dockerhub` --> "https://hub.docker.com/search?q=";
- Add search engine `npmpkg` --> "https://www.npmjs.com/search?q=";
- Add search engine `packagist` --> "https://packagist.org/?query=";
- Add search engine `gopkg` --> "https://pkg.go.dev/search?m=package&q=".
- Add new aliases in README.md `ohmyzsh/plugins/web-search/README.md`

## Other comments:

The aliases `npmpkg` and `gopkg` had to have "pkg" added to the name as they would conflict with other commands.

The aliases `dockerhub` and `packagist` got this way due to the name of the container registry itself and the Composer package repository being this way.

I already use them on my PC and I also did some research to see if they would conflict with any commands.