### PR TITLE
feat(python): add auto venv activation

### DIFF
--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -22,33 +22,18 @@ plugins=(... python)
 
 ## Virtual environments
 
-The plugin provides three utilities to manage Python 3.3+
-[venv](https://docs.python.org/3/library/venv.html) virtual
-environments:
+The plugin provides three utilities to manage Python 3.3+ [venv](https://docs.python.org/3/library/venv.html)
+virtual environments:
 
-- `mkv [name]`: Make a new virtual environment called *name* (else
-  `$PYTHON_VENV_NAME`, else "venv") in the current directory.
+- `mkv [name]`: make a new virtual environment called `name` (default: if set `$PYTHON_VENV_NAME`, else
+  `venv`) in the current directory.
 
-- `vrun [name]`: Activate the virtual environment called *name* (else
-  `$PYTHON_VENV_NAME`, else "venv") in the current directory.
+- `vrun [name]`: Activate the virtual environment called `name` (default: if set `$PYTHON_VENV_NAME`, else
+  `venv`) in the current directory.
 
-- `auto_vrun`: Automatically activate the venv virtual environment when
-  cd’ing into a directory containing `venv/bin/activate`, and
-  automatically deactivate it when cd’ing into any other directory,
-  including subdirectories.
-  - To enable, set `PYTHON_AUTO_VRUN` to anything. For example:
-
-        export PYTHON_AUTO_VRUN='true'
-  - To disable, either unset the environment variable:
-
-        unset PYTHON_AUTO_VRUN
-    or entirely remove `auto_vrun` from the list of functions associated
-    with the `chpwd` hook:
-
-        add-zsh-hook -d chpwd auto_vrun
-    If you disable `auto_vrun` while a virtual environment is active,
-    you'll need to manually `deactivate`.
-  - The default virtual environment name is "venv". To use a different
-    name, set `PYTHON_VENV_NAME`. For example:
-
-        export PYTHON_VENV_NAME='.venv'
+- `auto_vrun`: Automatically activate the venv virtual environment when entering a directory containing
+  `<venv-name>/bin/activate`, and automatically deactivate it when navigating out of it (including
+  subdirectories!).
+  - To enable the feature, set `export PYTHON_AUTO_VRUN=true` before sourcing oh-my-zsh.
+  - The default virtual environment name is `venv`. To use a different name, set
+    `export PYTHON_VENV_NAME=<venv-name>`. For example: `export PYTHON_VENV_NAME=".venv"`

--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -22,7 +22,9 @@ plugins=(... python)
 
 ## Virtual environments
 
-The plugin provides three utilities to manage Python venvs:
+The plugin provides three utilities to manage Python 3.3+
+[venv](https://docs.python.org/3/library/venv.html) virtual
+environments:
 
 - `mkv [name]`: make a new virtual environment called `name` (default: `venv`) in current directory.
 
@@ -30,10 +32,21 @@ The plugin provides three utilities to manage Python venvs:
 
 - `auto_vrun`: Automatically activate the venv virtual environment when
   cd’ing into a directory containing `venv/bin/activate`, and
-  automatically deactivate the venv virtual environment when cd’ing into
-  any other directory.
-  - Set the environment variable `VENV_NAME` to auto-activate on a
-  different venv name. (Example: `VENV_NAME=.venv`).
-  - Set the environment variable `DISABLE_AUTO_VRUN` to anything to
-  deactivate `auto_vrun`. (Example: `DISABLE_AUTO_VRUN=true`) Unset
-  `DISABLE_AUTO_VRUN` to re-enable.
+  automatically deactivate it when cd’ing into any other directory,
+  including subdirectories.
+  - To enable, set `PYTHON_AUTO_VRUN` to anything. For example:
+
+        export PYTHON_AUTO_VRUN='true'
+  - To disable, either unset the environment variable:
+
+        unset PYTHON_AUTO_VRUN
+    or entirely remove `auto_vrun` from the list of functions associated
+    with the `chpwd` hook:
+
+        add-zsh-hook -d chpwd auto_vrun
+    If you disable `auto_vrun` while a virtual environment is active,
+    you'll need to manually `deactivate`.
+  - The default virtual environment name is "venv". To use a different
+    name, set `PYTHON_VENV_NAME`. For example:
+
+        export PYTHON_VENV_NAME='.venv'

--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -26,9 +26,11 @@ The plugin provides three utilities to manage Python 3.3+
 [venv](https://docs.python.org/3/library/venv.html) virtual
 environments:
 
-- `mkv [name]`: make a new virtual environment called `name` (default: `venv`) in current directory.
+- `mkv [name]`: Make a new virtual environment called *name* (else
+  `$PYTHON_VENV_NAME`, else "venv") in the current directory.
 
-- `vrun [name]`: activate virtual environment called `name` (default: `venv`) in current directory.
+- `vrun [name]`: Activate the virtual environment called *name* (else
+  `$PYTHON_VENV_NAME`, else "venv") in the current directory.
 
 - `auto_vrun`: Automatically activate the venv virtual environment when
   cd’ing into a directory containing `venv/bin/activate`, and

--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -22,8 +22,18 @@ plugins=(... python)
 
 ## Virtual environments
 
-The plugin provides two utilities to manage Python venvs:
+The plugin provides three utilities to manage Python venvs:
 
 - `mkv [name]`: make a new virtual environment called `name` (default: `venv`) in current directory.
 
 - `vrun [name]`: activate virtual environment called `name` (default: `venv`) in current directory.
+
+- `auto_vrun`: Automatically activate the venv virtual environment when
+  cd’ing into a directory containing `venv/bin/activate`, and
+  automatically deactivate the venv virtual environment when cd’ing into
+  any other directory.
+  - Set the environment variable `VENV_NAME` to auto-activate on a
+  different venv name. (Example: `VENV_NAME=.venv`).
+  - Set the environment variable `DISABLE_AUTO_VRUN` to anything to
+  deactivate `auto_vrun`. (Example: `DISABLE_AUTO_VRUN=true`) Unset
+  `DISABLE_AUTO_VRUN` to re-enable.

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -53,9 +53,9 @@ alias pyserver="python3 -m http.server"
 ## venv utilities
 
 # Activate a the python virtual environment specified.
-# If none specified, use 'venv'.
+# If none specified, use $PYTHON_VENV_NAME, else 'venv'.
 function vrun() {
-  local name="${1:-venv}"
+  local name="${1:-${PYTHON_VENV_NAME:-venv}}"
   local venvpath="${name:P}"
 
   if [[ ! -d "$venvpath" ]]; then
@@ -72,9 +72,10 @@ function vrun() {
   echo "Activated virtual environment ${name}"
 }
 
-# Create a new virtual environment, with default name 'venv'.
+# Create a new virtual environment using the specified name.
+# If none specfied, use $PYTHON_VENV_NAME, else 'venv'.
 function mkv() {
-  local name="${1:-venv}"
+  local name="${1:-${PYTHON_VENV_NAME:-venv}}"
   local venvpath="${name:P}"
 
   python3 -m venv "${name}" || return

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -82,16 +82,14 @@ function mkv() {
   vrun "${name}"
 }
 
-# Virtual environment is assumed to be named "venv".
-# Set VENV_NAME to another name if you use a different name, maybe ".venv".
-# To disable, set DISABLE_AUTO_VRUN to anything. Unset to re-enable.
+# Automatically activate venv when cd'ing into a directory
 auto_vrun() {
-    [ $DISABLE_AUTO_VRUN ] && return 0
-    local venvpath=${VENV_NAME:-'venv'}
-    if [ -e "${venvpath}/bin/activate" ]; then
+    [[ ! -n "$PYTHON_AUTO_VRUN" ]] && return 0
+    local venvpath="${PYTHON_VENV_NAME:-venv}"
+    if [[ -f "${venvpath}/bin/activate" ]]; then
         source "${venvpath}/bin/activate" > /dev/null 2>&1
     else
-        [ -n "$(command -v deactivate)" ] && deactivate > /dev/null 2>&1
+        [[ -n "$(command -v deactivate)" ]] && deactivate > /dev/null 2>&1
     fi
 }
 add-zsh-hook chpwd auto_vrun

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -81,3 +81,18 @@ function mkv() {
   echo >&2 "Created venv in '${venvpath}'"
   vrun "${name}"
 }
+
+# Virtual environment is assumed to be named "venv".
+# Set VENV_NAME to another name if you use a different name, maybe ".venv".
+# To disable, set DISABLE_AUTO_VRUN to anything. Unset to re-enable.
+auto_vrun() {
+    [ $DISABLE_AUTO_VRUN ] && return 0
+    local venvpath=${VENV_NAME:-'venv'}
+    if [ -e "${venvpath}/bin/activate" ]; then
+        source "${venvpath}/bin/activate" > /dev/null 2>&1
+    else
+        [ -n "$(command -v deactivate)" ] && deactivate > /dev/null 2>&1
+    fi
+}
+add-zsh-hook chpwd auto_vrun
+auto_vrun

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -51,11 +51,12 @@ alias pyserver="python3 -m http.server"
 
 
 ## venv utilities
+: ${PYTHON_VENV_NAME:=venv}
 
 # Activate a the python virtual environment specified.
 # If none specified, use $PYTHON_VENV_NAME, else 'venv'.
 function vrun() {
-  local name="${1:-${PYTHON_VENV_NAME:-venv}}"
+  local name="${1:-$PYTHON_VENV_NAME}"
   local venvpath="${name:P}"
 
   if [[ ! -d "$venvpath" ]]; then
@@ -73,9 +74,9 @@ function vrun() {
 }
 
 # Create a new virtual environment using the specified name.
-# If none specfied, use $PYTHON_VENV_NAME, else 'venv'.
+# If none specfied, use $PYTHON_VENV_NAME
 function mkv() {
-  local name="${1:-${PYTHON_VENV_NAME:-venv}}"
+  local name="${1:-$PYTHON_VENV_NAME}"
   local venvpath="${name:P}"
 
   python3 -m venv "${name}" || return
@@ -83,15 +84,15 @@ function mkv() {
   vrun "${name}"
 }
 
-# Automatically activate venv when cd'ing into a directory
-auto_vrun() {
-    [[ ! -n "$PYTHON_AUTO_VRUN" ]] && return 0
-    local venvpath="${PYTHON_VENV_NAME:-venv}"
-    if [[ -f "${venvpath}/bin/activate" ]]; then
-        source "${venvpath}/bin/activate" > /dev/null 2>&1
+if [[ "$PYTHON_AUTO_VRUN" == "true" ]]; then
+  # Automatically activate venv when changing dir
+  auto_vrun() {
+    if [[ -f "${PYTHON_VENV_NAME}/bin/activate" ]]; then
+      source "${PYTHON_VENV_NAME}/bin/activate" > /dev/null 2>&1
     else
-        [[ -n "$(command -v deactivate)" ]] && deactivate > /dev/null 2>&1
+      (( $+functions[deactivate] )) && deactivate > /dev/null 2>&1
     fi
-}
-add-zsh-hook chpwd auto_vrun
-auto_vrun
+  }
+  add-zsh-hook chpwd auto_vrun
+  auto_vrun
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds and runs a function that listens for directory changes. When cd'ing into a directory
  containing `venv/bin/activate`, it automatically activates the virtual environment.
  When cd'ing out of the directory, it automatically deactivates the virtual environment.
- It supports two global environment variables,
  - `VENV_NAME`  where a name different from `venv` can be specified. (For example,
    `.venv` is also suggested by the Python docs.)
  - Also, if anyone doesn't want this, they can simply set `DISABLE_AUTO_VRUN` and the listener
    will always exit without making any changes.

## Other comments:

Auto-activating the environment is a feature of the Ruby Version Manager (rvm). I really like that feature,
and researched till I could add it to my Python environments. I've been running this on my computer for
about six months without issues.
