### PR TITLE
feat(grep): exclude Python virtualenv from `grep`

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -10,7 +10,7 @@ else
     }
 
     # Ignore these folders (if the necessary grep flags are available)
-    EXC_FOLDERS="{.bzr,CVS,.git,.hg,.svn,.idea,.tox,.venv}"
+    EXC_FOLDERS="{.bzr,CVS,.git,.hg,.svn,.idea,.tox,.venv,venv}"
 
     # Check for --exclude-dir, otherwise check for --exclude. If --exclude
     # isn't available, --color won't be either (they were released at the same


### PR DESCRIPTION
The convention to use `.venv/` directories for Python virtualenv's are widespreasd. This directory is huge and gives very little value when grepping in a source code directory.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- exclude Python virtualenv (.venv) dir from the grep alias

## Other comments:

nope
