### PR TITLE
perf(async): avoid executing true

### DIFF
--- a/lib/async_prompt.zsh
+++ b/lib/async_prompt.zsh
@@ -3,6 +3,7 @@
 # https://github.com/woefe/git-prompt.zsh/blob/master/git-prompt.zsh
 
 zmodload zsh/system
+autoload -Uz is-at-least
 
 # For now, async prompt function handlers are set up like so:
 # First, define the async function handler and register the handler
@@ -93,7 +94,8 @@ function _omz_async_request {
 
     # There's a weird bug here where ^C stops working unless we force a fork
     # See https://github.com/zsh-users/zsh-autosuggestions/issues/364
-    command true
+    # and https://github.com/zsh-users/zsh-autosuggestions/pull/612
+    is-at-least 5.8 || command true
 
     # Save the PID from the handler child process
     read -u $fd "_OMZ_ASYNC_PIDS[$handler]"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Do not run `command true` (fork + exec) in `_omz_async_request` with zsh >= 5.8