### PR TITLE
feat(tmux): prioritize `tmux` terminfo

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -1,7 +1,7 @@
 # tmux
 
-This plugin provides aliases for [tmux](https://tmux.github.io/), the terminal multiplexer.
-To use it add `tmux` to the plugins array in your zshrc file.
+This plugin provides aliases for [tmux](https://tmux.github.io/), the terminal multiplexer. To use it add
+`tmux` to the plugins array in your zshrc file.
 
 ```zsh
 plugins=(... tmux)
@@ -29,16 +29,16 @@ The plugin also supports the following:
 
 ## Configuration Variables
 
-| Variable                            | Description                                                                                 |
-| ----------------------------------- | ------------------------------------------------------------------------------------------- |
-| `ZSH_TMUX_AUTOSTART`                | Automatically starts tmux (default: `false`)                                                |
-| `ZSH_TMUX_AUTOSTART_ONCE`           | Autostart only if tmux hasn't been started previously (default: `true`)                     |
-| `ZSH_TMUX_AUTOCONNECT`              | Automatically connect to a previous session if it exits (default: `true`)                   |
-| `ZSH_TMUX_AUTOQUIT`                 | Automatically closes terminal once tmux exits (default: `ZSH_TMUX_AUTOSTART`)               |
-| `ZSH_TMUX_FIXTERM`                  | Sets `$TERM` to 256-color term or not based on current terminal support                     |
-| `ZSH_TMUX_ITERM2`                   | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)                        |
-| `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `screen`)                              |
-| `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `screen-256color`                          |
-| `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`, `$XDG_CONFIG_HOME/tmux/tmux.conf`) |
-| `ZSH_TMUX_UNICODE`                  | Set `tmux -u` option to support unicode                                                     |
-| `ZSH_TMUX_DEFAULT_SESSION_NAME`     | Set tmux default session name when autostart is enabled                                     |
+| Variable                            | Description                                                                                                 |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `ZSH_TMUX_AUTOSTART`                | Automatically starts tmux (default: `false`)                                                                |
+| `ZSH_TMUX_AUTOSTART_ONCE`           | Autostart only if tmux hasn't been started previously (default: `true`)                                     |
+| `ZSH_TMUX_AUTOCONNECT`              | Automatically connect to a previous session if it exits (default: `true`)                                   |
+| `ZSH_TMUX_AUTOQUIT`                 | Automatically closes terminal once tmux exits (default: `ZSH_TMUX_AUTOSTART`)                               |
+| `ZSH_TMUX_FIXTERM`                  | Sets `$TERM` to 256-color term or not based on current terminal support                                     |
+| `ZSH_TMUX_ITERM2`                   | Sets the `-CC` option for iTerm2 tmux integration (default: `false`)                                        |
+| `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `tmux` if available, `screen` otherwise)               |
+| `ZSH_TMUX_FIXTERM_WITH_256COLOR`    | `$TERM` to use for 256-color terminals (default: `tmux-256color` if available, `screen-256color` otherwise) |
+| `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`, `$XDG_CONFIG_HOME/tmux/tmux.conf`)                 |
+| `ZSH_TMUX_UNICODE`                  | Set `tmux -u` option to support unicode                                                                     |
+| `ZSH_TMUX_DEFAULT_SESSION_NAME`     | Set tmux default session name when autostart is enabled                                                     |

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -18,13 +18,21 @@ fi
 # Set '-CC' option for iTerm2 tmux integration
 : ${ZSH_TMUX_ITERM2:=false}
 # The TERM to use for non-256 color terminals.
-# Tmux states this should be screen, but you may need to change it on
+# Tmux states this should be tmux|screen, but you may need to change it on
 # systems without the proper terminfo
-: ${ZSH_TMUX_FIXTERM_WITHOUT_256COLOR:=screen}
+if [[ -e /usr/share/terminfo/t/tmux ]]; then
+  : ${ZSH_TMUX_FIXTERM_WITHOUT_256COLOR:=tmux}
+else
+  : ${ZSH_TMUX_FIXTERM_WITHOUT_256COLOR:=screen}
+fi
 # The TERM to use for 256 color terminals.
-# Tmux states this should be screen-256color, but you may need to change it on
+# Tmux states this should be (tmux|screen)-256color, but you may need to change it on
 # systems without the proper terminfo
-: ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=screen-256color}
+if [[ -e /usr/share/terminfo/t/tmux-256color]]; then
+  : ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=tmux-256color}
+else
+  : ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=screen-256color}
+fi
 # Set the configuration path
 if [[ -e $HOME/.tmux.conf ]]; then
   : ${ZSH_TMUX_CONFIG:=$HOME/.tmux.conf}

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -28,7 +28,7 @@ fi
 # The TERM to use for 256 color terminals.
 # Tmux states this should be (tmux|screen)-256color, but you may need to change it on
 # systems without the proper terminfo
-if [[ -e /usr/share/terminfo/t/tmux-256color]]; then
+if [[ -e /usr/share/terminfo/t/tmux-256color ]]; then
   : ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=tmux-256color}
 else
   : ${ZSH_TMUX_FIXTERM_WITH_256COLOR:=screen-256color}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- The default value for `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` and `ZSH_TMUX_FIXTERM_WITH_256COLOR` now will use `tmux-(256color)?` if exist. This is in accordance to the important note specified in the [tmux FAQ page](https://github.com/tmux/tmux/wiki/FAQ)

## Other comments:

It seems `tmux-256color` provides support for some text formatting that `xterm-256color` doesn't. For instance, [the former supports italics while the latter doesn't](https://github.com/gpakosz/.tmux/issues/382).
