### PR TITLE
fix(ssh-agent): don't start new agent if screen/tmux symlink exists

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -98,8 +98,10 @@ function _add_identities() {
 
 # Add a nifty symlink for screen/tmux if agent forwarding is enabled
 if zstyle -t :omz:plugins:ssh-agent agent-forwarding \
-   && [[ -n "$SSH_AUTH_SOCK" && ! -L "$SSH_AUTH_SOCK" ]]; then
-  ln -sf "$SSH_AUTH_SOCK" /tmp/ssh-agent-$USERNAME-screen
+   && [[ -n "$SSH_AUTH_SOCK" ]]; then
+  if [[ ! -L "$SSH_AUTH_SOCK" ]]; then
+    ln -sf "$SSH_AUTH_SOCK" /tmp/ssh-agent-$USERNAME-screen
+  fi
 else
   _start_agent
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Issue:

The ssh-agent plugin provides a symlink of SSH_AUTH_SOCK with a stable name, so that tmux/screen users can reference this name in their configs, e.g. in .tmux.conf:
```
# https://blog.testdouble.com/posts/2016-11-18-reconciling-tmux-and-ssh-agent-forwarding/
# Remove SSH_AUTH_SOCK to disable tmux automatically resetting the variable
set -g update-environment "DISPLAY SSH_ASKPASS SSH_AGENT_PID \
                             SSH_CONNECTION WINDOWID XAUTHORITY"

# Use a symlink to look up SSH authentication
# cannot use $USERNAME because this special zsh var is not available here...
# hope $USER is same
setenv -g SSH_AUTH_SOCK /tmp/ssh-agent-$USER-screen
```

However, up to now, the if conditions in the plugin were formulated such that, if the symlink already exists, a new ssh-agent would be started, thereby overwriting the SSH_AUTH_SOCK from the symlink. This defeats the whole purpose of the symlink mechanism.
Steps to reproduce issue:

1. Enable agent forwarding on client and enable ssh-agent plugin + forwarding on server, add lines above to .tmux.conf
2. Start ssh agent on client, add a key
3. Connect to server with installed ssh-agent plugin (plugin will create the symlink now)
4. Start new tmux session (tmux will set SSH_AUTH_SOCK in session to symlink now)
5. Start zsh inside the tmux session

Because SSH_AUTH_SOCK is now a symlink, the ssh-agent plugin called from zsh inside the tmux session will decide to start a new agent, which overwrites SSH_AUTH_SOCK and breaks forwarding inside tmux.

## Changes:

This PR changes the conditions such that, if forwarding is enabled and SSH_AUTH_SOCK is not empty, we never start a new ssh agent.