### PR TITLE
feat(macos): `ofd` now opens any directory

### DIFF
--- a/plugins/macos/README.md
+++ b/plugins/macos/README.md
@@ -17,7 +17,7 @@ Original author: [Sorin Ionescu](https://github.com/sorin-ionescu)
 | `tab`         | Open the current directory in a new tab                  |
 | `split_tab`   | Split the current terminal tab horizontally              |
 | `vsplit_tab`  | Split the current terminal tab vertically                |
-| `ofd`         | Open the current directory in a Finder window            |
+| `ofd`         | Open passed directories (or $PWD by default) in Finder   |
 | `pfd`         | Return the path of the frontmost Finder window           |
 | `pfs`         | Return the current Finder selection                      |
 | `cdf`         | `cd` to the current Finder directory                     |

--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -3,7 +3,8 @@
 0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
 
-# Open the current directory in a Finder window
+# Open in Finder the directories passed as arguments, or the current directory if
+# no directories are passed
 function ofd {
   if (( ! $# )); then
     open_command $PWD


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

I also tested the code locally (see all scenarios above) and it works as expected (`zsh 5.9 (x86_64-apple-darwin23.0)`)

## Changes:

This PR fixes the `ofd` function to not open the `$PWD` in Finder if there are other arguments passed.

I often use `ofd`, but almost equally often I use `ofd <path>`, but in that case, two Finder windows are opened: one with `$PWD`, and the second one with the path I passed. I think this behavior is a small bug, so I changed it.

### Without these changes

- `ofd` opens `$PWD` in Finder
- `ofd .` opens `$PWD` in Finder
- `ofd path1` opens `$PWD` and `path1` in Finder
- `ofd path1 path2` opens `$PWD`, `path1` and `path2` in Finder

### With these changes

- `ofd` opens `$PWD` in Finder
- `ofd .` opens `$PWD` in Finder
- `ofd path1` opens `path1` in Finder
- `ofd path1 path2` opens `path1` and `path2` in Finder
