### PR TITLE
feat(kubectl) add general aliases 

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -26,6 +26,9 @@ plugins=(... kubectl)
 |          |                                                    | **General aliases**                                                                              |
 | kdel     | `kubectl delete`                                   | Delete resources by filenames, stdin, resources and names, or by resources and label selector    |
 | kdelf    | `kubectl delete -f`                                | Delete a pod using the type and name specified in -f argument                                    |
+| kg       | `kubectl get`                                      | Display one or many resources                                                                    |
+| ke       | `kubectl edit`                                     | Edit a resource on the server                                                                    |
+| kd       | `kubectl describe`                                 | Show details of a specific resource or group of resources                                        |
 |          |                                                    | **Pod management**                                                                               |
 | kgp      | `kubectl get pods`                                 | List all pods in ps output format                                                                |
 | kgpl     | `kgp -l`                                           | Get pods by label. Example: `kgpl "app=myapp" -n myns`                                           |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -36,6 +36,9 @@ alias kcgc='kubectl config get-contexts'
 # General aliases
 alias kdel='kubectl delete'
 alias kdelf='kubectl delete -f'
+alias kg='kubectl get'
+alias ke='kubectl edit'
+alias kd='kubectl descirbe'
 
 # Pod management.
 alias kgp='kubectl get pods'

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -38,7 +38,7 @@ alias kdel='kubectl delete'
 alias kdelf='kubectl delete -f'
 alias kg='kubectl get'
 alias ke='kubectl edit'
-alias kd='kubectl descirbe'
+alias kd='kubectl describe'
 
 # Pod management.
 alias kgp='kubectl get pods'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
Aliases for general kubectl usage, `get/edit/describe`

Added aliases to run the following commands
```
kubectl get      -> kg
kubectl edit     -> ke
kubectl describe -> kd
```

## Other comments:

...
