### PR TITLE
chore(agnoster): typo

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -228,7 +228,7 @@ prompt_virtualenv() {
 }
 
 # Conda Virtualenv
-promp_conda_virtualenv() {
+prompt_conda_virtualenv() {
   if [[ -n $CONDA_PROMPT_MODIFIER ]]; then
     prompt_segment black default ${CONDA_PROMPT_MODIFIER:1:-2}
   fi
@@ -274,7 +274,7 @@ build_prompt() {
   prompt_bzr
   prompt_hg
   prompt_end
-  promp_conda_virtualenv
+  prompt_conda_virtualenv
 }
 
 PROMPT='%{%f%b%k%}$(build_prompt) '


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fix typo: promp_conda_virtualenv

    `promp_conda_virtualenv` --> `prompt_conda_virtualenv`

## Other comments:

...
