### PR TITLE
feat(arduino-cli): add completion plugin

### DIFF
--- a/plugins/arduino-cli/README.md
+++ b/plugins/arduino-cli/README.md
@@ -1,0 +1,8 @@
+# Arduino CLI plugin
+
+This plugin adds completion for the [arduino-cli](https://github.com/arduino/arduino-cli) tool.
+To use it, add `arduino-cli` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... arduino-cli)
+```

--- a/plugins/arduino-cli/arduino-cli.plugin.zsh
+++ b/plugins/arduino-cli/arduino-cli.plugin.zsh
@@ -1,0 +1,14 @@
+if (( ! $+commands[arduino-cli] )); then
+  return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `arduino-cli`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_arduino-cli" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _arduino-cli
+  _comps[arduino-cli]=_arduino-cli
+fi
+
+# Generate and load arduino-cli completion
+arduino-cli completion zsh >! "$ZSH_CACHE_DIR/completions/_arduino-cli" &|


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds autocompletion for [arduino-cli](https://github.com/arduino/arduino-cli)

## Other comments:
- Uses the zsh command completion generated by arduino-cli itself like as kubectl does.
