### PR TITLE
feat(extract): add support for `.crx` (Chrome extension format)

### DIFF
--- a/plugins/extract/_extract
+++ b/plugins/extract/_extract
@@ -1,7 +1,54 @@
 #compdef extract
 #autoload
 
+local -a exts=(
+  7z
+  aar
+  apk
+  bz2
+  cab
+  cpio
+  crx
+  deb
+  ear
+  gz
+  ipa
+  ipsw
+  jar
+  lrz
+  lz4
+  lzma
+  obscpio
+  rar
+  rpm
+  sublime-package
+  tar
+  tar.bz2
+  tar.gz
+  tar.lrz
+  tar.lz
+  tar.lz4
+  tar.xz
+  tar.zma
+  tar.zst
+  tbz
+  tbz2
+  tgz
+  tlz
+  txz
+  tzst
+  vsix
+  war
+  whl
+  xpi
+  xz
+  Z
+  zip
+  zpaq
+  zst
+)
+
 _arguments \
   '(-r --remove)'{-r,--remove}'[Remove archive.]' \
-  "*::archive file:_files -g '(#i)*.(7z|Z|apk|aar|bz2|cab|cpio|deb|ear|gz|ipa|ipsw|jar|lrz|lz4|lzma|obscpio|rar|rpm|sublime-package|tar|tar.bz2|tar.gz|tar.lrz|tar.lz|tar.lz4|tar.xz|tar.zma|tar.zst|tbz|tbz2|tgz|tlz|txz|tzst|war|whl|xpi|xz|zip|zst|zpaq)(-.)'" \
+  "*::archive file:_files -g '(#i)*.(${(j:|:)exts})(-.)'" \
     && return 0

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -76,7 +76,7 @@ EOF
       (*.lz4) lz4 -d "$full_path" ;;
       (*.lzma) unlzma "$full_path" ;;
       (*.z) uncompress "$full_path" ;;
-      (*.zip|*.war|*.jar|*.ear|*.sublime-package|*.ipa|*.ipsw|*.xpi|*.apk|*.aar|*.whl|*.vsix) unzip "$full_path" ;;
+      (*.zip|*.war|*.jar|*.ear|*.sublime-package|*.ipa|*.ipsw|*.xpi|*.apk|*.aar|*.whl|*.vsix|*.crx) unzip "$full_path" ;;
       (*.rar) unrar x -ad "$full_path" ;;
       (*.rpm)
         rpm2cpio "$full_path" | cpio --quiet -id ;;


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds support for extracting `.crx` files (Chrome extension format)
- Refactors `_extract` into an array of extensions for improved DX
