### PR TITLE
fix(ssh): allow multiple definitions per host

### DIFF
--- a/plugins/ssh/ssh.plugin.zsh
+++ b/plugins/ssh/ssh.plugin.zsh
@@ -4,9 +4,16 @@
 # Filter out wildcard host sections.
 _ssh_configfile="$HOME/.ssh/config"
 if [[ -f "$_ssh_configfile" ]]; then
-  _hosts=($(egrep '^Host.*' "$_ssh_configfile" | awk '{print $2}' | grep -v '^*' | sed -e 's/\.*\*$//'))
-  zstyle ':completion:*:hosts' hosts $_hosts
-  unset _hosts
+  _ssh_hosts=($(
+    egrep '^Host.*' "$_ssh_configfile" |\
+    awk '{for (i=2; i<=NF; i++) print $i}' |\
+    sort |\
+    uniq |\
+    grep -v '^*' |\
+    sed -e 's/\.*\*$//'
+  ))
+  zstyle ':completion:*:hosts' hosts $_ssh_hosts
+  unset _ssh_hosts
 fi
 unset _ssh_configfile
 


### PR DESCRIPTION

With the small changes in this commit we split all the host values in lines, sort them out and make a unique array of them.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Update SSH plugin.

## Other comments:

The current completion doesn't work correctly when there are multiple hosts per line, e.g.:

```
Host foo bar baz
```

SSH config also allows to have repeated hosts, e.g.:

```
Host foo bar
  ...

Host foo
  ...
```
