### PR TITLE
feat(eza): create plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Plugin owners
 plugins/archlinux/                  @ratijas
+plugins/dbt/                        @msempere
 plugins/eza/                        @pepoluan
 plugins/genpass/                    @atoponce
 plugins/git-lfs/                    @hellovietduc
@@ -7,8 +8,7 @@ plugins/gitfast/                    @felipec
 plugins/react-native                @esthor
 plugins/sdk/                        @rgoldberg
 plugins/shell-proxy/                @septs
+plugins/starship/                   @axieax
 plugins/universalarchive/           @Konfekt
 plugins/wp-cli/                     @joshmedeski
 plugins/zoxide/                     @ajeetdsouza
-plugins/starship/                   @axieax
-plugins/dbt/                        @msempere

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Plugin owners
 plugins/archlinux/                  @ratijas
+plugins/eza/                        @pepoluan
 plugins/genpass/                    @atoponce
 plugins/git-lfs/                    @hellovietduc
 plugins/gitfast/                    @felipec

--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -86,13 +86,18 @@ Default: Not set, which means the default behavior of `eza` will take place.
 
 ## Aliases
 
-Note that aliases may be modified by Configuration.
+**Notes:**
+
+* Aliases may be modified by Configuration
+* The term "files" without "only" qualifier means both files & directories
 
 
 | Alias   | Command           | Description                                                                 |
 | ------- | ----------------- | --------------------------------------------------------------------------- |
 | `la`    | `eza -la`         | List all files (except . and ..) as a long list                             |
-| `ldot`  | `eza -ld .*`      | List all dotfiles (directories shown as entries instead of recursed into)   |
+| `ldot`  | `eza -ld .*`      | List dotfiles only (directories shown as entries instead of recursed into)  |
+| `lD`    | `eza -lD`         | List only directories (excluding dotdirs) as a long list                    |
+| `lDD`   | `eza -laD`        | List only directories (including dotdirs) as a long list                    |
 | `ll`    | `eza -l`          | List files as a long list                                                   |
 | `ls`    | `eza`             | Plain eza call                                                              |
 | `lS`    | `eza -l -ssize`   | List files as a long list, sorted by size                                   |

--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -20,9 +20,9 @@ All configurations are done using the `zstyle` command in the `:omz:plugins:eza`
 zstyle ':omz:plugins:eza' 'dirs-first' $BOOL
 ```
 
-If `1`, directories will be grouped first.
+If `true`, directories will be grouped first.
 
-Default: `0`
+Default: `false`
 
 
 ### `showgroup`
@@ -31,9 +31,9 @@ Default: `0`
 zstyle ':omz:plugins:eza' 'showgroup' $BOOL
 ```
 
-If `1` (default), always add `-g` flag to show the group ownership.
+If `true` (default), always add `-g` flag to show the group ownership.
 
-Default: `1`
+Default: `true`
 
 
 ### `time-style`

--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -12,6 +12,7 @@ plugins=(... eza)
 
 All configurations are done using the `zstyle` command in the `:omz:plugins:eza` namespace.
 
+**NOTE:** The configuring needs to be done prior to OMZ loading the plugins. When the plugin is loaded, changing the `zstyle` won't have any effect.
 
 ### `dirs-first`
 

--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -100,6 +100,8 @@ Default: Not set, which means the default behavior of `eza` will take place.
 | `lDD`   | `eza -laD`        | List only directories (including dotdirs) as a long list                    |
 | `ll`    | `eza -l`          | List files as a long list                                                   |
 | `ls`    | `eza`             | Plain eza call                                                              |
+| `lsd`   | `eza -d`          | List specified files with directories as entries, in a grid                 |
+| `lsdl`  | `eza -dl`         | List specified files with directories as entries, in a long list            |
 | `lS`    | `eza -l -ssize`   | List files as a long list, sorted by size                                   |
 | `lT`    | `eza -l -snewest` | List files as a long list, sorted by date (newest last)                     |
 

--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -25,6 +25,17 @@ If `true`, directories will be grouped first.
 Default: `false`
 
 
