### PR TITLE
Fix issue with homebrew-installed nc taking precedence in $PATH

### DIFF
--- a/plugins/shell-proxy/ssh-proxy.py
+++ b/plugins/shell-proxy/ssh-proxy.py
@@ -21,8 +21,12 @@ if parsed.scheme not in proxy_protocols:
     raise TypeError('unsupported proxy protocol: "{}"'.format(parsed.scheme))
 
 def make_argv():
-    yield "nc"
-    if sys.platform in {'linux', 'cygwin'}:
+    if sys.platform == 'darwin':
+        # 'nc' in $PATH may be installed by homebrew, if without path
+        yield "/usr/bin/nc"
+    else:
+        yield "nc"
+    if sys.platform in {'linux', 'cygwin', 'darwin'}:
         # caveats: the built-in netcat of most linux distributions and cygwin support proxy type
         # caveats: macOS built-in netcat command not supported proxy-type
         yield "-X" # --proxy-type


### PR DESCRIPTION
This commit addresses a problem where the nc command installed via homebrew was being used preferentially over the intended version due to its higher precedence in the $PATH environment variable. Adjustments have been made to ensure the script selects the correct nc executable, avoiding conflicts and ensuring consistent behavior across different setups.

```bash
$ which nc
/opt/homebrew/bin/nc
```

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
