### PR TITLE
Fix space in the PROMPT

### DIFF
--- a/themes/sonicradish.zsh-theme
+++ b/themes/sonicradish.zsh-theme
@@ -20,7 +20,7 @@ if [[ $EUID -ne 0 ]] ; then
 	ROOT_ICON=""
 fi
 
-PROMPT='%{$ROOT_ICON_COLOR%}$ROOT_ICON%{$reset_color%}%{$MACHINE_NAME_COLOR%}%m➜  %{$reset_color%}%{$PROMPT_SUCCESS_COLOR%}%c%{$reset_color%} %{$GIT_PROMPT_INFO%}$(git_prompt_info)%{$GIT_DIRTY_COLOR%}$(git_prompt_status) %{$reset_color%}%{$PROMPT_PROMPT%}ᐅ %{$reset_color%} '
+PROMPT='%{$ROOT_ICON_COLOR%}$ROOT_ICON%{$reset_color%}%{$MACHINE_NAME_COLOR%}%m ➜ %{$reset_color%}%{$PROMPT_SUCCESS_COLOR%}%c%{$reset_color%} %{$GIT_PROMPT_INFO%}$(git_prompt_info)%{$GIT_DIRTY_COLOR%}$(git_prompt_status) %{$reset_color%}%{$PROMPT_PROMPT%}ᐅ %{$reset_color%} '
 
 #RPS1="${return_code}"
 


### PR DESCRIPTION
Add a space before ➜ and remove additional space after that

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- There was a space missing before `➜` and additional space after that. Updated it to add a space before the icon and remove the additional space.

## Other comments:

...
