### PR TITLE
fix(themes): resolve hanging issue across selected themes

### DIFF
--- a/themes/linuxonly.zsh-theme
+++ b/themes/linuxonly.zsh-theme
@@ -34,25 +34,25 @@ add-zsh-hook precmd prompt_jnrowe_precmd
 
 prompt_jnrowe_precmd () {
     vcs_info
+}
 
-    if [ "${vcs_info_msg_0_}" = "" ]; then
-        dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$c4%}%/ %{$c0%}(%{$c5%}%?%{$c0%})"
-        PROMPT='${dir_status} ${ret_status}%{$reset_color%}
+if [ "${vcs_info_msg_0_}" = "" ]; then
+    dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$c4%}%/ %{$c0%}(%{$c5%}%?%{$c0%})"
+    PROMPT='${dir_status} ${ret_status}%{$reset_color%}
 > '
-    elif [[ $(git diff --cached --name-status 2>/dev/null ) != "" ]]; then
-        dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$c4%}%/ %{$c0%}(%{$c5%}%?%{$c0%})"
-        PROMPT='${vcs_info_msg_0_}
+elif [[ $(git diff --cached --name-status 2>/dev/null ) != "" ]]; then
+    dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$c4%}%/ %{$c0%}(%{$c5%}%?%{$c0%})"
+    PROMPT='${vcs_info_msg_0_}
 ${dir_status} ${vcs_info_msg_0_}%{$reset_color%}
 > '
-    elif [[ $(git diff --name-status 2>/dev/null ) != "" ]]; then
-        dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$c4%}%/ %{$c0%}(%{$c5%}%?%{$c0%})"
-        PROMPT='${vcs_info_msg_0_}
+elif [[ $(git diff --name-status 2>/dev/null ) != "" ]]; then
+    dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$c4%}%/ %{$c0%}(%{$c5%}%?%{$c0%})"
+    PROMPT='${vcs_info_msg_0_}
 ${dir_status}%{$reset_color%}
 %{$c9%}·>%{$c0%} '
-    else
-        dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$c4%}%/ %{$c0%}(%{$c5%}%?%{$c0%})"
-        PROMPT='${vcs_info_msg_0_}
+else
+    dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$c4%}%/ %{$c0%}(%{$c5%}%?%{$c0%})"
+    PROMPT='${vcs_info_msg_0_}
 ${dir_status} ${vcs_info_msg_0_}%{$reset_color%}
 > '
-    fi
-}
+fi

--- a/themes/pygmalion-virtualenv.zsh-theme
+++ b/themes/pygmalion-virtualenv.zsh-theme
@@ -47,8 +47,8 @@ prompt_pygmalion_precmd(){
   if [[ $prompt_length -gt 40 ]]; then
     nl=$'\n%{\r%}'
   fi
-
-  PROMPT="${base_prompt}\$(git_prompt_info)${nl}${post_prompt}"
 }
 
 prompt_setup_pygmalion
+
+PROMPT="${base_prompt}\$(git_prompt_info)${nl}${post_prompt}"

--- a/themes/pygmalion.zsh-theme
+++ b/themes/pygmalion.zsh-theme
@@ -25,8 +25,8 @@ prompt_pygmalion_precmd(){
   local gitinfo_nocolor=${gitinfo//\%\{[^\}]##\}}
   local exp_nocolor="$(print -P \"${base_prompt_nocolor}${gitinfo_nocolor}${post_prompt_nocolor}\")"
   local prompt_length=${#exp_nocolor}
-
-  PROMPT="${base_prompt}\$(git_prompt_info)${post_prompt}"
 }
 
 prompt_setup_pygmalion
+
+PROMPT="${base_prompt}\$(git_prompt_info)${post_prompt}"

--- a/themes/trapd00r.zsh-theme
+++ b/themes/trapd00r.zsh-theme
@@ -108,25 +108,26 @@ add-zsh-hook precmd prompt_jnrowe_precmd
 
 prompt_jnrowe_precmd () {
   vcs_info
-  if [ "${vcs_info_msg_0_}" = "" ]; then
-    dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$(zsh_path)%} %{$c0%}(%{$c5%}%?%{$c0%})"
-    PROMPT='${dir_status} ${ret_status}%{$reset_color%}
+}
+
+if [ "${vcs_info_msg_0_}" = "" ]; then
+  dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$(zsh_path)%} %{$c0%}(%{$c5%}%?%{$c0%})"
+  PROMPT='${dir_status} ${ret_status}%{$reset_color%}
 > '
