### PR TITLE
feat(git): add support for tag creation

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -205,7 +205,7 @@ plugins=(... git)
 | `gta`                  | `git tag --annotate`                                                                                                            |
 | `gts`                  | `git tag -s`                                                                                                                    |
 | `gtv`                  | `git tag \| sort -V`                                                                                                            |
-| `gtc`                  | `git tag -a <tagName> -m <message/tagName>`                                                                                     |
+| `gtc`                  | `git tag -a <tagName> -m <message/tagName> && git push origin <tagName>`                                                        |
 | `gignore`              | `git update-index --assume-unchanged`                                                                                           |
 | `gunignore`            | `git update-index --no-assume-unchanged`                                                                                        |
 | `gwch`                 | `git whatchanged -p --abbrev-commit --pretty=medium`                                                                            |

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -11,7 +11,7 @@ plugins=(... git)
 ## Aliases
 
 | Alias                  | Command                                                                                                                         |
-| :--------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+|:-----------------------|:--------------------------------------------------------------------------------------------------------------------------------|
 | `grt`                  | `cd "$(git rev-parse --show-toplevel \|\| echo .)"`                                                                             |
 | `ggpnp`                | `ggl && ggp`                                                                                                                    |
 | `ggpur`                | `ggu`                                                                                                                           |
@@ -205,6 +205,7 @@ plugins=(... git)
 | `gta`                  | `git tag --annotate`                                                                                                            |
 | `gts`                  | `git tag -s`                                                                                                                    |
 | `gtv`                  | `git tag \| sort -V`                                                                                                            |
+| `gtc`                  | `git tag -a <tagName> -m <message/tagName>`                                                                                     |
 | `gignore`              | `git update-index --assume-unchanged`                                                                                           |
 | `gunignore`            | `git update-index --no-assume-unchanged`                                                                                        |
 | `gwch`                 | `git whatchanged -p --abbrev-commit --pretty=medium`                                                                            |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -327,11 +327,12 @@ function ggp() {
 }
 compdef _git ggp=git-checkout
 
-function git_tag_add() {
+function git_tag_create() {
     local tagName=$1
     local message=${2:-$tagName}
 
     git tag -a "$tagName" -m "$message"
+    git push origin $tagName
 }
 
 alias gpu='git push upstream'
@@ -398,7 +399,7 @@ alias gswm='git switch $(git_main_branch)'
 alias gta='git tag --annotate'
 alias gts='git tag --sign'
 alias gtv='git tag | sort -V'
-alias gtc='git_tag_add'
+alias gtc='git_tag_create'
 alias gignore='git update-index --assume-unchanged'
 alias gunignore='git update-index --no-assume-unchanged'
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -327,6 +327,13 @@ function ggp() {
 }
 compdef _git ggp=git-checkout
 
+function git_tag_add() {
+    local tagName=$1
+    local message=${2:-$tagName}
+
+    git tag -a "$tagName" -m "$message"
+}
+
 alias gpu='git push upstream'
 alias grb='git rebase'
 alias grba='git rebase --abort'
@@ -391,6 +398,7 @@ alias gswm='git switch $(git_main_branch)'
 alias gta='git tag --annotate'
 alias gts='git tag --sign'
 alias gtv='git tag | sort -V'
+alias gtc='git_tag_add'
 alias gignore='git update-index --assume-unchanged'
 alias gunignore='git update-index --no-assume-unchanged'
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Create a new alias (`gtc`) which can be used to create new tags. Adding a tagname is mandatory, the message is optional and will default to the tagname.

## Other comments:

While working as a software developer where continous releasing is a must, creating tags in an easy way will save us some trouble. Since `gta` is already in use, I choose to create the alias `gtc` which stands for `git tag create`.
By using this alias you will be able to quickly create tags manually and push them towards origin in one go. This could in theory replace the current `gta` alias as it does the same, but push it towards origin as well.
Another option would be to expand `gta` so that it also pushes the tag towards origin.

@mcornella / @carlosala what are your thoughts about this?