### PR TITLE
fix(fastfile): substituted non-standard 'default' command for zsh parameter expansion

### DIFF
--- a/plugins/fastfile/fastfile.plugin.zsh
+++ b/plugins/fastfile/fastfile.plugin.zsh
@@ -5,8 +5,8 @@
 # If they are not set yet, they will be
 # overwritten with their default values
 
-default fastfile_dir        "${HOME}/.fastfile"
-default fastfile_var_prefix "§"
+fastfile_dir="${fastfile_dir:-${HOME}/.fastfile}"
+fastfile_var_prefix="${fastfile_var_prefix:-§}"
 
 ###########################
 # Impl


### PR DESCRIPTION
'default' is not a standard command in zsh causing this plug-in to break in vanilla zsh. By substituting 'default' for zsh's built-in parameter expansion we are able to assign default values to unset variables while remaining compatible with vanilla zsh. Without this change, user's configs are liable to break.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- FIX: Two 'command not found' that broke the plug-in in vanilla zsh environments.
- REFACTOR: Replaced external command invocations with built-in zsh parameter expansions.

## Other comments:

...
