### PR TITLE
feat(python): autovenv keeps activated on subdirs

### DIFF
--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -35,5 +35,6 @@ virtual environments:
   `<venv-name>/bin/activate`, and automatically deactivate it when navigating out of it (including
   subdirectories!).
   - To enable the feature, set `export PYTHON_AUTO_VRUN=true` before sourcing oh-my-zsh.
-  - The default virtual environment name is `venv`. To use a different name, set
+  - Plugin activates first virtual environment in lexicographic order whose name begins with `<venv-name>`.
+    The default virtual environment name is `venv`. To use a different name, set
     `export PYTHON_VENV_NAME=<venv-name>`. For example: `export PYTHON_VENV_NAME=".venv"`

--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -32,8 +32,8 @@ virtual environments:
   `venv`) in the current directory.
 
 - `auto_vrun`: Automatically activate the venv virtual environment when entering a directory containing
-  `<venv-name>/bin/activate`, and automatically deactivate it when navigating out of it (including
-  subdirectories!).
+  `<venv-name>/bin/activate`, and automatically deactivate it when navigating out of it (keeps venv activated
+  in subdirectories).
   - To enable the feature, set `export PYTHON_AUTO_VRUN=true` before sourcing oh-my-zsh.
   - Plugin activates first virtual environment in lexicographic order whose name begins with `<venv-name>`.
     The default virtual environment name is `venv`. To use a different name, set

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -87,11 +87,14 @@ function mkv() {
 if [[ "$PYTHON_AUTO_VRUN" == "true" ]]; then
   # Automatically activate venv when changing dir
   auto_vrun() {
-    if [[ -f "${PYTHON_VENV_NAME}/bin/activate" ]]; then
-      source "${PYTHON_VENV_NAME}/bin/activate" > /dev/null 2>&1
-    else
-      (( $+functions[deactivate] )) && deactivate > /dev/null 2>&1
-    fi
+    for activator in "${PYTHON_VENV_NAME}"*/bin/activate(N); do
+      if [[ -f "${activator}" ]]; then
+        source "${activator}" > /dev/null 2>&1
+        return
+      fi
+    done
+
+    (( $+functions[deactivate] )) && deactivate > /dev/null 2>&1
   }
   add-zsh-hook chpwd auto_vrun
   auto_vrun

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -86,12 +86,19 @@ function mkv() {
 
 if [[ "$PYTHON_AUTO_VRUN" == "true" ]]; then
   # Automatically activate venv when changing dir
-  auto_vrun() {
-    for activator in "${PYTHON_VENV_NAME}"*/bin/activate(N); do
-      if [[ -f "${activator}" ]]; then
-        source "${activator}" > /dev/null 2>&1
-        return
-      fi
+  function auto_vrun() {
+    local dirname="$PWD"
+
+    while
+      for activator in "${dirname}/${PYTHON_VENV_NAME}"*/bin/activate(N); do
+        if [[ -f "${activator}" ]]; then
+          source "${activator}" > /dev/null 2>&1
+          return
+        fi
+      done
+      [[ -n "$dirname" ]]
+    do
+      dirname=${dirname%/*}
     done
 
     (( $+functions[deactivate] )) && deactivate > /dev/null 2>&1

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -87,21 +87,20 @@ function mkv() {
 if [[ "$PYTHON_AUTO_VRUN" == "true" ]]; then
   # Automatically activate venv when changing dir
   function auto_vrun() {
-    local dirname="$PWD"
+    # deactivate if we're on a different dir than VIRTUAL_ENV states
+    # we don't deactivate subdirectories!
+    if (( $+functions[deactivate] )) && [[ $PWD != ${VIRTUAL_ENV:h}* ]]; then
+      deactivate > /dev/null 2>&1
+    fi
 
-    while
-      for activator in "${dirname}/${PYTHON_VENV_NAME}"*/bin/activate(N); do
-        if [[ -f "${activator}" ]]; then
-          source "${activator}" > /dev/null 2>&1
-          return
-        fi
+    if [[ $PWD != ${VIRTUAL_ENV:h} ]]; then
+      for _file in "${PYTHON_VENV_NAME}"*/bin/activate(N.); do
+        # make sure we're not in a venv already
+        (( $+functions[deactivate] )) && deactivate > /dev/null 2>&1
+        source $_file > /dev/null 2>&1
+        break
       done
-      [[ -n "$dirname" ]]
-    do
-      dirname=${dirname%/*}
-    done
-
-    (( $+functions[deactivate] )) && deactivate > /dev/null 2>&1
+    fi
   }
   add-zsh-hook chpwd auto_vrun
   auto_vrun


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

1. `auto_vrun` function uses `PYTHON_VENV_NAME` as pattern rather than full name.
2. `auto_vrun` function searches for venv not only in current directory but also in parent directories.

## Other comments:

1. Allows auto-activation of  venvs with descriptive names that follow naming convention: (e.g. venv_name, venv-description, venvsomething).
2. Does not deactivate venv when entering a subdirectory of a project but only when cd'ing up the directory tree. That is more natural behavior in most use cases.
