### PR TITLE
Removed unhelpful debug mode

### DIFF
--- a/plugins/wd/wd.sh
+++ b/plugins/wd/wd.sh
@@ -90,7 +90,6 @@ Commands:
     clean                Remove points warping to nonexistent directories (will prompt unless --force is used)
 
     -v | --version  Print version
-    -d | --debug    Exit after execution with exit codes (for testing)
     -c | --config   Specify config file (default ~/.warprc)
     -q | --quiet    Suppress all output
     -f | --force    Allows overwriting without warning (for add & clean)
@@ -436,7 +435,6 @@ zparseopts -D -E \
     c:=wd_alt_config -config:=wd_alt_config \
     q=wd_quiet_mode -quiet=wd_quiet_mode \
     v=wd_print_version -version=wd_print_version \
-    d=wd_debug_mode -debug=wd_debug_mode \
     f=wd_force_mode -force=wd_force_mode
 
 if [[ ! -z $wd_print_version ]]
@@ -583,9 +581,4 @@ unset args
 unset points
 unset val &> /dev/null # fixes issue #1
 
-if [[ -n $wd_debug_mode ]]
-then
-    exit $WD_EXIT_CODE
-else
-    unset wd_debug_mode
-fi
+return $WD_EXIT_CODE


### PR DESCRIPTION

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The return value of the 'wd' command is always '0' by default so it cannot be processed by another program.
The return value is given as degguage mode associated with an exit which does not allow it to be used with '$?'.

- Removed debug mode
- Returns a relevant value to the shell


## Example:

Before the change:
![image](https://github.com/user-attachments/assets/ff25c7b2-0640-4cea-b8fc-665682b05d1e)


Now with this PR:
![image](https://github.com/user-attachments/assets/8746da3a-43b1-4241-92ec-161f61934a10)


