### PR TITLE
Remove rtx backwards compatibility in mise.plugin.zsh

### DIFF
--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -1,23 +1,17 @@
-# TODO: 2024-01-03 remove rtx support
-local __mise=mise
 if (( ! $+commands[mise] )); then
-  if (( $+commands[rtx] )); then
-    __mise=rtx
-  else
-    return
-  fi
+  return
 fi
 
 # Load mise hooks
-eval "$($__mise activate zsh)"
+eval "$(mise activate zsh)"
 
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `mise`. Otherwise, compinit will have already done that.
-if [[ ! -f "$ZSH_CACHE_DIR/completions/_$__mise" ]]; then
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_mise" ]]; then
   typeset -g -A _comps
-  autoload -Uz _$__mise
-  _comps[$__mise]=_$__mise
+  autoload -Uz _mise
+  _comps[mise]=_mise
 fi
 
 # Generate and load mise completion
-$__mise completion zsh >| "$ZSH_CACHE_DIR/completions/_$__mise" &|
+mise completion zsh >| "$ZSH_CACHE_DIR/completions/_mise" &|


### PR DESCRIPTION
This is not necessary given that the rtx plugin is still around

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
