### PR TITLE
fix(nvm): use `command cat` to avoid alias

### DIFF
--- a/plugins/nvm/nvm.plugin.zsh
+++ b/plugins/nvm/nvm.plugin.zsh
@@ -50,7 +50,7 @@ function _omz_setup_autoload {
     zstyle -t ':omz:plugins:nvm' silent-autoload && nvm_silent="--silent"
 
     if [[ -n "$nvmrc_path" ]]; then
-      local nvmrc_node_version=$(nvm version $(cat "$nvmrc_path" | tr -dc '[:print:]'))
+      local nvmrc_node_version=$(nvm version $(command cat "$nvmrc_path" | tr -dc '[:print:]'))
 
       if [[ "$nvmrc_node_version" = "N/A" ]]; then
         nvm install


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
- When `cat` is aliased to something like `bat --style=number` ([bat](https://github.com/sharkdp/bat)), `$(cat "$nvmrc_path" | tr -dc '[:print:]')` fails because of additional information that these helpful tools display. This change fixes this behavior by using non-aliased version of `cat` command, which I think is a safer option to use within zsh plugins.

## Other comments:
**Reasoning / Steps to reproduce**

![image](https://github.com/ohmyzsh/ohmyzsh/assets/11130898/307d2be8-dae5-41cf-a67e-c6792f8b508e)
