### PR TITLE
docs(kubectx): add quoting to array keys

### DIFF
--- a/plugins/kubectx/README.md
+++ b/plugins/kubectx/README.md
@@ -17,9 +17,9 @@ One can rename default context name for better readability.
 
 _Example_. Add to **.zshrc**:
 ```
-kubectx_mapping[minikube]="mini"
-kubectx_mapping[context_name_from_kubeconfig]="$emoji[wolf_face]"
-kubectx_mapping[production_cluster]="%{$fg[yellow]%}prod!%{$reset_color%}"
+kubectx_mapping["minikube"]="mini"
+kubectx_mapping["context_name_from_kubeconfig"]="$emoji[wolf_face]"
+kubectx_mapping["production_cluster"]="%{$fg[yellow]%}prod!%{$reset_color%}"
 ```
 
 ![staging](stage.png)


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

After merging #12191, keys in the associative array of available contexts now need to be quoted.

## Other comments:

Not sure if this change is to be considered a bug or if just fixing the documentation is enough.