### PR TITLE
feat(async_prompt): standardize async prompt api

### DIFF
--- a/themes/minimal.zsh-theme
+++ b/themes/minimal.zsh-theme
@@ -23,4 +23,8 @@ vcs_status() {
   fi
 }
 
-PROMPT='%2~ $(vcs_status)»%b '
+# Register the sync function
+autoload -Uz _omz_make_async_function
+_omz_make_async_function vcs_status
+
+PROMPT='%2~ $(vcs_status_async)»%b '

--- a/themes/robbyrussell.zsh-theme
+++ b/themes/robbyrussell.zsh-theme
@@ -1,5 +1,5 @@
 PROMPT="%(?:%{$fg_bold[green]%}%1{➜%} :%{$fg_bold[red]%}%1{➜%} ) %{$fg[cyan]%}%c%{$reset_color%}"
-PROMPT+=' $(git_prompt_info)'
+PROMPT+=' $(git_prompt_info_async)'
 
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}git:(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Introduces a utility function to make async prompt functions from sync ones

## Pending

- [ ] Make final decision on naming
- [ ] Review whether applied solution (duplicating function, making sync one) is robust enough
- [ ] Adapt all themes to use async function
- [ ] Add feature to toggle this on and off
