### PR TITLE
Fix some typos

### DIFF
--- a/plugins/bedtools/_bedtools
+++ b/plugins/bedtools/_bedtools
@@ -47,7 +47,7 @@ case $state in
         "random[Generate random intervals in a genome.]" \
         "reldist[Calculate the distribution of relative distances b/w two files.]" \
         "sample[Sample random records from file using reservoir sampling.]" \
-        "shuffle[Randomly redistrubute intervals in a genome.]" \
+        "shuffle[Randomly redistribute intervals in a genome.]" \
         "slop[Adjust the size of intervals.]" \
         "sort[Order the intervals in a file.]" \
         "subtract[Remove intervals based on overlaps b/w two files.]" \

--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -24,7 +24,7 @@ if (( ! $+commands[brew] )); then
 fi
 
 if [[ -z "$HOMEBREW_PREFIX" ]]; then
-  # Maintain compatability with potential custom user profiles, where we had
+  # Maintain compatibility with potential custom user profiles, where we had
   # previously relied on always sourcing shellenv. OMZ plugins should not rely
   # on this to be defined due to out of order processing.
   export HOMEBREW_PREFIX="$(brew --prefix)"

--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -39,7 +39,7 @@ if (( ! $+commands[docker] )); then
   return
 fi
 
-# Standarized $0 handling
+# Standardized $0 handling
 # https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
 0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
 0="${${(M)0:#/*}:-$PWD/$0}"

--- a/plugins/emoji/update_emoji.py
+++ b/plugins/emoji/update_emoji.py
@@ -1,6 +1,6 @@
 """
 Update Emoji.py
-Refeshes OMZ emoji database based on the latest Unicode spec
+Refreshes OMZ emoji database based on the latest Unicode spec
 """
 import re
 import json
@@ -95,7 +95,7 @@ def name_to_omz(_name, _group, _subgroup, _status):
         shortname = snake_case(_name)
     # Special treatment by status
     # Enables us to have every emoji combination,
-    # even the one that are not officially sanctionned
+    # even the one that are not officially sanctioned
     # and are implemented by, say, only one vendor
     if _status == "unqualified":
         shortname += "_unqualified"

--- a/plugins/gem/gem.plugin.zsh
+++ b/plugins/gem/gem.plugin.zsh
@@ -23,7 +23,7 @@ if is-at-least 5.5; then
 fi
 
 {
-  # Standarized $0 handling
+  # Standardized $0 handling
   # https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
   0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
   0="${${(M)0:#/*}:-$PWD/$0}"

--- a/plugins/history-substring-search/history-substring-search.zsh
+++ b/plugins/history-substring-search/history-substring-search.zsh
@@ -295,8 +295,8 @@ _history-substring-search-begin() {
     fi
 
     #
-    # Escape and join query parts with wildcard character '*' as seperator
-    # `(j:CHAR:)` join array to string with CHAR as seperator
+    # Escape and join query parts with wildcard character '*' as separator
+    # `(j:CHAR:)` join array to string with CHAR as separator
     #
     local search_pattern="${(j:*:)_history_substring_search_query_parts[@]//(#m)[\][()|\\*?#<>~^]/\\$MATCH}*"
 

--- a/plugins/hitchhiker/fortunes/hitchhiker
+++ b/plugins/hitchhiker/fortunes/hitchhiker
@@ -42,7 +42,7 @@
 
 - Zaphod.
 %
-"`In those days spirits were brave, the stakes were high, men were REAL men, women were REAL women, and small furry creatures from Alpha Centauri were REAL small furry creatures from Aplha Centauri.'"
+"`In those days spirits were brave, the stakes were high, men were REAL men, women were REAL women, and small furry creatures from Alpha Centauri were REAL small furry creatures from Alpha Centauri.'"
 
 - The Book getting all nostalgic.
 %

--- a/plugins/lpass/_lpass
+++ b/plugins/lpass/_lpass
@@ -78,7 +78,7 @@ _lpass() {
                 has_sync=1
             ;;
             status)
-               _arguments : '(-q --quiet)'{-q,--quiet}'[Supress output to stdout]'
+               _arguments : '(-q --quiet)'{-q,--quiet}'[Suppress output to stdout]'
                 has_color=1
             ;;
             sync)

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -74,7 +74,7 @@ function vrun() {
 }
 
 # Create a new virtual environment using the specified name.
-# If none specfied, use $PYTHON_VENV_NAME
+# If none specified, use $PYTHON_VENV_NAME
 function mkv() {
   local name="${1:-$PYTHON_VENV_NAME}"
   local venvpath="${name:P}"

--- a/plugins/rails/_rails
+++ b/plugins/rails/_rails
@@ -366,10 +366,10 @@ _rails_generate() {
           ;|
         (controller|job|model|resource|scaffold)
           opts+=(
-            '--parent=[The parent class for the generated controler]:parent class'
+            '--parent=[The parent class for the generated controller]:parent class'
           )
           ;|
-        (controler|mailer|resource|scaffold|scaffold_controller)
+        (controller|mailer|resource|scaffold|scaffold_controller)
           opts+=(
             '(-e --template-engine)'{-e,--template-engine=}'[Template engine to be invoked]:engine:(erb)'
           )

--- a/plugins/swiftpm/_swift
+++ b/plugins/swiftpm/_swift
@@ -634,7 +634,7 @@ _swift_package_unedit() {
     integer ret=1
     local -a args
     args+=(
-        '--force[Unedit the package even if it has uncommited and unpushed changes]'
+        '--force[Unedit the package even if it has uncommitted and unpushed changes]'
         ':package-name:'
         '--version[Show the version.]'
         '(-help -h --help)'{-help,-h,--help}'[Show help information.]'

--- a/plugins/zsh-navigation-tools/README.md
+++ b/plugins/zsh-navigation-tools/README.md
@@ -185,7 +185,7 @@ Result is stored as `$reply[REPLY]` (`$` isn't needed before `REPLY` because
 of arithmetic context inside `[]`). The returned array might be different from
 input arguments as `n-list` can process them via incremental search or uniq
 mode. `$REPLY` is the index in that possibly processed array. If `$REPLY`
-equals `-1` it means that no selection have been made (user quitted via `q`
+equals `-1` it means that no selection have been made (user quit via `q`
 key).
 
 To set up entries that can be jumped to with `[`,`]` keys add their indices to

--- a/plugins/zsh-navigation-tools/doc/n-preview
+++ b/plugins/zsh-navigation-tools/doc/n-preview
@@ -170,7 +170,7 @@ while (( 1 )); do
     elif [ -n "$keypad" ]; then
         final_key="$keypad"
     else
-        _vpreview_status_msg "Inproper input detected"
+        _vpreview_status_msg "Improper input detected"
         zcurses refresh status 
     fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Fix typos

## Other comments:

Used [CLI tool `typos`](https://github.com/crate-ci/typos) to find these - rejected some false positives.
