### PR TITLE
Remove last zsh call in install.sh

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -549,8 +549,6 @@ EOF
     echo "${FMT_YELLOW}Run zsh to try it out.${FMT_RESET}"
     exit
   fi
-
-  exec zsh -l
 }
 
 main "$@"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The call restarts zsh with the `-l` flag. In my case, I'm writing a script to bootstrap a new machine and this forces me to either put the ohmyzsh installation at the end, or to find some other way.

I would like to either choose by a flag to run that, for now that's just a convenience feature.