+### `git-status`
+
+```zsh
+zstyle ':omz:plugins:eza' 'git-status' $BOOL
+```
+
+If `true`, always add `--git` flag to indicate git status (if tracked / in a git repo).
+
+Default: `false`
+
+
 ### `header`
 
 ```zsh

--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -17,51 +17,51 @@ All configurations are done using the `zstyle` command in the `:omz:plugins:eza`
 ### `dirs-first`
 
 ```zsh
-zstyle ':omz:plugins:eza' 'dirs-first' $BOOL
+zstyle ':omz:plugins:eza' 'dirs-first' yes|no
 ```
 
-If `true`, directories will be grouped first.
+If `yes`, directories will be grouped first.
 
-Default: `false`
+Default: `no`
 
 
 ### `git-status`
 
 ```zsh
-zstyle ':omz:plugins:eza' 'git-status' $BOOL
+zstyle ':omz:plugins:eza' 'git-status' yes|no
 ```
 
-If `true`, always add `--git` flag to indicate git status (if tracked / in a git repo).
+If `yes`, always add `--git` flag to indicate git status (if tracked / in a git repo).
 
-Default: `false`
+Default: `no`
 
 
 ### `header`
 
 ```zsh
-zstyle ':omz:plugins:eza' 'header' $BOOL
+zstyle ':omz:plugins:eza' 'header' yes|no
 ```
 
-If `true`, always add `-h` flag to add a header row for each column.
+If `yes`, always add `-h` flag to add a header row for each column.
 
-Default: `false`
+Default: `no`
 
 
 ### `showgroup`
 
 ```zsh
-zstyle ':omz:plugins:eza' 'showgroup' $BOOL
+zstyle ':omz:plugins:eza' 'showgroup' yes|no
 ```
 
-If `true` (default), always add `-g` flag to show the group ownership.
+If `yes` (default), always add `-g` flag to show the group ownership.
 
-Default: `true`
+Default: `yes`
 
 
 ### `size-prefix`
 
 ```zsh
-zstyle ':omz:plugins:eza' 'size-prefix' ('binary'|'none'|'si')
+zstyle ':omz:plugins:eza' 'size-prefix' (binary|none|si)
 ```
 
 Choose the prefix to be used in displaying file size:

--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -47,6 +47,21 @@ If `true` (default), always add `-g` flag to show the group ownership.
 Default: `true`
 
 
+### `size-prefix`
+
+```zsh
+zstyle ':omz:plugins:eza' 'size-prefix' ('binary'|'none'|'si')
+```
+
+Choose the prefix to be used in displaying file size:
+
+* `binary` -- use [binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix) such as "Ki", "Mi", "Gi" and so on
+* `none` -- don't use any prefix, show size in bytes
+* `si` (default) -- use [Metric/S.I. prefixes](https://en.wikipedia.org/wiki/Metric_prefix)
+
+Default: `si`
+
+
 ### `time-style`
 
 ```zsh

--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -12,7 +12,8 @@ plugins=(... eza)
 
 All configurations are done using the `zstyle` command in the `:omz:plugins:eza` namespace.
 
-**NOTE:** The configuring needs to be done prior to OMZ loading the plugins. When the plugin is loaded, changing the `zstyle` won't have any effect.
+**NOTE:** The configuring needs to be done prior to OMZ loading the plugins. When the plugin is loaded,
+changing the `zstyle` won't have any effect.
 
 ### `dirs-first`
 
@@ -24,7 +25,6 @@ If `yes`, directories will be grouped first.
 
 Default: `no`
 
-
 ### `git-status`
 
 ```zsh
@@ -34,7 +34,6 @@ zstyle ':omz:plugins:eza' 'git-status' yes|no
 If `yes`, always add `--git` flag to indicate git status (if tracked / in a git repo).
 
 Default: `no`
-
 
 ### `header`
 
@@ -46,17 +45,15 @@ If `yes`, always add `-h` flag to add a header row for each column.
 
 Default: `no`
 
-
-### `showgroup`
+### `show-group`
 
 ```zsh
