### PR TITLE
Typo and defaults fix README.md

### DIFF
--- a/plugins/alias-finder/README.md
+++ b/plugins/alias-finder/README.md
@@ -15,9 +15,9 @@ To enable it for every single command, set zstyle in your `~/.zshrc`.
 # ~/.zshrc
 
 zstyle ':omz:plugins:alias-finder' autoload yes # disabled by default
-zstyle ':omz:plugins:alias-finder' longer yes # disabled by default
-zstyle ':omz:plugins:alias-finder' exact yes # disabled by default
-zstyle ':omz:plugins:alias-finder' cheaper yes # disabled by default
+zstyle ':omz:plugins:alias-finder' longer yes # enabled by default
+zstyle ':omz:plugins:alias-finder' exact yes # enabled by default
+zstyle ':omz:plugins:alias-finder' cheaper yes # enabled by default
 ```
 
 As you can see, options are also available with zstyle.
@@ -63,6 +63,6 @@ Running the shortest `gs` shell alias that it found:
 
 - Use `--longer` or `-l` to include aliases where the source is longer than the input (in other words, the source could contain the whole input).
 - Use `--exact` or `-e` to avoid aliases where the source is shorter than the input (in other words, the source must be the same with the input).
-- Use `--cheaper` or `-c` to avoid aliases where the destination is longer than the input (in other words, the destination must be the shorter than the input).
+- Use `--cheaper` or `-c` to avoid aliases where the destination is longer than the input (in other words, the destination must be shorter than the input).
 
 


### PR DESCRIPTION
Defaults stated in the docs seem to be incorrect: 

https://github.com/ohmyzsh/ohmyzsh/blob/62cf1201b031399e7251abeee859e895ee825a48/plugins/alias-finder/alias-finder.plugin.zsh#L17-L19

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
