### PR TITLE
fix(timer): skip timer after running `clear`

### DIFF
--- a/plugins/timer/timer.plugin.zsh
+++ b/plugins/timer/timer.plugin.zsh
@@ -23,9 +23,12 @@ __timer_display_timer_precmd() {
     local tdiff=$((cmd_end_time - __timer_cmd_start_time))
     unset __timer_cmd_start_time
     if [[ -z "${TIMER_THRESHOLD}" || ${tdiff} -ge "${TIMER_THRESHOLD}" ]]; then
+      local last_cmd=$(fc -ln -1 | awk '{print $1}')
+      if [[ "$last_cmd" != clear ]]; then
         local tdiffstr=$(__timer_format_duration ${tdiff})
         local cols=$((COLUMNS - ${#tdiffstr} - 1))
         echo -e "\033[1A\033[${cols}C ${tdiffstr}"
+      fi 
     fi
   fi
 }

--- a/plugins/timer/timer.plugin.zsh
+++ b/plugins/timer/timer.plugin.zsh
@@ -23,7 +23,7 @@ __timer_display_timer_precmd() {
     local tdiff=$((cmd_end_time - __timer_cmd_start_time))
     unset __timer_cmd_start_time
     if [[ -z "${TIMER_THRESHOLD}" || ${tdiff} -ge "${TIMER_THRESHOLD}" ]]; then
-      local last_cmd=$(fc -ln -1 | awk '{print $1}')
+      local last_cmd="${history[$((HISTCMD - 1))]%% *}"
       if [[ "$last_cmd" != clear ]]; then
         local tdiffstr=$(__timer_format_duration ${tdiff})
         local cols=$((COLUMNS - ${#tdiffstr} - 1))


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- fix(timer): Add check to see if last command that was run was `clear` and if so, don’t print the output of the timer. 

## Other comments:
The current behavior of the timer plugin is that it outputs the result of the timer even when the last command is the `clear` command. This poses a problem because once the screen has been cleared, it adds one more line to print the timer at the top of the screen before then printing out the terminal prompt. To fix this, I have added a simple check to see if the last command run is the `clear` command and if so, do not print the result of the timer. 