### PR TITLE
Add Support for Tabby Terminal in Macos Plugin

### DIFF
--- a/plugins/macos/README.md
+++ b/plugins/macos/README.md
@@ -8,14 +8,11 @@ To start using it, add the `macos` plugin to your plugins array in `~/.zshrc`:
 plugins=(... macos)
 ```
 
-Original author: [Sorin Ionescu](https://github.com/sorin-ionescu)
-Added Support for Tabby: [theredcmdcraft](https://github.com/theredcmdcraft)
-
 ## Supported Terminals
-- iTerm
-- iTerm2
-- Hyper
-- Tabby (https://github.com/Eugeny/tabby)
+- [iTerm](https://iterm.sourceforge.net/)
+- [iTerm2](https://iterm2.com/)
+- [Hyper](https://hyper.is/)
+- [Tabby](https://tabby.sh/)
 
 ## Commands
 
@@ -44,7 +41,9 @@ Added Support for Tabby: [theredcmdcraft](https://github.com/theredcmdcraft)
 
 ## Acknowledgements
 
-This application makes use of the following third party scripts:
+Original author: [Sorin Ionescu](https://github.com/sorin-ionescu)
+
+This application makes use of the following third-party scripts:
 
 [shpotify](https://github.com/hnarayanan/shpotify)
 

--- a/plugins/macos/README.md
+++ b/plugins/macos/README.md
@@ -9,6 +9,13 @@ plugins=(... macos)
 ```
 
 Original author: [Sorin Ionescu](https://github.com/sorin-ionescu)
+Added Support for Tabby: [theredcmdcraft](https://github.com/theredcmdcraft)
+
+## Supported Terminals
+- iTerm
+- iTerm2
+- Hyper
+- Tabby (https://github.com/Eugeny/tabby)
 
 ## Commands
 

--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -79,6 +79,13 @@ EOF
         key code 36  #(presses enter)
       end tell
 EOF
+
+  elif [[ "$the_app" == 'Tabby' ]]; then
+    osascript >/dev/null <<EOF
+      tell application "System Events"
+        tell process "Tabby" to keystroke "t" using command down
+      end tell
+EOF
   else
     echo "$0: unsupported terminal app: $the_app" >&2
     return 1
@@ -126,6 +133,12 @@ EOF
       delay 1
       keystroke "${command} \n"
     end tell
+EOF
+  elif [[ "$the_app" == 'Tabby' ]]; then
+    osascript >/dev/null <<EOF
+      tell application "System Events"
+        tell process "Tabby" to keystroke "D" using command down
+      end tell
 EOF
   else
     echo "$0: unsupported terminal app: $the_app" >&2
@@ -175,6 +188,12 @@ EOF
       delay 1
       keystroke "${command} \n"
     end tell
+EOF
+  elif [[ "$the_app" == 'Tabby' ]]; then
+    osascript >/dev/null <<EOF
+      tell application "System Events"
+        tell process "Tabby" to keystroke "d" using command down
+      end tell
 EOF
   else
     echo "$0: unsupported terminal app: $the_app" >&2


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added Support for Tabby Terminal for MacOS-Plugin

## Other comments:

Please tell me, if I should change anything :-)
