### PR TITLE
feat(opentofu): add `apply -auto-approve` alias

### DIFF
--- a/plugins/opentofu/README.md
+++ b/plugins/opentofu/README.md
@@ -15,23 +15,24 @@ plugins=(... opentofu)
 
 ## Aliases
 
-| Alias  | Command               |
-|--------|-----------------------|
-| `tt`   | `tofu`                |
-| `tta`  | `tofu apply`          |
-| `ttc`  | `tofu console`        |
-| `ttd`  | `tofu destroy`        |
-| `ttf`  | `tofu fmt`            |
-| `ttfr` | `tofu fmt -recursive` |
-| `tti`  | `tofu init`           |
-| `tto`  | `tofu output`         |
-| `ttp`  | `tofu plan`           |
-| `ttv`  | `tofu validate`       |
-| `tts`  | `tofu state`          |
-| `ttsh` | `tofu show`           |
-| `ttr`  | `tofu refresh`        |
-| `ttt`  | `tofu test`           |
-| `ttws` | `tofu workspace`      |
+| Alias  | Command                      |
+|--------|------------------------------|
+| `tt`   | `tofu`                       |
+| `tta`  | `tofu apply`                 |
+| `ttaa` | `tofu apply -auto-approve`   |
+| `ttc`  | `tofu console`               |
+| `ttd`  | `tofu destroy`               |
+| `ttf`  | `tofu fmt`                   |
+| `ttfr` | `tofu fmt -recursive`        |
+| `tti`  | `tofu init`                  |
+| `tto`  | `tofu output`                |
+| `ttp`  | `tofu plan`                  |
+| `ttv`  | `tofu validate`              |
+| `tts`  | `tofu state`                 |
+| `ttsh` | `tofu show`                  |
+| `ttr`  | `tofu refresh`               |
+| `ttt`  | `tofu test`                  |
+| `ttws` | `tofu workspace`             |
 
 
 ## Prompt functions

--- a/plugins/opentofu/opentofu.plugin.zsh
+++ b/plugins/opentofu/opentofu.plugin.zsh
@@ -29,6 +29,7 @@ function tofu_version_prompt_info() {
 
 alias tt='tofu'
 alias tta='tofu apply'
+alias ttaa='tofu apply -auto-approve'
 alias ttc='tofu console'
 alias ttd='tofu destroy'
 alias ttf='tofu fmt'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added `apply -auto-approve` alias on opentofu.

## Other comments:

Similar commit on terraform https://github.com/ohmyzsh/ohmyzsh/commit/865291cb7af2fef7e67128fd4294f3ffa9b08c3d
