### PR TITLE
feat(chezmoi): add completion plugin

### DIFF
--- a/plugins/chezmoi/README.md
+++ b/plugins/chezmoi/README.md
@@ -1,0 +1,11 @@
+# chezmoi Plugin
+
+## Introduction
+
+This `chezmoi` plugin sets up completion for [chezmoi](https://chezmoi.io).
+
+To use it, add `chezmoi` to the plugins array of your zshrc file:
+
+```bash
+plugins=(... chezmoi)
+```

--- a/plugins/chezmoi/chezmoi.plugin.zsh
+++ b/plugins/chezmoi/chezmoi.plugin.zsh
@@ -1,0 +1,14 @@
+# COMPLETION FUNCTION
+if (( ! $+commands[chezmoi] )); then
+  return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `chezmoi`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_chezmoi" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _chezmoi
+  _comps[chezmoi]=_chezmoi
+fi
+
+chezmoi completion zsh >| "$ZSH_CACHE_DIR/completions/_chezmoi" &|


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add plugin for `chezmoi` which adds autocomplete.

## Other comments:

- No aliases added, this is handled in #12241.
- This implements/supersedes #8852.
