### PR TITLE
fix(git): update prefix map for modified files

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -227,7 +227,7 @@ function _omz_git_prompt_status() {
   prefix_constant_map=(
     '\?\? '     'UNTRACKED'
     'A  '       'ADDED'
-    'M  '       'ADDED'
+    'M  '       'MODIFIED'
     'MM '       'MODIFIED'
     ' M '       'MODIFIED'
     'AM '       'MODIFIED'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Files with short status `M` were incorrectly being considered as `ADDED` instead of `MODIFIED`. This updates the mapping to `MODIFIED`
