### PR TITLE
feat(laravel): add aliases laravel 11

### DIFF
--- a/plugins/laravel/README.md
+++ b/plugins/laravel/README.md
@@ -36,6 +36,10 @@ plugins=(... laravel)
 | `pamj`  |  `php artisan make:job` |
 | `paml`  |  `php artisan make:listener` |
 | `pamn`  |  `php artisan make:notification` |
+| `pamcl` | `php artisan make:class` |
+| `pamen` | `php artisan make:enum` |
+| `pami`  | `php artisan make:interface` |
+| `pamtr` | `php artisan make:trait` |
 
 ## Clears
 

--- a/plugins/laravel/laravel.plugin.zsh
+++ b/plugins/laravel/laravel.plugin.zsh
@@ -25,6 +25,10 @@ alias pamj='php artisan make:job'
 alias paml='php artisan make:listener'
 alias pamn='php artisan make:notification'
 alias pampp='php artisan make:provider'
+alias pamcl='php artisan make:class'
+alias pamen='php artisan make:enum'
+alias pami='php artisan make:interface'
+alias pamtr='php artisan make:trait'
 
 
 # Clears


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added `pamcl` alias for `php artisan make:class`
- Added `pamen` alias for `php artisan make:enum`
- Added `pami` alias for `php artisan make:interface`
- Added `pamtr` alias for `php artisan make:trait`

## Other comments:

Laravel version 11 introduced new artisan commands, see https://laravel.com/docs/11.x/releases#new-artisan-commands. I think it would be nice to have this aliases for laravel plugin makers alias.