### PR TITLE
fix(agnoster): print white text over black

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -48,7 +48,7 @@ esac
 : ${AGNOSTER_DIR_BG:=blue}
 
 # user@host
-: ${AGNOSTER_CONTEXT_FG:=default}
+: ${AGNOSTER_CONTEXT_FG:=white}
 : ${AGNOSTER_CONTEXT_BG:=black}
 
 # Git related
@@ -85,6 +85,7 @@ esac
 : ${AGNOSTER_STATUS_RETVAL_FG:=red}
 : ${AGNOSTER_STATUS_ROOT_FG:=yellow}
 : ${AGNOSTER_STATUS_JOB_FG:=cyan}
+: ${AGNOSTER_STATUS_FG:=white}
 : ${AGNOSTER_STATUS_BG:=black}
 
 ## Non-Color settings - set to 'true' to enable
@@ -327,7 +328,7 @@ prompt_status() {
   [[ $UID -eq 0 ]] && symbols+="%{%F{$AGNOSTER_STATUS_ROOT_FG}%}⚡"
   [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{$AGNOSTER_STATUS_JOB_FG}%}⚙"
 
-  [[ -n "$symbols" ]] && prompt_segment "$AGNOSTER_STATUS_BG" default "$symbols"
+  [[ -n "$symbols" ]] && prompt_segment "$AGNOSTER_STATUS_BG" "$AGNOSTER_STATUS_FG" "$symbols"
 }
 
 #AWS Profile:


### PR DESCRIPTION
This makes them readable in light terminals too and not only dark ones.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Prints white text rather than default-colored text on black segments (context and status)

## Other comments:

### Before

![Capture d’écran du 2024-06-25 14-16-20](https://github.com/ohmyzsh/ohmyzsh/assets/2536339/2c8e5ac9-bc14-4a4e-ad8a-5324831b3ab5)

![Capture d’écran du 2024-06-25 14-16-47](https://github.com/ohmyzsh/ohmyzsh/assets/2536339/9263ae27-53e5-46e0-a882-0015daba6d15)

### After (no change for dark)

![Capture d’écran du 2024-06-25 14-16-04](https://github.com/ohmyzsh/ohmyzsh/assets/2536339/e2db55f3-a2c0-4570-b9f4-2eaf1852789c)
