### PR TITLE
fix(shell-proxy): support ssh-proxy using http proxy in cygwin

### DIFF
--- a/plugins/shell-proxy/ssh-proxy.py
+++ b/plugins/shell-proxy/ssh-proxy.py
@@ -22,7 +22,8 @@ if parsed.scheme not in proxy_protocols:
 
 def make_argv():
     yield "nc"
-    if sys.platform == 'linux':
+    if sys.platform in {'linux', 'cygwin'}:
+        # caveats: the built-in netcat of most linux distributions and cygwin support proxy type
         # caveats: macOS built-in netcat command not supported proxy-type
         yield "-X" # --proxy-type
         # Supported protocols are 4 (SOCKS v4), 5 (SOCKS v5) and connect (HTTP proxy).


### PR DESCRIPTION
The ssh-proxy.py generates `nc` commands to connect the proxy. However, in cygwin, it does not set the protocol type, leading to `nc` using wrong default protocol (socks5) if we actually use an http proxy.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add a check ("cygwin") for sys.platform
