### PR TITLE
feat(systemadmin): add `ping6` alias with count limit

### DIFF
--- a/plugins/systemadmin/README.md
+++ b/plugins/systemadmin/README.md
@@ -13,6 +13,7 @@ plugins=(... systemadmin)
 | Alias   | Command                                                                    | Description                                                        |
 |---------|----------------------------------------------------------------------------|--------------------------------------------------------------------|
 | ping    | `ping -c 5`                                                                | Sends only 5 ICMP Messages                                         |
+| ping6   | `ping6 -c 5`                                                               | Sends only 5 ICMPv6 Messages                                       |
 | clr     | `clear; echo Currently logged in on $TTY, as $USERNAME in directory $PWD.` | Clears the screen and prints the current user, TTY, and directory  |
 | path    | `print -l $path`                                                           | Displays PATH with each entry on a separate line                   |
 | mkdir   | `mkdir -pv`                                                                | Automatically create parent directories and display verbose output |

--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -21,6 +21,7 @@ function retlog() {
 }
 
 alias ping='ping -c 5'
+alias ping6='ping6 -c 5'
 alias clr='clear; echo Currently logged in on $TTY, as $USERNAME in directory $PWD.'
 alias path='print -l $path'
 alias mkdir='mkdir -pv'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- feat(systemadmin): Add alias for `ping6` adding a count limit

## Other comments:

- Reason for new alias: `ping` already has the limit set, ipv6 becomes more and more widespread, hence `ping6` should receive the same treatment.
- Can't reopen #4997 so this is the new one.
