### PR TITLE
fix(history)!: fix arg passing to `fc` for `history` command

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -12,8 +12,8 @@ function omz_history {
     # if -l provided, run as if calling `fc' directly
     builtin fc "$@"
   else
-    # unless a number is provided, show all history events (starting from 1)
-    [[ ${@[-1]-} = *[0-9]* ]] && builtin fc -l "$@" || builtin fc -l "$@" 1
+    # otherwise, run `fc -l` with a custom format
+    builtin fc -l "$@"
   fi
 }
 


### PR DESCRIPTION
fixes #12334 by not forcing the `1` argument and giving the user more control. 

