### PR TITLE
Add uv plugin

### DIFF
--- a/plugins/uv/README.md
+++ b/plugins/uv/README.md
@@ -1,6 +1,6 @@
-# uv Plugin
+# uv plugin
 
-This plugin automatically installs [uv](https://github.com/astral-sh/uv)'s completions for you, and keeps them up to date.
+This plugin automatically installs [uv](https://github.com/astral-sh/uv)'s completions for you, and keeps them up to date. It also adds convenient aliases for common usage.
 
 To use it, add `uv` to the plugins array in your zshrc file:
 

--- a/plugins/uv/README.md
+++ b/plugins/uv/README.md
@@ -1,0 +1,28 @@
+# uv Plugin
+
+This plugin automatically installs [uv](https://github.com/astral-sh/uv)'s completions for you, and keeps them up to date.
+
+To use it, add `uv` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... uv)
+```
+
+## Aliases
+
+| Alias | Command                                                                 | Description                                                          |
+|:----- |------------------------------------------------------------------------ |:-------------------------------------------------------------------- |
+| uva   | `uv add`                                                                | Add packages to the project                                          |
+| uvexp | `uv export --format requirements-txt --no-hashes --output-file requirements.txt --quiet` | Export the lock file to `requirements.txt`          |
+| uvl   | `uv lock`                                                               | Lock the dependencies                                                |
+| uvlr  | `uv lock --refresh`                                                     | Rebuild the lock file without upgrading dependencies                 |
+| uvlu  | `uv lock --upgrade`                                                     | Lock the dependencies to the newest compatible versions              |
+| uvp   | `uv pip`                                                                | Manage pip packages                                                  |
+| uvpy  | `uv python`                                                             | Manage Python installs                                               |
+| uvr   | `uv run`                                                                | Run commands within the project's environment                        |
+| uvrm  | `uv remove`                                                             | Remove packages from the project                                     |
+| uvs   | `uv sync`                                                               | Sync the environment with the lock file                              |
+| uvsr  | `uv sync --refresh`                                                     | "Force" sync the environment with the lock file (ignore cache)       |
+| uvsu  | `uv sync --upgrade`                                                     | Sync the environment, allowing upgrades and ignoring the lock file   |
+| uvup  | `uv self update`                                                        | Update the UV tool to the latest version                             |
+| uvv   | `uv venv`                                                               | Manage virtual environments                                          |

--- a/plugins/uv/uv.plugin.zsh
+++ b/plugins/uv/uv.plugin.zsh
@@ -1,0 +1,38 @@
+# Return immediately if uv is not found
+if (( ! ${+commands[uv]} )); then
+  return
+fi
+
+alias uva='uv add'
+alias uvexp='uv export --format requirements-txt --no-hashes --output-file requirements.txt --quiet'
+alias uvl='uv lock'
+alias uvlr='uv lock --refresh'
+alias uvlu='uv lock --upgrade'
+alias uvp='uv pip'
+alias uvpy='uv python'
+alias uvr='uv run'
+alias uvrm='uv remove'
+alias uvs='uv sync'
+alias uvsr='uv sync --refresh'
+alias uvsu='uv sync --upgrade'
+alias uvup='uv self update'
+alias uvv='uv venv'
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_uv" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _uv
+  _comps[uv]=_uv
+fi
+
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_uvx" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _uvx
+  _comps[uvx]=_uvx
+fi
+
+# uv and uvx are installed together (uvx is an alias to `uv tool run`)  
+# Overwrites the file each time as completions might change with uv versions.
+uv generate-shell-completion zsh >| "$ZSH_CACHE_DIR/completions/_uv" &|
+uvx --generate-shell-completion zsh >| "$ZSH_CACHE_DIR/completions/_uvx" &|


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add the `uv.plugin.zsh` file with the plugin for [`uv`](https://github.com/astral-sh/uv), a Python package manager (and more) akin to `poetry`.

## Other comments:

- Aliases I added are based on the usual workflow with Python package managers, so it's fairly standard I'd say. Only debatable ones are `uvlu` and `uvlr`, which are (commonly used for me) variants of `uvl` (and same for `uvs`, `uvsu` and `uvsr`).
- I don't know how to properly split an `alias` into a multiline string to follow the 80 character limit. I didn't check the _code follows the code style guide_ entry because of this.
