### PR TITLE
feat(sdkman): add basic initialization for sdkman

### DIFF
--- a/plugins/sdkman/README.md
+++ b/plugins/sdkman/README.md
@@ -1,0 +1,14 @@
+# sdkman
+
+Plugin for SDKMAN, a tool for managing parallel versions of multiple Software Development Kits on most Unix based systems.
+Provides initialization for different scenarios where users may have installed.
+
+To use it, add `sdkman` to your plugins array in your zshrc file:
+
+```zsh
+plugins=(... sdkman)
+```
+
+## Requirements
+
+* [SDKMAN](http://sdkman.io/)

--- a/plugins/sdkman/sdkman.plugin.zsh
+++ b/plugins/sdkman/sdkman.plugin.zsh
@@ -1,0 +1,8 @@
+if [[ -z "$SDKMAN_DIR" ]]; then
+  if [[ -d "$HOME/.sdkman" ]]; then
+    export SDKMAN_DIR="$HOME/.sdkman"
+  else
+    export SDKMAN_DIR="$(brew --prefix sdkman-cli)/libexec" || echo "Cannot find SDKMAN!"
+  fi
+fi
+[[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]] && source "${SDKMAN_DIR}/bin/sdkman-init.sh"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Address Issue #12222 to provide basic initialization for `sdkman`.

## Other comments:

The [previous sdk plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/sdk) has not been updated in 4 years and does not work with current versions of sdkman. Activating with sdkman's new init provides autocomplete already, so I thought it best to go with a new plugin with a more descriptive name.