-zstyle ':omz:plugins:eza' 'showgroup' yes|no
+zstyle ':omz:plugins:eza' 'show-group' yes|no
 ```
 
 If `yes` (default), always add `-g` flag to show the group ownership.
 
 Default: `yes`
-
 
 ### `size-prefix`
 
@@ -66,12 +63,12 @@ zstyle ':omz:plugins:eza' 'size-prefix' (binary|none|si)
 
 Choose the prefix to be used in displaying file size:
 
-* `binary` -- use [binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix) such as "Ki", "Mi", "Gi" and so on
-* `none` -- don't use any prefix, show size in bytes
-* `si` (default) -- use [Metric/S.I. prefixes](https://en.wikipedia.org/wiki/Metric_prefix)
+- `binary` -- use [binary prefixes](https://en.wikipedia.org/wiki/Binary_prefix) such as "Ki", "Mi", "Gi" and
+  so on
+- `none` -- don't use any prefix, show size in bytes
+- `si` (default) -- use [Metric/S.I. prefixes](https://en.wikipedia.org/wiki/Metric_prefix)
 
 Default: `si`
-
 
 ### `time-style`
 
@@ -83,25 +80,22 @@ Sets the `--time-style` option of `eza`. (See `man eza` for the options)
 
 Default: Not set, which means the default behavior of `eza` will take place.
 
-
 ## Aliases
 
 **Notes:**
 
-* Aliases may be modified by Configuration
-* The term "files" without "only" qualifier means both files & directories
+- Aliases may be modified by Configuration
+- The term "files" without "only" qualifier means both files & directories
 
-
-| Alias   | Command           | Description                                                                 |
-| ------- | ----------------- | --------------------------------------------------------------------------- |
-| `la`    | `eza -la`         | List all files (except . and ..) as a long list                             |
-| `ldot`  | `eza -ld .*`      | List dotfiles only (directories shown as entries instead of recursed into)  |
-| `lD`    | `eza -lD`         | List only directories (excluding dotdirs) as a long list                    |
-| `lDD`   | `eza -laD`        | List only directories (including dotdirs) as a long list                    |
-| `ll`    | `eza -l`          | List files as a long list                                                   |
-| `ls`    | `eza`             | Plain eza call                                                              |
-| `lsd`   | `eza -d`          | List specified files with directories as entries, in a grid                 |
-| `lsdl`  | `eza -dl`         | List specified files with directories as entries, in a long list            |
-| `lS`    | `eza -l -ssize`   | List files as a long list, sorted by size                                   |
-| `lT`    | `eza -l -snewest` | List files as a long list, sorted by date (newest last)                     |
-
+| Alias  | Command           | Description                                                                |
+| ------ | ----------------- | -------------------------------------------------------------------------- |
+| `la`   | `eza -la`         | List all files (except . and ..) as a long list                            |
+| `ldot` | `eza -ld .*`      | List dotfiles only (directories shown as entries instead of recursed into) |
+| `lD`   | `eza -lD`         | List only directories (excluding dotdirs) as a long list                   |
+| `lDD`  | `eza -laD`        | List only directories (including dotdirs) as a long list                   |
+| `ll`   | `eza -l`          | List files as a long list                                                  |
+| `ls`   | `eza`             | Plain eza call                                                             |
+| `lsd`  | `eza -d`          | List specified files with directories as entries, in a grid                |
+| `lsdl` | `eza -dl`         | List specified files with directories as entries, in a long list           |
+| `lS`   | `eza -l -ssize`   | List files as a long list, sorted by size                                  |
+| `lT`   | `eza -l -snewest` | List files as a long list, sorted by date (newest last)                    |

--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -25,6 +25,17 @@ If `true`, directories will be grouped first.
 Default: `false`
 
 
+### `header`
+
+```zsh
+zstyle ':omz:plugins:eza' 'header' $BOOL
+```
+
+If `true`, always add `-h` flag to add a header row for each column.
+
+Default: `false`
+
+
 ### `showgroup`
 
 ```zsh

