### PR TITLE
feat(toolbox): add function to show toolbox name

### DIFF
--- a/plugins/toolbox/README.md
+++ b/plugins/toolbox/README.md
@@ -10,7 +10,8 @@ plugins=(... toolbox)
 
 ## Prompt function
 
-This plugins adds `toolbox_prompt_info()` function. Using it in your prompt, it will show the toolbox indicator ⬢ (if you are running in a toolbox container), and nothing if not.
+This plugins adds `toolbox_prompt_info()` function. Using it in your prompt, it will show the toolbox
+indicator ⬢ (if you are running in a toolbox container), and nothing if not.
 
 You can use it by adding `$(toolbox_prompt_info)` to your `PROMPT` or `RPROMPT` variable:
 
@@ -18,9 +19,11 @@ You can use it by adding `$(toolbox_prompt_info)` to your `PROMPT` or `RPROMPT` 
 RPROMPT='$(toolbox_prompt_info)'
 ```
 
+In the same way, it adds `toolbox_prompt_name()`, showing the name of the containerized environment.
+
 ## Aliases
 
-| Alias | Command              | Description                            |
-|-------|----------------------|----------------------------------------|
-| tbe   | `toolbox enter`      | Enters the toolbox environment         |
-| tbr   | `toolbox run`        | Run a command in an existing toolbox   |
+| Alias | Command         | Description                          |
+| ----- | --------------- | ------------------------------------ |
+| tbe   | `toolbox enter` | Enters the toolbox environment       |
+| tbr   | `toolbox run`   | Run a command in an existing toolbox |

--- a/plugins/toolbox/toolbox.plugin.zsh
+++ b/plugins/toolbox/toolbox.plugin.zsh
@@ -3,8 +3,7 @@ function toolbox_prompt_info() {
 }
 
 function toolbox_prompt_name() {
-  [[ -f /run/.containerenv ]] &&
-    echo $(cat /run/.containerenv | awk -F\" '/name/ { print$2 }')
+  [[ -f /run/.containerenv ]] && cat /run/.containerenv | awk -F\" '/name/ { print$2 }'
 }
 
 alias tbe="toolbox enter"

--- a/plugins/toolbox/toolbox.plugin.zsh
+++ b/plugins/toolbox/toolbox.plugin.zsh
@@ -2,5 +2,10 @@ function toolbox_prompt_info() {
   [[ -f /run/.toolboxenv ]] && echo "⬢"
 }
 
+function toolbox_prompt_name() {
+  [[ -f /run/.containerenv ]] &&
+    echo $(cat /run/.containerenv | awk -F\" '/name/ { print$2 }')
+}
+
 alias tbe="toolbox enter"
 alias tbr="toolbox run"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

This allows the use of `$(toolbox_prompt_name)` function in order to display the toolbox name in prompt as such:

```
~ > toolbox enter fedora-40
fedora-40 ~ > exit
~ > toolbox enter xelatex
xelatex ~ >
```

