### PR TITLE
gradle plugin: introduce ZSH_GRADLE_PLUGIN_ALIAS_ENABLED

### DIFF
--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -1,6 +1,6 @@
 # Gradle plugin
 
-This plugin adds completions and aliases for [Gradle](https://gradle.org/).
+This plugin adds completions and aliases for [Gradle](https://gradle.org).
 
 To use it, add `gradle` to the plugins array in your zshrc file:
 
@@ -8,14 +8,20 @@ To use it, add `gradle` to the plugins array in your zshrc file:
 plugins=(... gradle)
 ```
 
-## Usage
+## Completion
 
-This plugin creates a function called `gradle-or-gradlew`, which is aliased
-to `gradle`, which is used to determine whether the current project directory
-has a gradlew file. If `gradlew` is present it will be used, otherwise `gradle`
-is used instead. Gradle tasks can be executed directly without regard for
-whether it is `gradle` or `gradlew`. It also supports being called from
-any directory inside the root project directory.
+This plugin uses [the completion from the Gradle project](https://github.com/gradle/gradle-completion),
+which is distributed under the MIT license.
+
+## Gradle command alias
+
+If environment variable `ZSH_GRADLE_PLUGIN_ALIAS` is set, this plugin creates a
+function called `gradle-or-gradlew`, which is aliased to `gradle`, which is used
+to determine whether the current project directory has a gradlew file. If
+`gradlew` is present it will be used, otherwise `gradle` is used instead. Gradle
+tasks can be executed directly without regard for whether it is `gradle` or
+`gradlew`. It also supports being called from any directory inside the root
+project directory.
 
 Examples:
 
@@ -24,7 +30,3 @@ gradle test
 gradle build
 ```
 
-## Completion
-
-This plugin uses [the completion from the Gradle project](https://github.com/gradle/gradle-completion),
-which is distributed under the MIT license.

--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -1,3 +1,7 @@
+if [ -z "${ZSH_GRADLE_PLUGIN_ALIAS:-}" ]; then
+	return 0
+fi
+
 # Looks for a gradlew file in the current working directory
 # or any of its parent directories, and executes it if found.
 # Otherwise it will call gradle directly.


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The `gradle` provides two things:
- gradle zsh completion, which I want
- [`gradle-or-gradlew`](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/gradle#usage) function, which I don't want

This PR disables the `gradle-or-gradlew` function by default, and updates the plugin's README to explain this behavior.