### PR TITLE
feat(agnoster): add color config and add some git stuff

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -46,7 +46,7 @@
 : ${AGNOSTER_GIT_CLEAN_FG:=black}
 : ${AGNOSTER_GIT_CLEAN_BG:=green}
 : ${AGNOSTER_GIT_DIRTY_FG:=black}
-: ${AGNOSTER_GIT_DIRTY_BG:=orange}
+: ${AGNOSTER_GIT_DIRTY_BG:=yellow}
 
 # Mercurial related
 : ${AGNOSTER_HG_NEWFILE_FG:=white}

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -29,13 +29,22 @@
 # jobs are running in this shell will all be displayed automatically when
 # appropriate.
 
+### Segment drawing
+# A few utility functions to make it easy and re-usable to draw segmented prompts
+
+CURRENT_BG='NONE'
+
+case ${SOLARIZED_THEME:-dark} in
+    light) CURRENT_FG='white';;
+    *)     CURRENT_FG='black';;
+esac
 
 ### Theme Configuration Initialization
 #
 # Override these settings in your ~/.zshrc
 
 # Current working directory
-: ${AGNOSTER_DIR_FG:=black}
+: ${AGNOSTER_DIR_FG:=${CURRENT_FG}}
 : ${AGNOSTER_DIR_BG:=blue}
 
 # user@host
@@ -43,7 +52,7 @@
 : ${AGNOSTER_CONTEXT_BG:=black}
 
 # Git related
-: ${AGNOSTER_GIT_CLEAN_FG:=black}
+: ${AGNOSTER_GIT_CLEAN_FG:=${CURRENT_FG}}
 : ${AGNOSTER_GIT_CLEAN_BG:=green}
 : ${AGNOSTER_GIT_DIRTY_FG:=black}
 : ${AGNOSTER_GIT_DIRTY_BG:=yellow}
@@ -53,7 +62,7 @@
 : ${AGNOSTER_HG_NEWFILE_BG:=red}
 : ${AGNOSTER_HG_CHANGED_FG:=black}
 : ${AGNOSTER_HG_CHANGED_BG:=yellow}
-: ${AGNOSTER_HG_CLEAN_FG:=black}
+: ${AGNOSTER_HG_CLEAN_FG:=${CURRENT_FG}}
 : ${AGNOSTER_HG_CLEAN_BG:=green}
 
 # VirtualEnv colors
@@ -72,16 +81,6 @@
 # Show git working dir in the style "/git/root   master  relative/dir" instead of "/git/root/relative/dir   master"
 : ${AGNOSTER_GIT_INLINE:=false}
 
-
-### Segment drawing
-# A few utility functions to make it easy and re-usable to draw segmented prompts
-
-CURRENT_BG='NONE'
-
-case ${SOLARIZED_THEME:-dark} in
-    light) CURRENT_FG='white';;
-    *)     CURRENT_FG='black';;
-esac
 
 # Special Powerline characters
 

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -29,6 +29,50 @@
 # jobs are running in this shell will all be displayed automatically when
 # appropriate.
 
+
+### Theme Configuration Initialization
+#
+# Override these settings in your ~/.zshrc
+
+# Current working directory
+: ${AGNOSTER_DIR_FG:=black}
+: ${AGNOSTER_DIR_BG:=blue}
+
+# user@host
+: ${AGNOSTER_CONTEXT_FG:=default}
+: ${AGNOSTER_CONTEXT_BG:=black}
+
+# Git related
+: ${AGNOSTER_GIT_CLEAN_FG:=black}
+: ${AGNOSTER_GIT_CLEAN_BG:=green}
+: ${AGNOSTER_GIT_DIRTY_FG:=black}
+: ${AGNOSTER_GIT_DIRTY_BG:=orange}
+
+# Mercurial related
+: ${AGNOSTER_HG_NEWFILE_FG:=white}
+: ${AGNOSTER_HG_NEWFILE_BG:=red}
+: ${AGNOSTER_HG_CHANGED_FG:=black}
+: ${AGNOSTER_HG_CHANGED_BG:=red}
+: ${AGNOSTER_HG_CLEAN_FG:=black}
+: ${AGNOSTER_HG_CLEAN_BG:=green}
+
+# VirtualEnv colors
+: ${AGNOSTER_VENV_FG:=blue}
+: ${AGNOSTER_VENV_BG:=black}
+
+# Status symbols
+: ${AGNOSTER_STATUS_RETVAL_FG:=red}
+: ${AGNOSTER_STATUS_ROOT_FG:=yellow}
+: ${AGNOSTER_STATUS_JOB_FG:=cyan}
+: ${AGNOSTER_STATUS_BG:=black}
+
+## Non-Color settings - set to 'true' to enable
+# Show the actual numeric return value rather than a cross symbol.
+: ${AGNOSTER_STATUS_RETVAL_NUMERIC:=false}
+# Show git working dir in the style "/git/root   master  relative/dir" instead of "/git/root/relative/dir   master"
+: ${AGNOSTER_GIT_INLINE:=false}
+
+
 ### Segment drawing
 # A few utility functions to make it easy and re-usable to draw segmented prompts
 
