### PR TITLE
fix: Use `-L` to check for symlinks in conditional expressions (#12457)

### DIFF
--- a/lib/diagnostics.zsh
+++ b/lib/diagnostics.zsh
@@ -131,7 +131,7 @@ function _omz_diag_dump_one_big_text() {
           sha_str=$sha_str[1]
           extra_str+=" SHA $sha_str"
         fi
-        if [[ -h "$progfile" ]]; then
+        if [[ -L "$progfile" ]]; then
           extra_str+=" ( -> ${progfile:A} )"
         fi
       fi
@@ -199,7 +199,7 @@ function _omz_diag_dump_one_big_text() {
   builtin echo
   if [[ -e $ZSH_CUSTOM ]]; then
     local custom_dir=$ZSH_CUSTOM
-    if [[ -h $custom_dir ]]; then
+    if [[ -L $custom_dir ]]; then
       custom_dir=$(builtin cd $custom_dir && pwd -P)
     fi
     builtin echo "oh-my-zsh custom dir:"
@@ -309,9 +309,9 @@ function _omz_diag_dump_check_core_commands() {
 
 function _omz_diag_dump_echo_file_w_header() {
   local file=$1
-  if [[ ( -f $file || -h $file ) ]]; then
+  if [[ ( -f $file || -L $file ) ]]; then
     builtin echo "========== $file =========="
-    if [[ -h $file ]]; then
+    if [[ -L $file ]]; then
       builtin echo "==========    ( => ${file:A} )   =========="
     fi
     command cat $file

--- a/plugins/chruby/chruby.plugin.zsh
+++ b/plugins/chruby/chruby.plugin.zsh
@@ -20,7 +20,7 @@ _source-from-homebrew() {
 
   local _brew_prefix
   # check default brew prefix
-  if [[ -h /usr/local/opt/chruby ]];then
+  if [[ -L /usr/local/opt/chruby ]];then
     _brew_prefix="/usr/local/opt/chruby"
   else
     # ok , it is not default prefix

--- a/plugins/rbfu/rbfu.plugin.zsh
+++ b/plugins/rbfu/rbfu.plugin.zsh
@@ -18,7 +18,7 @@ function _rbfu_rubies_print() {
   rb_out="$rb"
 
   # If the ruby is a symlink, add @ to the name.
-  if [[ -h "$1" ]]; then
+  if [[ -L "$1" ]]; then
     rb_out="${rb_out}${fg[green]}@${reset_color}"
   fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- In conditional expressions (`[[ ... ]]`), use `-L` instead of `-h` as this avoids conflicting with a somewhat common global `-h` alias recommended by [`bat`](https://github.com/sharkdp/bat?tab=readme-ov-file#highlighting---help-messages)

Fixes #12457

## Other comments:

Tested locally. With a global `-h` alias, executing `source ~/.zshrc` in an existing session triggers:
```
❯ source ~/.zshrc
/Users/clay/.oh-my-zsh/lib/diagnostics.zsh:134: parse error near `>&'
```
With this change, no errors are emitted:
```
❯ source ~/.zshrc
```
