### PR TITLE
fix(gem): regression with gem completion

### DIFF
--- a/plugins/gem/gem.plugin.zsh
+++ b/plugins/gem/gem.plugin.zsh
@@ -11,7 +11,7 @@ function gemy {
 if [[ ! -f "$ZSH_CACHE_DIR/completions/_gem" ]]; then
   typeset -g -A _comps
   autoload -Uz _gem
-  _comps[docker]=_gem
+  _comps[gem]=_gem
 fi
 
 # zsh 5.5 already provides completion for `_gem`. With this we ensure that


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

There was a typo setting completions for docker instead of gem. Fixing.
Closes #12725 