### PR TITLE
feat(git-commit): Use git-dash commands

### DIFF
--- a/plugins/git-commit/README.md
+++ b/plugins/git-commit/README.md
@@ -1,7 +1,6 @@
 # git-commit plugin
 
-The git-commit plugin adds several
-[git aliases](https://www.git-scm.com/docs/git-config#Documentation/git-config.txt-alias) for
+The git-commit plugin adds several git subcommands for
 [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) messages.
 
 To use it, add `git-commit` to the plugins array in your zshrc file:
@@ -31,15 +30,13 @@ Where `type` is one of the following:
 - `test`
 - `wip`
 
-> NOTE: the alias for `revert` type is `rev`, as otherwise it conflicts with the git command of the same name.
-> It will still generate a commit message in the format `revert: <message>`
-
-> ⚠️ Enabling this plugin will (potentially) overwrite all `alias.<type>` that you manually set. Use with
-> care!
+> NOTE: the subcommand for `revert` type is `rev`, as otherwise it conflicts with the
+> git command of the same name. It will still generate a commit message in the format
+> `revert: <message>`
 
 ## Examples
 
-| Git alias                                     | Command                                              |
+| Git subcommand                                | Command                                              |
 | --------------------------------------------- | ---------------------------------------------------- |
 | `git style "remove trailing whitespace"`      | `git commit -m "style: remove trailing whitespace"`  |
 | `git wip "work in progress"`                  | `git commit -m "work in progress"`                   |

--- a/plugins/git-commit/git-commands/git-build
+++ b/plugins/git-commit/git-commands/git-build
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/git-chore
+++ b/plugins/git-commit/git-commands/git-chore
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/git-ci
+++ b/plugins/git-commit/git-commands/git-ci
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/git-docs
+++ b/plugins/git-commit/git-commands/git-docs
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/git-feat
+++ b/plugins/git-commit/git-commands/git-feat
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/git-fix
+++ b/plugins/git-commit/git-commands/git-fix
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/git-perf
+++ b/plugins/git-commit/git-commands/git-perf
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/git-refactor
+++ b/plugins/git-commit/git-commands/git-refactor
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/git-rev
+++ b/plugins/git-commit/git-commands/git-rev
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/git-style
+++ b/plugins/git-commit/git-commands/git-style
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/git-test
+++ b/plugins/git-commit/git-commands/git-test
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/git-wip
+++ b/plugins/git-commit/git-commands/git-wip
@@ -1,0 +1,1 @@
+./omz_git_commit

--- a/plugins/git-commit/git-commands/omz_git_commit
+++ b/plugins/git-commit/git-commands/omz_git_commit
@@ -1,0 +1,34 @@
+#!/usr/bin/env zsh
+
+_omz_git_commit() {
+  0=${(%):-%x}
+  if [[ "$0" != */git-* ]]; then
+    echo >&2 "Expecting command named git-foo. Got '$0'."
+    return 1
+  fi
+
+  local _type="${0##*/git-}"
+  local _scope _attention _message
+  while [ $# -ne 0 ]; do
+  case $1 in
+    -s | --scope )
+      if [ -z $2 ]; then
+        echo >&2 "Missing scope!"
+        return 1
+      fi
+      _scope="$2"
+      shift 2
+      ;;
+    -a | --attention )
+      _attention="!"
+      shift 1
+      ;;
+    * )
+      _message="${_message} $1"
+      shift 1
+      ;;
+  esac
+  done
+  git commit -m "${_type}${_scope:+(${_scope})}${_attention}:${_message}"
+}
+_omz_git_commit "$@"

--- a/plugins/git-commit/git-commit.plugin.zsh
+++ b/plugins/git-commit/git-commit.plugin.zsh
@@ -1,58 +1,46 @@
-local _rev="$(git -C $ZSH rev-parse HEAD 2> /dev/null)"
-if [[ $_rev == $(git config --global --get oh-my-zsh.git-commit-alias 2> /dev/null) ]]; then
-  return
-fi
-git config --global oh-my-zsh.git-commit-alias "$_rev"
+# Add git-commit commands directory to path
+path=("$ZSH/plugins/git-commit/git-commands" $path)
 
-local -a _git_commit_aliases
-_git_commit_aliases=(
-  'build'
-  'chore'
-  'ci'
-  'docs'
-  'feat'
-  'fix'
-  'perf'
-  'refactor'
-  'revert'
-  'style'
-  'test'
-  'wip'
-)
+# Append completions for custom git commands
+() {
+  local -a git_user_commands
+  zstyle -a ':completion:*:*:git:*' user-commands 'git_user_commands' \
+    || git_user_commands=()
+  git_user_commands+=(
+    build:'Commit with a message indicating a build' \
+    chore:'Commit with a message indicating a chore' \
+    ci:'Commit with a message indicating a CI change' \
+    docs:'Commit with a message indicating an update to the documentation' \
+    feat:'Commit with a message indicating a feature' \
+    fix:'Commit with a message indicating a fix' \
+    perf:'Commit with a message indicating a performance enhancement' \
+    refactor:'Commit with a message indicating a refactor' \
+    revert:'Commit with a message indicating a revert' \
+    style:'Commit with a message indicating a style change' \
+    test:'Commit with a message indicating updates to tests' \
+    wip:'Commit with a message indicating a work in progress'
+  )
+  zstyle ':completion:*:*:git:*' user-commands "${git_user_commands[@]}"
+}
 
-local _alias _type
-for _type in "${_git_commit_aliases[@]}"; do
-  # an alias can't be named "revert" because the git command takes precedence
-  # https://stackoverflow.com/a/3538791
-  case "$_type" in
-    revert) _alias=rev ;;
-    *) _alias=$_type ;;
-  esac
-
-  local _func='!a() {
-local _scope _attention _message
-while [ $# -ne 0 ]; do
-case $1 in
-  -s | --scope )
-    if [ -z $2 ]; then
-      echo "Missing scope!"
-      return 1
+########################################################################################
+### Remove below after Jan 2025:
+########################################################################################
+# Clean up aliases from the prior implementation of git-commit. Can be safely removed
+# once everyone's .gitconfig has been restored.
+() {
+  git config --global --get oh-my-zsh.git-commit-alias &> /dev/null || return
+  local -a old_git_aliases=(
+    'build'  'chore'     'ci'
+    'docs'   'feat'      'fix'
+    'perf'   'refactor'  'rev'
+    'style'  'test'      'wip'
+  )
+  local git_alias
+  for git_alias in $old_git_aliases; do
+    if [[ "$(git config --global --get alias.$git_alias | tr '\n' ' ')" == "!a() { local _scope _attention _message"* ]]; then
+      git config --global --unset alias.$git_alias
     fi
-    _scope="$2"
-    shift 2
-    ;;
-  -a | --attention )
-    _attention="!"
-    shift 1
-    ;;
-  * )
-    _message="${_message} $1"
-    shift 1
-    ;;
-esac
-done
-git commit -m "'$_type'${_scope:+(${_scope})}${_attention}:${_message}"
-}; a'
-
-  git config --global alias.$_alias "$_func"
-done
+  done
+  git config --global --unset oh-my-zsh.git-commit-alias
+}


### PR DESCRIPTION
Issue: ohmyzsh/ohmyzsh#12627

This commit refactors the prior implementation which used git aliases and modified .gitconfig. This implementation uses proper git-dash commands, which are all just symlinks to one handler - omz_git_commit.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

See #12627
