### PR TITLE
Fix uninstall script

### DIFF
--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -16,8 +16,14 @@ if [ "$confirmation" != y ] && [ "$confirmation" != Y ]; then
   exit
 fi
 
-echo "Removing ~/.oh-my-zsh"
-if [ -d ~/.oh-my-zsh ]; then
+# echo "Removing ~/.oh-my-zsh"
+# if [ -d ~/.oh-my-zsh ]; then
+#   rm -rf ~/.oh-my-zsh
+# fi
+echo "Removing oh-my-zsh directory"
+if [ -n "$ZSH" -a -d "$ZSH" ]; then
+  rm -rf "$ZSH"
+elif [ -d ~/.oh-my-zsh ]; then
   rm -rf ~/.oh-my-zsh
 fi
 


### PR DESCRIPTION
## Changes:
- Make the uninstall script remove the oh-my-zsh directly according to environmental variable `$ZSH`.

## Other comments:
- The original implementation was hardcoded with `~/.oh-my-zsh`, which can't remove custom installed paths. By removing where the `$ZSH` variable points to, it fixes the issue.
