### PR TITLE
Simplify Pygmalion Theme

### DIFF
--- a/themes/pygmalion.zsh-theme
+++ b/themes/pygmalion.zsh-theme
@@ -1,7 +1,7 @@
 # Yay! High voltage and arrows!
 
 prompt_setup_pygmalion(){
-  setopt localoptions extendedglob
+  setopt localoptions nopromptsubst extendedglob
 
   ZSH_THEME_GIT_PROMPT_PREFIX="%{$reset_color%}%{$fg[green]%}"
   ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
@@ -10,22 +10,6 @@ prompt_setup_pygmalion(){
 
   base_prompt='%{$fg[magenta]%}%n%{$reset_color%}%{$fg[cyan]%}@%{$reset_color%}%{$fg[yellow]%}%m%{$reset_color%}%{$fg[red]%}:%{$reset_color%}%{$fg[cyan]%}%0~%{$reset_color%}%{$fg[red]%}|%{$reset_color%}'
   post_prompt='%{$fg[cyan]%}⇒%{$reset_color%}  '
-
-  base_prompt_nocolor=${base_prompt//\%\{[^\}]##\}}
-  post_prompt_nocolor=${post_prompt//\%\{[^\}]##\}}
-
-  autoload -U add-zsh-hook
-  add-zsh-hook precmd prompt_pygmalion_precmd
-}
-
-prompt_pygmalion_precmd(){
-  setopt localoptions nopromptsubst extendedglob
-
-  local gitinfo=$(git_prompt_info)
-  local gitinfo_nocolor=${gitinfo//\%\{[^\}]##\}}
-  local exp_nocolor="$(print -P \"${base_prompt_nocolor}${gitinfo_nocolor}${post_prompt_nocolor}\")"
-  local prompt_length=${#exp_nocolor}
-
   PROMPT="${base_prompt}\$(git_prompt_info)${post_prompt}"
 }
 

--- a/themes/pygmalion.zsh-theme
+++ b/themes/pygmalion.zsh-theme
@@ -1,16 +1,12 @@
 # Yay! High voltage and arrows!
 
-prompt_setup_pygmalion(){
-  setopt localoptions nopromptsubst extendedglob
+ZSH_THEME_GIT_PROMPT_PREFIX="%{${reset_color}%}%F{green}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{${reset_color}%} "
+ZSH_THEME_GIT_PROMPT_DIRTY="%F{yellow}⚡%f"
+ZSH_THEME_GIT_PROMPT_CLEAN=""
 
-  ZSH_THEME_GIT_PROMPT_PREFIX="%{$reset_color%}%{$fg[green]%}"
-  ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
-  ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[yellow]%}⚡%{$reset_color%}"
-  ZSH_THEME_GIT_PROMPT_CLEAN=""
+base_prompt="%{${reset_color}%}%F{magenta}%n%F{cyan}@%F{yellow}%m%F{red}:%F{cyan}%0~%F{red}|%f"
+post_prompt="%{${reset_color}%}%F{cyan}⇒%f  "
 
-  base_prompt='%{$fg[magenta]%}%n%{$reset_color%}%{$fg[cyan]%}@%{$reset_color%}%{$fg[yellow]%}%m%{$reset_color%}%{$fg[red]%}:%{$reset_color%}%{$fg[cyan]%}%0~%{$reset_color%}%{$fg[red]%}|%{$reset_color%}'
-  post_prompt='%{$fg[cyan]%}⇒%{$reset_color%}  '
-  PROMPT="${base_prompt}\$(git_prompt_info)${post_prompt}"
-}
-
-prompt_setup_pygmalion
+PROMPT="${base_prompt}\$(git_prompt_info)${post_prompt}"
+unset base_prompt post_prompt


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The Pygmalion theme previously had some logic for counting line length and taking action based on line length. The action was removed in c52441b624c0b1fa075bc6110032bd4e75311909, but the counting still needlessly happens. 

This commit removes the code to count line length, and simplifies the Pygmalion theme by moving the "precmd" into the setup. 

## Other comments:

As a bonus unintended side effect, this makes the Pygmalion theme compatible with the current async prompting logic (i.e. after this change, Pygmalion is no longer affected by https://github.com/ohmyzsh/ohmyzsh/issues/12328)
