### PR TITLE
Add `t` option to omz_history function

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -2,7 +2,7 @@
 function omz_history {
   # parse arguments and remove from $@
   local clear list stamp
-  zparseopts -E -D c=clear l=list f=stamp E=stamp i=stamp
+  zparseopts -E -D c=clear l=list f=stamp E=stamp i=stamp t:=stamp
 
   if [[ -n "$clear" ]]; then
     # if -c provided, clobber the history file


### PR DESCRIPTION
The `t` option takes a strftime format specification as argument. This fixes cases in which $HIST_STAMPS is set to a value outrange `"mm/dd/yyyy|dd.mm.yyyy|yyyy-mm-dd"`.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `t` option to the zparseoptions to fix #12364 
## Other comments:

...
