### PR TITLE
fix(starship)!: keep `ZSH_THEME` when Starship is not found

### DIFF
--- a/plugins/starship/starship.plugin.zsh
+++ b/plugins/starship/starship.plugin.zsh
@@ -1,7 +1,7 @@
-# ignore oh-my-zsh theme
-unset ZSH_THEME
-
 if (( $+commands[starship] )); then
+  # ignore oh-my-zsh theme
+  unset ZSH_THEME
+
   eval "$(starship init zsh)"
 else
   echo '[oh-my-zsh] starship not found, please install it from https://starship.rs'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

BREAKING CHANGE: starship plugin will keep ZSH_THEME as a fallback if Starship is not found. You can put ZSH_THEME="" before running oh-my-zsh.sh to keep the previous behavior where starship plugin always unset the Zsh theme.

## Background:

While I usually use Starship to configure the prompt style, some of my environments don't have Starship installed (by default). I want to use one of Oh My Zsh themes as the fallback instead of the default Zsh prompt if Starship is not (or cannot be) installed. 

## Tests:

- [x] `ZSH_THEME` is used when starship plugin is enabled and Starship is not installed.
- [x] The Starship prompt is used when starship plugin is enabled and Starship is installed.

## Other comments:

CC @axieax as the author of the great plugin