### PR TITLE
feat(ssh-agent): add keys regardless of filename

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -39,13 +39,16 @@ function _add_identities() {
     return
   fi
 
-  # add default keys if no identities were set up via zstyle
-  # this is to mimic the call to ssh-add with no identities
-  if [[ ${#identities} -eq 0 ]]; then
-    # key list found on `ssh-add` man page's DESCRIPTION section
-    for id in id_rsa id_dsa id_ecdsa id_ed25519 id_ed25519_sk identity; do
-      # check if file exists
-      [[ -f "$HOME/.ssh/$id" ]] && identities+=($id)
+  # If no keys specified in zstyle, add default keys.
+  # Mimics calling ssh-add with no arguments.
+  if [[ ${#identities[@]} -eq 0 ]]; then
+    # Iterate over files in .ssh folder.
+    for file in "$HOME/.ssh"/*; do
+      # Check if file is a regular file and starts with "-----BEGIN OPENSSH PRIVATE KEY-----".
+      if [[ -f "$file" && $(head -n 1 "$file") =~ ^-----BEGIN\ OPENSSH\ PRIVATE\ KEY----- ]]; then
+        # Add filename (without path) to identities array.
+        identities+=("${file##*/}")
+      fi
     done
   fi
 

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -45,7 +45,7 @@ function _add_identities() {
     # Iterate over files in .ssh folder.
     for file in "$HOME/.ssh"/*; do
       # Check if file is a regular file and starts with "-----BEGIN OPENSSH PRIVATE KEY-----".
-      if [[ -f "$file" && $(head -n 1 "$file") =~ ^-----BEGIN\ OPENSSH\ PRIVATE\ KEY----- ]]; then
+      if [[ -f "$file" && $(command head -n 1 "$file") =~ ^-----BEGIN\ OPENSSH\ PRIVATE\ KEY----- ]]; then
         # Add filename (without path) to identities array.
         identities+=("${file##*/}")
       fi


### PR DESCRIPTION
This pull request enhances the `ssh-agent` plugin to add all files in the user's `~/.ssh/` directory that start with `-----BEGIN OPENSSH PRIVATE KEY-----`, regardless of their filenames.

Previously, the plugin only added keys with hardcoded names (e.g., `id_rsa`, `id_dsa`). This change addresses the issue where users with custom key names were unable to automatically load their keys through the plugin.

By including all valid OpenSSH private keys, this enhancement improves compatibility and flexibility for users who prefer to use custom key names or manage their keys in a non-standard way.
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (N/A - No new aliases introduced)

## Changes:

- Modified the `_add_identities` function in `plugins/ssh-agent/ssh-agent.plugin.zsh` to iterate through all files in `~/.ssh/` and add those that start with `-----BEGIN OPENSSH PRIVATE KEY-----` to the `identities` array.

## Other comments:

This change should not affect users who rely on the plugin to load keys with the default hardcoded names. It simply extends the functionality to accommodate a wider range of use cases.

Fixes #12740 