### PR TITLE
docs(command-not-found): mention gentoo support

### DIFF
--- a/plugins/command-not-found/README.md
+++ b/plugins/command-not-found/README.md
@@ -30,5 +30,6 @@ It works out of the box with the command-not-found packages for:
 - [NixOS](https://github.com/NixOS/nixpkgs/tree/master/nixos/modules/programs/command-not-found)
 - [Termux](https://github.com/termux/command-not-found)
 - [SUSE](https://www.unix.com/man-page/suse/1/command-not-found/)
+- [Gentoo](https://github.com/AndrewAmmerlaan/command-not-found-gentoo/tree/main)
 
 You can add support for other platforms by submitting a Pull Request.


### PR DESCRIPTION
SUSE's /usr/bin/command-not-found works for Gentoo, too

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
Just a small comment that mentions that this works out of the box on gentoo.

## Small comments:
I'm not sure whether to link to the github page of the package or to the actual package on https://packages.gentoo.org. I think users would find the github page more useful because it also mentions that pfl should be installed.
