### PR TITLE
feat(tmux): sessions named as current dir

### DIFF
--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -37,6 +37,7 @@ The plugin also supports the following:
 | `ZSH_TMUX_AUTOQUIT`                 | Automatically closes terminal once tmux exits (default: `ZSH_TMUX_AUTOSTART`)                               |
 | `ZSH_TMUX_CONFIG`                   | Set the configuration path (default: `$HOME/.tmux.conf`, `$XDG_CONFIG_HOME/tmux/tmux.conf`)                 |
 | `ZSH_TMUX_DEFAULT_SESSION_NAME`     | Set tmux default session name when autostart is enabled                                                     |
+| `ZSH_TMUX_AUTONAME_SESSION`         | Automatically name new sessions based on the basename of `$PWD` (default: `false`)                          |
 | `ZSH_TMUX_DETACHED`                 | Set the detached mode (default: `false`)                                                                    |
 | `ZSH_TMUX_FIXTERM`                  | Sets `$TERM` to 256-color term or not based on current terminal support                                     |
 | `ZSH_TMUX_FIXTERM_WITHOUT_256COLOR` | `$TERM` to use for non 256-color terminals (default: `tmux` if available, `screen` otherwise)               |


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

When `$ZSH_TMUX_AUTONAME_SESSION=true`, name the tmux session after the working directory.

If you are in `~/foo/bar`, the name will be `bar`. If you are in `~/`, the name will be `home`.