### PR TITLE
docs(alias-finder): add some examples

### DIFF
--- a/plugins/alias-finder/README.md
+++ b/plugins/alias-finder/README.md
@@ -2,7 +2,7 @@
 
 This plugin searches the defined aliases and outputs any that match the command inputted. This makes learning new aliases easier.
 
-## Usage
+## Setup
 
 To use it, add `alias-finder` to the `plugins` array of your zshrc file:
 ```
@@ -21,6 +21,41 @@ zstyle ':omz:plugins:alias-finder' cheaper yes # disabled by default
 ```
 
 As you can see, options are also available with zstyle.
+
+## Usage
+
+When you execute a command alias finder will look at your defined aliases and suggest shorter aliases you could have used, for example:
+
+Running the un-aliased `git status` command:
+```sh
+╭─tim@fox ~/repo/gitopolis ‹main› 
+╰─$ git status
+
+gst='git status'         # <=== shorter suggestion from alias-finder
+
+On branch main
+Your branch is up-to-date with 'origin/main'.
+nothing to commit, working tree clean
+```
+
+Running a shorter `git st` alias from `.gitconfig` that it suggested :
+```sh
+╭─tim@fox ~/repo/gitopolis ‹main› 
+╰─$ git st
+gs='git st'         # <=== shorter suggestion from alias-finder
+## main...origin/main
+```
+
+Running the shortest `gs` shell alias that it found:
+```sh
+╭─tim@fox ~/repo/gitopolis ‹main› 
+╰─$ gs
+         # <=== no suggestions alias-finder because this is the shortest
+## main...origin/main
+```
+
+![image](https://github.com/ohmyzsh/ohmyzsh/assets/19378/39642750-fb10-4f1a-b7f9-f36789eeb01b)
+
 
 ### Options
 


### PR DESCRIPTION
Being new to ohmyzsh it wasn't immediately obvious to me what this plugin did or how to use it. I've added some examples to hopefully make it more obvious to future readers.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources. - n/a
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below. - n/a

## Changes:

- Add usage info to alias-finder plugin
