### PR TITLE
fix(tmux): add completion for alias functions

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -57,6 +57,19 @@ function _build_tmux_alias {
       tmux $2 $3 \"\$@\"
     fi
   }"
+
+  local f s
+  f="_omz_tmux_alias_${1}"
+  s=(${(z)2})
+
+  eval "function ${f}() {
+    shift words;
+    words=(tmux ${@:2} \$words);
+    ((CURRENT+=${#s[@]}+1))
+    _tmux
+  }"
+
+  compdef "$f" "$1"
 }
 
 alias tksv='tmux kill-server'


### PR DESCRIPTION
Fixes #12282
Closes #12278 

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes completion for aliased functions (`ta`, `tad`, and `tkss`) introduced in [fix(tmux): do not pass empty flags to aliases #12232](https://github.com/ohmyzsh/ohmyzsh/pull/12232).

## Other comments:

Inspired by https://github.com/ohmyzsh/ohmyzsh/blob/e0c6cb147030350c8e27dbdeda6e8a4d367d1e66/plugins/debian/debian.plugin.zsh#L120-L133