### PR TITLE
fix(docker-compose): completion regression

### DIFF
--- a/plugins/docker-compose/_docker-compose
+++ b/plugins/docker-compose/_docker-compose
@@ -128,7 +128,7 @@ __docker-compose_subcommand() {
                 '--resolve-image-digests[Pin image tags to digests.]' \
                 '--services[Print the service names, one per line.]' \
                 '--volumes[Print the volume names, one per line.]' \
-                '--hash[Print the service config hash, one per line. Set "service1,service2" for a list of specified services.]' \ && ret=0
+                '--hash[Print the service config hash, one per line. Set "service1,service2" for a list of specified services.]' && ret=0
             ;;
         (create)
             _arguments \


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Remove unnecessary backslash causing error in `docker-compose config`  completions.

![error](https://github.com/ohmyzsh/ohmyzsh/assets/1637663/70548889-6e46-477f-9949-d86b8a56484e)

