### PR TITLE
ci(dependencies): use tag version in git commit if available

### DIFF
--- a/.github/workflows/dependencies/updater.py
+++ b/.github/workflows/dependencies/updater.py
@@ -228,7 +228,7 @@ class Dependency:
                     self.__apply_upstream_changes()
 
                     # Add all changes and commit
-                    has_new_commit = Git.add_and_commit(self.name, short_sha)
+                    has_new_commit = Git.add_and_commit(self.name, new_version)
 
                     if has_new_commit:
                         # Push changes to remote


### PR DESCRIPTION
Related: https://github.com/ohmyzsh/ohmyzsh/pull/12747#issuecomment-2410440748

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Use `new_version` (aware of tag version) instead of `short_sha` to generate commit subject
- Not tested!