### PR TITLE
fix(mise): update environment when loading the plugin

### DIFF
--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -11,6 +11,9 @@ fi
 # Load mise hooks
 eval "$($__mise activate zsh)"
 
+# Hook mise into current environment
+eval "$($__mise hook-env -s zsh)"
+
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `mise`. Otherwise, compinit will have already done that.
 if [[ ! -f "$ZSH_CACHE_DIR/completions/_$__mise" ]]; then


### PR DESCRIPTION
Now mise installs can be found by any following OMZ plugins.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Run `mise hook-env` automatically

## Other comments:

...
