### PR TITLE
Add abbreviations to screen plugin

### DIFF
--- a/plugins/screen/README.md
+++ b/plugins/screen/README.md
@@ -8,3 +8,7 @@ To use it add `screen` to the plugins array in your zshrc file.
 ```zsh
 plugins=(... screen)
 ```
+# Plugin commands
+- `sls` runs `screen -ls` to list active screen sessions.
+- `sr` runs `screen -r` to reconnect to a detached session.
+- `ss <session_name>` runs `session -S <session_name>` to start a session.


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add abbreviations to `screen -ls`, `screen -r` and `screen -ls`.


