### PR TITLE
feat(tmux): add option for detached mode

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -19,13 +19,13 @@ The plugin also supports the following:
 | ---------- | -------------------------- | -------------------------------------------------------- |
 | `ta`       | tmux attach -t             | Attach new tmux session to already running named session |
 | `tad`      | tmux attach -d -t          | Detach named tmux session                                |
-| `ts`       | tmux new-session -s        | Create a new named tmux session                          |
-| `tl`       | tmux list-sessions         | Displays a list of running tmux sessions                 |
-| `tksv`     | tmux kill-server           | Terminate all running tmux sessions                      |
+| `tds`      | `_tmux_directory_session`  | Creates or attaches to a session for the current path    |
 | `tkss`     | tmux kill-session -t       | Terminate named running tmux session                     |
+| `tksv`     | tmux kill-server           | Terminate all running tmux sessions                      |
+| `tl`       | tmux list-sessions         | Displays a list of running tmux sessions                 |
 | `tmux`     | `_zsh_tmux_plugin_run`     | Start a new tmux session                                 |
 | `tmuxconf` | `$EDITOR $ZSH_TMUX_CONFIG` | Open .tmux.conf file with an editor                      |
-| `tds`      | `_tmux_directory_session`  | Creates or attaches to a session for the current path    |
+| `ts`       | tmux new-session -s        | Create a new named tmux session                          |
 
 ## Configuration Variables
 
@@ -35,10 +35,11 @@ The plugin also supports the following:
 | `ZSH_TMUX_AUTOSTART_ONCE`           | Autostart only if tmux hasn't been started previously (default: `true`)                     |
 | `ZSH_TMUX_AUTOCONNECT`              | Automatically connect to a previous session if it exits (default: `true`)                   |
 | `ZSH_TMUX_AUTOQUIT`                 | Automatically closes terminal once tmux exits (default: `ZSH_TMUX_AUTOSTART`)               |
+| `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`, `$XDG_CONFIG_HOME/tmux/tmux.conf`) |
+| `ZSH_TMUX_DEFAULT_SESSION_NAME`     | Set tmux default session name when autostart is enabled                                     |
+| `ZSH_TMUX_DETACHED`                 | Set detached mode (default: `false`)                                                        |
 | `ZSH_TMUX_FIXTERM`                  | Sets `$TERM` to 256-color term or not based on current terminal support                     |
-| `ZSH_TMUX_ITERM2`                   | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)                        |
 | `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `screen`)                              |
 | `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `screen-256color`                          |
-| `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`, `$XDG_CONFIG_HOME/tmux/tmux.conf`) |
+| `ZSH_TMUX_ITERM2`                   | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)                        |
 | `ZSH_TMUX_UNICODE`                  | Set `tmux -u` option to support unicode                                                     |
-| `ZSH_TMUX_DEFAULT_SESSION_NAME`     | Set tmux default session name when autostart is enabled                                     |

--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -37,7 +37,7 @@ The plugin also supports the following:
 | `ZSH_TMUX_AUTOQUIT`                 | Automatically closes terminal once tmux exits (default: `ZSH_TMUX_AUTOSTART`)               |
 | `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`, `$XDG_CONFIG_HOME/tmux/tmux.conf`) |
 | `ZSH_TMUX_DEFAULT_SESSION_NAME`     | Set tmux default session name when autostart is enabled                                     |
-| `ZSH_TMUX_DETACHED`                 | Set detached mode (default: `false`)                                                        |
+| `ZSH_TMUX_DETACHED`                 | Set the detached mode (default: `false`)                                                        |
 | `ZSH_TMUX_FIXTERM`                  | Sets `$TERM` to 256-color term or not based on current terminal support                     |
 | `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `screen`)                              |
 | `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `screen-256color`                          |

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -14,6 +14,8 @@ fi
 # Automatically close the terminal when tmux exits
 : ${ZSH_TMUX_AUTOQUIT:=$ZSH_TMUX_AUTOSTART}
 # Set term to screen or screen-256color based on current terminal support
+: ${ZSH_TMUX_DETACHED:=false}
+# Set detached mode
 : ${ZSH_TMUX_FIXTERM:=true}
 # Set '-CC' option for iTerm2 tmux integration
 : ${ZSH_TMUX_ITERM2:=false}
@@ -79,9 +81,9 @@ function _zsh_tmux_plugin_run() {
 
   # Try to connect to an existing session.
   if [[ -n "$ZSH_TMUX_DEFAULT_SESSION_NAME" ]]; then
-    [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]] && $tmux_cmd attach -t $ZSH_TMUX_DEFAULT_SESSION_NAME
+    [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]] && $tmux_cmd attach ${ZSH_TMUX_DETACHED:+"-d"} -t $ZSH_TMUX_DEFAULT_SESSION_NAME
   else
-    [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]] && $tmux_cmd attach
+    [[ "$ZSH_TMUX_AUTOCONNECT" == "true" ]] && $tmux_cmd attach ${ZSH_TMUX_DETACHED:+"-d"}
   fi
 
   # If failed, just run tmux, fixing the TERM variable if requested.


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- I honestly don't know why this wasn't added earlier. It's a feature I use frequently because it compels me to keep only one section active and adjust the screen size accordingly.

## Other comments:

- I also took the liberty of defining the README.md list of features and aliases in alphabetical order, improving the pattern and organization.
