### PR TITLE
feat(git): implement async completion git_prompt_status

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -9,7 +9,7 @@ function __git_prompt_git() {
   GIT_OPTIONAL_LOCKS=0 command git "$@"
 }
 
-function _omz_git_prompt_status() {
+function _omz_git_prompt_info() {
   # If we are on a folder not tracked by git, get out.
   # Otherwise, check for hide-info at global and local repository level
   if ! __git_prompt_git rev-parse --git-dir &> /dev/null \
@@ -40,6 +40,12 @@ function _omz_git_prompt_status() {
 # Enable async prompt by default unless the setting is at false / no
 if zstyle -T ':omz:alpha:lib:git' async-prompt; then
   function git_prompt_info() {
+    if [[ -n "$_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]" ]]; then
+      echo -n "$_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]"
+    fi
+  }
+
+  function git_prompt_status() {
     if [[ -n "$_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]" ]]; then
       echo -n "$_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]"
     fi
@@ -51,8 +57,13 @@ if zstyle -T ':omz:alpha:lib:git' async-prompt; then
     # Check if git_prompt_info is used in a prompt variable
     case "${PS1}:${PS2}:${PS3}:${PS4}:${RPS1}:${RPS2}:${RPS3}:${RPS4}" in
     *(\$\(git_prompt_info\)|\`git_prompt_info\`)*)
+      _omz_register_handler _omz_git_prompt_info
+      ;;
+    esac
+
+    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPS1}:${RPS2}:${RPS3}:${RPS4}" in
+    *(\$\(git_prompt_status\)|\`git_prompt_status\`)*)
       _omz_register_handler _omz_git_prompt_status
-      return
       ;;
     esac
 
@@ -65,6 +76,9 @@ if zstyle -T ':omz:alpha:lib:git' async-prompt; then
   precmd_functions=(_defer_async_git_register $precmd_functions)
 else
   function git_prompt_info() {
+    _omz_git_prompt_info
+  }
+  function git_prompt_status() {
     _omz_git_prompt_status
   }
 fi
@@ -197,7 +211,7 @@ function git_prompt_long_sha() {
   SHA=$(__git_prompt_git rev-parse HEAD 2> /dev/null) && echo "$ZSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$ZSH_THEME_GIT_PROMPT_SHA_AFTER"
 }
 
-function git_prompt_status() {
+function _omz_git_prompt_status() {
   [[ "$(__git_prompt_git config --get oh-my-zsh.hide-status 2>/dev/null)" = 1 ]] && return
 
   # Maps a git status prefix to an internal constant


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- `git_prompt_status` is now asynchronous like `git_prompt_info`, it's important since there are themes using both

## Other comments:
 - the handler for git_prompt_info was incorrectly named _omz_git_prompt_status
 - _defer_async_git_register was kept in precmd, there is no need to call it on each prompt