### PR TITLE
feat(bgnotify): add config to pass extra args

### DIFF
--- a/plugins/bgnotify/README.md
+++ b/plugins/bgnotify/README.md
@@ -38,6 +38,7 @@ One can configure a few things:
 - `bgnotify_bell` enabled or disables the terminal bell (default true)
 - `bgnotify_threshold` sets the notification threshold time (default 6 seconds)
 - `function bgnotify_formatted` lets you change the notification. You can for instance customize the message and pass in an icon.
+- `bgnotify_extraargs` appends extra args to notifier (e.g. `-e` for notify-send to create a transient notification)
 
 Use these by adding a function definition before the your call to source. Example:
 

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -117,15 +117,15 @@ function bgnotify {
   local icon="$3"
   if (( ${+commands[terminal-notifier]} )); then # macOS
     local term_id=$(bgnotify_programid)
-    terminal-notifier -message "$message" -title "$title" ${=icon:+-appIcon "$icon"} ${=term_id:+-activate "$term_id"} &>/dev/null
+    terminal-notifier -message "$message" -title "$title" ${=icon:+-appIcon "$icon"} ${=term_id:+-activate "$term_id"} ${=bgnotify_extraargs:-} &>/dev/null
   elif (( ${+commands[growlnotify]} )); then # macOS growl
-    growlnotify -m "$title" "$message"
+    growlnotify -m "$title" "$message" ${=bgnotify_extraargs:-}
   elif (( ${+commands[notify-send]} )); then
-    notify-send "$title" "$message" ${=icon:+--icon "$icon"}
+    notify-send "$title" "$message" ${=icon:+--icon "$icon"} ${=bgnotify_extraargs:-}
   elif (( ${+commands[kdialog]} )); then # KDE
-    kdialog --title "$title" --passivepopup  "$message" 5
+    kdialog --title "$title" --passivepopup  "$message" 5 ${=bgnotify_extraargs:-}
   elif (( ${+commands[notifu]} )); then # cygwin
-    notifu /m "$message" /p "$title" ${=icon:+/i "$icon"}
+    notifu /m "$message" /p "$title" ${=icon:+/i "$icon"} ${=bgnotify_extraargs:-}
   fi
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Add a new option `bgnotify_extraargs` for `bgnotify` to pass user defined args to notifier

It is useful for some notifier. e.g. `notify-send` will by default send a persistent notification keeping in notification bar. We can add an arg `-e` to `notify-send` so that the notification will be transient.

Other useful extra args for `notify-send` could be `--urgency` to specifies the urgency level

I believe in that it is also useful for other notifier than `notify-send`
