### PR TITLE
fix(yarn): use `builtin cd` in completion

### DIFF
--- a/plugins/yarn/_yarn
+++ b/plugins/yarn/_yarn
@@ -86,7 +86,7 @@ _global_commands=(
 )
 
 _yarn_find_package_json() {
-  local dir=$(cd "$1" && pwd)
+  local dir=$(builtin cd "$1" && pwd)
 
   while true
   do
@@ -109,7 +109,7 @@ _yarn_commands_scripts() {
 
   if [[ -n $opt_args[--cwd] ]]; then
     packageJson=$(_yarn_find_package_json $opt_args[--cwd])
-    binaries=($(cd $opt_args[--cwd] && echo node_modules/.bin/*(x:t)))
+    binaries=($(builtin cd $opt_args[--cwd] && echo node_modules/.bin/*(x:t)))
   else
     packageJson=$(_yarn_find_package_json $pwd)
     binaries=($(echo node_modules/.bin/*(x:t)))
@@ -130,9 +130,9 @@ _yarn_scripts() {
   if [[ -n $_yarn_run_cwd ]]; then
     packageJson=$(_yarn_find_package_json $_yarn_run_cwd)
     if [[ -d "${_yarn_run_cwd}/node_modules" ]]; then
-      binaries=($(cd $_yarn_run_cwd && echo node_modules/.bin/*(x:t)))
+      binaries=($(builtin cd $_yarn_run_cwd && echo node_modules/.bin/*(x:t)))
     else
-      binaries=($(cd $_yarn_run_cwd && yarn bin | perl -wln -e 'm{^[^:]+: (\S+)$} and print $1'))
+      binaries=($(builtin cd $_yarn_run_cwd && yarn bin | perl -wln -e 'm{^[^:]+: (\S+)$} and print $1'))
     fi
   else
     packageJson=$(_yarn_find_package_json $pwd)


### PR DESCRIPTION
This simply replaces 3 instances of `cd` in the `_yarn` completion script with `builtin cd` to avoid issues in the case that `cd` has been aliased or redefined. While this may sound like an unusual situation, consider the example below.

Example: `cd` is 'enhanced' to list contents of the new directory, e.g.
```shell
function cd () {
    builtin cd "$1"
    ls -laFhGT
}
```
Chaos ensues on invoking completion, `yarn ⇥` <kbd>tab</kbd>

<a href="https://asciinema.org/a/ejagW9I1NnnSpciUanxshhx0r" target="_blank"><img src="https://asciinema.org/a/ejagW9I1NnnSpciUanxshhx0r.svg" alt="asciinema of yarn completion bug" style="max-width:500px;"  width="500" /></a>

Here is a video screen recording if asciinema link goes away:
<video controls muted src="https://github.com/ohmyzsh/ohmyzsh/assets/8978069/82cd8f18-ba01-4ab8-8d5b-147d8500a547">
  <source src="https://github.com/ohmyzsh/ohmyzsh/assets/8978069/82cd8f18-ba01-4ab8-8d5b-147d8500a547" type="video/mp4" />
<a href="https://github.com/ohmyzsh/ohmyzsh/assets/8978069/82cd8f18-ba01-4ab8-8d5b-147d8500a547" target="_blank">video link</a>
</video>


## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- ~~[ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.~~

## Changes:

- replaced 3 instances of `cd` with `builtin cd` in `_yarn` completion definition script

## Other comments:

I can't really think of a better way to do this. I considered `/bin/cd`, but we can pretty safely assume that the user's shell is `zsh` and `builtin cd` always works.