### PR TITLE
feat(git): add `gclf` alias

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -165,6 +165,7 @@ alias gcpa='git cherry-pick --abort'
 alias gcpc='git cherry-pick --continue'
 alias gclean='git clean --interactive -d'
 alias gcl='git clone --recurse-submodules'
+alias gclf='git clone --recursive --shallow-submodules --filter=blob:none --also-filter-submodules'
 
 function gccd() {
   setopt localoptions extendedglob


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- This PR adds an alias that results in git clone that can be significantly less in size. While doing so, it still preserves ability to easily check out the the cloned repository history, since it is not a shallow clone (its `depth` is not being reduced). 

  The alias has become my default for cloning repositories over the recent years.
  
  For example:
  ```sh
  # gclf
  git clone --recursive --shallow-submodules --filter=blob:none --also-filter-submodules \
  https://github.com/webui-dev/webui.git webui-filtered # ~10,2MB
  ```
  ```sh
  # glc
  git clone --recurse-submodules https://github.com/webui-dev/webui.git # ~34,4MB
  ```
  
  The style of the added alias matches with other git alias like:
  https://github.com/ohmyzsh/ohmyzsh/blob/677f5010daf226509cc19d7244a689df82820c82/plugins/git/git.plugin.zsh#L111-L112
  https://github.com/ohmyzsh/ohmyzsh/blob/677f5010daf226509cc19d7244a689df82820c82/plugins/git/git.plugin.zsh#L118-L119
 

## Other comments:

...
