### PR TITLE
Update zshrc template to use `uname -m` for automatic architecture detection in ARCHFLAGS configuration

### DIFF
--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -89,7 +89,7 @@ source $ZSH/oh-my-zsh.sh
 # fi
 
 # Compilation flags
-# export ARCHFLAGS="-arch x86_64"
+# export ARCHFLAGS="-arch $(uname -m)"
 
 # Set personal aliases, overriding those provided by Oh My Zsh libs,
 # plugins, and themes. Aliases can be placed here, though Oh My Zsh


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

I changed the configuration line related to `Compilation flags` in the zshrc template (`zshrc.zsh-template`) file.

**ORIGINAL:**
```zsh
# Compilation flags
# export ARCHFLAGS="-arch x86_64"
```

Instead of redefining this configuration line in the template, I propose using `uname -m`, which allows you to access this information without having to define it manually.

**MODIFICATION:**
```zsh
# Compilation flags
# export ARCHFLAGS="-arch $(uname -m)"
```

This way, if you are not using an `x86_64` architecture, you will no longer need to remember to change this detail, only to uncomment the configuration line.


## Other comments:

This modification simplifies the configuration process and ensures compatibility with various architectures without manual intervention.