@@ -89,8 +133,16 @@ prompt_end() {
 # Context: user@hostname (who am I and where am I)
 prompt_context() {
   if [[ "$USERNAME" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
-    prompt_segment black default "%(!.%{%F{yellow}%}.)%n@%m"
+    prompt_segment "$AGNOSTER_CONTEXT_BG" "$AGNOSTER_CONTEXT_FG" "%(!.%{%F{yellow}%}.)%n@%m"
   fi
+}
+
+prompt_git_relative() {
+  local repo_root=$(git rev-parse --show-toplevel)
+  local path_in_repo=$(pwd | sed "s/^$(echo "$repo_root" | sed 's:/:\\/:g;s/\$/\\$/g')//;s:^/::;s:/$::;")
+  if [[ $path_in_repo != '' ]]; then
+    prompt_segment "$AGNOSTER_DIR_BG" "$AGNOSTER_DIR_FG" "$path_in_repo"
+  fi;
 }
 
 # Git: branch/detached head, dirty status
@@ -113,9 +165,9 @@ prompt_git() {
     ref="◈ $(command git describe --exact-match --tags HEAD 2> /dev/null)" || \
     ref="➦ $(command git rev-parse --short HEAD 2> /dev/null)"
     if [[ -n $dirty ]]; then
-      prompt_segment yellow black
+      prompt_segment "$AGNOSTER_GIT_DIRTY_BG" "$AGNOSTER_GIT_DIRTY_FG"
     else
-      prompt_segment green $CURRENT_FG
+      prompt_segment "$AGNOSTER_GIT_CLEAN_BG" "$AGNOSTER_GIT_CLEAN_FG"
     fi
 
     local ahead behind
@@ -149,6 +201,7 @@ prompt_git() {
     zstyle ':vcs_info:*' actionformats ' %u%c'
     vcs_info
     echo -n "${${ref:gs/%/%%}/refs\/heads\//$PL_BRANCH_CHAR }${vcs_info_msg_0_%% }${mode}"
+    [[ $AGNOSTER_GIT_INLINE == 'true' ]] && prompt_git_relative
   fi
 }
 
@@ -186,15 +239,15 @@ prompt_hg() {
     if $(command hg prompt >/dev/null 2>&1); then
       if [[ $(command hg prompt "{status|unknown}") = "?" ]]; then
         # if files are not added
-        prompt_segment red white
+        prompt_segment "$AGNOSTER_HG_NEWFILE_BG" "$AGNOSTER_HG_NEWFILE_FG"
         st='±'
       elif [[ -n $(command hg prompt "{status|modified}") ]]; then
         # if any modification
-        prompt_segment yellow black
+        prompt_segment "$AGNOSTER_HG_CHANGED_BG" "$AGNOSTER_HG_CHANGED_FG"
         st='±'
       else
         # if working copy is clean
-        prompt_segment green $CURRENT_FG
+        prompt_segment "$AGNOSTER_HG_CLEAN_BG" "$AGNOSTER_HG_CLEAN_FG"
       fi
       echo -n ${$(command hg prompt "☿ {rev}@{branch}"):gs/%/%%} $st
     else
@@ -202,13 +255,13 @@ prompt_hg() {
       rev=$(command hg id -n 2>/dev/null | sed 's/[^-0-9]//g')
       branch=$(command hg id -b 2>/dev/null)
       if command hg st | command grep -q "^\?"; then
-        prompt_segment red black
+        prompt_segment "$AGNOSTER_HG_NEWFILE_BG" "$AGNOSTER_HG_NEWFILE_FG"
         st='±'
       elif command hg st | command grep -q "^[MA]"; then
-        prompt_segment yellow black
+        prompt_segment "$AGNOSTER_HG_CHANGED_BG" "$AGNOSTER_HG_CHANGED_FG"
         st='±'
       else
-        prompt_segment green $CURRENT_FG
+        prompt_segment "$AGNOSTER_HG_CLEAN_BG" "$AGNOSTER_HG_CLEAN_FG"
       fi
       echo -n "☿ ${rev:gs/%/%%}@${branch:gs/%/%%}" $st
     fi
@@ -217,13 +270,18 @@ prompt_hg() {
 
 # Dir: current working directory
 prompt_dir() {
-  prompt_segment blue $CURRENT_FG '%~'
+  if [[ $AGNOSTER_GIT_INLINE == 'true' ]] && $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
+    # Git repo and inline path enabled, hence only show the git root
+    prompt_segment "$AGNOSTER_DIR_BG" "$AGNOSTER_DIR_FG" "$(git rev-parse --show-toplevel | sed "s:^$HOME:~:")"
+  else
+    prompt_segment "$AGNOSTER_DIR_BG" "$AGNOSTER_DIR_FG" '%~'
+  fi
 }
 
 # Virtualenv: current working virtualenv
 prompt_virtualenv() {
   if [[ -n "$VIRTUAL_ENV" && -n "$VIRTUAL_ENV_DISABLE_PROMPT" ]]; then
-    prompt_segment blue black "(${VIRTUAL_ENV:t:gs/%/%%})"
+    prompt_segment "$AGNOSTER_VENV_BG" "$AGNOSTER_VENV_FG" "(${VIRTUAL_ENV:t:gs/%/%%})"
   fi
 }
 
@@ -234,11 +292,15 @@ prompt_virtualenv() {
 prompt_status() {
   local -a symbols
 
-  [[ $RETVAL -ne 0 ]] && symbols+="%{%F{red}%}✘"
-  [[ $UID -eq 0 ]] && symbols+="%{%F{yellow}%}⚡"
-  [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{cyan}%}⚙"
+  if [[ $AGNOSTER_STATUS_RETVAL_NUMERIC == 'true' ]]; then
+    [[ $RETVAL -ne 0 ]] && symbols+="%{%F{$AGNOSTER_STATUS_RETVAL_FG}%}$RETVAL"
+  else
+    [[ $RETVAL -ne 0 ]] && symbols+="%{%F{$AGNOSTER_STATUS_RETVAL_FG}%}✘"
+  fi
+  [[ $UID -eq 0 ]] && symbols+="%{%F{$AGNOSTER_STATUS_ROOT_FG}%}⚡"
+  [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{$AGNOSTER_STATUS_JOB_FG}%}⚙"
 
-  [[ -n "$symbols" ]] && prompt_segment black default "$symbols"
+  [[ -n "$symbols" ]] && prompt_segment "$AGNOSTER_STATUS_BG" default "$symbols"
 }
 
 #AWS Profile:

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -127,6 +127,18 @@ prompt_end() {
   CURRENT_BG=''
 }
 
+git_toplevel() {
+	local repo_root=$(git rev-parse --show-toplevel)
+	if [[ $repo_root = '' ]]; then
+		# We are in a bare repo. Use git dir as root
+		repo_root=$(git rev-parse --git-dir)
+		if [[ $repo_root = '.' ]]; then
+			repo_root=$(pwd)
+		fi
+	fi
+	echo -n $repo_root
+}
+
 ### Prompt components
 # Each component will draw itself, and hide itself if no information needs to be shown
 
@@ -138,11 +150,7 @@ prompt_context() {
 }
 
 prompt_git_relative() {
-  local repo_root=$(git rev-parse --show-toplevel)
-	if [[ $repo_root = '' ]]; then
-		# We are in a bare repo. Use git dir as root
-		repo_root=$(git rev-parse --git-dir)
-	fi
+  local repo_root=$(git_toplevel)
   local path_in_repo=$(pwd | sed "s/^$(echo "$repo_root" | sed 's:/:\\/:g;s/\$/\\$/g')//;s:^/::;s:/$::;")
   if [[ $path_in_repo != '' ]]; then
     prompt_segment "$AGNOSTER_DIR_BG" "$AGNOSTER_DIR_FG" "$path_in_repo"
@@ -276,7 +284,7 @@ prompt_hg() {
 prompt_dir() {
   if [[ $AGNOSTER_GIT_INLINE == 'true' ]] && $(git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
     # Git repo and inline path enabled, hence only show the git root
-    prompt_segment "$AGNOSTER_DIR_BG" "$AGNOSTER_DIR_FG" "$(git rev-parse --show-toplevel | sed "s:^$HOME:~:")"
+    prompt_segment "$AGNOSTER_DIR_BG" "$AGNOSTER_DIR_FG" "$(git_toplevel | sed "s:^$HOME:~:")"
   else
     prompt_segment "$AGNOSTER_DIR_BG" "$AGNOSTER_DIR_FG" '%~'
   fi

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -158,7 +158,7 @@ git_toplevel() {
 # Context: user@hostname (who am I and where am I)
 prompt_context() {
   if [[ "$USERNAME" != "$DEFAULT_USER" || -n "$SSH_CLIENT" ]]; then
-    prompt_segment "$AGNOSTER_CONTEXT_BG" "$AGNOSTER_CONTEXT_FG" "%(!.%{%F{yellow}%}.)%n@%m"
+    prompt_segment "$AGNOSTER_CONTEXT_BG" "$AGNOSTER_CONTEXT_FG" "%(!.%{%F{$AGNOSTER_STATUS_ROOT_FG}%}.)%n@%m"
   fi
 }
 

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -146,7 +146,7 @@ git_toplevel() {
 		# We are in a bare repo. Use git dir as root
 		repo_root=$(git rev-parse --git-dir)
 		if [[ $repo_root = '.' ]]; then
-			repo_root=$(pwd)
+			repo_root=$PWD
 		fi
 	fi
 	echo -n $repo_root

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -52,13 +52,13 @@
 : ${AGNOSTER_HG_NEWFILE_FG:=white}
 : ${AGNOSTER_HG_NEWFILE_BG:=red}
 : ${AGNOSTER_HG_CHANGED_FG:=black}
-: ${AGNOSTER_HG_CHANGED_BG:=red}
+: ${AGNOSTER_HG_CHANGED_BG:=yellow}
 : ${AGNOSTER_HG_CLEAN_FG:=black}
 : ${AGNOSTER_HG_CLEAN_BG:=green}
 
 # VirtualEnv colors
-: ${AGNOSTER_VENV_FG:=blue}
-: ${AGNOSTER_VENV_BG:=black}
+: ${AGNOSTER_VENV_FG:=black}
+: ${AGNOSTER_VENV_BG:=blue}
 
 # Status symbols
 : ${AGNOSTER_STATUS_RETVAL_FG:=red}

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -57,6 +57,12 @@ esac
 : ${AGNOSTER_GIT_DIRTY_FG:=black}
 : ${AGNOSTER_GIT_DIRTY_BG:=yellow}
 
+# Bazaar related
+: ${AGNOSTER_BZR_CLEAN_FG:=${CURRENT_FG}}
+: ${AGNOSTER_BZR_CLEAN_BG:=green}
+: ${AGNOSTER_BZR_DIRTY_FG:=black}
+: ${AGNOSTER_BZR_DIRTY_BG:=yellow}
+
 # Mercurial related
 : ${AGNOSTER_HG_NEWFILE_FG:=white}
 : ${AGNOSTER_HG_NEWFILE_BG:=red}
@@ -68,6 +74,12 @@ esac
 # VirtualEnv colors
 : ${AGNOSTER_VENV_FG:=black}
 : ${AGNOSTER_VENV_BG:=blue}
+
+# AWS Profile colors
+: ${AGNOSTER_AWS_PROD_FG:=yellow}
+: ${AGNOSTER_AWS_PROD_BG:=red}
+: ${AGNOSTER_AWS_FG:=black}
+: ${AGNOSTER_AWS_BG:=green}
 
 # Status symbols
 : ${AGNOSTER_STATUS_RETVAL_FG:=red}
@@ -236,12 +248,12 @@ prompt_bzr() {
     status_all=$(echo -n "$bzr_status" | head -n1 | wc -m)
     revision=${$(command bzr log -r-1 --log-format line | cut -d: -f1):gs/%/%%}
     if [[ $status_mod -gt 0 ]] ; then
-      prompt_segment yellow black "bzr@$revision ✚"
+      prompt_segment "$AGNOSTER_BZR_DIRTY_BG" "$AGNOSTER_BZR_DIRTY_FG" "bzr@$revision ✚"
     else
       if [[ $status_all -gt 0 ]] ; then
-        prompt_segment yellow black "bzr@$revision"
+        prompt_segment "$AGNOSTER_BZR_DIRTY_BG" "$AGNOSTER_BZR_DIRTY_FG" "bzr@$revision"
       else
-        prompt_segment green black "bzr@$revision"
+        prompt_segment "$AGNOSTER_BZR_CLEAN_BG" "$AGNOSTER_BZR_CLEAN_FG" "bzr@$revision"
       fi
     fi
   fi
@@ -326,8 +338,8 @@ prompt_status() {
 prompt_aws() {
   [[ -z "$AWS_PROFILE" || "$SHOW_AWS_PROMPT" = false ]] && return
   case "$AWS_PROFILE" in
-    *-prod|*production*) prompt_segment red yellow  "AWS: ${AWS_PROFILE:gs/%/%%}" ;;
-    *) prompt_segment green black "AWS: ${AWS_PROFILE:gs/%/%%}" ;;
+    *-prod|*production*) prompt_segment "$AGNOSTER_AWS_PROD_BG" "$AGNOSTER_AWS_PROD_FG"  "AWS: ${AWS_PROFILE:gs/%/%%}" ;;
+    *) prompt_segment "$AGNOSTER_AWS_BG" "$AGNOSTER_AWS_FG" "AWS: ${AWS_PROFILE:gs/%/%%}" ;;
   esac
 }
 

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -80,6 +80,8 @@ esac
 : ${AGNOSTER_STATUS_RETVAL_NUMERIC:=false}
 # Show git working dir in the style "/git/root   master  relative/dir" instead of "/git/root/relative/dir   master"
 : ${AGNOSTER_GIT_INLINE:=false}
+# Show the git branch status in the prompt rather than the generic branch symbol
+: ${AGNOSTER_GIT_BRANCH_STATUS:=true}
 
 
 # Special Powerline characters
@@ -181,15 +183,17 @@ prompt_git() {
       prompt_segment "$AGNOSTER_GIT_CLEAN_BG" "$AGNOSTER_GIT_CLEAN_FG"
     fi
 
-    local ahead behind
-    ahead=$(command git log --oneline @{upstream}.. 2>/dev/null)
-    behind=$(command git log --oneline ..@{upstream} 2>/dev/null)
-    if [[ -n "$ahead" ]] && [[ -n "$behind" ]]; then
-      PL_BRANCH_CHAR=$'\u21c5'
-    elif [[ -n "$ahead" ]]; then
-      PL_BRANCH_CHAR=$'\u21b1'
-    elif [[ -n "$behind" ]]; then
-      PL_BRANCH_CHAR=$'\u21b0'
+    if [[ $AGNOSTER_GIT_BRANCH_STATUS == 'true' ]]; then
+      local ahead behind
+      ahead=$(command git log --oneline @{upstream}.. 2>/dev/null)
+      behind=$(command git log --oneline ..@{upstream} 2>/dev/null)
+      if [[ -n "$ahead" ]] && [[ -n "$behind" ]]; then
+        PL_BRANCH_CHAR=$'\u21c5'
+      elif [[ -n "$ahead" ]]; then
+        PL_BRANCH_CHAR=$'\u21b1'
+      elif [[ -n "$behind" ]]; then
+        PL_BRANCH_CHAR=$'\u21b0'
+      fi
     fi
 
     if [[ -e "${repo_path}/BISECT_LOG" ]]; then

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -139,6 +139,10 @@ prompt_context() {
 
 prompt_git_relative() {
   local repo_root=$(git rev-parse --show-toplevel)
+	if [[ $repo_root = '' ]]; then
+		# We are in a bare repo. Use git dir as root
+		repo_root=$(git rev-parse --git-dir)
+	fi
   local path_in_repo=$(pwd | sed "s/^$(echo "$repo_root" | sed 's:/:\\/:g;s/\$/\\$/g')//;s:^/::;s:/$::;")
   if [[ $path_in_repo != '' ]]; then
     prompt_segment "$AGNOSTER_DIR_BG" "$AGNOSTER_DIR_FG" "$path_in_repo"


### PR DESCRIPTION
This is a rebase of the excellent work @Kilobyte22 did in #3434. These were the initial features in that PR:

- Setting color for all kinds of elements, by setting an appropriate config variable to the color name in your zshrc. A full list of colors can be found in `themes/agnoster.zsh-theme`. Example:

      AGNOSTER_GIT_DIRTY_BG=red # Set the git prompt background color to red for dirty repos

- Allowing to separate the git root and the relative path in your prompt by setting `AGNOSTER_GIT_INLINE` to `true`. You will then have a segment for the git root (ie. `~/.oh-my-zsh`) followed by the existing git branch segment (ie. `master`) and finally the relative directory path (ie. `themes`)
- By setting `AGNOSTER_STATUS_RETVAL_NUMERIC` to `true`, the return value in the status prompt will be the numeric return value instead of an X.

In addition, I added the following functionality:

- Update the theming to support bzr and aws profile
- Update the theming to work with the solarized theme changes in #4680.
- Update one missed color variable
- Add the ability to disable the branch icon changes from #7209 

@carlosala since he is the one who requested that this be rebased. 😄 