### PR TITLE
fix: changed minimal theme to use the default git prompt

### DIFF
--- a/themes/minimal.zsh-theme
+++ b/themes/minimal.zsh-theme
@@ -19,7 +19,7 @@ vcs_status() {
   elif (( ${+functions[in_hg]} )) && in_hg; then
     hg_prompt_info
   else
-    git_prompt_info
+    _omz_git_prompt_info
   fi
 }
 


### PR DESCRIPTION
# Context
I made this change locally and it fix the git prompt for me. I noticed that there are many other themes using the `git_prompt_info` function so probably my approach isn't the correct way to fix the root cause of the issue but I'm willing to make the proper change if I get some guidance.

# Changes
- Use the default git prompt function in the minimal theme.