### PR TITLE
fix(eza): icons tab completion

### DIFF
--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -32,7 +32,7 @@ function _configure_eza() {
     _EZA_TAIL+=("--git")
   fi
   if zstyle -t ':omz:plugins:eza' 'icons'; then
-    _EZA_TAIL+=("--icons")
+    _EZA_TAIL+=("--icons=auto")
   fi
   zstyle -s ':omz:plugins:eza' 'time-style' _val
   if [[ $_val ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Explicitly pass the default `automatic` argument to `--icons` flag, if icons are configured to display. Without this argument, it causes tab-completion not to work.

See issue on Eza's tracker here: https://github.com/eza-community/eza/issues/964#issuecomment-2143417856

Also occurred to me on zsh 5.9 in Arch Linux.

## Other comments:

Follow up to PR #12469 merged 3 days ago from this PR, adding support for this option
