### PR TITLE
feat(fishy): add color to username

### DIFF
--- a/themes/fishy.zsh-theme
+++ b/themes/fishy.zsh-theme
@@ -16,7 +16,8 @@ _fishy_collapsed_wd() {
 }
 
 local user_color='green'; [ $UID -eq 0 ] && user_color='red'
-PROMPT='%n@%m %{$fg[$user_color]%}$(_fishy_collapsed_wd)%{$reset_color%}%(!.#.>) '
+local host_color='white'; [ -n "$SSH_CLIENT" ] || [ -n "$SSH_TTY" ] && host_color='yellow'
+PROMPT='%{$fg[$user_color]%}%n%{$reset_color%}@%{$fg[$host_color]%}%m %{$fg[$user_color]%}$(_fishy_collapsed_wd)%{$reset_color%}%(!.#.>) '
 PROMPT2='%{$fg[red]%}\ %{$reset_color%}'
 
 local return_status="%{$fg_bold[red]%}%(?..%?)%{$reset_color%}"


### PR DESCRIPTION
Modifies the prompt in fishy.zsh-theme to display the hostname in a different color (yellow) when the user is connected via SSH. Additionally, the username is now displayed in a separate color block, improving readability and making it easier to distinguish different components of the prompt.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Modified the fishy theme prompt to add color to the username. This is consistent with the current version of fish-shell.
- Modified the fishy theme prompt to display the hostname in a different color (yellow) when the user is connected via SSH. This is consistent with the current version of fish-shell.
