### PR TITLE
fix(tmux): do not pass empty flags to aliases

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -47,7 +47,7 @@ fi
 : ${ZSH_TMUX_UNICODE:=false}
 
 # ALIASES
-function _build_alias {
+function _build_tmux_alias {
   eval "function $1 {
     if [[ \${1::1} == '-' ]]; then
       tmux $2 \"\$@\"
@@ -61,10 +61,12 @@ alias tksv='tmux kill-server'
 alias tl='tmux list-sessions'
 alias tmuxconf='$EDITOR $ZSH_TMUX_CONFIG'
 
-_build_alias "ta" "attach" "-t"
-_build_alias "tad" "attach -d" "-t"
-_build_alias "ts" "new-session" "-s"
-_build_alias "tkss" "kill-session" "-t"
+_build_tmux_alias "ta" "attach" "-t"
+_build_tmux_alias "tad" "attach -d" "-t"
+_build_tmux_alias "ts" "new-session" "-s"
+_build_tmux_alias "tkss" "kill-session" "-t"
+
+unfunction _build_tmux_alias
 
 # Determine if the terminal supports 256 colors
 if [[ $terminfo[colors] == 256 ]]; then

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -49,7 +49,7 @@ fi
 # ALIASES
 function _build_tmux_alias {
   eval "function $1 {
-    if [[ \${1::1} == '-' ]]; then
+    if [[ -z \$1 ]] || [[ \${1::1} == '-' ]]; then
       tmux $2 \"\$@\"
     else
       tmux $2 $3 \"\$@\"

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -37,13 +37,42 @@ fi
 : ${ZSH_TMUX_UNICODE:=false}
 
 # ALIASES
-alias ta='tmux attach -t'
-alias tad='tmux attach -d -t'
-alias ts='tmux new-session -s'
 alias tl='tmux list-sessions'
 alias tksv='tmux kill-server'
-alias tkss='tmux kill-session -t'
 alias tmuxconf='$EDITOR $ZSH_TMUX_CONFIG'
+
+function ts() {
+  if [[ $@ == -* ]]; then
+    tmux new-session $@
+  else
+    tmux new-session ${@:+-s}$@
+  fi
+}
+
+function tkss() {
+  if [[ $@ == -* ]]; then
+    tmux kill-session $@
+  else
+    tmux kill-session ${@:+-t}$@
+  fi
+}
+
+function ta() {
+  if [[ $@ == -* ]]; then
+    tmux attach-session $@
+  else
+    tmux attach-session ${@:+-t}$@
+
+  fi
+}
+
+function tad() {
+  if [[ $@ == -* ]]; then
+    tmux attach-session -d $@
+  else
+    tmux attach-session -d ${@:+-t}$@
+  fi
+}
 
 # Determine if the terminal supports 256 colors
 if [[ $terminfo[colors] == 256 ]]; then

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -47,42 +47,24 @@ fi
 : ${ZSH_TMUX_UNICODE:=false}
 
 # ALIASES
-alias tl='tmux list-sessions'
+function _build_alias {
+  eval "function $1 {
+    if [[ \${1::1} == '-' ]]; then
+      tmux $2 \"\$@\"
+    else
+      tmux $2 $3 \"\$@\"
+    fi
+  }"
+}
+
 alias tksv='tmux kill-server'
+alias tl='tmux list-sessions'
 alias tmuxconf='$EDITOR $ZSH_TMUX_CONFIG'
 
-function ts() {
-  if [[ $@ == -* ]]; then
-    tmux new-session $@
-  else
-    tmux new-session ${@:+-s}$@
-  fi
-}
-
-function tkss() {
-  if [[ $@ == -* ]]; then
-    tmux kill-session $@
-  else
-    tmux kill-session ${@:+-t}$@
-  fi
-}
-
-function ta() {
-  if [[ $@ == -* ]]; then
-    tmux attach-session $@
-  else
-    tmux attach-session ${@:+-t}$@
-
-  fi
-}
-
-function tad() {
-  if [[ $@ == -* ]]; then
-    tmux attach-session -d $@
-  else
-    tmux attach-session -d ${@:+-t}$@
-  fi
-}
+_build_alias "ta" "attach" "-t"
+_build_alias "tad" "attach -d" "-t"
+_build_alias "ts" "new-session" "-s"
+_build_alias "tkss" "kill-session" "-t"
 
 # Determine if the terminal supports 256 colors
 if [[ $terminfo[colors] == 256 ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Removes the -t flag from the aliases. (Fixes #12230)

## Other comments:

If passing -t does something important, this may not be ideal. AFAICT `tmux attach-session` and `tmux attach-session -t` are identical.
