### PR TITLE
fix(docker): support completion on snap installs

### DIFF
--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -57,6 +57,6 @@ fi
     ! is-at-least 23.0.0 ${${(s:,:z)"$(command docker --version)"}[3]}; then
         command cp "${0:h}/completions/_docker" "$ZSH_CACHE_DIR/completions/_docker"
       else
-        command docker completion zsh >| "$ZSH_CACHE_DIR/completions/_docker"
+        command docker completion zsh | tee "$ZSH_CACHE_DIR/completions/_docker" > /dev/null
   fi
 } &|


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- This is a replication of #10723 for the same problem showing around snap installs of docker

## Other comments:

- @mcornella I didn't open an issue as to not add overhead for something I took off @strowk 's PR (#10723 ) following issue #10722 . LMK if an issue is indeed needed. I'd be happy to comply.
- The bug here exhibited the same behavior for docker plugin as described in #10722. Namely: `write /dev/stdout: permission denied` on each new shell when docker plugin is enabled. Debugging showed the error stems from the redirection.
- Untested yet. Not sure how to test without `omz pr test ...`