### PR TITLE
fix(nvm): use `nvm version` when needed

### DIFF
--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -54,7 +54,7 @@ function _omz_setup_autoload {
 
       if [[ "$nvmrc_node_version" = "N/A" ]]; then
         nvm install
-      elif [[ "$nvmrc_node_version" != "$node_version" ]]; then
+      elif [[ "$nvmrc_node_version" != "$(nvm version)" ]]; then
         nvm use $nvm_silent
       fi
     elif [[ -n "$(PWD=$OLDPWD nvm_find_nvmrc)" ]] && [[ "$(nvm version)" != "$(nvm version default)" ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes missing changes of https://github.com/ohmyzsh/ohmyzsh/commit/fd01fd66ce27c669e5ffaea94460a37423d1e134. Seems like `$node_version` was removed in that commit but not replaced in every usage.

## Other comments:
- Related code snippet seems to be coming from [nvm-sh#zsh](https://github.com/nvm-sh/nvm?tab=readme-ov-file#zsh)
- Similar/related `nvm-sh` change: https://github.com/nvm-sh/nvm/pull/2874/