### PR TITLE
fix(pass): completion for multiple repositories

### DIFF
--- a/plugins/pass/_pass
+++ b/plugins/pass/_pass
@@ -20,6 +20,8 @@
 
 _pass () {
 	local cmd
+  local rootcontext
+  rootcontext=$curcontext
 	if (( CURRENT > 2)); then
 		cmd=${words[2]}
 		# Set the context for the subcommand.
@@ -123,8 +125,9 @@ _pass_cmd_show () {
 _pass_complete_entries_helper () {
 	local IFS=$'\n'
 	local prefix
-	zstyle -s ":completion:${curcontext}:" prefix prefix || prefix="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
-	_values -C 'passwords' ${$(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print 2>/dev/null | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' -e 's#\\#\\\\#g' -e 's#:#\\:#g' | sort):-""}
+	zstyle -s ":completion:${rootcontext}:" prefix prefix ||
+prefix="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
+  _values -C 'passwords' ${$(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print 2>/dev/null | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' -e 's#\\#\\\\#g' -e 's#:#\\:#g' | sort):-""}
 }
 
 _pass_complete_entries_with_subdirs () {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- changed pass plugin according to https://lists.zx2c4.com/pipermail/password-store/2019-January/003502.html I don't know why this wasn't merged upstream, but this fixes the completion if you use multiple repositories

## Other comments:

without the fix `workpass secre[tab]` works but `workpass edit secre[tab]` would search the default pass directory for that secret
