### PR TITLE
feat(git): add escape hatch to enable async prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Twitter), and join us on [Discord](https://discord.gg/ohmyzsh).
   - [Custom Plugins And Themes](#custom-plugins-and-themes)
   - [Enable GNU ls In macOS And freeBSD Systems](#enable-gnu-ls-in-macos-and-freebsd-systems)
   - [Skip Aliases](#skip-aliases)
-  - [Disable async git prompt](#disable-async-git-prompt)
+  - [Async git prompt](#async-git-prompt)
 - [Getting Updates](#getting-updates)
   - [Updates Verbosity](#updates-verbosity)
   - [Manual Updates](#manual-updates)
@@ -415,7 +415,7 @@ zstyle ':omz:lib:directories' aliases no
 > It is also not currently aware of "aliases" that are defined as functions. Example of such are `gccd`,
 > `ggf`, or `ggl` functions from the git plugin.
 
-### Disable async git prompt
+### Async git prompt
 
 Async prompt functions are an experimental feature (included on April 3, 2024) that allows Oh My Zsh to render
 prompt information asynchronously. This can improve prompt rendering performance, but it might not work well
@@ -424,6 +424,14 @@ turn it off by setting the following in your .zshrc file, before Oh My Zsh is so
 
 ```sh
 zstyle ':omz:alpha:lib:git' async-prompt no
+```
+
+If your problem is that the git prompt just stopped appearing, you can try to force it setting the following
+configuration before `oh-my-zsh.sh` is sourced. If it still does not work, please open an issue with your
+case.
+
+```sh
+zstyle ':omz:alpha:lib:git' async-prompt force
 ```
 
 ## Getting Updates

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 <p align="center"><img src="https://ohmyzsh.s3.amazonaws.com/omz-ansi-github.png" alt="Oh My Zsh"></p>
 
-Oh My Zsh is an open source, community-driven framework for managing your [zsh](https://www.zsh.org/) configuration.
+Oh My Zsh is an open source, community-driven framework for managing your [zsh](https://www.zsh.org/)
+configuration.
 
 Sounds boring. Let's try again.
 
 **Oh My Zsh will not make you a 10x developer...but you may feel like one.**
 
-Once installed, your terminal shell will become the talk of the town _or your money back!_ With each keystroke in your command prompt, you'll take advantage of the hundreds of powerful plugins and beautiful themes. Strangers will come up to you in cafés and ask you, _"that is amazing! are you some sort of genius?"_
+Once installed, your terminal shell will become the talk of the town _or your money back!_ With each keystroke
+in your command prompt, you'll take advantage of the hundreds of powerful plugins and beautiful themes.
+Strangers will come up to you in cafés and ask you, _"that is amazing! are you some sort of genius?"_
 
-Finally, you'll begin to get the sort of attention that you have always felt you deserved. ...or maybe you'll use the time that you're saving to start flossing more often. 😬
+Finally, you'll begin to get the sort of attention that you have always felt you deserved. ...or maybe you'll
+use the time that you're saving to start flossing more often. 😬
 
-To learn more, visit [ohmyz.sh](https://ohmyz.sh), follow [@ohmyzsh](https://x.com/ohmyzsh) on X (formerly Twitter), and join us on [Discord](https://discord.gg/ohmyzsh).
+To learn more, visit [ohmyz.sh](https://ohmyz.sh), follow [@ohmyzsh](https://x.com/ohmyzsh) on X (formerly
+Twitter), and join us on [Discord](https://discord.gg/ohmyzsh).
 
 [![CI](https://github.com/ohmyzsh/ohmyzsh/workflows/CI/badge.svg)](https://github.com/ohmyzsh/ohmyzsh/actions?query=workflow%3ACI)
 [![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/ohmyzsh?label=%40ohmyzsh&logo=x&style=flat)](https://twitter.com/intent/follow?screen_name=ohmyzsh)
@@ -62,26 +67,28 @@ To learn more, visit [ohmyz.sh](https://ohmyz.sh), follow [@ohmyzsh](https://x.c
 
 ### Operating System Compatibility
 
-| O/S            | Status  |
-| :------------- | :-----: |
-| Android        |   ✅    |
-| freeBSD        |   ✅    |
-| LCARS          |   🛸    |
-| Linux          |   ✅    |
-| macOS          |   ✅    |
-| OS/2 Warp      |   ❌    |
-| Windows (WSL2) |   ✅    |
-
+| O/S            | Status |
+| :------------- | :----: |
+| Android        |   ✅   |
+| freeBSD        |   ✅   |
+| LCARS          |   🛸   |
+| Linux          |   ✅   |
+| macOS          |   ✅   |
+| OS/2 Warp      |   ❌   |
+| Windows (WSL2) |   ✅   |
 
 ### Prerequisites
 
-- [Zsh](https://www.zsh.org) should be installed (v4.3.9 or more recent is fine but we prefer 5.0.8 and newer). If not pre-installed (run `zsh --version` to confirm), check the following wiki instructions here: [Installing ZSH](https://github.com/ohmyzsh/ohmyzsh/wiki/Installing-ZSH)
+- [Zsh](https://www.zsh.org) should be installed (v4.3.9 or more recent is fine but we prefer 5.0.8 and
+  newer). If not pre-installed (run `zsh --version` to confirm), check the following wiki instructions here:
+  [Installing ZSH](https://github.com/ohmyzsh/ohmyzsh/wiki/Installing-ZSH)
 - `curl` or `wget` should be installed
 - `git` should be installed (recommended v2.4.11 or higher)
 
 ### Basic Installation
 
-Oh My Zsh is installed by running one of the following commands in your terminal. You can install this via the command-line with either `curl`, `wget` or another similar tool.
+Oh My Zsh is installed by running one of the following commands in your terminal. You can install this via the
+command-line with either `curl`, `wget` or another similar tool.
 
 | Method    | Command                                                                                           |
 | :-------- | :------------------------------------------------------------------------------------------------ |
@@ -89,38 +96,44 @@ Oh My Zsh is installed by running one of the following commands in your terminal
 | **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"`   |
 | **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"` |
 
-Alternatively, the installer is also mirrored outside GitHub. Using this URL instead may be required if you're in a country like China or India (for certain ISPs), that blocks `raw.githubusercontent.com`:
+Alternatively, the installer is also mirrored outside GitHub. Using this URL instead may be required if you're
+in a country like China or India (for certain ISPs), that blocks `raw.githubusercontent.com`:
 
-| Method    | Command                                                                                           |
-| :-------- | :------------------------------------------------------------------------------------------------ |
-| **curl**  | `sh -c "$(curl -fsSL https://install.ohmyz.sh/)"`                                                 |
-| **wget**  | `sh -c "$(wget -O- https://install.ohmyz.sh/)"`                                                   |
-| **fetch** | `sh -c "$(fetch -o - https://install.ohmyz.sh/)"`                                                 |
+| Method    | Command                                           |
+| :-------- | :------------------------------------------------ |
+| **curl**  | `sh -c "$(curl -fsSL https://install.ohmyz.sh/)"` |
+| **wget**  | `sh -c "$(wget -O- https://install.ohmyz.sh/)"`   |
+| **fetch** | `sh -c "$(fetch -o - https://install.ohmyz.sh/)"` |
 
-_Note that any previous `.zshrc` will be renamed to `.zshrc.pre-oh-my-zsh`. After installation, you can move the configuration you want to preserve into the new `.zshrc`._
+_Note that any previous `.zshrc` will be renamed to `.zshrc.pre-oh-my-zsh`. After installation, you can move
+the configuration you want to preserve into the new `.zshrc`._
 
 #### Manual Inspection
 
-It's a good idea to inspect the install script from projects you don't yet know. You can do
-that by downloading the install script first, looking through it so everything looks normal,
-then running it:
+It's a good idea to inspect the install script from projects you don't yet know. You can do that by
+downloading the install script first, looking through it so everything looks normal, then running it:
 
 ```sh
 wget https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh
 sh install.sh
 ```
 
-If the above URL times out or otherwise fails, you may have to substitute the URL for `https://install.ohmyz.sh` to be able to get the script.
+If the above URL times out or otherwise fails, you may have to substitute the URL for
+`https://install.ohmyz.sh` to be able to get the script.
 
 ## Using Oh My Zsh
 
 ### Plugins
 
-Oh My Zsh comes with a shitload of plugins for you to take advantage of. You can take a look in the [plugins](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins) directory and/or the [wiki](https://github.com/ohmyzsh/ohmyzsh/wiki/Plugins) to see what's currently available.
+Oh My Zsh comes with a shitload of plugins for you to take advantage of. You can take a look in the
+[plugins](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins) directory and/or the
+[wiki](https://github.com/ohmyzsh/ohmyzsh/wiki/Plugins) to see what's currently available.
 
 #### Enabling Plugins
 
-Once you spot a plugin (or several) that you'd like to use with Oh My Zsh, you'll need to enable them in the `.zshrc` file. You'll find the zshrc file in your `$HOME` directory. Open it with your favorite text editor and you'll see a spot to list all the plugins you want to load.
+Once you spot a plugin (or several) that you'd like to use with Oh My Zsh, you'll need to enable them in the
+`.zshrc` file. You'll find the zshrc file in your `$HOME` directory. Open it with your favorite text editor
+and you'll see a spot to list all the plugins you want to load.
 
 ```sh
 vi ~/.zshrc
@@ -140,21 +153,28 @@ plugins=(
 )
 ```
 
-_Note that the plugins are separated by whitespace (spaces, tabs, new lines...). **Do not** use commas between them or it will break._
+_Note that the plugins are separated by whitespace (spaces, tabs, new lines...). **Do not** use commas between
+them or it will break._
 
 #### Using Plugins
 
-Each built-in plugin includes a **README**, documenting it. This README should show the aliases (if the plugin adds any) and extra goodies that are included in that particular plugin.
+Each built-in plugin includes a **README**, documenting it. This README should show the aliases (if the plugin
+adds any) and extra goodies that are included in that particular plugin.
 
 ### Themes
 
-We'll admit it. Early in the Oh My Zsh world, we may have gotten a bit too theme happy. We have over one hundred and fifty themes now bundled. Most of them have [screenshots](https://github.com/ohmyzsh/ohmyzsh/wiki/Themes) on the wiki (We are working on updating this!). Check them out!
+We'll admit it. Early in the Oh My Zsh world, we may have gotten a bit too theme happy. We have over one
+hundred and fifty themes now bundled. Most of them have
+[screenshots](https://github.com/ohmyzsh/ohmyzsh/wiki/Themes) on the wiki (We are working on updating this!).
+Check them out!
 
 #### Selecting A Theme
 
-_Robby's theme is the default one. It's not the fanciest one. It's not the simplest one. It's just the right one (for him)._
+_Robby's theme is the default one. It's not the fanciest one. It's not the simplest one. It's just the right
+one (for him)._
 
-Once you find a theme that you'd like to use, you will need to edit the `~/.zshrc` file. You'll see an environment variable (all caps) in there that looks like:
+Once you find a theme that you'd like to use, you will need to edit the `~/.zshrc` file. You'll see an
+environment variable (all caps) in there that looks like:
 
 ```sh
 ZSH_THEME="robbyrussell"
@@ -167,23 +187,32 @@ ZSH_THEME="agnoster" # (this is one of the fancy ones)
 # see https://github.com/ohmyzsh/ohmyzsh/wiki/Themes#agnoster
 ```
 
+<!-- prettier-ignore-start -->
 > [!NOTE]
 > You will many times see screenshots for a zsh theme, and try it out, and find that it doesn't look the same for you.
-> 
-> This is because many themes require installing a [Powerline Font](https://github.com/powerline/fonts) or a [Nerd Font](https://github.com/ryanoasis/nerd-fonts) in order to render properly.
-> Without them, these themes will render weird prompt symbols. Check out [the FAQ](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ#i-have-a-weird-character-in-my-prompt) for more information.
+<!-- prettier-ignore-end -->
+
+> This is because many themes require installing a [Powerline Font](https://github.com/powerline/fonts) or a
+> [Nerd Font](https://github.com/ryanoasis/nerd-fonts) in order to render properly. Without them, these themes
+> will render weird prompt symbols. Check out
+> [the FAQ](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ#i-have-a-weird-character-in-my-prompt) for more
+> information.
 >
-> Also, beware that themes only control what your prompt looks like. This is, the text you see before or after your cursor, where you'll type your commands.
-> Themes don't control things such as the colors of your terminal window (known as _color scheme_) or the font of your terminal. These are settings that you can change in your terminal emulator.
-> For more information, see [what is a zsh theme](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ#what-is-a-zsh-theme).
+> Also, beware that themes only control what your prompt looks like. This is, the text you see before or after
+> your cursor, where you'll type your commands. Themes don't control things such as the colors of your
+> terminal window (known as _color scheme_) or the font of your terminal. These are settings that you can
+> change in your terminal emulator. For more information, see
+> [what is a zsh theme](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ#what-is-a-zsh-theme).
 
 Open up a new terminal window and your prompt should look something like this:
 
 ![Agnoster theme](https://cloud.githubusercontent.com/assets/2618447/6316862/70f58fb6-ba03-11e4-82c9-c083bf9a6574.png)
 
-In case you did not find a suitable theme for your needs, please have a look at the wiki for [more of them](https://github.com/ohmyzsh/ohmyzsh/wiki/External-themes).
+In case you did not find a suitable theme for your needs, please have a look at the wiki for
+[more of them](https://github.com/ohmyzsh/ohmyzsh/wiki/External-themes).
 
-If you're feeling feisty, you can let the computer select one randomly for you each time you open a new terminal window.
+If you're feeling feisty, you can let the computer select one randomly for you each time you open a new
+terminal window.
 
 ```sh
 ZSH_THEME="random" # (...please let it be pie... please be some pie..)
@@ -206,7 +235,8 @@ ZSH_THEME_RANDOM_IGNORED=(pygmalion tjkirch_mod)
 
 ### FAQ
 
-If you have some more questions or issues, you might find a solution in our [FAQ](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ).
+If you have some more questions or issues, you might find a solution in our
+[FAQ](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ).
 
 ## Advanced Topics
 
@@ -214,16 +244,16 @@ If you're the type that likes to get their hands dirty, these sections might res
 
 ### Advanced Installation
 
-Some users may want to manually install Oh My Zsh, or change the default path or other settings that
-the installer accepts (these settings are also documented at the top of the install script).
+Some users may want to manually install Oh My Zsh, or change the default path or other settings that the
+installer accepts (these settings are also documented at the top of the install script).
 
 #### Custom Directory
 
-The default location is `~/.oh-my-zsh` (hidden in your home directory, you can access it with `cd ~/.oh-my-zsh`)
+The default location is `~/.oh-my-zsh` (hidden in your home directory, you can access it with
+`cd ~/.oh-my-zsh`)
 
 If you'd like to change the install directory with the `ZSH` environment variable, either by running
-`export ZSH=/your/path` before installing, or by setting it before the end of the install pipeline
-like this:
+`export ZSH=/your/path` before installing, or by setting it before the end of the install pipeline like this:
 
 ```sh
 ZSH="$HOME/.dotfiles/oh-my-zsh" sh install.sh
@@ -231,32 +261,33 @@ ZSH="$HOME/.dotfiles/oh-my-zsh" sh install.sh
 
 #### Unattended Install
 
-If you're running the Oh My Zsh install script as part of an automated install, you can pass the `--unattended`
-flag to the `install.sh` script. This will have the effect of not trying to change
-the default shell, and it also won't run `zsh` when the installation has finished.
+If you're running the Oh My Zsh install script as part of an automated install, you can pass the
+`--unattended` flag to the `install.sh` script. This will have the effect of not trying to change the default
+shell, and it also won't run `zsh` when the installation has finished.
 
 ```sh
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 ```
 
-If you're in China, India, or another country that blocks `raw.githubusercontent.com`, you may have to substitute the URL for `https://install.ohmyz.sh` for it to install.
+If you're in China, India, or another country that blocks `raw.githubusercontent.com`, you may have to
+substitute the URL for `https://install.ohmyz.sh` for it to install.
 
 #### Installing From A Forked Repository
 
 The install script also accepts these variables to allow the installation of a different repository:
 
-- `REPO` (default: `ohmyzsh/ohmyzsh`): this takes the form of `owner/repository`. If you set
-  this variable, the installer will look for a repository at `https://github.com/{owner}/{repository}`.
+- `REPO` (default: `ohmyzsh/ohmyzsh`): this takes the form of `owner/repository`. If you set this variable,
+  the installer will look for a repository at `https://github.com/{owner}/{repository}`.
 
-- `REMOTE` (default: `https://github.com/${REPO}.git`): this is the full URL of the git repository
-  clone. You can use this setting if you want to install from a fork that is not on GitHub (GitLab,
-  Bitbucket...) or if you want to clone with SSH instead of HTTPS (`git@github.com:user/project.git`).
+- `REMOTE` (default: `https://github.com/${REPO}.git`): this is the full URL of the git repository clone. You
+  can use this setting if you want to install from a fork that is not on GitHub (GitLab, Bitbucket...) or if
+  you want to clone with SSH instead of HTTPS (`git@github.com:user/project.git`).
 
   _NOTE: it's incompatible with setting the `REPO` variable. This setting will take precedence._
 
 - `BRANCH` (default: `master`): you can use this setting if you want to change the default branch to be
-  checked out when cloning the repository. This might be useful for testing a Pull Request, or if you
-  want to use a branch other than `master`.
+  checked out when cloning the repository. This might be useful for testing a Pull Request, or if you want to
+  use a branch other than `master`.
 
 For example:
 
@@ -302,16 +333,21 @@ Once you open up a new terminal window, it should load zsh with Oh My Zsh's conf
 
 If you have any hiccups installing, here are a few common fixes.
 
-- You _might_ need to modify your `PATH` in `~/.zshrc` if you're not able to find some commands after switching to `oh-my-zsh`.
-- If you installed manually or changed the install location, check the `ZSH` environment variable in `~/.zshrc`.
+- You _might_ need to modify your `PATH` in `~/.zshrc` if you're not able to find some commands after
+  switching to `oh-my-zsh`.
+- If you installed manually or changed the install location, check the `ZSH` environment variable in
+  `~/.zshrc`.
 
 ### Custom Plugins And Themes
 
-If you want to override any of the default behaviors, just add a new file (ending in `.zsh`) in the `custom/` directory.
+If you want to override any of the default behaviors, just add a new file (ending in `.zsh`) in the `custom/`
+directory.
 
-If you have many functions that go well together, you can put them as a `XYZ.plugin.zsh` file in the `custom/plugins/` directory and then enable this plugin.
+If you have many functions that go well together, you can put them as a `XYZ.plugin.zsh` file in the
+`custom/plugins/` directory and then enable this plugin.
 
-If you would like to override the functionality of a plugin distributed with Oh My Zsh, create a plugin of the same name in the `custom/plugins/` directory and it will be loaded instead of the one in `plugins/`.
+If you would like to override the functionality of a plugin distributed with Oh My Zsh, create a plugin of the
+same name in the `custom/plugins/` directory and it will be loaded instead of the one in `plugins/`.
 
 ### Enable GNU ls In macOS And freeBSD Systems
 
@@ -331,9 +367,9 @@ _Note: this is not compatible with `DISABLE_LS_COLORS=true`_
 
 <a name="remove-directories-aliases"></a>
 
-If you want to skip default Oh My Zsh aliases (those defined in `lib/*` files) or plugin aliases,
-you can use the settings below in your `~/.zshrc` file, **before Oh My Zsh is loaded**. Note that
-there are many different ways to skip aliases, depending on your needs.
+If you want to skip default Oh My Zsh aliases (those defined in `lib/*` files) or plugin aliases, you can use
+the settings below in your `~/.zshrc` file, **before Oh My Zsh is loaded**. Note that there are many different
+ways to skip aliases, depending on your needs.
 
 ```sh
 # Skip all aliases, in lib files and enabled plugins
@@ -372,19 +408,19 @@ zstyle ':omz:lib:directories' aliases no
 
 #### Notice <!-- omit in toc -->
 
-> This feature is currently in a testing phase and it may be subject to change in the future.
-> It is also not currently compatible with plugin managers such as zpm or zinit, which don't
-> source the init script (`oh-my-zsh.sh`) where this feature is implemented in.
+> This feature is currently in a testing phase and it may be subject to change in the future. It is also not
+> currently compatible with plugin managers such as zpm or zinit, which don't source the init script
+> (`oh-my-zsh.sh`) where this feature is implemented in.
 
-> It is also not currently aware of "aliases" that are defined as functions. Example of such
-> are `gccd`, `ggf`, or `ggl` functions from the git plugin.
+> It is also not currently aware of "aliases" that are defined as functions. Example of such are `gccd`,
+> `ggf`, or `ggl` functions from the git plugin.
 
 ### Disable async git prompt
 
-Async prompt functions are an experimental feature (included on April 3, 2024) that allows Oh My Zsh to render prompt information
-asynchronously. This can improve prompt rendering performance, but it might not work well with some setups. We hope that's not an
-issue, but if you're seeing problems with this new feature, you can turn it off by setting the following in your .zshrc file,
-before Oh My Zsh is sourced:
+Async prompt functions are an experimental feature (included on April 3, 2024) that allows Oh My Zsh to render
+prompt information asynchronously. This can improve prompt rendering performance, but it might not work well
+with some setups. We hope that's not an issue, but if you're seeing problems with this new feature, you can
+turn it off by setting the following in your .zshrc file, before Oh My Zsh is sourced:
 
 ```sh
 zstyle ':omz:alpha:lib:git' async-prompt no
@@ -392,7 +428,8 @@ zstyle ':omz:alpha:lib:git' async-prompt no
 
 ## Getting Updates
 
-By default, you will be prompted to check for updates every 2 weeks. You can choose other update modes by adding a line to your `~/.zshrc` file, **before Oh My Zsh is loaded**:
+By default, you will be prompted to check for updates every 2 weeks. You can choose other update modes by
+adding a line to your `~/.zshrc` file, **before Oh My Zsh is loaded**:
 
 1. Automatic update without confirmation prompt:
 
@@ -435,7 +472,8 @@ zstyle ':omz:update' verbose silent # only errors
 
 ### Manual Updates
 
-If you'd like to update at any point in time (maybe someone just released a new plugin and you don't want to wait a week?) you just need to run:
+If you'd like to update at any point in time (maybe someone just released a new plugin and you don't want to
+wait a week?) you just need to run:
 
 ```sh
 omz update
@@ -447,25 +485,31 @@ Magic! 🎉
 
 Oh My Zsh isn't for everyone. We'll miss you, but we want to make this an easy breakup.
 
-If you want to uninstall `oh-my-zsh`, just run `uninstall_oh_my_zsh` from the command-line. It will remove itself and revert your previous `bash` or `zsh` configuration.
+If you want to uninstall `oh-my-zsh`, just run `uninstall_oh_my_zsh` from the command-line. It will remove
+itself and revert your previous `bash` or `zsh` configuration.
 
 ## How Do I Contribute To Oh My Zsh?
 
 Before you participate in our delightful community, please read the [code of conduct](CODE_OF_CONDUCT.md).
 
-I'm far from being a [Zsh](https://www.zsh.org/) expert and suspect there are many ways to improve – if you have ideas on how to make the configuration easier to maintain (and faster), don't hesitate to fork and send pull requests!
+I'm far from being a [Zsh](https://www.zsh.org/) expert and suspect there are many ways to improve – if you
+have ideas on how to make the configuration easier to maintain (and faster), don't hesitate to fork and send
+pull requests!
 
-We also need people to test out pull requests. So take a look through [the open issues](https://github.com/ohmyzsh/ohmyzsh/issues) and help where you can.
+We also need people to test out pull requests. So take a look through
+[the open issues](https://github.com/ohmyzsh/ohmyzsh/issues) and help where you can.
 
 See [Contributing](CONTRIBUTING.md) for more details.
 
 ### Do Not Send Us Themes
 
-We have (more than) enough themes for the time being. Please add your theme to the [external themes](https://github.com/ohmyzsh/ohmyzsh/wiki/External-themes) wiki page.
+We have (more than) enough themes for the time being. Please add your theme to the
+[external themes](https://github.com/ohmyzsh/ohmyzsh/wiki/External-themes) wiki page.
 
 ## Contributors
 
-Oh My Zsh has a vibrant community of happy users and delightful contributors. Without all the time and help from our contributors, it wouldn't be so awesome.
+Oh My Zsh has a vibrant community of happy users and delightful contributors. Without all the time and help
+from our contributors, it wouldn't be so awesome.
 
 Thank you so much!
 
@@ -484,7 +528,9 @@ We're on social media:
 
 ## Merchandise
 
-We have [stickers, shirts, and coffee mugs available](https://shop.planetargon.com/collections/oh-my-zsh?utm_source=github) for you to show off your love of Oh My Zsh. Again, you will become the talk of the town!
+We have
+[stickers, shirts, and coffee mugs available](https://shop.planetargon.com/collections/oh-my-zsh?utm_source=github)
+for you to show off your love of Oh My Zsh. Again, you will become the talk of the town!
 
 ## License
 
@@ -494,4 +540,6 @@ Oh My Zsh is released under the [MIT license](LICENSE.txt).
 
 ![Planet Argon](https://pa-github-assets.s3.amazonaws.com/PARGON_logo_digital_COL-small.jpg)
 
-Oh My Zsh was started by the team at [Planet Argon](https://www.planetargon.com/?utm_source=github), a [Ruby on Rails development agency](https://www.planetargon.com/services/ruby-on-rails-development?utm_source=github). Check out our [other open source projects](https://www.planetargon.com/open-source?utm_source=github).
+Oh My Zsh was started by the team at [Planet Argon](https://www.planetargon.com/?utm_source=github), a
+[Ruby on Rails development agency](https://www.planetargon.com/services/ruby-on-rails-development?utm_source=github).
+Check out our [other open source projects](https://www.planetargon.com/open-source?utm_source=github).

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -44,6 +44,7 @@ function _omz_git_prompt_info() {
 # - https://github.com/ohmyzsh/ohmyzsh/issues/12331
 # - https://github.com/ohmyzsh/ohmyzsh/issues/12360
 # TODO(2024-06-12): @mcornella remove workaround when CentOS 7 reaches EOL
+local _style
 if zstyle -t ':omz:alpha:lib:git' async-prompt \
   || { is-at-least 5.0.6 && zstyle -T ':omz:alpha:lib:git' async-prompt }; then
   function git_prompt_info() {
@@ -81,6 +82,21 @@ if zstyle -t ':omz:alpha:lib:git' async-prompt \
   # Register the async handler first. This needs to be done before
   # the async request prompt is run
   precmd_functions=(_defer_async_git_register $precmd_functions)
+elif zstyle -s ':omz:alpha:lib:git' async-prompt _style && [[ $_style == "force" ]]; then
+  function git_prompt_info() {
+    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}" ]]; then
+      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}"
+    fi
+  }
+
+  function git_prompt_status() {
+    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}" ]]; then
+      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}"
+    fi
+  }
+
+  _omz_register_handler _omz_git_prompt_info
+  _omz_register_handler _omz_git_prompt_status
 else
   function git_prompt_info() {
     _omz_git_prompt_info


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

With this changes users can force the registration of async callbacks for git prompt, escaping from the requirement of having it in the theme.