### PR TITLE
feat(yarn)!: add optional support for yarn berry

### DIFF
--- a/plugins/yarn/README.md
+++ b/plugins/yarn/README.md
@@ -1,7 +1,7 @@
 # Yarn plugin
 
-This plugin adds completion for the [Yarn package manager](https://yarnpkg.com/en/),
-as well as some aliases for common Yarn commands.
+This plugin adds completion for the [Yarn package manager](https://yarnpkg.com/en/), as well as some aliases
+for common Yarn commands.
 
 To use it, add `yarn` to the plugins array in your zshrc file:
 
@@ -11,48 +11,64 @@ plugins=(... yarn)
 
 ## Global scripts directory
 
-It also adds `yarn` global scripts dir (commonly `~/.yarn/bin`) to the `$PATH`.
-To disable this feature, set the following style in your `.zshrc`:
+It also adds `yarn` global scripts dir (commonly `~/.yarn/bin`) to the `$PATH`. To disable this feature, set
+the following style in your `.zshrc`:
 
 ```zsh
 zstyle ':omz:plugins:yarn' global-path no
 ```
 
+## Yarn Berry
+
+If you are using Yarn berry (a.k.a. Yarn version 2 or higher) as your global Yarn version you should configure
+this plugin to configure its aliases accordingly, set the following style in your `.zshrc`:
+
+```zsh
+zstyle ':omz:plugins:yarn' berry yes
+```
+
 ## Aliases
 
-| Alias | Command                                   | Description                                                                   |
-| ----- | ----------------------------------------- | ----------------------------------------------------------------------------- |
-| y     | `yarn`                                    | The Yarn command                                                              |
-| ya    | `yarn add`                                | Install a package in dependencies (`package.json`)                            |
-| yad   | `yarn add --dev`                          | Install a package in devDependencies (`package.json`)                         |
-| yap   | `yarn add --peer`                         | Install a package in peerDependencies (`package.json`)                        |
-| yb    | `yarn build`                              | Run the build script defined in `package.json`                                |
-| ycc   | `yarn cache clean`                        | Clean yarn's global cache of packages                                         |
-| yd    | `yarn dev`                                | Run the dev script defined in `package.json`                                  |
-| yf    | `yarn format`                             | Run the dev script defined in `package.json`                                  |
-| yga   | `yarn global add`                         | Install packages globally on your operating system                            |
-| ygls  | `yarn global list`                        | Lists global installed packages                                               |
-| ygrm  | `yarn global remove`                      | Remove global installed packages from your OS                                 |
-| ygu   | `yarn global upgrade`                     | Upgrade packages installed globally to their latest version                   |
-| yh    | `yarn help`                               | Show help for a yarn command                                                  |
-| yi    | `yarn init`                               | Interactively creates or updates a package.json file                          |
-| yin   | `yarn install`                            | Install dependencies defined in `package.json`                                |
-| yln   | `yarn lint`                               | Run the lint script defined in `package.json`                                 |
-| ylnf  | `yarn lint --fix`                         | Run the lint script defined in `package.json`to automatically fix problems    |
-| yls   | `yarn list`                               | List installed packages                                                       |
-| yout  | `yarn outdated`                           | Check for outdated package dependencies                                       |
-| yp    | `yarn pack`                               | Create a compressed gzip archive of package dependencies                      |
-| yrm   | `yarn remove`                             | Remove installed packages                                                     |
-| yrun  | `yarn run`                                | Run a defined package script                                                  |
-| ys    | `yarn serve`                              | Start the dev server                                                          |
-| yst   | `yarn start`                              | Run the start script defined in `package.json`                                |
-| yt    | `yarn test`                               | Run the test script defined in `package.json`                                 |
-| ytc   | `yarn test --coverage`                    | Run the test script defined in `package.json` with coverage                   |
-| yuc   | `yarn global upgrade && yarn cache clean` | Upgrade global packages and clean yarn's global cache                         |
-| yui   | `yarn upgrade-interactive`                | Prompt for which outdated packages to upgrade                                 |
-| yuil  | `yarn upgrade-interactive --latest`       | Prompt for which outdated packages to upgrade to the latest available version |
-| yup   | `yarn upgrade`                            | Upgrade packages to their latest version                                      |
-| yv    | `yarn version`                            | Update the version of your package                                            |
-| yw    | `yarn workspace`                          | Run a command within a single workspace.                                      |
-| yws   | `yarn workspaces`                         | Run a command within all defined workspaces.                                  |
-| yy    | `yarn why`                                | Show why a package has been installed, detailing which other packages depend on it |
+- Aliases marked with <sup>`*`</sup> are only available when using Yarn v1 (non-berry)
+- Aliases marked with <sup>`b`</sup> are only available when using Yarn berry
+
+| Alias              | Command                                                                                               | Description                                                                        |
+| ------------------ | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| y                  | `yarn`                                                                                                | The Yarn command                                                                   |
+| ya                 | `yarn add`                                                                                            | Install a package in dependencies (`package.json`)                                 |
+| yad                | `yarn add --dev`                                                                                      | Install a package in devDependencies (`package.json`)                              |
+| yap                | `yarn add --peer`                                                                                     | Install a package in peerDependencies (`package.json`)                             |
+| yb                 | `yarn build`                                                                                          | Run the build script defined in `package.json`                                     |
+| ycc                | `yarn cache clean`                                                                                    | Clean yarn's global cache of packages                                              |
+| yd                 | `yarn dev`                                                                                            | Run the dev script defined in `package.json`                                       |
+| yf                 | `yarn format`                                                                                         | Run the dev script defined in `package.json`                                       |
+| yh                 | `yarn help`                                                                                           | Show help for a yarn command                                                       |
+| yi                 | `yarn init`                                                                                           | Interactively creates or updates a package.json file                               |
+| yin                | `yarn install`                                                                                        | Install dependencies defined in `package.json`                                     |
+| yln                | `yarn lint`                                                                                           | Run the lint script defined in `package.json`                                      |
+| ylnf               | `yarn lint --fix`                                                                                     | Run the lint script defined in `package.json`to automatically fix problems         |
+| yp                 | `yarn pack`                                                                                           | Create a compressed gzip archive of package dependencies                           |
+| yrm                | `yarn remove`                                                                                         | Remove installed packages                                                          |
+| yrun               | `yarn run`                                                                                            | Run a defined package script                                                       |
+| ys                 | `yarn serve`                                                                                          | Start the dev server                                                               |
+| yst                | `yarn start`                                                                                          | Run the start script defined in `package.json`                                     |
+| yt                 | `yarn test`                                                                                           | Run the test script defined in `package.json`                                      |
+| ytc                | `yarn test --coverage`                                                                                | Run the test script defined in `package.json` with coverage                        |
+| yui                | `yarn upgrade-interactive`                                                                            | Prompt for which outdated packages to upgrade                                      |
+| yuil               | `yarn upgrade-interactive --latest` (or see `yui` when using [yarn berry](#yarn-berry))               | Prompt for which outdated packages to upgrade to the latest available version      |
+| yii                | `yarn install --frozen-lockfile` (or `yarn install --immutable` when using [yarn berry](#yarn-berry)) | Install dependencies and abort if the lockfile was to be modified                  |
+| yifl               | `yii`                                                                                                 | Install dependencies and abort if the lockfile was to be modified                  |
+| yup                | `yarn upgrade`                                                                                        | Upgrade packages to their latest version                                           |
+| yv                 | `yarn version`                                                                                        | Update the version of your package                                                 |
+| yw                 | `yarn workspace`                                                                                      | Run a command within a single workspace.                                           |
+| yws                | `yarn workspaces`                                                                                     | Run a command within all defined workspaces.                                       |
+| yy                 | `yarn why`                                                                                            | Show why a package has been installed, detailing which other packages depend on it |
+| yga<sup>`*`</sup>  | `yarn global add`                                                                                     | Install packages globally on your operating system                                 |
+| ygls<sup>`*`</sup> | `yarn global list`                                                                                    | Lists global installed packages                                                    |
+| ygrm<sup>`*`</sup> | `yarn global remove`                                                                                  | Remove global installed packages from your OS                                      |
+| ygu<sup>`*`</sup>  | `yarn global upgrade`                                                                                 | Upgrade packages installed globally to their latest version                        |
+| yls<sup>`*`</sup>  | `yarn list`                                                                                           | List installed packages                                                            |
+| yout<sup>`*`</sup> | `yarn outdated`                                                                                       | Check for outdated package dependencies                                            |
+| yuca<sup>`*`</sup> | `yarn global upgrade && yarn cache clean`                                                             | Upgrade global packages and clean yarn's global cache                              |
+| ydlx<sup>`b`</sup> | `yarn dlx`                                                                                            | Run a package in a temporary environment.                                          |
+| yn<sup>`b`</sup>   | `yarn node`                                                                                           | Run node with the hook already setup.                                              |

--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -1,6 +1,5 @@
-# Get the configured version of yarn
+# Check if the user has configured Yarn Berry
 is_yarn_berry="false"
-
 if zstyle -t ':omz:plugins:yarn' berry; then
   is_yarn_berry="true"
 fi

--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -1,9 +1,3 @@
-# Check if the user has configured Yarn Berry
-is_yarn_berry="false"
-if zstyle -t ':omz:plugins:yarn' berry; then
-  is_yarn_berry="true"
-fi
-
 if zstyle -T ':omz:plugins:yarn' global-path; then
   # Skip yarn call if default global bin dir exists
   [[ -d "$HOME/.yarn/bin" ]] && bindir="$HOME/.yarn/bin" || bindir="$(yarn global bin 2>/dev/null)"
@@ -37,22 +31,6 @@ alias yst="yarn start"
 alias yt="yarn test"
 alias ytc="yarn test --coverage"
 alias yui="yarn upgrade-interactive"
-
-# --latest flag was removed in yarn berry so we execute the base command
-if [[ ${is_yarn_berry} == "true" ]]; then
-  alias yuil='yui'
-else
-  alias yuil='yarn upgrade-interactive --latest'
-fi
-
-# The flag for installing with restrictive lockfile was changed in yarn berry
-if [[ ${is_yarn_berry} == "true" ]]; then
-  alias yii='yarn install --immutable'
-else
-  alias yii='yarn install --frozen-lockfile'
-fi
-
-alias yifl="yii"
 alias yup="yarn upgrade"
 alias yv="yarn version"
 alias yw="yarn workspace"
@@ -60,10 +38,22 @@ alias yws="yarn workspaces"
 alias yy="yarn why"
 
 # Commands that are specific to the yarn version being used
-if [[ ${is_yarn_berry} == "true" ]]; then
+if zstyle -t ':omz:plugins:yarn' berry; then
+  # aliases that differ
+  alias yuil='yui' # --latest flag was removed in yarn berry
+  alias yii='yarn install --immutable'
+  alias yifl='yarn install --immutable'
+
+  # unique aliases
   alias ydlx="yarn dlx"
   alias yn="yarn node"
 else
+  # aliases that differ
+  alias yuil='yarn upgrade-interactive --latest'
+  alias yii='yarn install --frozen-lockfile'
+  alias yifl='yarn install --frozen-lockfile'
+
+  # unique aliases
   alias yga="yarn global add"
   alias ygls="yarn global list"
   alias ygrm="yarn global remove"

--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -1,3 +1,7 @@
+# Yarn version checking
+autoload -Uz is-at-least
+yarn_version="$(yarn --version 2>/dev/null)"
+
 if zstyle -T ':omz:plugins:yarn' global-path; then
   # Skip yarn call if default global bin dir exists
   [[ -d "$HOME/.yarn/bin" ]] && bindir="$HOME/.yarn/bin" || bindir="$(yarn global bin 2>/dev/null)"
@@ -18,17 +22,11 @@ alias yb="yarn build"
 alias ycc="yarn cache clean"
 alias yd="yarn dev"
 alias yf="yarn format"
-alias yga="yarn global add"
-alias ygls="yarn global list"
-alias ygrm="yarn global remove"
-alias ygu="yarn global upgrade"
 alias yh="yarn help"
 alias yi="yarn init"
 alias yin="yarn install"
 alias yln="yarn lint"
 alias ylnf="yarn lint --fix"
-alias yls="yarn list"
-alias yout="yarn outdated"
 alias yp="yarn pack"
 alias yrm="yarn remove"
 alias yrun="yarn run"
@@ -36,11 +34,29 @@ alias ys="yarn serve"
 alias yst="yarn start"
 alias yt="yarn test"
 alias ytc="yarn test --coverage"
-alias yuc="yarn global upgrade && yarn cache clean"
 alias yui="yarn upgrade-interactive"
-alias yuil="yarn upgrade-interactive --latest"
+# --latest flag was removed in yarn berry so we execute the base command
+is-at-least 2.0.0 "$yarn_version" \
+  && alias yuil='yui' \
+  || alias yuil='yarn upgrade-interactive --latest'
+# The flag for installing with restrictive lockfile was changed in yarn berry
+is-at-least 2.0.0 "$yarn_version" \
+  && alias yii='yarn install --immutable' \
+  || alias yii='yarn install --frozen-lockfile'
+alias yifl="yii"
 alias yup="yarn upgrade"
 alias yv="yarn version"
 alias yw="yarn workspace"
 alias yws="yarn workspaces"
 alias yy="yarn why"
+
+# These commands should only be registered if Yarn v1 is used
+if [ ! $(is-at-least 2.0.0 "$yarn_version") ]; then
+    alias yga="yarn global add"
+    alias ygls="yarn global list"
+    alias ygrm="yarn global remove"
+    alias ygu="yarn global upgrade"
+    alias yls="yarn list"
+    alias yout="yarn outdated"
+    alias yuca="yarn global upgrade && yarn cache clean"
+fi

--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -1,6 +1,9 @@
-# Yarn version checking
-autoload -Uz is-at-least
-yarn_version="$(yarn --version 2>/dev/null)"
+# Get the configured version of yarn
+is_yarn_berry="false"
+
+if zstyle -t ':omz:plugins:yarn' berry; then
+  is_yarn_berry="true"
+fi
 
 if zstyle -T ':omz:plugins:yarn' global-path; then
   # Skip yarn call if default global bin dir exists
@@ -35,14 +38,21 @@ alias yst="yarn start"
 alias yt="yarn test"
 alias ytc="yarn test --coverage"
 alias yui="yarn upgrade-interactive"
+
 # --latest flag was removed in yarn berry so we execute the base command
-is-at-least 2.0.0 "$yarn_version" \
-  && alias yuil='yui' \
-  || alias yuil='yarn upgrade-interactive --latest'
+if [[ ${is_yarn_berry} == "true" ]]; then
+  alias yuil='yui'
+else
+  alias yuil='yarn upgrade-interactive --latest'
+fi
+
 # The flag for installing with restrictive lockfile was changed in yarn berry
-is-at-least 2.0.0 "$yarn_version" \
-  && alias yii='yarn install --immutable' \
-  || alias yii='yarn install --frozen-lockfile'
+if [[ ${is_yarn_berry} == "true" ]]; then
+  alias yii='yarn install --immutable'
+else
+  alias yii='yarn install --frozen-lockfile'
+fi
+
 alias yifl="yii"
 alias yup="yarn upgrade"
 alias yv="yarn version"
@@ -51,7 +61,7 @@ alias yws="yarn workspaces"
 alias yy="yarn why"
 
 # These commands should only be registered if Yarn v1 is used
-if [ ! $(is-at-least 2.0.0 "$yarn_version") ]; then
+if [[ ${is_yarn_berry} == "false" ]]; then
     alias yga="yarn global add"
     alias ygls="yarn global list"
     alias ygrm="yarn global remove"
@@ -59,4 +69,9 @@ if [ ! $(is-at-least 2.0.0 "$yarn_version") ]; then
     alias yls="yarn list"
     alias yout="yarn outdated"
     alias yuca="yarn global upgrade && yarn cache clean"
+else
+  alias ydlx="yarn dlx"
+  alias yn="yarn node"
 fi
+
+unset is_yarn_berry

--- a/plugins/yarn/yarn.plugin.zsh
+++ b/plugins/yarn/yarn.plugin.zsh
@@ -59,18 +59,18 @@ alias yw="yarn workspace"
 alias yws="yarn workspaces"
 alias yy="yarn why"
 
-# These commands should only be registered if Yarn v1 is used
-if [[ ${is_yarn_berry} == "false" ]]; then
-    alias yga="yarn global add"
-    alias ygls="yarn global list"
-    alias ygrm="yarn global remove"
-    alias ygu="yarn global upgrade"
-    alias yls="yarn list"
-    alias yout="yarn outdated"
-    alias yuca="yarn global upgrade && yarn cache clean"
-else
+# Commands that are specific to the yarn version being used
+if [[ ${is_yarn_berry} == "true" ]]; then
   alias ydlx="yarn dlx"
   alias yn="yarn node"
+else
+  alias yga="yarn global add"
+  alias ygls="yarn global list"
+  alias ygrm="yarn global remove"
+  alias ygu="yarn global upgrade"
+  alias yls="yarn list"
+  alias yout="yarn outdated"
+  alias yuca="yarn global upgrade && yarn cache clean"
 fi
 
 unset is_yarn_berry


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- This updates the yarn plugin to better support Yarn berry (aka Yarn v2 and beyond) because some commands are no longer available or changed in modern Yarn.
- A new pair of aliases `yii` and `yifl` are added. These are to install dependencies while locking versions down to the `yarn.lock` file. The reason `yifl` is an alias for `yii` is to respect that for v1 it's **y**arn **i**nstall --**f**rozen-**l**ockfile, whereas for berry it's **y**arn **i**nstall --**i**mmutable, so `yii`.
- The aliases `ydlx` and `yn` are added to cover [`yarn dlx`](https://yarnpkg.com/cli/dlx) and [`yarn node`](https://yarnpkg.com/cli/node)

## Other comments:

Version checking inspired by the git plugin
