### PR TITLE
autojump plugin: fix for 'pkgsrc' installation path on macOS

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -13,6 +13,7 @@ autojump_paths=(
   /opt/local/etc/profile.d/autojump.sh                     # macOS with MacPorts
   /usr/local/etc/profile.d/autojump.sh                     # macOS with Homebrew (default)
   /opt/homebrew/etc/profile.d/autojump.sh                  # macOS with Homebrew (default on M1 macs)
+  /opt/pkg/share/autojump/autojump.zsh                     # macOS with pkgsrc
   /etc/profiles/per-user/$USER/etc/profile.d/autojump.sh   # macOS Nix, Home Manager and flakes
 )
 


### PR DESCRIPTION
The added path is currently default for Apple Silicon installations with 'pkgsrc' - https://pkgsrc.smartos.org/

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

This is really a simple fix...

```
❯ pwd
/opt/pkg/share/autojump
❯ tree
.
├── autojump.bash
├── autojump.fish
├── autojump.sh
├── autojump.tcsh
├── autojump.zsh
└── icon.png

0 directories, 6 files
```
