### PR TITLE
fix(docker-compose): fix test for `docker-compose` executable

### DIFF
--- a/plugins/docker-compose/docker-compose.plugin.zsh
+++ b/plugins/docker-compose/docker-compose.plugin.zsh
@@ -1,5 +1,8 @@
-# support Compose v2 as docker CLI plugin
-[[ -x "$(command -v docker-compose)" ]] && dccmd='docker-compose' || dccmd='docker compose'
+# Support Compose v2 as docker CLI plugin
+#
+# This tests that the (old) docker-compose command is in $PATH and that
+# it resolves to an existing executable file if it's a symlink.
+[[ -x "${commands[docker-compose]:A}" ]] && dccmd='docker-compose' || dccmd='docker compose'
 
 alias dco="$dccmd"
 alias dcb="$dccmd build"

--- a/plugins/docker-compose/docker-compose.plugin.zsh
+++ b/plugins/docker-compose/docker-compose.plugin.zsh
@@ -1,5 +1,5 @@
 # support Compose v2 as docker CLI plugin
-(( ${+commands[docker-compose]} )) && dccmd='docker-compose' || dccmd='docker compose'
+[[ -x "$(command -v docker-compose)" ]] && dccmd='docker-compose' || dccmd='docker compose'
 
 alias dco="$dccmd"
 alias dcb="$dccmd build"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
Before
`(( ${+commands[docker-compose]} )) && dccmd='docker-compose' || dccmd='docker compose'`
After
`[[ -x "$(command -v docker-compose)" ]] && dccmd='docker-compose' || dccmd='docker compose'`

## Other comments:
Fixes https://github.com/ohmyzsh/ohmyzsh/issues/12553

To test, on MacOS with latest Docker Desktop. Can be replicated on any Linux, just use appropriate path.

Create failing symlink
```sh
rm -rf /usr/local/bin/docker-compose
ln -s  /Applications/Docker.app/Contents/Resources/bin/docker-compose /usr/local/bin/docker-compose

# execute
[[ -x "$(command -v docker-compose)" ]] && dccmd='docker-compose' || dccmd='docker compose'
#check output
echo $dccmd
# docker compose

# fix symlink with proper path to docker-compose plugin
rm -rf /usr/local/bin/docker-compose
ln -s  /Applications/Docker.app/Contents/Resources/cli-plugins/docker-compose /usr/local/bin/docker-compose

# execute
[[ -x "$(command -v docker-compose)" ]] && dccmd='docker-compose' || dccmd='docker compose'

#check output
echo $dccmd
# docker-compose
```