### PR TITLE
feat(kube-ps1): add symlink support

### DIFF
--- a/plugins/kube-ps1/README.md
+++ b/plugins/kube-ps1/README.md
@@ -136,6 +136,7 @@ the following environment variables:
 | `KUBE_PS1_SUFFIX` | `)` | Prompt closing character |
 | `KUBE_PS1_CLUSTER_FUNCTION` | No default, must be user supplied | Function to customize how cluster is displayed |
 | `KUBE_PS1_NAMESPACE_FUNCTION` | No default, must be user supplied | Function to customize how namespace is displayed |
+| `KUBE_PS1_KUBECONFIG_SYMLINK` | `false` | Treat `KUBECONFIG` and `~/.kube/config` files as symbolic links |
 
 For terminals that do not support UTF-8, the symbol will be replaced with the
 string `k8s`.


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x] The PR title is descriptive.
- [ x] The PR doesn't replicate another PR which is already open.
- [ x] I have read the contribution guide and followed all the instructions.
- [ x] The code follows the code style guide detailed in the wiki.
- [ x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Add `KUBE_PS1_KUBECONFIG_SYMLINK` variable that defaults to `false`. This varialble will control the behaviour of `stat` and `zstat` commands. Users will be able to set the var to `true` and thus force the plugin to evaluate the mtime of the symlink instead of the real file. This will be useful when `~/.kube/config` is actually a symlink to a real kubeconfig, and the user regularly updates the symlink to point to another kubeconfig. 

## Other comments:

There was a pr https://github.com/ohmyzsh/ohmyzsh/issues/8786 that actually broke kube-ps1 for me. And this pr is an attempt to find a compromise without breaking anything.