-  # modified, to be committed
-  elif [[ $(git diff --cached --name-status 2>/dev/null ) != "" ]]; then
-    dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$(zsh_path)%} %{$c0%}(%{$c5%}%?%{$c0%})"
-    PROMPT='${vcs_info_msg_0_}%{$30%} %{$bg_bold[red]%}%{$fg_bold[cyan]%}C%{$fg_bold[black]%}OMMIT%{$reset_color%}
+# modified, to be committed
+elif [[ $(git diff --cached --name-status 2>/dev/null ) != "" ]]; then
+  dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$(zsh_path)%} %{$c0%}(%{$c5%}%?%{$c0%})"
+  PROMPT='${vcs_info_msg_0_}%{$30%} %{$bg_bold[red]%}%{$fg_bold[cyan]%}C%{$fg_bold[black]%}OMMIT%{$reset_color%}
 ${dir_status}%{$reset_color%}
 > '
-  elif [[ $(git diff --name-status 2>/dev/null ) != "" ]]; then
-    dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$(zsh_path)%} %{$c0%}(%{$c5%}%?%{$c0%})"
-    PROMPT='${vcs_info_msg_0_}%{$bg_bold[red]%}%{$fg_bold[blue]%}D%{$fg_bold[black]%}IRTY%{$reset_color%}
+elif [[ $(git diff --name-status 2>/dev/null ) != "" ]]; then
+  dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$(zsh_path)%} %{$c0%}(%{$c5%}%?%{$c0%})"
+  PROMPT='${vcs_info_msg_0_}%{$bg_bold[red]%}%{$fg_bold[blue]%}D%{$fg_bold[black]%}IRTY%{$reset_color%}
 ${dir_status}%{$reset_color%}
 %{$c13%}>%{$c0%} '
-  else
-    dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$(zsh_path)%} %{$c0%}(%{$c5%}%?%{$c0%})"
-    PROMPT='${vcs_info_msg_0_}
+else
+  dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$(zsh_path)%} %{$c0%}(%{$c5%}%?%{$c0%})"
+  PROMPT='${vcs_info_msg_0_}
 ${dir_status}%{$reset_color%}
 > '
-  fi
-}
+fi


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Moved PROMPT outside of the _precmd function.

## Other comments:

I encountered an issue after switching between themes using the [zsh-theme-changer.sh](https://gist.github.com/AlexZ005/316cf248bfb320ecb44f2171b5162e91) script. 
Some themes were preventing switching to another themes until the terminal was reopened. This behavior was observed on both Windows Subsystem for Linux (WSL) and Linux machines.

Themes that were causing this issue: linuxonly, pygmalion, pygmalion-virtualenv, trapd00r. Other themes did not present this problem

## Example scenario:

![Screenshot 2024-06-13 075326](https://github.com/ohmyzsh/ohmyzsh/assets/1636213/5c677e60-86c8-4172-b2fd-5a86ae472768)

## Steps to Reproduce the Issue:

1. Change to the gentoo theme:
sed -i "s/^ZSH_THEME=.*/ZSH_THEME=\"gentoo\"/" ~/.zshrc && source ~/.zshrc
2. Change to linuxonly theme:
sed -i "s/^ZSH_THEME=.*/ZSH_THEME=\"linuxonly\"/" ~/.zshrc && source ~/.zshrc
3. Attempt to switch to any other theme:
sed -i "s/^ZSH_THEME=.*/ZSH_THEME=\"random\"/" ~/.zshrc && source ~/.zshrc

Expected Outcome: Successfully switch to any other theme.
Actual Outcome: The previous theme remains active until logging out and back into the terminal.
