### PR TITLE
Add VirtualBox plugin providing status prompt and aliases

### DIFF
--- a/plugins/virtualbox/README.md
+++ b/plugins/virtualbox/README.md
@@ -1,0 +1,81 @@
+# VirtualBox plugin
+
+The `virtualbox` plugin provides many useful aliases for VirtualBox.
+
+To use it, add `virtualbox` to the plugins array of your `.zshrc` file:
+
+```zsh
+plugins=(... virtualbox)
+```
+
+## Aliases
+
+| Alias                  | Command                               | Description                                                        |
+|:-----------------------|:--------------------------------------|:-------------------------------------------------------------------|
+| `vbox-start`           | `VBoxManage startvm`                  | Start a virtual machine                                            |
+| `vbox-start-headless`  | `VBoxManage startvm --type=headless`  | Start a virtual machine (headless mode)                            |
+| `vbox-clone`           | `VBoxManage clonevm --register`       | Clone and register a virtual machine                               |
+| `vbox-create`          | `VBoxManage createvm --register`      | Create and register a new virtual machine                          |
+| `vbox-create-medium`   | `VBoxManage createmedium`             | Create a new medium                                                |
+| `vbox-delete`          | `VBoxManage unregistervm --delete`    | Unregister and delete a virtual machine                            |
+| `vbox-control`         | `VBoxManage controlvm`                | Control a virtual machine                                          |
+| `vbox-info`            | `VBoxManage showvminfo`               | Show information about a virtual machine                           |
+| `vbox-list`            | `VBoxManage list`                     | List system information and configuration                          |
+| `vbox-poweroff`        | `VBoxManage controlvm "$1" poweroff`  | Forcibly power off a virtual machine                               |
+| `vbox-shutdown`        | `VBoxManage controlvm "$1" shutdown`  | Gracefully shutdown a virtual machine                              |
+| `vbox-stop`            | `aliased to vbox-shutdown`            | -                                                                  |
+| `vbox-pause`           | `VBoxManage controlvm "$1" pause`     | Pause execution of a virtual machine                               |
+| `vbox-resume`          | `VBoxManage controlvm "$1" resume`    | Resume execution of a virtual machine                              |
+| `vbox-save`            | `VBoxManage controlvm "$1" savestate` | Save current state of a virtual machine                            |
+| `vbox-discard`         | `VBoxManage discardstate`             | Discard saved state of a virtual machine                           |
+| `vbox-reboot`          | `VBoxManage controlvm "$1" reboot`    | Reboot a virtual machine                                           |
+| `vbox-reset`           | `VBoxManage controlvm "$1" reset`     | Reset a virtual machine                                            |
+
+The prefix for the aliases can be customised by setting `ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX` (default: `vbox`).
+
+## Status prompt
+
+Add `$(virtualbox_prompt_info [vm_name] ...)` to your prompt to show the status
+of all specified virtual machines.
+
+The plugin will add the following to your prompt for each `$vm_name`.
+
+```text
+<prefix><vm_name>:<running|notrunning><suffix>
+```
+
+You can control these parts with the following variables:
+
+- `<prefix>`: Set `$ZSH_THEME_VIRTUALBOX_PROMPT_PREFIX`.
+
+- `<suffix>`: Set `$ZSH_THEME_VIRTUALBOX_PROMPT_SUFFIX`.
+
+- `<vm_name>`: name passed as parameter to the function. If you want it to be in ALL CAPS,
+  you can set the variable `$ZSH_THEME_VIRTUALBOX_PROMPT_CAPS` to a non-empty string.
+
+- `<running>`: shown if the virtual machine is running.
+  Set `$ZSH_THEME_VIRTUALBOX_PROMPT_RUNNING`.
+
+- `<notrunning>`: shown if the virtual machine is *not* running.
+  Set `$ZSH_THEME_VIRTUALBOX_PROMPT_NOTRUNNING`.
+
+You can set `ZSH_THEME_VIRTUALBOX_PROMPT_COUNT` to a non-empty string to show a
+count of running virtual machines / total.
+
+For example, if your prompt contains `PROMPT='$(virtualbox_prompt_info "Arch Linux" "Debian")'`
+and you set the following variables:
+
+```sh
+ZSH_THEME_VIRTUALBOX_PROMPT_COUNT="true"
+ZSH_THEME_VIRTUALBOX_PROMPT_PREFIX="["
+ZSH_THEME_VIRTUALBOX_PROMPT_SUFFIX="]"
+ZSH_THEME_VIRTUALBOX_PROMPT_RUNNING="+"
+ZSH_THEME_VIRTUALBOX_PROMPT_NOTRUNNING="X"
+ZSH_THEME_VIRTUALBOX_PROMPT_CAPS="true"
+```
+
+If `Arch Linux` is running, and `Debian` is not, then your prompt will look like this:
+
+```text
+[1 / 2][ARCH LINUX: +][DEBIAN: X]
+```

