### PR TITLE
feat(fzf): add support for Fedora package

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -148,6 +148,27 @@ function fzf_setup_using_opensuse() {
   return 0
 }
 
+function fzf_setup_using_fedora() {
+  (( $+commands[fzf] )) || return 1
+
+  local completions="/usr/share/zsh/site-functions/fzf"
+  local key_bindings="/usr/share/fzf/shell/key-bindings.zsh"
+
+  if [[ ! -f "$completions" || ! -f "$key_bindings" ]]; then
+    return 1
+  fi
+
+  if [[ -o interactive && "$DISABLE_FZF_AUTO_COMPLETION" != "true" ]]; then
+    source "$completions" 2>/dev/null
+  fi
+
+  if [[ "$DISABLE_FZF_KEY_BINDINGS" != "true" ]]; then
+    source "$key_bindings" 2>/dev/null
+  fi
+
+  return 0
+}
+
 function fzf_setup_using_openbsd() {
   # openBSD installs fzf in /usr/local/bin/fzf
   if [[ "$OSTYPE" != openbsd* ]] || (( ! $+commands[fzf] )); then
@@ -234,6 +255,7 @@ fzf_setup_using_fzf \
   || fzf_setup_using_openbsd \
   || fzf_setup_using_debian \
   || fzf_setup_using_opensuse \
+  || fzf_setup_using_fedora \
   || fzf_setup_using_cygwin \
   || fzf_setup_using_macports \
   || fzf_setup_using_base_dir \


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Fixes fzf plugin on Fedora. Plugin didn't previously find the completion script in `/usr/share/zsh/site-functions/fzf`.

## Other comments:

Used the above `fzf_setup_using_opensuse` as a base. Just fixed to use the correct paths on Fedora.
```
$ rpm -ql fzf | grep zsh
/usr/share/fzf/shell/key-bindings.zsh
/usr/share/zsh/site-functions
/usr/share/zsh/site-functions/fzf
```
