### PR TITLE
fix(tmux): Add completion for alias functions

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -59,11 +59,11 @@ function _build_tmux_alias {
 
 # ALIAS COMPLETION (Modified from https://github.com/zsh-users/zsh)
 _tmux-attach-session() {
-  local sessions
-  sessions=(${(f)"$(tmux list-session)"})
   [[ -n ${tmux_describe} ]] && print "attach or switch to a session" && return
 
-  # If no flag is given, complete with session names.
+  local sessions
+  sessions=(${(f)"$(tmux list-session)"})
+
   if (( CURRENT == 2 )); then
     _alternative \
       'commands:: _describe -t sessions "tmux session" sessions'
@@ -72,19 +72,17 @@ _tmux-attach-session() {
 
   if [[ $words[1] =~ ta ]]; then 
     _arguments -s \
-      '1:sessions' \
+      '1:session' \
       '-c+[specify working directory for the session]:directory:_directories' \
       '-d[detach other clients attached to target session]' \
       '-f+[set client flags]: :_tmux_client_flags' \
       '-r[put the client into read-only mode]' \
-      '-t+[specify target session]:target session: __tmux-sessions-separately' \
       "-E[don't apply update-environment option]" \
       '-x[with -d, send SIGHUP to the parent of the attached client]'
     elif [[ $words[1] = "tkss" ]]; then
       _arguments -s \
-        '1:sessions' \
+        '1:session' \
         '-a[kill all session except the one specified by -t]' \
-        '-t+[specify target session]:session:__tmux-sessions' \
         '-C[clear alerts (bell, activity, silence) in all windows linked to the session]'
     fi
 
@@ -94,24 +92,6 @@ _tmux-attach-session() {
 _tmux_client_flags() {
   _values -s , flag active-pane ignore-size no-output \
       'pause-after:time (seconds)' read-only wait-exit
-}
-
-__tmux-sessions-separately() {
-    local ret=1
-    local -a sessions detached_sessions attached_sessions
-    sessions=( ${${(f)"$(command tmux 2> /dev/null list-sessions)"}/:[ $'\t']##/:} )
-    detached_sessions=(    ${sessions:#*"(attached)"} )
-    attached_sessions=( ${(M)sessions:#*"(attached)"} )
-
-    # ### This seems to work without a _tags loop but not with it.  I suspect
-    # ### that has something to do with _describe doing its own _tags loop.
-    _tags detached-sessions attached-sessions
-    # Placing detached before attached means the default behaviour of this
-    # function better suits its only current caller, _tmux-attach-session().
-    _requested detached-sessions && _describe -t detached-sessions 'detached session' detached_sessions "$@" && ret=0
-    _requested attached-sessions && _describe -t attached-sessions 'attached session' attached_sessions "$@" && ret=0
-
-    return ret
 }
 
 alias tksv='tmux kill-server'

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -57,6 +57,14 @@ function _build_tmux_alias {
   }"
 }
 
+function _session_completion {
+  local sessions
+  sessions=(${(f)"$(tmux list-session)"})
+
+  _alternative \
+    'commands:: _describe -t sessions "tmux session" sessions'
+}
+
 alias tksv='tmux kill-server'
 alias tl='tmux list-sessions'
 alias tmuxconf='$EDITOR $ZSH_TMUX_CONFIG'
@@ -130,6 +138,10 @@ function _zsh_tmux_plugin_run() {
 
 # Use the completions for tmux for our function
 compdef _tmux _zsh_tmux_plugin_run
+
+# Provide session name completion for alias functions.
+compdef _session_completion ta tad tkss
+
 # Alias tmux to our wrapper function.
 alias tmux=_zsh_tmux_plugin_run
 


### PR DESCRIPTION
fix(tmux): Add completion for alias functions

Fixes https://github.com/ohmyzsh/ohmyzsh/issues/12282

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes completion for aliased functions (`ta`, `tad`, and `tkss`) introduced in https://github.com/ohmyzsh/ohmyzsh/pull/12232.
## Other comments:

I barely understand the ZSH completion system, but this seems to get the job done. `ta<tab>` and `tmux attach -t<tab>` seem to provide identical results. Any feedback is welcome.
