### PR TITLE
feat: change apple logo color based on previous return code

### DIFF
--- a/themes/apple.zsh-theme
+++ b/themes/apple.zsh-theme
@@ -1,5 +1,10 @@
 function toon {
-  echo -n ""
+  r=$?
+  if [ $r -eq 0 ]; then
+    echo -n "%{$fg[magenta]%}"
+  else
+    echo -n "[$r]"
+  fi
 }
 
 autoload -Uz vcs_info
@@ -18,7 +23,7 @@ theme_precmd () {
 }
 
 setopt prompt_subst
-PROMPT='%{$fg[magenta]%}$(toon)%{$reset_color%} %~/ %{$reset_color%}${vcs_info_msg_0_}%{$reset_color%}'
+PROMPT='$(toon)%{$reset_color%} %~/ %{$reset_color%}${vcs_info_msg_0_}%{$reset_color%}'
 
 autoload -U add-zsh-hook
 add-zsh-hook precmd theme_precmd


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

1. if return code is 0, print purple apple logo
2. if return code is not 0, print return code then white apple logo

<img width="336" alt="image" src="https://github.com/ohmyzsh/ohmyzsh/assets/14856245/0d5325c8-8b7d-4696-84b0-7ed31aa122f1">


## Other comments:
if you think user might not want to see the exact return code, I can change to 
- purple if previous command exits successfully(return code==0)
- white if otherwise
