### PR TITLE
fix(history): fix logic error in prompt for `history -c` (ohmyzsh#12472)

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -11,7 +11,7 @@ function omz_history {
     print -nu2 "This action will irreversibly delete your command history. Are you sure? [y/N] "
     builtin read -k1
     [[ "$REPLY" = $'\n' ]] || print -u2
-    [[ "$REPLY" != ([nN]|$'\n') ]] || return 0
+    [[ "$REPLY" != ([yY]) ]] && return 0
 
     print -nu2 >| "$HISTFILE"
     fc -p "$HISTFILE"


### PR DESCRIPTION

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes logic error from 35a6725 when using `history -c`
- Prompting for confirmation causes history to be deleted when typing anything but explicitly `n`, `N`, or sending `\n`. 
- New logic no longer proceeds with deletion when pressing wrong key and only deletes history when sending `y` or `Y`.

## Other comments:
Copying @mcornella as he was assigned to the original issue