### PR TITLE
fix(tmux):  use the offset parameter when extracting the first letter

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -49,7 +49,7 @@ fi
 # ALIASES
 function _build_tmux_alias {
   eval "function $1 {
-    if [[ -z \$1 ]] || [[ \${1::1} == '-' ]]; then
+    if [[ -z \$1 ]] || [[ \${1:0:1} == '-' ]]; then
       tmux $2 \"\$@\"
     else
       tmux $2 $3 \"\$@\"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Use the offset as 0 to extract the first letter when checking whether the parameter is a flag like `-t`.

## Other comments:

My zsh version is v5.8.1 and tmux version is 3.2a. After the change in [fix(tmux): do not pass empty flags to aliases](https://github.com/ohmyzsh/ohmyzsh/pull/12232), I found the alias command `ta server` can not work to attach the session. The error is `ta:1: closing brace expected`. This is caused by the omitted offset parameter. Add 0 as offset can fix it.
