### PR TITLE
feat(brew): add ba alias for brew autoremove

### DIFF
--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -45,6 +45,7 @@ alias bubu='bubo && bubc'
 alias bubug='bubo && bugbc'
 alias bfu='brew upgrade --formula'
 alias buz='brew uninstall --zap'
+alias ba='brew autoremove'
 
 function brews() {
   local formulae="$(brew leaves | xargs brew deps --installed --for-each)"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add ba for brew autoremove

## Other comments:

use **ba** to invoce `brew autoremove`
