### PR TITLE
Support version 5.10

### DIFF
--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -9,7 +9,7 @@
 # https://github.com/zsh-users/zsh/blob/f702e17b14d75aa21bff014168fa9048124db286/Functions/Zle/bracketed-paste-magic#L9-L12
 
 # Load bracketed-paste-magic if zsh version is >= 5.1
-if [[ ${ZSH_VERSION:0:3} -ge 5.1 ]]; then
+if [[ ${ZSH_VERSION%.${ZSH_VERSION#*.*.}} -ge 5.1 ]]; then
   set zle_bracketed_paste  # Explicitly restore this zsh default
   autoload -Uz bracketed-paste-magic
   zle -N bracketed-paste bracketed-paste-magic


### PR DESCRIPTION
Just taking the first three characters of `$ZSH_VERSION` would result in `5.10` becoming `5.1` and then failing this check. I've updated your logic to strip off the second dot and anything that follows it, thus ensuring all of these work: `5.10` `5.10.1` `5.10.1.2.3` `5.100`.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Simple bugfix for zsh 5.10 (for whenever that comes out)

