### PR TITLE
docs(eza): fix variable name to enable hyperlink flag

### DIFF
--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -93,7 +93,7 @@ Default: Not set, which means the default behavior of `eza` will take place.
 ### `hyperlink`
 
 ```zsh
-zstyle ':omz:plugins:eza' 'header' yes|no
+zstyle ':omz:plugins:eza' 'hyperlink' yes|no
 ```
 
 If `yes`, always add `--hyperlink` flag to create hyperlink with escape codes.


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The docs to enable the `hyperlink`-flag described setting the wrong variable. Probably just copy-pasted from the other part of the docs.

In the script where the variable is used, it's checking for the correct name. So it only seems to be a doc issue.

https://github.com/ohmyzsh/ohmyzsh/blob/be10a9127731e7c6a9a57f8c8c1789e233117ae9/plugins/eza/eza.plugin.zsh#L41-L43

## Other comments:

-
