### PR TITLE
feat(rails): adds tasks alias (rts)

### DIFF
--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -79,6 +79,7 @@ alias rsp='rails server --port'
 alias rsts='rails stats'
 alias rt='rails test'
 alias rta='rails test:all'
+alias rts='rails --tasks'
 alias ru='rails runner'
 
 # Foreman aliases


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds `rts` alias to rails plugin

## Other comments:

**Usage**

```
~ rts
bin/rails action_mailbox:ingress:exim                  # Relay an inbound email from Exim to Action Mailbox (URL and INGRESS_PASSWORD required)
bin/rails action_mailbox:ingress:postfix               # Relay an inbound email from Postfix to Action Mailbox (URL and INGRESS_PASSWORD required)
bin/rails action_mailbox:ingress:qmail                 # Relay an inbound email from Qmail to Action Mailbox (URL and INGRESS_PASSWORD required)
bin/rails action_mailbox:install                       # Install Action Mailbox and its dependencies
bin/rails action_mailbox:install:migrations            # Copy migrations from action_mailbox to application
...
~ 
```
