### PR TITLE
fix(bgnotify): use terminal-notifier args properly

### DIFF
--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -117,7 +117,7 @@ function bgnotify {
   local icon="$3"
   if (( ${+commands[terminal-notifier]} )); then # macOS
     local term_id=$(bgnotify_programid)
-    terminal-notifier -message "$message" -title "$title" ${=icon:+-appIcon "$icon"} ${=term_id:+-activate "$term_id" -sender "$term_id"} &>/dev/null
+    terminal-notifier -message "$message" -title "$title" ${=icon:+-appIcon "$icon"} ${=term_id:+-activate "$term_id"} &>/dev/null
   elif (( ${+commands[growlnotify]} )); then # macOS growl
     growlnotify -m "$title" "$message"
   elif (( ${+commands[notify-send]} )); then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- N/A If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
`bgnotify` notifications don't work in macOS when using latest version of `terminal-notifier`

After trying out the command calling `terminal-notifier` used to send notifications manually, could reproduce the issue. Removing `-sender` arg seems fixed the issue.

After reading [`terminal-notifier`'s README](https://github.com/julienXX/terminal-notifier/blob/2.0.0/README.markdown) seems this is actually expected:

> _`-sender ID`_
> [...]
> _Because of this it is important to note that **you cannot combine this with options like -execute and -activate** which depend on the sender of the notification to be ‘terminal-notifier’ to perform its work._

Using therefore only `-activate` argument so that the terminal is opened when tapping the notification

- Remove `-sender` flag. Use `-activate` only as instructed per `terminal-notifier` docs

## Other comments:

