### PR TITLE
feat(git-commit): added new flags

### DIFF
--- a/plugins/git-commit/README.md
+++ b/plugins/git-commit/README.md
@@ -42,6 +42,28 @@ Where `type` is one of the following:
 | Git alias                                     | Command                                              |
 | --------------------------------------------- | ---------------------------------------------------- |
 | `git style "remove trailing whitespace"`      | `git commit -m "style: remove trailing whitespace"`  |
-| `git wip "work in progress"`                  | `git commit -m "work in progress"`                   |
+| `git wip -a "work in progress"`               | `git commit -m "wip!: work in progress"`             |
 | `git fix -s "router" "correct redirect link"` | `git commit -m "fix(router): correct redirect link"` |
-| `git rev -s "api" "rollback v2"`              | `git commit -m "revert(api): rollback v2"`           |
+| `git rev -a -s "api" "rollback v2"`           | `git commit -m "revert(api)!: rollback v2"`          |
+
+## Conventional Commits List
+
+| Type     | Name                     | Description                                                                                            |
+| -------- | ------------------------ | ------------------------------------------------------------------------------------------------------ |
+| build    | Builds                   | Change that affect the build system or external dependencies (exemple scopes: composer and/or npm)     |
+| chore    | Chores                   | Other changes that don't modify src or test files                                                      |
+| ci       | Continuous Integrations  | Changes to our CI configuration files and scripts                                                      |
+| docs     | Documantation            | Documentation onyl changes                                                                             |
+| feat     | Features                 | A new feature                                                                                          |
+| fix      | Bug Fixes                | A bug fix                                                                                              |
+| perf     | Performance Improvements | A code change that improves performance                                                                |
+| refactor | Code Refactoring         | A code change tha neither fixes a bug nor adds a feature                                               |
+| rev      | Reverts                  | Reverts a previous commit                                                                              |
+| style    | Styles                   | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
+| test     | Tests                    | Adding missing tests or correcting existing tests                                                      |
+
+## Extras
+
+| Type  | Name             | Description                                                                       |
+| ----- | ---------------- | --------------------------------------------------------------------------------- |
+| wip   | Work In Progress | Denote commits that are still in progress and not ready for integration or review |

--- a/plugins/git-commit/README.md
+++ b/plugins/git-commit/README.md
@@ -12,6 +12,9 @@ plugins=(... git-commit)
 
 ```zsh
 git <type> [(-s, --scope) "<scope>"] "<message>"
+git <type> [(-a, --attention)] "<message>"
+git <type> [(-s, --scope) "<scope>"] [(-a, --attention)] "<message>"
+git <type> [(-sa, -as)] "<scope>" "<message>" "<message>"
 ```
 
 > ⚠️ Single/Double quotes around the scope and message are required

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -24,19 +24,19 @@ _git_commit_flags=(
   '-as'
 )
 
