### PR TITLE
feat(zoxide): add option to override cmd

### DIFF
--- a/plugins/zoxide/README.md
+++ b/plugins/zoxide/README.md
@@ -10,5 +10,8 @@ To use it, add `zoxide` to the plugins array in your `.zshrc` file:
 ```zsh
 plugins=(... zoxide)
 ```
+## Overriding `z` Alias
+
+You can set the `ZOXIDE_CMD_OVERRIDE`, which will be passed to the `--cmd` flag of `zoxide init`. This allows you to set your `z` command to a default of `cd`.
 
 **Note:** you have to [install zoxide](https://github.com/ajeetdsouza/zoxide#step-1-install-zoxide) first.

--- a/plugins/zoxide/zoxide.plugin.zsh
+++ b/plugins/zoxide/zoxide.plugin.zsh
@@ -1,5 +1,5 @@
 if (( $+commands[zoxide] )); then
-  eval "$(zoxide init zsh)"
+  eval "$(zoxide init --cmd ${ZOXIDE_CMD_OVERRIDE:-z} zsh)"
 else
   echo '[oh-my-zsh] zoxide not found, please install it from https://github.com/ajeetdsouza/zoxide'
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Updating `zoxide.plugin.zsh` to set the `--cmd` argument to the `ZOXIDE_CMD_OVERRIDE` variable with a default of `z`.