### PR TITLE
feat(kubectl): kg alias

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -15,6 +15,9 @@ kubectl completion zsh 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_kubectl" &|
 # This command is used a LOT both below and in daily life
 alias k=kubectl
 
+# General purpose get for the resources which don't have aliases like custom resources.
+alias kg=kubectl get
+
 # Execute a kubectl command against all namespaces
 alias kca='_kca(){ kubectl "$@" --all-namespaces;  unset -f _kca; }; _kca'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added `kg` alias for `kubectl get`

## Other comments:

This PR introduces a new alias for `kubectl get` command if a resource doesn't have an alias this command comes handy. Examples:

```shell
$ kg persistetvolumes
$ kg serviceaccounts default -o yaml
```

