### PR TITLE
feat(kubectl) add aliases for certificate

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -129,6 +129,11 @@ plugins=(... kubectl)
 | kej      | `kubectl edit job`                                 | Edit a Job in details                                                                            |
 | kdj      | `kubectl describe job`                             | Describe the Job                                                                                 |
 | kdelj    | `kubectl delete job`                               | Delete the Job                                                                                   |
+|          |                                                    | **Certificate management**                                                                               |
+| kgcert   | `kubectl get certificate`                          | List Certificate in the namespace                                                          |
+| kgcerta  | `kubectl get certificate --all-namespaces`         | List Certificates in all namespaces                                                                            |
+| kdcert   | `kubectl describe certificate`                     | Describe the Certificate                                                                                 |
+| kdelcert | `kubectl delete certificate`                       | Delete the Certificate                                                                                   |
 
 ## Wrappers
 

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -178,6 +178,12 @@ alias kej='kubectl edit job'
 alias kdj='kubectl describe job'
 alias kdelj='kubectl delete job'
 
+# Certificate management.
+alias kgcert='kubectl get certificate'
+alias kgcerta='kubectl get certificate --all-namespaces'
+alias kdcert='kubectl describe certificate'
+alias kdelcert='kubectl delete certificate'
+
 # Utility print functions (json / yaml)
 function _build_kubectl_out_alias {
   setopt localoptions norcexpandparam


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x] The PR title is descriptive.
- [ x] The PR doesn't replicate another PR which is already open.
- [ x] I have read the contribution guide and followed all the instructions.
- [ x] The code follows the code style guide detailed in the wiki.
- [ x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x] The code is stable and I have tested it myself, to the best of my abilities.
- [ x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Recently I have had the need to interact with certificates that are being setup as part of deployment. 

Added aliases to run the following commands
- `kubectl get certificate`
- `kubectl get certificate --all-namespaces`
- `kubectl describe certificate`
- `kubectl delete certificate`   

## Other comments:

...
