### PR TITLE
fix(async): bypass zsh 5.0.2 crash on `zle reset-prompt`

### DIFF
--- a/lib/async_prompt.zsh
+++ b/lib/async_prompt.zsh
@@ -124,7 +124,7 @@ function _omz_async_callback() {
 
     # Repaint prompt if output has changed
     if [[ "$old_output" != "${_OMZ_ASYNC_OUTPUT[$handler]}" ]]; then
-      zle reset-prompt
+      zle .reset-prompt
       zle -R
     fi
 

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -39,21 +39,17 @@ function _omz_git_prompt_info() {
   echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref:gs/%/%%}${upstream:gs/%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
 }
 
-# Use async version if setting is enabled, or undefined but zsh version is at least 5.0.6
-# https://github.com/ohmyzsh/ohmyzsh/issues/12331#issuecomment-2059460268
-if zstyle -t ':omz:alpha:lib:git' async-prompt \
-  || { is-at-least 5.0.6 && zstyle -T ':omz:alpha:lib:git' async-prompt }; then
+# Use async version if setting is enabled or undefined
+if zstyle -T ':omz:alpha:lib:git' async-prompt; then
   function git_prompt_info() {
-    setopt localoptions noksharrays
-    if [[ -n "$_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]" ]]; then
-      echo -n "$_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]"
+    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}" ]]; then
+      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}"
     fi
   }
 
   function git_prompt_status() {
-    setopt localoptions noksharrays
-    if [[ -n "$_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]" ]]; then
-      echo -n "$_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]"
+    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}" ]]; then
+      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}"
     fi
   }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Use `zle .reset-prompt` in `_omz_async_callback` to bypass crash reported in #12331 (test)

## Other comments:

~~This is only a test based on a hunch related to [[1]] and [[2]] fixed in 5.0.6.~~ Confirmed to solve the issue in [[3]].

[1]: https://www.zsh.org/mla/workers/2014/msg00237.html
[2]: https://github.com/zsh-users/zsh/commit/97115e0e7f33378390aabd3c15d0cd69bf8d191c
[3]: https://github.com/ohmyzsh/ohmyzsh/issues/12331#issuecomment-2065941645