### PR TITLE
enabled showing number of git stashes for themes and applied the change to af-magic theme

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -19,7 +19,6 @@ function git_prompt_info() {
 
   local ref
   ref=$(__git_prompt_git symbolic-ref --short HEAD 2> /dev/null) \
-  || ref=$(__git_prompt_git describe --tags --exact-match HEAD 2> /dev/null) \
   || ref=$(__git_prompt_git rev-parse --short HEAD 2> /dev/null) \
   || return 0
 
@@ -36,6 +35,8 @@ function git_prompt_info() {
 # Checks if working tree is dirty
 function parse_git_dirty() {
   local STATUS
+  local STASH_STATUS
+  local STASH_VALID=false
   local -a FLAGS
   FLAGS=('--porcelain')
   if [[ "$(__git_prompt_git config --get oh-my-zsh.hide-dirty)" != "1" ]]; then
@@ -53,11 +54,23 @@ function parse_git_dirty() {
         ;;
     esac
     STATUS=$(__git_prompt_git status ${FLAGS} 2> /dev/null | tail -n 1)
+    STASH_STATUS="$(git stash list | wc -l)"
+  fi
+  if [[ ! -z ${ZSH_THEME_GIT_PROMPT_STASH} && ! -z ${ZSH_THEME_GIT_PROMPT_STASH_DIRTY} && ! -z ${ZSH_THEME_GIT_RESET_COLOR} ]]; then
+    STASH_VALID=true
   fi
   if [[ -n $STATUS ]]; then
-    echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
+    if [[ ! -z ${STASH_STATUS} && ${STASH_STATUS} != 0 && ${STASH_VALID} == true ]]; then
+      echo "${ZSH_THEME_GIT_PROMPT_STASH_DIRTY}${STASH_STATUS}${ZSH_THEME_GIT_RESET_COLOR}"
+    else
+      echo "$ZSH_THEME_GIT_PROMPT_DIRTY"
+    fi
   else
-    echo "$ZSH_THEME_GIT_PROMPT_CLEAN"
+    if [[ ! -z ${STASH_STATUS} && ${STASH_STATUS} != 0 && ${STASH_VALID} ]]; then
+      echo "$ZSH_THEME_GIT_PROMPT_STASH${STASH_STATUS}${ZSH_THEME_GIT_RESET_COLOR}"
+    else
+      echo "$ZSH_THEME_GIT_PROMPT_CLEAN"
+    fi
   fi
 }
 

--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -6,12 +6,11 @@
 # dashed separator size
 function afmagic_dashes {
   # check either virtualenv or condaenv variables
-  local python_env_dir="${VIRTUAL_ENV:-$CONDA_DEFAULT_ENV}"
-  local python_env="${python_env_dir##*/}"
+  local python_env="${VIRTUAL_ENV:-$CONDA_DEFAULT_ENV}"
 
   # if there is a python virtual environment and it is displayed in
   # the prompt, account for it when returning the number of dashes
-  if [[ -n "$python_env" && "$PS1" = *\(${python_env}\)* ]]; then
+  if [[ -n "$python_env" && "$PS1" = \(* ]]; then
     echo $(( COLUMNS - ${#python_env} - 3 ))
   else
     echo $COLUMNS
@@ -34,6 +33,9 @@ RPS1+=" ${FG[237]}%n@%m%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_PREFIX=" ${FG[075]}(${FG[078]}"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 ZSH_THEME_GIT_PROMPT_DIRTY="${FG[214]}*%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_STASH="${FG[214]}\$"
+ZSH_THEME_GIT_RESET_COLOR="%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_STASH_DIRTY="${FG[214]}*\$"
 ZSH_THEME_GIT_PROMPT_SUFFIX="${FG[075]})%{$reset_color%}"
 
 # hg settings


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x] The PR title is descriptive.
- [ x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ x] The code follows the code style guide detailed in the wiki.
- [ x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- in git.sh I check the stash list and if the theme variables are set, it reports the number of stashed entries in the git status
- in af-magic.sh I set the necessary variables to enable visualizing the stash
- if those are not set, this logic is ignored
## Other comments:

...
