### PR TITLE
feat(web-search): add chatgpt

### DIFF
--- a/plugins/web-search/README.md
+++ b/plugins/web-search/README.md
@@ -50,6 +50,7 @@ Available search contexts are:
 | `npmpkg`              | `https://www.npmjs.com/search?q=`               |
 | `packagist`           | `https://packagist.org/?query=`                 |
 | `gopkg`               | `https://pkg.go.dev/search?m=package&q=`        |
+| `chatgpt`             | `https://chat.openai.com?q=`                    |
 
 Also there are aliases for bang-searching DuckDuckGo:
 

--- a/plugins/web-search/README.md
+++ b/plugins/web-search/README.md
@@ -50,17 +50,17 @@ Available search contexts are:
 | `npmpkg`              | `https://www.npmjs.com/search?q=`               |
 | `packagist`           | `https://packagist.org/?query=`                 |
 | `gopkg`               | `https://pkg.go.dev/search?m=package&q=`        |
-| `chatgpt`             | `https://chat.openai.com?q=`                    |
+| `chatgpt`             | `https://chatgpt.com/?q=`                       |
 
 Also there are aliases for bang-searching DuckDuckGo:
 
-| Context   | Bang  |
-| --------- | ----- |
-| `wiki`    | `!w`  |
-| `news`    | `!n`  |
-| `map`     | `!m`  |
-| `image`   | `!i`  |
-| `ducky`   | `!`   |
+| Context | Bang |
+| ------- | ---- |
+| `wiki`  | `!w` |
+| `news`  | `!n` |
+| `map`   | `!m` |
+| `image` | `!i` |
+| `ducky` | `!`  |
 
 ### Custom search engines
 

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -31,7 +31,7 @@ function web_search() {
     npmpkg          "https://www.npmjs.com/search?q="
     packagist       "https://packagist.org/?query="
     gopkg           "https://pkg.go.dev/search?m=package&q="
-    chatgpt         "https://chat.openai.com?q="
+    chatgpt         "https://chatgpt.com/?q="
   )
 
   # check whether the search engine is supported

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -31,6 +31,7 @@ function web_search() {
     npmpkg          "https://www.npmjs.com/search?q="
     packagist       "https://packagist.org/?query="
     gopkg           "https://pkg.go.dev/search?m=package&q="
+    chatgpt         "https://chat.openai.com?q="
   )
 
   # check whether the search engine is supported
@@ -83,6 +84,7 @@ alias dockerhub='web_search dockerhub'
 alias npmpkg='web_search npmpkg'
 alias packagist='web_search packagist'
 alias gopkg='web_search gopkg'
+alias chatgpt='web_search chatgpt'
 
 #add your own !bang searches here
 alias wiki='web_search duckduckgo \!w'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add search with chatgpt --> "https://chat.openai.com?q=";
- Add new aliases in README.md ohmyzsh/plugins/web-search/README.md

## Other comments:

ChatGPT like LLMs are a great developer resource while building stuff and I've been using it since a long time to debug stuff, would be great to have an util in the CLI as well.

We can do other LLMs as well like perplexity but not sure if they support search through query. 

Also it'll work with `!!` operator to search about last query using chatgpt (which works for all the other alias as well)
...
