### PR TITLE
fix(essembeh): fix git info in prompt

### DIFF
--- a/themes/essembeh.zsh-theme
+++ b/themes/essembeh.zsh-theme
@@ -11,21 +11,7 @@
 # git plugin
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[cyan]%}("
 ZSH_THEME_GIT_PROMPT_SUFFIX=") %{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_UNTRACKED="%%"
-ZSH_THEME_GIT_PROMPT_ADDED="+"
-ZSH_THEME_GIT_PROMPT_MODIFIED="*"
-ZSH_THEME_GIT_PROMPT_RENAMED="~"
-ZSH_THEME_GIT_PROMPT_DELETED="!"
-ZSH_THEME_GIT_PROMPT_UNMERGED="?"
 
-function zsh_essembeh_gitstatus {
-	ref=$(git symbolic-ref HEAD 2> /dev/null) || return
-	GIT_STATUS=$(git_prompt_status)
-	if [[ -n $GIT_STATUS ]]; then
-		GIT_STATUS=" $GIT_STATUS"
-	fi
-	echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$GIT_STATUS$ZSH_THEME_GIT_PROMPT_SUFFIX"
-}
 
 # by default, use green for user@host and no prefix
 local ZSH_ESSEMBEH_COLOR="green"
@@ -46,5 +32,5 @@ if [[ $UID = 0 ]]; then
 	# always use magenta for root sessions, even in ssh
 	ZSH_ESSEMBEH_COLOR="magenta"
 fi
-PROMPT='${ZSH_ESSEMBEH_PREFIX}%{$fg[$ZSH_ESSEMBEH_COLOR]%}%n@%M%{$reset_color%}:%{%B$fg[yellow]%}%~%{$reset_color%b%} $(zsh_essembeh_gitstatus)%(!.#.$) '
+PROMPT='${ZSH_ESSEMBEH_PREFIX}%{$fg[$ZSH_ESSEMBEH_COLOR]%}%n@%M%{$reset_color%}:%{%B$fg[yellow]%}%~%{$reset_color%b%} $(git_prompt_info)%(!.#.$) '
 RPROMPT="%(?..%{$fg[red]%}%?%{$reset_color%})"


### PR DESCRIPTION
- with latest nixos zsh/ohmyzsh update, git informations in prompt were not displayed

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
