### PR TITLE
feat(extract): add support for .vsix files (VS Code extension)

### DIFF
--- a/plugins/extract/README.md
+++ b/plugins/extract/README.md
@@ -52,6 +52,7 @@ plugins=(... extract)
 | `tlz`             | Tarball with lzma compression        |
 | `txz`             | Tarball with lzma2 compression       |
 | `tzst`            | Tarball with zstd compression        |
+| `vsix`            | VS Code extension zip file           |
 | `war`             | Web Application archive (Java-based) |
 | `whl`             | Python wheel file                    |
 | `xpi`             | Mozilla XPI module file              |

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -76,7 +76,7 @@ EOF
       (*.lz4) lz4 -d "$full_path" ;;
       (*.lzma) unlzma "$full_path" ;;
       (*.z) uncompress "$full_path" ;;
-      (*.zip|*.war|*.jar|*.ear|*.sublime-package|*.ipa|*.ipsw|*.xpi|*.apk|*.aar|*.whl) unzip "$full_path" ;;
+      (*.zip|*.war|*.jar|*.ear|*.sublime-package|*.ipa|*.ipsw|*.xpi|*.apk|*.aar|*.whl|*.vsix) unzip "$full_path" ;;
       (*.rar) unrar x -ad "$full_path" ;;
       (*.rpm)
         rpm2cpio "$full_path" | cpio --quiet -id ;;


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Allows extracting `.vsix` files using `unzip`
