### PR TITLE
fix(catimg): add support to `magick` binary

### DIFF
--- a/plugins/catimg/README.md
+++ b/plugins/catimg/README.md
@@ -1,6 +1,7 @@
 # catimg
 
-Plugin for displaying images on the terminal using the `catimg.sh` script provided by [posva](https://github.com/posva/catimg)
+Plugin for displaying images on the terminal using the `catimg.sh` script provided by
+[posva](https://github.com/posva/catimg)
 
 To use it, add `catimg` to the plugins array in your zshrc file:
 
@@ -10,7 +11,7 @@ plugins=(... catimg)
 
 ## Requirements
 
-- `convert` (ImageMagick)
+- `magick convert` (ImageMagick)
 
 ## Functions
 

--- a/plugins/catimg/catimg.plugin.zsh
+++ b/plugins/catimg/catimg.plugin.zsh
@@ -9,9 +9,11 @@
 
 
 function catimg() {
-  if [[ -x  `which convert` ]]; then
-    zsh $ZSH/plugins/catimg/catimg.sh $@
+  if (( $+commands[magick] )); then
+    CONVERT_CMD="magick" zsh $ZSH/plugins/catimg/catimg.sh $@
+  elif (( $+commands[convert] )); then
+    CONVERT_CMD="convert" zsh $ZSH/plugins/catimg/catimg.sh $@
   else
-    echo "catimg need convert (ImageMagick) to work)"
+    echo "catimg need magick/convert (ImageMagick) to work)"
   fi
 }

--- a/plugins/catimg/catimg.sh
+++ b/plugins/catimg/catimg.sh
@@ -43,23 +43,23 @@ if [ ! "$WIDTH" ]; then
 else
   COLS=$(expr $WIDTH "/" $(echo -n "$CHAR" | wc -c))
 fi
-WIDTH=$(convert "$IMG" -print "%w\n" /dev/null)
+WIDTH=$(magick "$IMG" -print "%w\n" /dev/null)
 if [ "$WIDTH" -gt "$COLS" ]; then
   WIDTH=$COLS
 fi
 
 REMAP=""
-if convert "$IMG" -resize $COLS\> +dither -remap $COLOR_FILE /dev/null ; then
+if magick "$IMG" -resize $COLS\> +dither -remap $COLOR_FILE /dev/null ; then
   REMAP="-remap $COLOR_FILE"
 else
   echo "The version of convert is too old, don't expect good results :(" >&2
-  #convert "$IMG" -colors 256 PNG8:tmp.png
+  #magick "$IMG" -colors 256 PNG8:tmp.png
   #IMG="tmp.png"
 fi
 
 # Display the image
 I=0
-convert "$IMG" -resize $COLS\> +dither `echo $REMAP` txt:- 2>/dev/null |
+magick "$IMG" -resize $COLS\> +dither `echo $REMAP` txt:- 2>/dev/null |
 sed -e 's/.*none.*/NO NO NO/g' -e '1d;s/^.*(\(.*\)[,)].*$/\1/g;y/,/ /' |
 while read R G B f; do
   if [ ! "$R" = "NO" ]; then

--- a/plugins/catimg/catimg.sh
+++ b/plugins/catimg/catimg.sh
@@ -7,6 +7,10 @@
 # GitHub: https://github.com/posva/catimg                                      #
 ################################################################################
 
+# this should come from outside, either `magick` or `convert`
+# from imagemagick v7 and ahead `convert` is deprecated
+: ${CONVERT_CMD:=convert}
+
 function help() {
   echo "Usage catimg [-h] [-w width] [-c char] img"
   echo "By default char is \"  \" and w is the terminal width"
@@ -43,23 +47,23 @@ if [ ! "$WIDTH" ]; then
 else
   COLS=$(expr $WIDTH "/" $(echo -n "$CHAR" | wc -c))
 fi
-WIDTH=$(magick "$IMG" -print "%w\n" /dev/null)
+WIDTH=$($CONVERT_CMD "$IMG" -print "%w\n" /dev/null)
 if [ "$WIDTH" -gt "$COLS" ]; then
   WIDTH=$COLS
 fi
 
 REMAP=""
-if magick "$IMG" -resize $COLS\> +dither -remap $COLOR_FILE /dev/null ; then
+if $CONVERT_CMD "$IMG" -resize $COLS\> +dither -remap $COLOR_FILE /dev/null ; then
   REMAP="-remap $COLOR_FILE"
 else
   echo "The version of convert is too old, don't expect good results :(" >&2
-  #magick "$IMG" -colors 256 PNG8:tmp.png
-  #IMG="tmp.png"
+  # $CONVERT_CMD "$IMG" -colors 256 PNG8:tmp.png
+  # IMG="tmp.png"
 fi
 
 # Display the image
 I=0
-magick "$IMG" -resize $COLS\> +dither `echo $REMAP` txt:- 2>/dev/null |
+$CONVERT_CMD "$IMG" -resize $COLS\> +dither `echo $REMAP` txt:- 2>/dev/null |
 sed -e 's/.*none.*/NO NO NO/g' -e '1d;s/^.*(\(.*\)[,)].*$/\1/g;y/,/ /' |
 while read R G B f; do
   if [ ! "$R" = "NO" ]; then


### PR DESCRIPTION

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Change deprecated in imagemagick v7 convert command to magick

## Other comments:

https://github.com/ImageMagick/ImageMagick/commit/75a5c6d168379dd6e74f207468444cb2cff11720