### PR TITLE
feat(kubectl): add alias for unset current-context

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -20,6 +20,7 @@ plugins=(... kubectl)
 |          |                                                    | **Manage configuration quickly to switch contexts between local, dev and staging**               |
 | kcuc     | `kubectl config use-context`                       | Set the current-context in a kubeconfig file                                                     |
 | kcsc     | `kubectl config set-context`                       | Set a context entry in kubeconfig                                                                |
+| kucc     | `kubectl config unset current-context`             | Unset the current-context in a kubeconfig file                                                   |
 | kcdc     | `kubectl config delete-context`                    | Delete the specified context from the kubeconfig                                                 |
 | kccc     | `kubectl config current-context`                   | Display the current-context                                                                      |
 | kcgc     | `kubectl config get-contexts`                      | List of contexts available                                                                       |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -29,6 +29,7 @@ alias kcuc='kubectl config use-context'
 alias kcsc='kubectl config set-context'
 alias kcdc='kubectl config delete-context'
 alias kccc='kubectl config current-context'
+alias kucc='kubectl config unset current-context'
 
 # List all contexts
 alias kcgc='kubectl config get-contexts'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Introducing a new kubectl alias `kucc` to unset current-context 
- Adding documentation to the plugin readme 
 
`kubectl config unset current-context`

## Other comments:

...