-remove_flags() {
-  local regex=$(
-    IFS="|"
-    echo "${_git_commit_flags[*]}"
-  )
-
-  echo $(sed -E "s/\s($regex)\s|\s($regex)$//g" <<<"$1")
-}
-
 build_message() {
   local argv=("$@")
   local argc=${#@}
   local i=1
+
+  remove_flags() {
+    local regex=$(
+      IFS="|"
+      echo "${_git_commit_flags[*]}"
+    )
+
+    echo $(sed -E "s/\s($regex)\s|\s($regex)$//g" <<<"$1")
+  }
 
   while [[ $i -lt $argc ]]; do
     local flag="${argv[$i]}"

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -14,7 +14,6 @@ _git_commit_aliases=(
   'wip'
 )
 
-local -a _git_commit_flags
 _git_commit_flags=(
   '-s'
   '--scope'
@@ -33,7 +32,7 @@ remove_flags() {
   message=$(sed -E "s/\s($regex)\s|\s($regex)$//g" <<< "$message")
 
   echo "$message"
-}
+};
 
 build_message () {
   if [[ "$*" =~ (-sa|-as) ]]; then
@@ -77,4 +76,4 @@ for type in "${_git_commit_aliases[@]}"; do
   fi
 done
 
-unset _git_commit_aliases _flags alias type
+unset _git_commit_aliases _git_commit_flags alias type

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -29,12 +29,6 @@ build_message() {
   local argc=${#@}
   local i=1
 
-  remove_flags() {
-    local regex="${(j:|:)_git_commit_flags}"
-
-    echo -n $(sed -E "s/\s*($regex)\s*//g" <<< "$1")
-  }
-
   while [[ $i -lt $argc ]]; do
     local flag="${argv[$i]}"
     local value="${argv[$i + 1]}"
@@ -59,7 +53,7 @@ build_message() {
   done
 
   local template="'$type'${scope}$attention: ${@}"
-  local message=$(remove_flags "$template" "${_git_commit_flags[@]}")
+  local message=$(noglob sed -E "s/\s*(${(j:|:)_git_commit_flags})\s*//g" <<< "$template")
 
   git commit -m "$message"
 }

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -32,7 +32,7 @@ remove_flags() {
 build_message () {
   local argv=("$@")
   local argc=${#@}
-  local i=0
+  local i=1
 
   while [[ $i -lt $argc ]];
   do

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -24,21 +24,23 @@ _git_commit_flags=(
 )
 
 remove_flags() {
-  local regex=$(IFS="|"; echo "${_git_commit_flags[*]}")
+  local regex=$(
+    IFS="|"
+    echo "${_git_commit_flags[*]}"
+  )
 
-  echo $(sed -E "s/\s($regex)\s|\s($regex)$//g" <<< "$1")
-};
+  echo $(sed -E "s/\s($regex)\s|\s($regex)$//g" <<<"$1")
+}
 
-build_message () {
+build_message() {
   local argv=("$@")
   local argc=${#@}
   local i=1
 
-  while [[ $i -lt $argc ]];
-  do
+  while [[ $i -lt $argc ]]; do
     local flag="${argv[$i]}"
     local value="${argv[$i + 1]}"
-    local next=$[$i + 1]
+    local next=$(($i + 1))
 
     if [[ "$flag" =~ (-sa|-as) ]]; then
       local attention='!'
@@ -55,14 +57,14 @@ build_message () {
       local scope="($value)"
       i=$next
     fi
-  i=$next
+    i=$next
   done
 
-  local template="'$type'${scope}$attention: ${@}";
+  local template="'$type'${scope}$attention: ${@}"
   local message=$(remove_flags "$template" "${_git_commit_flags[@]}")
 
   git commit -m "$message"
-};
+}
 
 local alias type
 for type in "${_git_commit_aliases[@]}"; do

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -30,10 +30,7 @@ build_message() {
   local i=1
 
   remove_flags() {
-    local regex=$(
-      IFS="|"
-      echo "${_git_commit_flags[*]}"
-    )
+    local regex="${(j:|:)_git_commit_flags}"
 
     echo $(sed -E "s/\s($regex)\s|\s($regex)$//g" <<<"$1")
   }

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -24,14 +24,9 @@ _git_commit_flags=(
 )
 
 remove_flags() {
-  local message="$1"
-  local flags=("${@:2}")
-
   local regex=$(IFS="|"; echo "${_git_commit_flags[*]}")
 
-  message=$(sed -E "s/\s($regex)\s|\s($regex)$//g" <<< "$message")
-
-  echo "$message"
+  echo $(sed -E "s/\s($regex)\s|\s($regex)$//g" <<< "$1")
 };
 
 build_message () {

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -32,7 +32,7 @@ build_message() {
   remove_flags() {
     local regex="${(j:|:)_git_commit_flags}"
 
-    echo $(sed -E "s/\s($regex)\s|\s($regex)$//g" <<<"$1")
+    echo -n $(sed -E "s/\s*($regex)\s*//g" <<< "$1")
   }
 
   while [[ $i -lt $argc ]]; do

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -14,6 +14,7 @@ _git_commit_aliases=(
   'wip'
 )
 
+typeset -a _git_commit_flags
 _git_commit_flags=(
   '-s'
   '--scope'

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -27,7 +27,7 @@ remove_flags() {
   local message="$1"
   local flags=("${@:2}")
 
-  local regex=$(IFS="|"; echo "${flags[*]}")
+  local regex=$(IFS="|"; echo "${_git_commit_flags[*]}")
 
   message=$(sed -E "s/\s($regex)\s|\s($regex)$//g" <<< "$message")
 
@@ -38,23 +38,18 @@ build_message () {
   if [[ "$*" =~ (-sa|-as) ]]; then
     local attention='!'
     local scope="($2)"
-    shift 2
   elif [[ "$1" =~ (-a|--attention) ]]; then
     local attention='!'
-    shift 1
   elif [[ "$2" =~ (-a|--attention) ]]; then
     local attention='!'
-    shift 1
   elif [[ "$*" =~ (-a|--attention) ]]; then
     local attention='!'
   fi
 
   if [[ "$*" =~ (-s|--scope) ]]; then
     local scope="($2)"
-    shift 2
   elif [[ "$2" =~ (-s|--scope) ]]; then
     local scope="($3)"
-    shift 2
   fi
 
   local message="'$type'${scope}$attention: $@";

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -35,26 +35,34 @@ remove_flags() {
 };
 
 build_message () {
-  if [[ "$*" =~ (-sa|-as) ]]; then
-    local attention='!'
-    local scope="($2)"
-  elif [[ "$1" =~ (-a|--attention) ]]; then
-    local attention='!'
-  elif [[ "$2" =~ (-a|--attention) ]]; then
-    local attention='!'
-  elif [[ "$*" =~ (-a|--attention) ]]; then
-    local attention='!'
-  fi
+  local argv=("$@")
+  local argc=${#@}
+  local i=0
 
-  if [[ "$*" =~ (-s|--scope) ]]; then
-    local scope="($2)"
-  elif [[ "$2" =~ (-s|--scope) ]]; then
-    local scope="($3)"
-  fi
+  while [ $i -lt $argc ];
+  do
+    if [[ "${argv[$i]}" =~ (-sa|-as) ]]; then
+      local attention='!'
+      local scope="(${argv[$i + 1]})"
+      i=$[$i + 1]
+    fi
 
-  local message="'$type'${scope}$attention: $@";
+    if [[ "${argv[$i]}" =~ (-a|--attention) ]]; then
+      local attention='!'
+      i=$[$i + 1]
+    fi
 
-  git commit -m $(remove_flags "$message" "${_git_commit_flags[@]}")
+    if [[ "${argv[$i]}" =~ (-s|--scope) ]]; then
+      local scope="(${argv[$i + 1]})"
+      i=$[$i + 1]
+    fi
+  i=$[$i + 1]
+  done
+
+  local template="'$type'${scope}$attention: ${@}";
+  local message=$(remove_flags "$template" "${_git_commit_flags[@]}")
+
+  git commit -m "$message"
 };
 
 local alias type

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -34,7 +34,7 @@ build_message () {
   local argc=${#@}
   local i=0
 
-  while [ $i -lt $argc ];
+  while [[ $i -lt $argc ]];
   do
     if [[ "${argv[$i]}" =~ (-sa|-as) ]]; then
       local attention='!'

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -52,7 +52,7 @@ build_message() {
     i=$next
   done
 
-  local template="'$type'${scope}$attention: ${@}"
+  local template="'$type'${scope}$attention:' ${@}'"
   local message=$(noglob sed -E "s/\s*(${(j:|:)_git_commit_flags})\s*//g" <<< "$template")
 
   git commit -m "$message"

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -14,6 +14,48 @@ _git_commit_aliases=(
   'wip'
 )
 
+local -a _git_commit_flags
+_git_commit_flags=(
+  '-s'
+  '--scope'
+  '-a'
+  '--attention'
+  '-sa'
+  '-as'
+)
+
+remove_flags() {
+  local message="$1"
+  local flags=("${@:2}")
+
+  local regex=$(IFS="|"; echo "${flags[*]}")
+
+  message=$(sed -E "s/\s($regex)\s|\s($regex)$//g" <<< "$message")
+
+  echo "$message"
+}
+
+build_message () {
+  if [[ "$*" =~ (-sa|-as) ]]; then
+    local attention='!'
+    local scope="($2)"
+    shift 2
+  else
+    if [[ "$*" =~ (-s|--scope) ]]; then
+      local scope="($2)"
+      shift 2
+    fi
+
+    if [[ "$*" =~ (-a|--attention) ]]; then
+      local attention='!'
+    fi
+  fi
+
+  local message="'$type'${scope}$attention: $@";
+
+  git commit -m $(remove_flags "$message" "${_git_commit_flags[@]}")
+};
+
 local alias type
 for type in "${_git_commit_aliases[@]}"; do
   # an alias can't be named "revert" because the git command takes precedence
@@ -23,10 +65,9 @@ for type in "${_git_commit_aliases[@]}"; do
   *) alias=$type ;;
   esac
 
-  local func='!a() { if [ "$1" = "-s" ] || [ "$1" = "--scope" ]; then local scope="$2"; shift 2; git commit -m "'$type'(${scope}): ${@}"; else git commit -m "'$type': ${@}"; fi }; a'
   if ! git config --global --get-all alias.${alias} >/dev/null 2>&1; then
-    git config --global alias.${alias} "$func"
+    git config --global alias.${alias} build_message
   fi
 done
 
-unset _git_commit_aliases alias type func
+unset _git_commit_aliases _flags alias type

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -36,22 +36,26 @@ build_message () {
 
   while [[ $i -lt $argc ]];
   do
-    if [[ "${argv[$i]}" =~ (-sa|-as) ]]; then
+    local flag="${argv[$i]}"
+    local value="${argv[$i + 1]}"
+    local next=$[$i + 1]
+
+    if [[ "$flag" =~ (-sa|-as) ]]; then
       local attention='!'
-      local scope="(${argv[$i + 1]})"
-      i=$[$i + 1]
+      local scope="($value)"
+      i=$next
     fi
 
-    if [[ "${argv[$i]}" =~ (-a|--attention) ]]; then
+    if [[ "$flag" =~ (-a|--attention) ]]; then
       local attention='!'
-      i=$[$i + 1]
+      i=$next
     fi
 
-    if [[ "${argv[$i]}" =~ (-s|--scope) ]]; then
-      local scope="(${argv[$i + 1]})"
-      i=$[$i + 1]
+    if [[ "$flag" =~ (-s|--scope) ]]; then
+      local scope="($value)"
+      i=$next
     fi
-  i=$[$i + 1]
+  i=$next
   done
 
   local template="'$type'${scope}$attention: ${@}";

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -51,7 +51,7 @@ build_message () {
       i=$next
     fi
 
-    if [[ "$flag" =~ (-s|--scope) ]]; then
+    if [[ "$flag" =~ (-s|--scope) && -n "$value" ]]; then
       local scope="($value)"
       i=$next
     fi

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -40,15 +40,22 @@ build_message () {
     local attention='!'
     local scope="($2)"
     shift 2
-  else
-    if [[ "$*" =~ (-s|--scope) ]]; then
-      local scope="($2)"
-      shift 2
-    fi
+  elif [[ "$1" =~ (-a|--attention) ]]; then
+    local attention='!'
+    shift 1
+  elif [[ "$2" =~ (-a|--attention) ]]; then
+    local attention='!'
+    shift 1
+  elif [[ "$*" =~ (-a|--attention) ]]; then
+    local attention='!'
+  fi
 
-    if [[ "$*" =~ (-a|--attention) ]]; then
-      local attention='!'
-    fi
+  if [[ "$*" =~ (-s|--scope) ]]; then
+    local scope="($2)"
+    shift 2
+  elif [[ "$2" =~ (-s|--scope) ]]; then
+    local scope="($3)"
+    shift 2
   fi
 
   local message="'$type'${scope}$attention: $@";


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
- [Commit message with ! to draw attention to breaking change](https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with--to-draw-attention-to-breaking-change)
```zsh
git <type> [(-a, --attention)] "<message>"
git <type> [(-s, --scope) "<scope>"] [(-a, --attention)] "<message>"
git <type> [(-sa, -as)] "<scope>" "<message>"
```
- Update of documentation related to types