--- a/plugins/virtualbox/virtualbox.plugin.zsh
+++ b/plugins/virtualbox/virtualbox.plugin.zsh
@@ -1,0 +1,85 @@
+# VirtualBox aliases
+
+ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX="${ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX:-vbox}"
+
+# VBoxManage
+declare -A manage_commands=(
+  ["start"]="startvm"
+  ["start-headless"]="startvm --type=headless"
+  ["clone"]="clonevm --register"
+  ["create"]="createvm --register"
+  ["create-medium"]="createmedium"
+  ["discard"]="discardstate"
+  ["delete"]="unregistervm --delete"
+  ["control"]="controlvm"
+  ["info"]="showvminfo"
+  ["list"]="list"
+)
+
+for c in "${(k)manage_commands[@]}"; do
+  alias "${ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX}-${c}"="VBoxManage ${manage_commands[${c}]}"
+done
+
+unset c manage_commands
+
+# Functions
+function ${ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX}-poweroff() {
+  VBoxManage controlvm "$1" poweroff
+}
+
+function ${ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX}-shutdown() {
+  VBoxManage controlvm "$1" shutdown
+}
+
+function ${ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX}-pause() {
+  VBoxManage controlvm "$1" pause
+}
+
+function ${ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX}-resume() {
+  VBoxManage controlvm "$1" resume
+}
+
+function ${ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX}-save() {
+  VBoxManage controlvm "$1" savestate
+}
+
+function ${ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX}-reboot() {
+  VBoxManage controlvm "$1" reboot
+}
+
+function ${ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX}-reset() {
+  VBoxManage controlvm "$1" reset
+}
+
+alias "${ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX}-stop"="${ZSH_PLUGIN_VIRTUALBOX_ALIAS_PREFIX}-shutdown"
+
+# VirtualBox prompt
+function virtualbox_prompt_info() {
+  if [[ -n "${ZSH_THEME_VIRTUALBOX_PROMPT_COUNT}" ]]; then
+    local vm_count="$(VBoxManage list runningvms | wc -l)"
+    local vm_total="$(VBoxManage list vms | wc -l)"
+
+    echo -n "${ZSH_THEME_VIRTUALBOX_PROMPT_PREFIX}"
+    echo -n "${vm_count} / ${vm_total}"
+    echo -n "${ZSH_THEME_VIRTUALBOX_PROMPT_SUFFIX}"
+  fi
+
+  local vm_name
+  for vm_name in "$@"; do
+    echo -n "${ZSH_THEME_VIRTUALBOX_PROMPT_PREFIX}"
+
+    if [[ -n "${ZSH_THEME_VIRTUALBOX_PROMPT_CAPS}" ]]; then
+      echo -n "${(U)vm_name:gs/%/%%}:"
+    else
+      echo -n "${vm_name:gs/%/%%}:"
+    fi
+
+    if VBoxManage list runningvms | grep -w "\"${vm_name}\"" &>/dev/null; then
+      echo -n "${ZSH_THEME_VIRTUALBOX_PROMPT_RUNNING}"
+    else
+      echo -n "${ZSH_THEME_VIRTUALBOX_PROMPT_NOTRUNNING}"
+    fi
+
+    echo -n "${ZSH_THEME_VIRTUALBOX_PROMPT_SUFFIX}"
+  done
+}


### PR DESCRIPTION
## Standards checklist:

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add new plugin `virtualbox.plugin.zsh` to provide a status prompt and aliases for frequently used commands to manage a [VirtualBox](https://www.virtualbox.org) instance.

## Other comments:

Additional aliases assist with frequent administration and management of virtual machines, allowing actions such as starting, creating or deleting a virtual machine to be much simpler.

For example: `vbox-poweroff "Arch Linux"` => `VBoxManage controlvm "Arch Linux" poweroff`

Additionally, a configurable status prompt `virtualbox_prompt_info` can be used to monitor the health of all and/or individual virtual machines.