### PR TITLE
fix(bun): set `SHELL` when generating completions

### DIFF
--- a/plugins/bun/bun.plugin.zsh
+++ b/plugins/bun/bun.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_bun" ]]; then
   _comps[bun]=_bun
 fi
 
-bun completions >| "$ZSH_CACHE_DIR/completions/_bun" &|
+SHELL=zsh bun completions >| "$ZSH_CACHE_DIR/completions/_bun" &|


### PR DESCRIPTION


## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- fix(bun): bun completions should explicitly set SHELL

## Other comments:

`bun completions` results in a file according to the current `$SHELL`, but if you don´t have ZSH as your `$SHELL`(for example, because you didn't or couldn't run chsh), the plugin will create a bash script as the completions script. This commit fixes this.

Users with broken completions probably need to remove their `$ZSH_CACHE_DIR/completions/_bun` so it is created again properly. 