### PR TITLE
chore(gitfast): remove update script

### DIFF
--- a/.github/dependencies.yml
+++ b/.github/dependencies.yml
@@ -2,7 +2,7 @@ dependencies:
   plugins/gitfast:
     repo: felipec/git-completion
     branch: master
-    version: tag:v2.0
+    version: tag:v2.1
     postcopy: |
       set -e
       rm -rf git-completion.plugin.zsh Makefile README.adoc t tools

--- a/plugins/gitfast/README.md
+++ b/plugins/gitfast/README.md
@@ -7,9 +7,3 @@ To use it, add `gitfast` to the plugins array in your zshrc file:
 ```zsh
 plugins=(... gitfast)
 ```
-
-## Aliases
-
-An earlier version of the plugin also loaded the git plugin. If you want to keep those
-aliases enable the [git plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git)
-as well.

--- a/plugins/gitfast/gitfast.plugin.zsh
+++ b/plugins/gitfast/gitfast.plugin.zsh
@@ -1,6 +1,6 @@
 # Handle $0 according to the standard:
 # https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
-0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
 
 source "${0:A:h}/git-prompt.sh"

--- a/plugins/gitfast/update
+++ b/plugins/gitfast/update
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-url="https://raw.githubusercontent.com/felipec/git-completion"
-version="2.0"
-
-curl -s -o _git "${url}/v${version}/git-completion.zsh" &&
-curl -s -o git-completion.bash "${url}/v${version}/git-completion.bash" &&
-curl -s -o git-prompt.sh "${url}/v${version}/git-prompt.sh"

--- a/plugins/gitfast/update
+++ b/plugins/gitfast/update
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 url="https://raw.githubusercontent.com/felipec/git-completion"
-version="1.3.7"
+version="2.0"
 
 curl -s -o _git "${url}/v${version}/git-completion.zsh" &&
 curl -s -o git-completion.bash "${url}/v${version}/git-completion.bash" &&


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- General update

## Other comments:

I've removed the `update` script since it seems a GitHub action is already taking care of the updating. I also updated the plug-in standard code to match upstream. And I removed the aliases section in the readme, since it only applies to ancient versions of oh-my-zsh.