### PR TITLE
improvement: Using `/usr/bin/env` as shebang.

### DIFF
--- a/plugins/coffee/coffee.plugin.zsh
+++ b/plugins/coffee/coffee.plugin.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # compile a string of coffeescript and print to output
 cf () {

--- a/plugins/pm2/_pm2
+++ b/plugins/pm2/_pm2
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 #compdef pm2
 #autoload
 

--- a/plugins/scd/scd
+++ b/plugins/scd/scd
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 
 emulate -L zsh
 

--- a/plugins/wd/wd.plugin.zsh
+++ b/plugins/wd/wd.plugin.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # WARP DIRECTORY
 # ==============

--- a/plugins/wd/wd.sh
+++ b/plugins/wd/wd.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # WARP DIRECTORY
 # ==============

--- a/plugins/zsh-navigation-tools/doc/generate_single_file
+++ b/plugins/zsh-navigation-tools/doc/generate_single_file
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 local PLUGIN_FILE="doc/zshnavigationtools.plugin.zsh"
 

--- a/tools/theme_chooser.sh
+++ b/tools/theme_chooser.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Zsh Theme Chooser by fox (fox91 at anche dot no)
 # This program is free software. It comes without any warranty, to


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Using `/usr/bin/env` as shebang, it is more flexible.

## Other comments:

...
