### PR TITLE
fix(scd): don't use hardcoded path to sort executable

### DIFF
--- a/plugins/scd/scd
+++ b/plugins/scd/scd
@@ -445,7 +445,7 @@ _scd_Y19oug_match() {
     # build a list of matching directories reverse-sorted by their probabilities
     dmatching=( ${(f)"$(
         builtin printf "%s %s\n" ${(Oakv)drank} |
-        /usr/bin/sort -grk1 )"}
+        sort -grk1 )"}
     )
     dmatching=( ${dmatching#*[[:blank:]]} )
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Replaces `/usr/bin/sort` with `sort`

## Other comments:

The scd plugin assumes the `sort` executable is available under `/usr/bin` which is not the case for every distribution (NixOS here)
