### PR TITLE
refactor: service and service account aliases (Breaking change)

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -36,12 +36,13 @@ plugins=(... kubectl)
 | kgpl    | `kgp -l`                            | Get pods by label. Example: `kgpl "app=myapp" -n myns`                                           |
 | kgpn    | `kgp -n`                            | Get pods by namespace. Example: `kgpn kube-system`                                               |
 |         |                                     | **Service management**                                                                           |
-| kgs     | `kubectl get svc`                   | List all services in ps output format                                                            |
-| kgsw    | `kgs --watch`                       | After listing all services, watch for changes                                                    |
-| kgswide | `kgs -o wide`                       | After listing all services, output in plain-text format with any additional information          |
-| kes     | `kubectl edit svc`                  | Edit services(svc) from the default editor                                                       |
-| kds     | `kubectl describe svc`              | Describe all services in detail                                                                  |
-| kdels   | `kubectl delete svc`                | Delete all services matching passed argument                                                     |
+| kgsvc   | `kubectl get svc`                   | List all services in ps output format                                                            |
+| kgsvca  | `kubectl get svc --all-namespaces`  | List all services in ps output format targeting all namespaces                                   |
+| kgsvcw  | `kgs --watch`                       | After listing all services, watch for changes                                                    |
+| kgsvcwide | `kgs -o wide`                     | After listing all services, output in plain-text format with any additional information          |
+| kesvc   | `kubectl edit svc`                  | Edit services(svc) from the default editor                                                       |
+| kdsvc   | `kubectl describe svc`              | Describe all services in detail                                                                  |
+| kdelsvc | `kubectl delete svc`                | Delete all services matching passed argument                                                     |
 |         |                                     | **Ingress management**                                                                           |
 | kgi     | `kubectl get ingress`               | List ingress resources in ps output format                                                       |
 | kei     | `kubectl edit ingress`              | Edit ingress resource from the default editor                                                    |
@@ -109,8 +110,13 @@ plugins=(... kubectl)
 | ksss    | `kubectl scale statefulset`         | Scale a statefulset                                                                              |
 | krsss   | `kubectl rollout status statefulset`| Check the rollout status of a deployment                                                         |
 |         |                                     | **Service Accounts management**                                                                  |
-| kdsa    | `kubectl describe sa`               | Describe a service account in details                                                            |
-| kdelsa  | `kubectl delete sa`                 | Delete the service account                                                                       |
+| kgsa    | `kubectl get sa`                    | List all service accounts in ps output format                                                    |
+| kgsaa   | `kubectl get sa --all-namespaces`   | List all service accounts in ps output format targeting all namespaces                           |
+| kgsaw   | `kgsa --watch`                      | After listing all service accounts, watch for changes                                            |
+| kgsawide| `kgsa -o wide`                      | After listing all service accounts, output in plain-text format with any additional information  |
+| kesa    | `kubectl edit sa`                   | Edit service accounts(svc) from the default editor                                               |
+| kdsa    | `kubectl describe sa`               | Describe all service accounts in detail                                                          |
+| kdelsa  | `kubectl delete sa`                 | Delete all service accounts matching passed argument                                             |
 |         |                                     | **DaemonSet management**                                                                         |
 | kgds    | `kubectl get daemonset`             | List all DaemonSets in ps output format                                                          |
 | kgdsw   | `kgds --watch`                      | After listing all DaemonSets, watch for changes                                                  |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -54,13 +54,13 @@ alias kgpl='kgp -l'
 alias kgpn='kgp -n'
 
 # Service management.
-alias kgs='kubectl get svc'
-alias kgsa='kubectl get svc --all-namespaces'
-alias kgsw='kgs --watch'
-alias kgswide='kgs -o wide'
-alias kes='kubectl edit svc'
-alias kds='kubectl describe svc'
-alias kdels='kubectl delete svc'
+alias kgsvc='kubectl get svc'
+alias kgsvca='kubectl get svc --all-namespaces'
+alias kgsvcw='kgsvc --watch'
+alias kgsvcwide='kgsvc -o wide'
+alias kesvc='kubectl edit svc'
+alias kdsvc='kubectl describe svc'
+alias kdelsvc='kubectl delete svc'
 
 # Ingress management
 alias kgi='kubectl get ingress'
@@ -157,6 +157,11 @@ alias kdpvc='kubectl describe pvc'
 alias kdelpvc='kubectl delete pvc'
 
 # Service account management.
+alias kgsa="kubectl get sa"
+alias kgsaa="kubectl get sa --all-namespaces"
+alias kgsaw="kgsa --watch"
+alias kgsawide="kgsa -o wide"
+alias kesa="kubectl edit sa"
 alias kdsa="kubectl describe sa"
 alias kdelsa="kubectl delete sa"
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
This PR modifies how the `services` related aliases work, with the aim of standardizing them and allowing the usage of new aliases for `service accounts`, as they were overlapping. It's a breaking change since `kgs`, `kgsw`, `kgswide`, `kes`, `kds`, and `kdels` aliases are removed, and `kgsa` is now used to get service accounts information instead of services information.

## Other comments:
New aliases:

```bash
# Service management.
alias kgsvc='kubectl get svc'
alias kgsvca='kubectl get svc --all-namespaces'
alias kgsvcw='kgsvc --watch'
alias kgsvcwide='kgsvc -o wide'
alias kesvc='kubectl edit svc'
alias kdsvc='kubectl describe svc'
alias kdelsvc='kubectl delete svc'

# Service account management.
alias kgsa="kubectl get sa"
alias kgsaa="kubectl get sa --all-namespaces"
alias kgsaw="kgsa --watch"
alias kgsawide="kgsa -o wide"
alias kesa="kubectl edit sa"
alias kdsa="kubectl describe sa"
alias kdelsa="kubectl delete sa"
```
