### PR TITLE
Added https httpie command to completion sources

### DIFF
--- a/plugins/httpie/_httpie
+++ b/plugins/httpie/_httpie
@@ -1,4 +1,4 @@
-#compdef http
+#compdef http https
 # ------------------------------------------------------------------------------
 # Copyright (c) 2015 GitHub zsh-users - http://github.com/zsh-users
 # All rights reserved.


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- httpie completion now also works on its `https` command that previously wasn't completed.
