### PR TITLE
fix(poetry-env): activate a non-existent virtual environment

### DIFF
--- a/plugins/poetry-env/poetry-env.plugin.zsh
+++ b/plugins/poetry-env/poetry-env.plugin.zsh
@@ -14,10 +14,10 @@ _togglePoetryShell() {
   # activate the environment if pyproject.toml exists
   if [[ "$poetry_active" != 1 ]]; then
     if [[ -f "$PWD/pyproject.toml" ]]; then
-      if grep -q 'tool.poetry' "$PWD/pyproject.toml"; then
+      if grep -q 'tool.poetry' "$PWD/pyproject.toml" && venv_dir=$(poetry env info --path); then
         export poetry_active=1
         export poetry_dir="$PWD"
-        source "$(poetry env info --path)/bin/activate"
+        source "${venv_dir}/bin/activate"
       fi
     fi
   fi


### PR DESCRIPTION
activate a non-existent virtual environment.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Before activating the virtual environment, check whether the virtual environment exists.