### PR TITLE
fix(history): fix edge cases introduced in #12341

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -1,19 +1,19 @@
 ## History wrapper
 function omz_history {
-  local clear list
-  zparseopts -E c=clear l=list
+  local clear list stamp
+  zparseopts -E -D c=clear l=list f=stamp E=stamp i=stamp
 
   if [[ $# -eq 0 ]]; then
     # if no arguments provided, show full history starting from 1
-    builtin fc -l 1
+    builtin fc $stamp -l 1
   elif [[ -n "$clear" ]]; then
     # if -c provided, clobber the history file
     echo -n >| "$HISTFILE"
-    fc -p "$HISTFILE"
+    fc $stamp -p "$HISTFILE"
     echo >&2 History file deleted.
   elif [[ -n "$list" ]]; then
     # if -l provided, run as if calling `fc' directly
-    builtin fc "$@"
+    builtin fc $stamp "$@"
   else
     # otherwise, run `fc -l` with a custom format
     builtin fc -l "$@"

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -12,9 +12,6 @@ function omz_history {
     echo -n >| "$HISTFILE"
     fc -p "$HISTFILE"
     echo >&2 History file deleted.
-  elif [[ -n "$list" ]]; then
-    # if -l provided, run as if calling `fc' directly
-    builtin fc $stamp -l "$@"
   else
     # otherwise, run `fc -l` with a custom format
     builtin fc $stamp -l "$@"

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -1,5 +1,6 @@
 ## History wrapper
 function omz_history {
+  # parse arguments and remove from $@
   local clear list stamp
   zparseopts -E -D c=clear l=list f=stamp E=stamp i=stamp
 
@@ -9,14 +10,14 @@ function omz_history {
   elif [[ -n "$clear" ]]; then
     # if -c provided, clobber the history file
     echo -n >| "$HISTFILE"
-    fc $stamp -p "$HISTFILE"
+    fc -p "$HISTFILE"
     echo >&2 History file deleted.
   elif [[ -n "$list" ]]; then
     # if -l provided, run as if calling `fc' directly
-    builtin fc $stamp "$@"
+    builtin fc $stamp -l "$@"
   else
     # otherwise, run `fc -l` with a custom format
-    builtin fc -l "$@"
+    builtin fc $stamp -l "$@"
   fi
 }
 


### PR DESCRIPTION
Introduce local stamp and catch options -f, -E and -i to it.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add a local stamp variable and use `zparesopts` to catch option `-f`, `-E` or `-i'

## Other comments:

...
