### PR TITLE
fix(poetry-env): `poetry info --path` `cannot find directory '/bin/activate'` because...

### DIFF
--- a/plugins/poetry-env/poetry-env.plugin.zsh
+++ b/plugins/poetry-env/poetry-env.plugin.zsh
@@ -17,7 +17,7 @@ _togglePoetryShell() {
       if grep -q 'tool.poetry' "$PWD/pyproject.toml"; then
         export poetry_active=1
         export poetry_dir="$PWD"
-        source "$(poetry env info --path)/bin/activate"
+        poetry shell
       fi
     fi
   fi


### PR DESCRIPTION
... 'poetry info --path' does not return anything.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Poetry shell now invoked through it's own `poetry shell` instead of using `source ...`

## Other comments:

- This has not been tested extensively with other poetry versions.
