### PR TITLE
fix(tailscale): load completion when `tailscale` is an alias

### DIFF
--- a/plugins/tailscale/tailscale.plugin.zsh
+++ b/plugins/tailscale/tailscale.plugin.zsh
@@ -1,4 +1,4 @@
-if (( ! $+commands[tailscale] )); then
+if (( ! ($+commands[tailscale] || $+aliases[tailscale]) )); then
   return
 fi
 
@@ -8,6 +8,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_tailscale" ]]; then
   typeset -g -A _comps
   autoload -Uz _tailscale
   _comps[tailscale]=_tailscale
+  if (( $+aliases[tailscale] )); then
+    # `basename "$(alias tailscale | sed "s/.*=\(.*\)/\1/")"` should output executable name
+    compdef "$(basename "$(alias tailscale | sed "s/.*=\(.*\)/\1/")")"="tailscale"
+  fi
 fi
 
 tailscale completion zsh >| "$ZSH_CACHE_DIR/completions/_tailscale" &|

--- a/plugins/tailscale/tailscale.plugin.zsh
+++ b/plugins/tailscale/tailscale.plugin.zsh
@@ -1,4 +1,4 @@
-if (( ! ($+commands[tailscale] || $+aliases[tailscale]) )); then
+if (( ! $+commands[tailscale] && ! $+aliases[tailscale] )); then
   return
 fi
 
@@ -7,10 +7,11 @@ fi
 if [[ ! -f "$ZSH_CACHE_DIR/completions/_tailscale" ]]; then
   typeset -g -A _comps
   autoload -Uz _tailscale
-  _comps[tailscale]=_tailscale
-  if (( $+aliases[tailscale] )); then
-    # `basename "$(alias tailscale | sed "s/.*=\(.*\)/\1/")"` should output executable name
-    compdef "$(basename "$(alias tailscale | sed "s/.*=\(.*\)/\1/")")"="tailscale"
+
+  if (( $+commands[tailscale] )); then
+    _comps[tailscale]=_tailscale
+  elif (( $+aliases[tailscale] )); then
+    _comps[${aliases[tailscale]:t}]=_tailscale
   fi
 fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- only changes on tailscale plugin, no new aliases introduced.

## Other comments:

according to https://tailscale.com/kb/1080/cli?tab=macos, if a user is using App Store version of tailscale, it would be an alias tailscale="/Applications/Tailscale.app/Contents/MacOS/Tailscale". Current tailscale plugin does not work in that case.

cc @lukeab 