--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -1,0 +1,62 @@
+# eza plugin
+
+This provides aliases that invoke the [`eza`](https://github.com/eza-community/eza) utility rather than `ls`
+
+To use it add `eza` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... eza)
+```
+
+## Configuration
+
+All configurations are done using the `zstyle` command in the `:omz:plugins:eza` namespace.
+
+
+### `dirs-first`
+
+```zsh
+zstyle ':omz:plugins:eza' 'dirs-first' $BOOL
+```
+
+If `1`, directories will be grouped first.
+
+Default: `0`
+
+
+### `showgroup`
+
+```zsh
+zstyle ':omz:plugins:eza' 'showgroup' $BOOL
+```
+
+If `1` (default), always add `-g` flag to show the group ownership.
+
+Default: `1`
+
+
+### `time-style`
+
+```zsh
+zstyle ':omz:plugins:eza' 'time-style' $TIME_STYLE
+```
+
+Sets the `--time-style` option of `eza`. (See `man eza` for the options)
+
+Default: Not set, which means the default behavior of `eza` will take place.
+
+
+## Aliases
+
+Note that aliases may be modified by Configuration.
+
+
+| Alias   | Command           | Description                                                                 |
+| ------- | ----------------- | --------------------------------------------------------------------------- |
+| `la`    | `eza -la`         | List all files (except . and ..) as a long list                             |
+| `ldot`  | `eza -ld .*`      | List all dotfiles (directories shown as entries instead of recursed into)   |
+| `ll`    | `eza -l`          | List files as a long list                                                   |
+| `ls`    | `eza`             | Plain eza call                                                              |
+| `lS`    | `eza -l -ssize`   | List files as a long list, sorted by size                                   |
+| `lT`    | `eza -l -snewest` | List files as a long list, sorted by date (newest last)                     |
+

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -15,6 +15,18 @@ function _configure_eza() {
   if zstyle -t ':omz:plugins:eza' 'header'; then
     _EZA_HEAD+=("h")
   fi
+  zstyle -s ':omz:plugins:eza' 'size-prefix' _val
+  case "${_val:l}" in
+    binary)
+      _EZA_HEAD+=("b")
+      ;;
+    none)
+      _EZA_HEAD+=("B")
+      ;;
+  esac
+  if zstyle -s ':omz:plugins:eza' 'header'; then
+    _EZA_HEAD+=("h")
+  fi
   # Get the tail long-options
   if zstyle -t ':omz:plugins:eza' 'dirs-first'; then
     _EZA_TAIL+=("--group-directories-first")

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -9,13 +9,11 @@ typeset -a _EZA_TAIL
 function _configure_eza() {
   local _val
   # Get the head flags
-  zstyle -s ':omz:plugins:eza' 'showgroup' _val
-  if [[ -z $_val || $_val == 1 ]]; then
+  if zstyle -T ':omz:plugins:eza' 'showgroup'; then
     _EZA_HEAD+=("g")
   fi
   # Get the tail long-options
-  zstyle -s ':omz:plugins:eza' 'dirs-first' _val
-  if [[ $_val == 1 ]]; then
+  if zstyle -t ':omz:plugins:eza' 'dirs-first'; then
     _EZA_TAIL+=("--group-directories-first")
   fi
   zstyle -s ':omz:plugins:eza' 'time-style' _val

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -51,6 +51,8 @@ _alias_eza lD   lD
 _alias_eza lDD  lDa
 _alias_eza ll   l
 _alias_eza ls
+_alias_eza lsd  d
+_alias_eza lsdl dl
 _alias_eza lS   "l -ssize"
 _alias_eza lT   "l -snewest"
 

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -24,9 +24,6 @@ function _configure_eza() {
       _EZA_HEAD+=("B")
       ;;
   esac
-  if zstyle -s ':omz:plugins:eza' 'header'; then
-    _EZA_HEAD+=("h")
-  fi
   # Get the tail long-options
   if zstyle -t ':omz:plugins:eza' 'dirs-first'; then
     _EZA_TAIL+=("--group-directories-first")

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -50,6 +50,8 @@ function _alias_eza() {
 
 _alias_eza la   la
 _alias_eza ldot ld ".*"
+_alias_eza lD   lD
+_alias_eza lDD  lDa
 _alias_eza ll   l
 _alias_eza ls
 _alias_eza lS   "l -ssize"

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -27,9 +27,9 @@ function _configure_eza() {
 _configure_eza
 
 function _alias_eza() {
-  local _tail
-  _tail="${(j: :)_EZA_TAIL}"
-  alias "$1"="eza -${(j::)_EZA_HEAD}$2${_tail:+ }${_tail}${3:+ }$3"
+  local _head="${(j::)_EZA_HEAD}$2"
+  local _tail="${(j: :)_EZA_TAIL}"
+  alias "$1"="eza ${_head:+-}${_head}${_tail:+ }${_tail}${3:+ }$3"
 }
 
 _alias_eza la   la
@@ -43,4 +43,3 @@ unfunction _alias_eza
 unfunction _configure_eza
 unset _EZA_HEAD
 unset _EZA_TAIL
-

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -27,7 +27,7 @@ _configure_eza
 function _alias_eza() {
   local _head="${(j::)_EZA_HEAD}$2"
   local _tail="${(j: :)_EZA_TAIL}"
-  alias "$1"="eza ${_head:+-}${_head}${_tail:+ }${_tail}${3:+ }$3"
+  alias "$1"="eza${_head:+ -}${_head}${_tail:+ }${_tail}${3:+ }$3"
 }
 
 _alias_eza la   la

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -1,0 +1,43 @@
+
+
+typeset -a _EZA_HEAD
+typeset -a _EZA_TAIL
+
+function _configure_eza() {
+  local _val
+  # Get the head flags
+  zstyle -s ':omz:plugins:eza' 'showgroup' _val
+  if [[ -z $_val || $_val == 1 ]]; then
+    _EZA_HEAD+=("g")
+  fi
+  # Get the tail long-options
+  zstyle -s ':omz:plugins:eza' 'dirs-first' _val
+  if [[ $_val == 1 ]]; then
+    _EZA_TAIL+=("--group-directories-first")
+  fi
+  zstyle -s ':omz:plugins:eza' 'time-style' _val
+  if [[ $_val ]]; then
+    _EZA_TAIL+=("--time-style='$_val'")
+  fi
+}
+
+_configure_eza
+
+function _alias_eza() {
+  local _tail
+  _tail="${(j: :)_EZA_TAIL}"
+  alias "$1"="eza -${(j::)_EZA_HEAD}$2${_tail:+ }${_tail}${3:+ }$3"
+}
+
+_alias_eza la   la
+_alias_eza ldot ld ".*"
+_alias_eza ll   l
+_alias_eza ls
+_alias_eza lS   "l -ssize"
+_alias_eza lT   "l -snewest"
+
+unfunction _alias_eza
+unfunction _configure_eza
+unset _EZA_HEAD
+unset _EZA_TAIL
+

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -1,4 +1,7 @@
-
+if ! (( $+commands[eza] )); then
+  print "zsh eza plugin: eza not found. Please install eza before using this plugin." >&2
+  return 1
+fi
 
 typeset -a _EZA_HEAD
 typeset -a _EZA_TAIL

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -9,7 +9,7 @@ typeset -a _EZA_TAIL
 function _configure_eza() {
   local _val
   # Get the head flags
-  if zstyle -T ':omz:plugins:eza' 'showgroup'; then
+  if zstyle -T ':omz:plugins:eza' 'show-group'; then
     _EZA_HEAD+=("g")
   fi
   if zstyle -t ':omz:plugins:eza' 'header'; then

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -12,6 +12,9 @@ function _configure_eza() {
   if zstyle -T ':omz:plugins:eza' 'showgroup'; then
     _EZA_HEAD+=("g")
   fi
+  if zstyle -t ':omz:plugins:eza' 'header'; then
+    _EZA_HEAD+=("h")
+  fi
   # Get the tail long-options
   if zstyle -t ':omz:plugins:eza' 'dirs-first'; then
     _EZA_TAIL+=("--group-directories-first")

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -31,6 +31,9 @@ function _configure_eza() {
   if zstyle -t ':omz:plugins:eza' 'dirs-first'; then
     _EZA_TAIL+=("--group-directories-first")
   fi
+  if zstyle -t ':omz:plugins:eza' 'git-status'; then
+    _EZA_TAIL+=("--git")
+  fi
   zstyle -s ':omz:plugins:eza' 'time-style' _val
   if [[ $_val ]]; then
     _EZA_TAIL+=("--time-style='$_val'")


### PR DESCRIPTION
The `eza` plugin provides some configurable aliases to simplify usage of the [`eza`](https://github.com/eza-community/eza) tool.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

* Creates 5 aliases that are very common to invoke when using the `ls` command, but implemented using `eza` instead
* Allows limited configuration for `eza` defaults through usage of `zstyle` (see `README.md` for info)
