### PR TITLE
feat(poetry-env): support changing between two venv dirs

### DIFF
--- a/plugins/poetry-env/poetry-env.plugin.zsh
+++ b/plugins/poetry-env/poetry-env.plugin.zsh
@@ -6,14 +6,14 @@ _togglePoetryShell() {
   fi
 
   # Deactivate the current environment if moving out of a Poetry directory or into a different Poetry directory
-  if [[ "$poetry_active" == 1 ]] && { [[ $in_poetry_dir -eq 0 ]] || [[ "$PWD" != "$poetry_dir" ]]; }; then
+  if [[ $poetry_active -eq 1 ]] && { [[ $in_poetry_dir -eq 0 ]] || [[ "$PWD" != "$poetry_dir"* ]]; }; then
     export poetry_active=0
     unset poetry_dir
     deactivate
   fi
 
   # Activate the environment if in a Poetry directory and no environment is currently active
-  if [[ $in_poetry_dir -eq 1 ]] && [[ "$poetry_active" != 1 ]]; then
+  if [[ $in_poetry_dir -eq 1 ]] && [[ $poetry_active -ne 1 ]]; then
     venv_dir=$(poetry env info --path 2>/dev/null)
     if [[ -n "$venv_dir" ]]; then
       export poetry_active=1

--- a/plugins/poetry-env/poetry-env.plugin.zsh
+++ b/plugins/poetry-env/poetry-env.plugin.zsh
@@ -1,27 +1,27 @@
-# Automatic poetry environment activation/deactivation
 _togglePoetryShell() {
-  # deactivate environment if pyproject.toml doesn't exist and not in a subdir
-  if [[ ! -f "$PWD/pyproject.toml" ]] ; then
-    if [[ "$poetry_active" == 1 ]]; then
-      if [[ "$PWD" != "$poetry_dir"* ]]; then
-        export poetry_active=0
-        deactivate
-        return
-      fi
-    fi
+  # Determine if currently in a Poetry-managed directory
+  local in_poetry_dir=0
+  if [[ -f "$PWD/pyproject.toml" ]] && grep -q 'tool.poetry' "$PWD/pyproject.toml"; then
+    in_poetry_dir=1
   fi
 
-  # activate the environment if pyproject.toml exists
-  if [[ "$poetry_active" != 1 ]]; then
-    if [[ -f "$PWD/pyproject.toml" ]]; then
-      if grep -q 'tool.poetry' "$PWD/pyproject.toml" && venv_dir=$(poetry env info --path); then
-        export poetry_active=1
-        export poetry_dir="$PWD"
-        source "${venv_dir}/bin/activate"
-      fi
+  # Deactivate the current environment if moving out of a Poetry directory or into a different Poetry directory
+  if [[ "$poetry_active" == 1 ]] && { [[ $in_poetry_dir -eq 0 ]] || [[ "$PWD" != "$poetry_dir" ]]; }; then
+    export poetry_active=0
+    unset poetry_dir
+    deactivate
+  fi
+
+  # Activate the environment if in a Poetry directory and no environment is currently active
+  if [[ $in_poetry_dir -eq 1 ]] && [[ "$poetry_active" != 1 ]]; then
+    venv_dir=$(poetry env info --path 2>/dev/null)
+    if [[ -n "$venv_dir" ]]; then
+      export poetry_active=1
+      export poetry_dir="$PWD"
+      source "${venv_dir}/bin/activate"
     fi
   fi
 }
 autoload -U add-zsh-hook
 add-zsh-hook chpwd _togglePoetryShell
-_togglePoetryShell
+_togglePoetryShell # Initial call to check the current directory at shell startup


### PR DESCRIPTION
Support moving from one poetry directory to another poetry directory instead of only from a non-managed poetry directory into and out of poetry managed ones.



## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

This version of the script includes several improvements:

- **Deactivation Logic**: It checks if you're moving out of a Poetry directory or into a different Poetry directory. This ensures the current environment is deactivated when needed.
- **Reactivation Logic**: After potentially deactivating an environment, it checks if the new directory is a Poetry directory. If so, it activates the environment for the new directory.
- **Robustness Enhancements**: The script now properly checks for the existence of pyproject.toml and validates it contains Poetry configuration before attempting to activate an environment. It also handles potential errors from poetry env info --path more gracefully by redirecting stderr to /dev/null.
