### PR TITLE
feat (terraform): add `apply -auto-approve` alias

### DIFF
--- a/plugins/terraform/README.md
+++ b/plugins/terraform/README.md
@@ -15,22 +15,23 @@ plugins=(... terraform)
 
 ## Aliases
 
-| Alias  | Command                    |
-|--------|----------------------------|
-| `tf`   | `terraform`                |
-| `tfa`  | `terraform apply`          |
-| `tfc`  | `terraform console`        |
-| `tfd`  | `terraform destroy`        |
-| `tff`  | `terraform fmt`            |
-| `tffr` | `terraform fmt -recursive` |
-| `tfi`  | `terraform init`           |
-| `tfiu` | `terraform init -upgrade`  |
-| `tfo`  | `terraform output`         |
-| `tfp`  | `terraform plan`           |
-| `tfv`  | `terraform validate`       |
-| `tfs`  | `terraform state`          |
-| `tft`  | `terraform test`           |
-| `tfsh` | `terraform show`           |
+| Alias   | Command                          |
+|---------|----------------------------------|
+| `tf`    | `terraform`                      |
+| `tfa`   | `terraform apply`                |
+| `tfaa`  | `terraform apply -auto-approve`  |
+| `tfc`   | `terraform console`              |
+| `tfd`   | `terraform destroy`              |
+| `tff`   | `terraform fmt`                  |
+| `tffr`  | `terraform fmt -recursive`       |
+| `tfi`   | `terraform init`                 |
+| `tfiu`  | `terraform init -upgrade`        |
+| `tfo`   | `terraform output`               |
+| `tfp`   | `terraform plan`                 |
+| `tfv`   | `terraform validate`             |
+| `tfs`   | `terraform state`                |
+| `tft`   | `terraform test`                 |
+| `tfsh`  | `terraform show`                 |
 
 
 ## Prompt function

--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -17,6 +17,7 @@ function tf_version_prompt_info() {
 
 alias tf='terraform'
 alias tfa='terraform apply'
+alias tfaa='terraform apply -auto-approve'
 alias tfc='terraform console'
 alias tfd='terraform destroy'
 alias tff='terraform fmt'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added alias `tfaa` for `terraform apply -auto-approve` in terraform plugin.
