### PR TITLE
ci: bump `actions/checkout` version

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -26,7 +26,7 @@ jobs:
           - macos-latest
     steps:
       - name: Set up git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install zsh
         if: runner.os == 'Linux'
         run: sudo apt-get update; sudo apt-get install zsh
@@ -42,7 +42,7 @@ jobs:
       - test
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Vercel CLI
         run: npm install -g vercel
       - name: Setup project and deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.repository == 'ohmyzsh/ohmyzsh'
     steps:
       - name: Set up git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install zsh
         run: sudo apt-get update; sudo apt-get install zsh
       - name: Check syntax


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Resolve deprecation warnings in workflows, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

## Other comments:
