### PR TITLE
Add .dotnet tools to PATH

### DIFF
--- a/plugins/dotnet/dotnet.plugin.zsh
+++ b/plugins/dotnet/dotnet.plugin.zsh
@@ -1,4 +1,7 @@
-# This scripts is copied from (MIT License):
+# Enable usage of global dotnet tools.
+export PATH="$PATH:$HOME/.dotnet/tools/"
+
+# This script is copied from (MIT License):
 # https://raw.githubusercontent.com/dotnet/sdk/main/scripts/register-completions.zsh
 
 #compdef dotnet


### PR DESCRIPTION
When using `dotnet` with installed global tools this enables users to use any installed tools (`dotnet-trace` for instance) without having to manage the PATH.

I don't have time/energy/interest in altering my commits to meet the commit style. Consider this a "fancy" Issue. If someone wants to pull it in correctly: be my guest.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds dotnet tools to the path. That's it.

## Other comments:

There _MAY_ be a `DOTNET_DIR` we could use instead? I don't know. But I *do* know that this works.
