### PR TITLE
fix: Added support for `include` in config file to ssh plugin

### DIFF
--- a/plugins/ssh/ssh.plugin.zsh
+++ b/plugins/ssh/ssh.plugin.zsh
@@ -4,16 +4,52 @@
 # Filter out wildcard host sections.
 _ssh_configfile="$HOME/.ssh/config"
 if [[ -f "$_ssh_configfile" ]]; then
-  _ssh_hosts=($(
-    egrep '^Host.*' "$_ssh_configfile" |\
-    awk '{for (i=2; i<=NF; i++) print $i}' |\
-    sort |\
-    uniq |\
-    grep -v '^*' |\
-    sed -e 's/\.*\*$//'
-  ))
-  zstyle ':completion:*:hosts' hosts $_ssh_hosts
+
+  parse_ssh_config() {
+    local config_file="$1"
+
+    if [[ -f "$config_file" ]]; then
+      # Extract all "Host" entries
+      local hosts=($(
+       egrep -i '^Host.*' "$config_file" |\
+        awk '{for (i=2; i<=NF; i++) print $i}' |\
+        sort |\
+        uniq |\
+        grep -v '^*' |\
+        sed -e 's/\.*\*$//'
+              ))
+
+    # Add hosts to the global array
+    _ssh_hosts+=("${hosts[@]}")
+
+    # Handle Include directives by reading the files they reference
+    local includes=($(egrep '^Include ' "$config_file" | awk '{print $2}'))
+
+    # Loop through each included file or pattern
+    for include in "${includes[@]}"; do
+
+      # Resolve relative paths and handle wildcards
+      for file in $(eval echo $include); do
+        parse_ssh_config "$file"
+      done
+    done
+    fi
+  }
+
+
+  _ssh_hosts=()
+  # Start parsing from the main SSH config file
+  _ssh_configfile="$HOME/.ssh/config"
+  parse_ssh_config "$_ssh_configfile"
+  _final_hosts=($(sort <<< "${_ssh_hosts[@]}" |\
+        uniq |\
+        grep -v '^*' |\
+        sed -e 's/\.*\*$//'
+          ))
+
+  zstyle ':completion:*:hosts' hosts $_final_hosts
   unset _ssh_hosts
+  unset _final_hosts
 fi
 unset _ssh_configfile
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added a recursive function to resolve `Include` statements in ssh config files

## Other comments:

...
