### PR TITLE
fix(async): avoid blocking the shell while waiting

### DIFF
--- a/lib/async_prompt.zsh
+++ b/lib/async_prompt.zsh
@@ -96,8 +96,7 @@ function _omz_async_request {
     command true
 
     # Save the PID from the handler child process
-    read pid <&$fd
-    _OMZ_ASYNC_PIDS[$handler]=$pid
+    read -u $fd "_OMZ_ASYNC_PIDS[$handler]"
 
     # When the fd is readable, call the response handler
     zle -F "$fd" _omz_async_callback
@@ -119,7 +118,7 @@ function _omz_async_callback() {
     local old_output="${_OMZ_ASYNC_OUTPUT[$handler]}"
 
     # Read output from fd
-    _OMZ_ASYNC_OUTPUT[$handler]="$(cat <&$fd)"
+    IFS= read -r -u $fd -d '' "_OMZ_ASYNC_OUTPUT[$handler]"
 
     # Repaint prompt if output has changed
     if [[ "$old_output" != "${_OMZ_ASYNC_OUTPUT[$handler]}" ]]; then

--- a/lib/async_prompt.zsh
+++ b/lib/async_prompt.zsh
@@ -44,7 +44,7 @@ function _omz_register_handler {
 # Set up async handlers and callbacks
 function _omz_async_request {
   local -i ret=$?
-  typeset -gA _OMZ_ASYNC_FDS _OMZ_ASYNC_PIDS _OMZ_ASYNC_OUTPUT
+  typeset -gA _OMZ_ASYNC_FDS _OMZ_ASYNC_PIDS _OMZ_ASYNC_OUTPUT _OMZ_ASYNC_HANDLERS
 
   # executor runs a subshell for all async requests based on key
   local handler
@@ -82,16 +82,16 @@ function _omz_async_request {
     exec {fd}< <(
       # Tell parent process our PID
       builtin echo ${sysparams[pid]}
-      # Store handler name for callback
-      builtin echo $handler
       # Set exit code for the handler if used
-      (exit $ret)
+      () { return $ret }
       # Run the async function handler
       $handler
     )
 
     # Save FD for handler
     _OMZ_ASYNC_FDS[$handler]=$fd
+    # Save handler name for callback
+    _OMZ_ASYNC_HANDLERS[$fd]=$handler
 
     # There's a weird bug here where ^C stops working unless we force a fork
     # See https://github.com/zsh-users/zsh-autosuggestions/issues/364
@@ -114,9 +114,8 @@ function _omz_async_callback() {
   local err=$2  # Second arg will be passed in case of error
 
   if [[ -z "$err" || "$err" == "hup" ]]; then
-    # Get handler name from first line
-    local handler
-    read handler <&$fd
+    # Get handler name from fd
+    local handler=${_OMZ_ASYNC_HANDLERS[$fd]}
 
     # Store old output which is supposed to be already printed
     local old_output="${_OMZ_ASYNC_OUTPUT[$handler]}"
@@ -136,6 +135,9 @@ function _omz_async_callback() {
 
   # Always remove the handler
   zle -F "$fd"
+
+  # Remove the fd => handle name association
+  unset '_OMZ_ASYNC_HANDLERS[$fd]'
 
   # Unset global FD variable to prevent closing user created FDs in the precmd hook
   _OMZ_ASYNC_FDS[$handler]=-1


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Make sure `_omz_async_callback` is only called when the handler writes data (at the end), instead of just after the fork : it blocked the shell until the end of the async prompt handler
- Do not use a subshell to set the status
- Fixes #12290 (cc @mcornella)

## Other comments:
This is draft for now, as I cannot explain why the subshell could sometimes block for several seconds (which blocked the shell in `_omz_async_callback`).
Even when it didn't block, the subshell was 10-20ms slower anyway.
