### PR TITLE
fix(theme-chooser): use `env` in shebang

### DIFF
--- a/tools/theme_chooser.sh
+++ b/tools/theme_chooser.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Zsh Theme Chooser by fox (fox91 at anche dot no)
 # This program is free software. It comes without any warranty, to


### PR DESCRIPTION
When the zsh shell is installed at a non-default location like  `~/.nix-profile/bin/zsh` for installation via nix. I was getting

```console
zsh: ./.oh-my-zsh/tools/theme_chooser.sh: bad interpreter: /bin/zsh: no such file or directory
```

This change fixes that issue.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Replaces the shebang to make it more portable

```suggestion
- #!/bin/zsh
+ #!/usr/bin/env zsh
```
