### PR TITLE
fix(terraform): pass -chdir to completion commands

### DIFF
--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -173,17 +173,22 @@ compdef _terraform terraform
 }
 
 (( ${+functions[_terraform_metadata]} )) || _terraform_metadata() {
+  _arguments \
+    '*::terraform metadata command:_terraform_metadata_commands'
+}
+
+(( ${+functions[_terraform_metadata_commands]} )) || _terraform_metadata_commands() {
   local -a _metadata_cmds
   _metadata_cmds=(
     'functions:Show signatures and descriptions for the available functions'
   )
-  if [[ "${CURRENT}" -lt 3 ]]; then
+  if (( CURRENT == 1 )); then
     _describe -t commands "terraform metadata commands" _metadata_cmds
     return
   fi
 
   local curcontext="${curcontext}"
-  cmd="${${_metadata_cmds[(r)$words[2]:*]%%:*}}"
+  cmd="${${_metadata_cmds[(r)$words[1]:*]%%:*}}"
   curcontext="${curcontext%:*:*}:terraform-metadata-${cmd}:"
 
   if (( ${+functions[_terraform_metadata_$cmd]} )); then
@@ -195,8 +200,7 @@ compdef _terraform terraform
 
 (( ${+functions[_terraform_metadata_functions]} )) || _terraform_metadata_functions() {
   _arguments \
-    '-json' \
-    '::'
+    '-json[]'
 }
 
 (( ${+functions[_terraform_output]} )) || _terraform_output() {
@@ -230,27 +234,25 @@ compdef _terraform terraform
 }
 
 (( ${+functions[_terraform_providers]} )) || _terraform_providers() {
+  _arguments \
+    '-test-directory=[(path) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -W __chdir -/' \
+    '*::terraform providers command:_terraform_providers_commands'
+}
+
+(( ${+functions[_terraform_providers_commands]} )) || _terraform_providers_commands() {
   local -a _providers_cmds
   _providers_cmds=(
     'lock:Write out dependency locks for the configured providers'
     'mirror:Save local copies of all required provider plugins'
     'schema:Show schemas for the providers used in the configuration'
   )
-
-  local context state state_descr line
-  typeset -A opt_args
-
-  if [[ "${${#word[@]:#-*}}" -lt 3 ]]; then
-    _arguments \
-      '-test-directory=[(path) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -W __chdir -/' \
-      '*:: :->command'
-
+  if (( CURRENT == 1 )); then
     _describe -t commands "terraform providers commands" _providers_cmds
     return
   fi
 
   local curcontext="${curcontext}"
-  cmd="${${_providers_cmds[(r)$words[2]:*]%%:*}}"
+  cmd="${${_providers_cmds[(r)$words[1]:*]%%:*}}"
   curcontext="${curcontext%:*:*}:terraform-providers-${cmd}:"
 
   if (( ${+functions[_terraform_providers_$cmd]} )); then
@@ -277,8 +279,7 @@ compdef _terraform terraform
 
 (( ${+functions[_terraform_providers_schema]} )) || _terraform_providers_schema() {
   _arguments \
-    '-json[]' \
-    '::'
+    '-json[]'
 }
 
 (( ${+functions[_terraform_refresh]} )) || _terraform_refresh() {
@@ -305,6 +306,11 @@ compdef _terraform terraform
 }
 
 (( ${+functions[_terraform_state]} )) || _terraform_state() {
+  _arguments \
+    '*::terraform state command:_terraform_state_commands'
+}
+
+(( ${+functions[_terraform_state_commands]} )) || _terraform_state_commands() {
   local -a _state_cmds
   _state_cmds=(
     'list:List resources in the state'
@@ -315,13 +321,13 @@ compdef _terraform terraform
     'rm:Remove instances from the state'
     'show:Show a resource in the state'
   )
-  if [[ "${CURRENT}" -lt 3 ]]; then
+  if (( CURRENT == 1 )); then
     _describe -t commands "terraform state commands" _state_cmds
     return
   fi
 
   local curcontext="${curcontext}"
-  cmd="${${_state_cmds[(r)$words[2]:*]%%:*}}"
+  cmd="${${_state_cmds[(r)$words[1]:*]%%:*}}"
   curcontext="${curcontext%:*:*}:terraform-state-${cmd}:"
 
   if (( ${+functions[_terraform_state_$cmd]} )); then
@@ -451,6 +457,11 @@ compdef _terraform terraform
 }
 
 (( ${+functions[_terraform_workspace]} )) || _terraform_workspace() {
+  _arguments \
+    '*::terraform workspace command:_terraform_workspace_commands'
+}
+
+(( ${+functions[_terraform_workspace_commands]} )) || _terraform_workspace_commands() {
   local -a _workspace_cmds
   _workspace_cmds=(
     'delete:Delete a workspace'
@@ -459,13 +470,13 @@ compdef _terraform terraform
     'select:Select a workspace'
     'show:Show the name of the current workspace'
   )
-  if [[ "${CURRENT}" -lt 3 ]]; then
+  if (( CURRENT == 1 )); then
     _describe -t commands "terraform workspace commands" _workspace_cmds
     return
   fi
 
   local curcontext="${curcontext}"
-  cmd="${${_workspace_cmds[(r)$words[2]:*]%%:*}}"
+  cmd="${${_workspace_cmds[(r)$words[1]:*]%%:*}}"
   curcontext="${curcontext%:*:*}:terraform-workspace-${cmd}:"
 
   if (( ${+functions[_terraform_workspace_$cmd]} )); then

--- a/plugins/terraform/_terraform
+++ b/plugins/terraform/_terraform
@@ -29,7 +29,7 @@ compdef _terraform terraform
     'version:Show the current Terraform version'
     'workspace:Workspace management'
   )
-  if ((CURRENT == 1)); then
+  if (( CURRENT == 1 )); then
     _describe -t commands 'terraform commands' _terraform_cmds
     return
   fi
@@ -37,6 +37,8 @@ compdef _terraform terraform
   local curcontext="${curcontext}"
   cmd="${${_terraform_cmds[(r)$words[1]:*]%%:*}}"
   curcontext="${curcontext%:*:*}:terraform-${cmd}:"
+
+  local __chdir="${opt_args[-chdir]:-.}"
 
   if (( ${+functions[_terraform_$cmd]} )); then
     "_terraform_${cmd}"
@@ -48,7 +50,7 @@ compdef _terraform terraform
 (( ${+functions[_terraform_apply]} )) || _terraform_apply() {
   _arguments \
     '-auto-approve[Skip interactive approval of plan before applying.]' \
-    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
+    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -W __chdir -g "*.backup"' \
     '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
     '-destroy[Destroy Terraform-managed infrastructure. The command "terraform destroy" is a convenience alias for this option.]' \
     '-lock=[(true) Don'\''t hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.]:lock:(true false)' \
@@ -58,12 +60,12 @@ compdef _terraform terraform
     '-parallelism=[(10) Limit the number of parallel resource operations.]' \
     '-refresh=[(true) Skip checking for external changes to remote objects while creating the plan. This can potentially make planning faster, but at the expense of possibly planning against a stale record of the remote system state.]:refresh:(true false)' \
     '*-replace=[(resource) Force replacement of a particular resource instance using its resource address. If applying would'\''ve normally produced an update or no-op action for this instance, Terraform will replace it instead. You can use this option multiple times to replace more than one object.]:resource:__terraform_state_resources' \
-    '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]:statefile:_files -g "*.tfstate"' \
-    '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]:statefile:_files -W __chdir -g "*.tfstate"' \
+    '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -W __chdir -g "*.tfstate"' \
     '*-target=[(resource) Limit the operation to only the given module, resource, or resource instance and all of its dependencies. You can use this option multiple times to include more than one object. This is for exceptional use only.]:target:__terraform_state_resources' \
     '*-var=[(for=bar) Set a value for one of the input variables in the root module of the configuration. Use this option more than once to set more than one variable.]' \
-    '*-var-file=[(foo) Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.]:file:_files -g "*.tfvars{,.json}"' \
-    ':plan:_files -'
+    '*-var-file=[(foo) Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.]:file:_files -W __chdir -g "*.tfvars{,.json}"' \
+    ':plan:_files -W __chdir -'
 }
 
 (( ${+functions[_terraform_console]} )) || _terraform_console() {
@@ -71,13 +73,13 @@ compdef _terraform terraform
     '-state=[(terraform.tfstate) Legacy option for the local backend only. See the local backend'\''s documentation for more information.]' \
     '-plan[Create a new plan (as if running "terraform plan") and then evaluate expressions against its planned state, instead of evaluating against the current state. You can use this to inspect the effects of configuration changes that haven'\''t been applied yet.]' \
     '*-var=[(for=bar) Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-    '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
+    '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -W __chdir -g "*.tfvars{,.json}"'
 }
 
 (( ${+functions[_terraform_destroy]} )) || _terraform_destroy() {
   _arguments \
     '-auto-approve[Skip interactive approval of plan before applying.]' \
-    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
+    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -W __chdir -g "*.backup"' \
     '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
     '-lock=[(true) Don'\''t hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
@@ -85,11 +87,11 @@ compdef _terraform terraform
     '-no-color[If specified, output won'\''t contain any color.]' \
     '-parallelism=[(10) Limit the number of parallel resource operations.]' \
     '-refresh=[(true) Update state prior to checking for differences. This has no effect if a plan file is given to apply.]:refresh:(true false)' \
-    '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]:statefile:_files -g "*.tfstate"' \
-    '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(terraform.tfstate) Path to read and save state (unless state-out is specified).]:statefile:_files -W __chdir -g "*.tfstate"' \
+    '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -W __chdir -g "*.tfstate"' \
     '*-target=[(resource) Limit the operation to only the given module, resource, or resource instance and all of its dependencies. You can use this option multiple times to include more than one object. This is for exceptional use only.]:target:__terraform_state_resources' \
     '*-var=[(for=bar) Set a value for one of the input variables in the root module of the configuration. Use this option more than once to set more than one variable.]' \
-    '*-var-file=[(foo) Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.]:file:_files -g "*.tfvars{,.json}"'
+    '*-var-file=[(foo) Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.]:file:_files -W __chdir -g "*.tfvars{,.json}"'
 }
 
 (( ${+functions[_terraform_fmt]} )) || _terraform_fmt() {
@@ -100,7 +102,7 @@ compdef _terraform terraform
     '-check[Check if the input is formatted. Exit status will be 0 if all input is properly formatted and non-zero otherwise.]' \
     '-no-color[If specified, output won'\''t contain any color.]' \
     '-recursive[Also process files in subdirectories. By default, only the given directory (or current directory) is processed.]' \
-    '*:targets:_files -'
+    '*:targets:_files -W __chdir -'
 }
 
 (( ${+functions[_terraform_force-unlock]} )) || _terraform_force-unlock() {
@@ -113,29 +115,29 @@ compdef _terraform terraform
   _arguments \
     '-update[Check already-downloaded modules for available updates and install the newest versions available.]' \
     '-no-color[Disable text coloring in the output.]' \
-    '-test-directory=[(tests) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -/'
+    '-test-directory=[(tests) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -W __chdir -/'
 }
 
 (( ${+functions[_terraform_graph]} )) || _terraform_graph() {
   _arguments \
     '-draw-cycles[Highlight any cycles in the graph with colored edges. This helps when diagnosing cycle errors. This option is supported only when illustrating a real evaluation graph, selected using the -type=TYPE option.]' \
     '-module-depth=[(-1) (deprecated) In prior versions of Terraform, specified the depth of modules to show in the output.]' \
-    '-plan=[Render graph using the specified plan file instead of the configuration in the current directory. Implies -type=apply.]:plan:_files -' \
+    '-plan=[Render graph using the specified plan file instead of the configuration in the current directory. Implies -type=apply.]:plan:_files -W __chdir -' \
     '-type=[(plan) Type of operation graph to output. Can be: plan, plan-refresh-only, plan-destroy, or apply. By default Terraform just summarizes the relationships between the resources in your configuration, without any particular operation in mind. Full operation graphs are more detailed but therefore often harder to read.]:type:(plan plan-refresh-only plan-destroy apply)'
 }
 
 (( ${+functions[_terraform_import]} )) || _terraform_import() {
   _arguments \
-    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
-    '-config=[(path) Path to a directory of Terraform configuration files to use to configure the provider. Defaults to pwd. If no config files are present, they must be provided via the input prompts or env vars.]:config:_files -/' \
+    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -W __chdir -g "*.backup"' \
+    '-config=[(path) Path to a directory of Terraform configuration files to use to configure the provider. Defaults to pwd. If no config files are present, they must be provided via the input prompts or env vars.]:config:_files -W __chdir -/' \
     '-input=[(true) Disable interactive input prompts.]:input:(true false)' \
     '-lock=[(true) Don'\''t hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
     '-no-color[If specified, output will contain no color.]' \
-    '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -g "*.tfstate"' \
-    '-state-out=[(PATH) Path to the destination state file to write to. If this is not specified, the source state file will be used. This can be a new or existing path.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -W __chdir -g "*.tfstate"' \
+    '-state-out=[(PATH) Path to the destination state file to write to. If this is not specified, the source state file will be used. This can be a new or existing path.]:statefile:_files -W __chdir -g "*.tfstate"' \
     '*-var=[(for=bar) Set a variable in the Terraform configuration. This flag can be set multiple times. This is only useful with the "-config" flag.]' \
-    '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"' \
+    '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -W __chdir -g "*.tfvars{,.json}"' \
     ':addr:' \
     ':id:'
 }
@@ -143,21 +145,21 @@ compdef _terraform terraform
 (( ${+functions[_terraform_init]} )) || _terraform_init() {
   _arguments \
     '-backend=[(true) Disable backend or Terraform Cloud initialization for this configuration and use what was previously initialized instead.]:backend:(true false)' \
-    '-backend-config=[Configuration to be merged with what is in the configuration file'\''s '\''backend'\'' block. This can be either a path to an HCL file with key/value assignments (same format as terraform.tfvars) or a '\''key=value'\'' format, and can be specified multiple times. The backend type must be in the configuration itself.]:backend_config:_files -' \
+    '-backend-config=[Configuration to be merged with what is in the configuration file'\''s '\''backend'\'' block. This can be either a path to an HCL file with key/value assignments (same format as terraform.tfvars) or a '\''key=value'\'' format, and can be specified multiple times. The backend type must be in the configuration itself.]:backend_config:_files -W __chdir -' \
     '-force-copy[Suppress prompts about copying state data. This is equivalent to providing a "yes" to all confirmation prompts.]' \
-    '-from-module=[Copy the contents of the given module into the target directory before initialization.]:from_module:_files -/' \
+    '-from-module=[Copy the contents of the given module into the target directory before initialization.]:from_module:_files -W __chdir -/' \
     '-get=[(true) Disable downloading modules for this configuration.]:get:(true false)' \
     '-input=[(true) Disable interactive prompts. Note that some actions may require interactive prompts and will error if input is disabled.]:input:(true false)' \
     '-lock=[(true) Don'\''t hold a state lock during backend migration. This is dangerous if others might concurrently run commands against the same workspace.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
     '-no-color[If specified, output will contain no color.]' \
-    '-plugin-dir[Directory containing plugin binaries. This overrides all default search paths for plugins, and prevents the automatic installation of plugins. This flag can be used multiple times.]:plugin_dir:_files -/' \
+    '-plugin-dir[Directory containing plugin binaries. This overrides all default search paths for plugins, and prevents the automatic installation of plugins. This flag can be used multiple times.]:plugin_dir:_files -W __chdir -/' \
     '-reconfigure[Reconfigure the backend, ignoring any saved configuration.]' \
     '-migrate-state[Reconfigure a backend, and attempt to migrate any existing state.]' \
     '-upgrade[Install the latest module and provider versions allowed within configured constraints, overriding the default behavior of selecting exactly the version recorded in the dependency lockfile.]' \
     '-lockfile=[Set a dependency lockfile mode. Currently only "readonly" is valid.]:lockfile:( readonly )' \
     '-ignore-remote-version[A rare option used for Terraform Cloud and the remote backend only. Set this to ignore checking that the local and remote Terraform versions use compatible state representations, making an operation proceed even when there is a potential mismatch. See the documentation on configuring Terraform with Terraform Cloud for more information.]' \
-    '-test-directory=[(tests) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -/'
+    '-test-directory=[(tests) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -W __chdir -/'
 }
 
 (( ${+functions[_terraform_login]} )) || _terraform_login() {
@@ -199,7 +201,7 @@ compdef _terraform terraform
 
 (( ${+functions[_terraform_output]} )) || _terraform_output() {
   _arguments \
-    '-state=[(path) Path to the state file to read. Defaults to "terraform.tfstate". Ignored when remote state is used.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(path) Path to the state file to read. Defaults to "terraform.tfstate". Ignored when remote state is used.]:statefile:_files -W __chdir -g "*.tfstate"' \
     '-no-color[If specified, output will contain no color.]' \
     '-json[If specified, machine readable output will be printed in JSON format]' \
     '-raw[For value types that can be automatically converted to a string, will print the raw string directly, rather than a human-oriented representation of the value.]' \
@@ -221,10 +223,10 @@ compdef _terraform terraform
     '-refresh=[(true) Skip checking for external changes to remote objects while creating the plan. This can potentially make planning faster, but at the expense of possibly planning against a stale record of the remote system state.]:refresh:(true false)' \
     '-refresh-only[Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo any changes made outside of Terraform.]' \
     '*-replace=[(resource) Force replacement of a particular resource instance using its resource address. If the plan would'\''ve normally produced an update or no-op action for this instance, Terraform will plan to replace it instead. You can use this option multiple times to replace more than one object.]:replace:__terraform_state_resources' \
-    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]:statefile:_files -W __chdir -g "*.tfstate"' \
     '*-target=[(resource) Limit the planning operation to only the given module, resource, or resource instance and all of its dependencies. You can use this option multiple times to include more than one object. This is for exceptional use only.]:target:__terraform_state_resources' \
     '*-var=[(for=bar) Set a value for one of the input variables in the root module of the configuration. Use this option more than once to set more than one variable.]' \
-    '*-var-file=[(foo) Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.]:file:_files -g "*.tfvars{,.json}"'
+    '*-var-file=[(foo) Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.]:file:_files -W __chdir -g "*.tfvars{,.json}"'
 }
 
 (( ${+functions[_terraform_providers]} )) || _terraform_providers() {
@@ -235,9 +237,12 @@ compdef _terraform terraform
     'schema:Show schemas for the providers used in the configuration'
   )
 
-  if [[ "${CURRENT}" -lt 3 ]]; then
+  local context state state_descr line
+  typeset -A opt_args
+
+  if [[ "${${#word[@]:#-*}}" -lt 3 ]]; then
     _arguments \
-      '-test-directory=[(path) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -/' \
+      '-test-directory=[(path) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -W __chdir -/' \
       '*:: :->command'
 
     _describe -t commands "terraform providers commands" _providers_cmds
@@ -257,7 +262,7 @@ compdef _terraform terraform
 
 (( ${+functions[_terraform_providers_lock]} )) || _terraform_providers_lock() {
   _arguments \
-    '-fs-mirror=[(dir) Consult the given filesystem mirror directory instead of the origin registry for each of the given providers.]:fs_mirror:_files -/' \
+    '-fs-mirror=[(dir) Consult the given filesystem mirror directory instead of the origin registry for each of the given providers.]:fs_mirror:_files -W __chdir -/' \
     '-net-mirror=[(url) Consult the given network mirror (given as a base URL) instead of the origin registry for each of the given providers.]' \
     '*-platform=[(os_arch) Choose a target platform to request package checksums for.]' \
     '*:provider:'
@@ -267,7 +272,7 @@ compdef _terraform terraform
   _arguments \
     '*-platform=[(os_arch) Choose which target platform to build a mirror for.]' \
     '::' \
-    ':target_dir:_files -/'
+    ':target_dir:_files -W __chdir -/'
 }
 
 (( ${+functions[_terraform_providers_schema]} )) || _terraform_providers_schema() {
@@ -278,25 +283,25 @@ compdef _terraform terraform
 
 (( ${+functions[_terraform_refresh]} )) || _terraform_refresh() {
   _arguments \
-    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]::backupfile:_files -g "*.backup"' \
+    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]::backupfile:_files -W __chdir -g "*.backup"' \
     '-compact-warnings[If Terraform produces any warnings that are not accompanied by errors, show them in a more compact form that includes only the summary messages.]' \
     '-input=[(true) Ask for input for variables if not directly set.]:input:(true false)' \
     '-lock=[(true) Don'\''t hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
     '-no-color[If specified, output will not contain any color.]' \
     '-parallelism=[(10) Limit the number of parallel resource operations.]' \
-    '-state=[(path) Path to read and save state (unless state-out is specified). Defaults to "terraform.tfstate".]:statefile:_files -g "*.tfstate"' \
-    '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(path) Path to read and save state (unless state-out is specified). Defaults to "terraform.tfstate".]:statefile:_files -W __chdir -g "*.tfstate"' \
+    '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]:statefile:_files -W __chdir -g "*.tfstate"' \
     '*-target=[(resource) A Resource Address to target. Operation will be limited to this resource and its dependencies. This flag can be used multiple times.]:target:__terraform_state_resources' \
     '*-var=[(for=bar) Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-    '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -g "*.tfvars{,.json}"'
+    '*-var-file=[(foo) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]:file:_files -W __chdir -g "*.tfvars{,.json}"'
 }
 
 (( ${+functions[_terraform_show]} )) || _terraform_show() {
   _arguments \
     '-json[If specified, output the Terraform plan or state in a machine-readable form.]' \
     '-no-color[If specified, output will not contain any color.]' \
-    ':path:_files -g "*.tfstate"'
+    ':path:_files -W __chdir -g "*.tfstate"'
 }
 
 (( ${+functions[_terraform_state]} )) || _terraform_state() {
@@ -328,7 +333,7 @@ compdef _terraform terraform
 
 (( ${+functions[_terraform_state_list]} )) || _terraform_state_list() {
   _arguments \
-    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default, Terraform will consult the state of the currently-selected workspace.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default, Terraform will consult the state of the currently-selected workspace.]:statefile:_files -W __chdir -g "*.tfstate"' \
     '-id=[(id) Filters the results to include only instances whose resource types have an attribute named id whose value equals the given id string.]' \
     '*:address:__terraform_state_resources'
 }
@@ -336,13 +341,13 @@ compdef _terraform terraform
 (( ${+functions[_terraform_state_mv]} )) || _terraform_state_mv() {
   _arguments \
     '-dry-run[If set, prints out what would'\''ve been moved but doesn'\''t actually move anything.]' \
-    '-backup=[(PATH) Path where Terraform should write the backup for the original state. This can"t be disabled. If not set, Terraform will write it to the same path as the statefile with a ".backup" extension.]:backupfile:_files -g "*.backup"' \
-    '-backup-out=[(PATH) Path where Terraform should write the backup for the destination state. This can"t be disabled. If not set, Terraform will write it to the same path as the destination state file with a backup extension. This only needs to be specified if -state-out is set to a different path than -state.]:backupfile:_files -g "*.backup"' \
+    '-backup=[(PATH) Path where Terraform should write the backup for the original state. This can"t be disabled. If not set, Terraform will write it to the same path as the statefile with a ".backup" extension.]:backupfile:_files -W __chdir -g "*.backup"' \
+    '-backup-out=[(PATH) Path where Terraform should write the backup for the destination state. This can"t be disabled. If not set, Terraform will write it to the same path as the destination state file with a backup extension. This only needs to be specified if -state-out is set to a different path than -state.]:backupfile:_files -W __chdir -g "*.backup"' \
     '-ignore-remote-version[A rare option used for the remote backend only. See the remote backend documentation for more information.]' \
     '-lock=[(true) Don'\''t hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
-    '-state=[(path) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -g "*.tfstate"' \
-    '-state-out=[(path) Path to the destination state file to write to. If this isn"t specified, the source state file will be used. This can be a new or existing path.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(path) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -W __chdir -g "*.tfstate"' \
+    '-state-out=[(path) Path to the destination state file to write to. If this isn"t specified, the source state file will be used. This can be a new or existing path.]:statefile:_files -W __chdir -g "*.tfstate"' \
     '::' \
     ':source:__terraform_state_resources' \
     ':destination: '
@@ -360,10 +365,10 @@ compdef _terraform terraform
 (( ${+functions[_terraform_state_replace-provider]} )) || _terraform_state_replace-provider() {
   _arguments \
     '-auto-approve[Skip interactive approval.]' \
-    '-backup=[(PATH) Path where Terraform should write the backup for the state file. This can"t be disabled. If not set, Terraform will write it to the same path as the state file with a ".backup" extension.]:backupfile:_files -g "*.backup"' \
+    '-backup=[(PATH) Path where Terraform should write the backup for the state file. This can"t be disabled. If not set, Terraform will write it to the same path as the state file with a ".backup" extension.]:backupfile:_files -W __chdir -g "*.backup"' \
     '-lock=[(true) Don'\''t hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
-    '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -g "*.tfstate"' \
+    '-state=[(PATH) Path to the source state file. Defaults to the configured backend, or "terraform.tfstate"]:statefile:_files -W __chdir -g "*.tfstate"' \
     '::' \
     ':from_provider_fqn:' \
     ':to_provider_fqn:'
@@ -372,24 +377,24 @@ compdef _terraform terraform
 (( ${+functions[_terraform_state_rm]} )) || _terraform_state_rm() {
   _arguments \
     '-dry-run[If set, prints out what would'\''ve been removed but doesn'\''t actually remove anything.]' \
-    '-backup=[(PATH) Path where Terraform should write the backup for the original state.]::backupfile:_files -g "*.backup"' \
+    '-backup=[(PATH) Path where Terraform should write the backup for the original state.]::backupfile:_files -W __chdir -g "*.backup"' \
     '-ignore-remote-version[Continue even if remote and local Terraform versions are incompatible. This may result in an unusable workspace, and should be used with extreme caution.]' \
     '-lock=[(true) Don'\''t hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
-    '-state=[(PATH) Path to the state file to update. Defaults to the current workspace state.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(PATH) Path to the state file to update. Defaults to the current workspace state.]:statefile:_files -W __chdir -g "*.tfstate"' \
     '*:address:__terraform_state_resources'
 }
 
 (( ${+functions[_terraform_state_show]} )) || _terraform_state_show() {
   _arguments \
-    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]:statefile:_files -W __chdir -g "*.tfstate"' \
     "*:address:__terraform_state_resources"
 }
 
 (( ${+functions[__terraform_state_resources]} )) || __terraform_state_resources() {
   local resource
   local -a resources
-  terraform state list -state="${opt_args[-state]}" 2>/dev/null | while read -r resource; do
+  terraform -chdir="${__chdir}" state list -state="${opt_args[-state]}" 2>/dev/null | while read -r resource; do
     resources+=( "${resource}" )
   done
   compadd "${@}" - "${resources[@]}"
@@ -398,35 +403,35 @@ compdef _terraform terraform
 (( ${+functions[_terraform_taint]} )) || _terraform_taint() {
   _arguments \
     '-allow-missing[If specified, the command will succeed (exit code 0) even if the resource is missing.]' \
-    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
+    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -W __chdir -g "*.backup"' \
     '-ignore-remote-version[A rare option used for the remote backend only. See the remote backend documentation for more information.]' \
     '-lock=[(true) Don'\''t hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
-    '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]:statefile:_files -g "*.tfstate"' \
-    '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]:statefile:_files -W __chdir -g "*.tfstate"' \
+    '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]:statefile:_files -W __chdir -g "*.tfstate"' \
     '*:address:__terraform_state_resources'
 }
 
 (( ${+functions[_terraform_test]} )) || _terraform_test() {
   _arguments \
     '-cloud-run=[(source) If specified, Terraform will execute this test run remotely using Terraform Cloud. You must specify the source of a module registered in a private module registry as the argument to this flag. This allows Terraform to associate the cloud run with the correct Terraform Cloud module and organization.]' \
-    '*-filter=[(testfile) If specified, Terraform will only execute the test files specified by this flag. You can use this option multiple times to execute more than one test file.]:testfile:_files -g "*.tftest.hcl"' \
+    '*-filter=[(testfile) If specified, Terraform will only execute the test files specified by this flag. You can use this option multiple times to execute more than one test file.]:testfile:_files -W __chdir -g "*.tftest.hcl"' \
     '-json[If specified, machine readable output will be printed in JSON format]' \
     '-no-color[If specified, machine readable output will be printed in JSON format]' \
-    '-test-directory=[(path) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -/' \
+    '-test-directory=[(path) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -W __chdir -/' \
     '*-var=[(for=bar) Set a value for one of the input variables in the root module of the configuration. Use this option more than once to set more than one variable.]' \
-    '*-var-file=[(foo) Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.]:file:_files -g "*.tfvars{,.json}"' \
+    '*-var-file=[(foo) Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.]:file:_files -W __chdir -g "*.tfvars{,.json}"' \
     '-verbose[Print the plan or state for each test run block as it executes.]' \
 }
 
 (( ${+functions[_terraform_untaint]} )) || _terraform_untaint() {
   _arguments \
     '-allow-missing[If specified, the command will succeed (exit code 0) even if the resource is missing.]' \
-    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -g "*.backup"' \
+    '-backup=[(path) Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.]:backupfile:_files -W __chdir -g "*.backup"' \
     '-lock=[(true) Don'\''t hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
-    '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]:statefile:_files -g "*.tfstate"' \
-    '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(path) Path to read and save state (unless state-out is  specified). Defaults to "terraform.tfstate".]:statefile:_files -W __chdir -g "*.tfstate"' \
+    '-state-out=[(path) Path to write updated state file. By default, the "-state" path will be used.]:statefile:_files -W __chdir -g "*.tfstate"' \
     ':name:__terraform_state_resources'
 }
 
@@ -435,8 +440,8 @@ compdef _terraform terraform
     '-json[Produce output in a machine-readable JSON format, suitable for use in text editor integrations and other automated systems.]' \
     '-no-color[If specified, output will not contain any color.]' \
     '-no-tests[If specified, Terraform will not validate test files.]' \
-    '-test-directory=[(path) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -/' \
-    ':dir:_files -/'
+    '-test-directory=[(path) Set the Terraform test directory, defaults to "tests".]:test_directory:_files -W __chdir -/' \
+    ':dir:_files -W __chdir -/'
 }
 
 (( ${+functions[_terraform_version]} )) || _terraform_version() {
@@ -487,7 +492,7 @@ compdef _terraform terraform
   _arguments \
     '-lock=[(true) Don'\''t hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.]:lock:(true false)' \
     '-lock-timeout=[(0s) Duration to retry a state lock.]' \
-    '-state=[(path) Copy an existing state file into the new workspace.]:statefile:_files -g "*.tfstate"' \
+    '-state=[(path) Copy an existing state file into the new workspace.]:statefile:_files -W __chdir -g "*.tfstate"' \
     '::' \
     ':name:'
 }
@@ -506,7 +511,7 @@ compdef _terraform terraform
 (( ${+functions[__terraform_workspaces]} )) || __terraform_workspaces() {
   local workspace
   local -a workspaces
-  terraform workspace list | while read -r workspace; do
+  terraform -chdir="${__chdir}" workspace list | while read -r workspace; do
     if [[ -z "${workspace}" ]]; then
       continue
     fi
@@ -517,7 +522,7 @@ compdef _terraform terraform
 
 _terraform() {
   _arguments \
-    '-chdir=[(DIR) Switch to a different working directory before executing the given subcommand.]:chdir:_files -/' \
+    '-chdir=[(DIR) Switch to a different working directory before executing the given subcommand.]:chdir:_files -W __chdir -/' \
     '-help[Show this help output, or the help for a specified subcommand.]' \
     '-version[An alias for the "version" subcommand.]' \
     '*::terraform command:_terraform_commands'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- pass -chdir to completion commands
- stabilize sub-sub-commands completion

## Other comments:

Thank you @carlosala for the quick merge on #12252 :bow:
