### PR TITLE
Fix(ssh-agent): Support all SSH private key formats

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -44,8 +44,8 @@ function _add_identities() {
   if [[ ${#identities[@]} -eq 0 ]]; then
     # Iterate over files in .ssh folder.
     for file in "$HOME/.ssh"/*; do
-      # Check if file is a regular file and starts with "-----BEGIN OPENSSH PRIVATE KEY-----".
-      if [[ -f "$file" && $(command head -n 1 "$file") =~ ^-----BEGIN\ OPENSSH\ PRIVATE\ KEY----- ]]; then
+      # Check if file is a valid private key using file magic.
+      if [[ -f "$file" && $(file -b "$file") == *"private key"* ]]; then
         # Add filename (without path) to identities array.
         identities+=("${file##*/}")
       fi

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -39,8 +39,7 @@ function _add_identities() {
     return
   fi
 
-  # If no keys specified in zstyle, add default keys.
-  # Mimics calling ssh-add with no arguments.
+  # If no keys specified in zstyle, loads all private keys in ~/.ssh
   if [[ ${#identities[@]} -eq 0 ]]; then
     # Iterate over files in .ssh folder.
     for file in "$HOME/.ssh"/*; do

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -45,7 +45,7 @@ function _add_identities() {
     # Iterate over files in .ssh folder.
     for file in "$HOME/.ssh"/*; do
       # Check if file is a valid private key using file magic.
-      if [[ -f "$file" && $(file -b "$file") == *"private key"* ]]; then
+      if [[ -f "$file" && $(command file -b "$file") == *"private key"* ]]; then
         # Add filename (without path) to identities array.
         identities+=("${file##*/}")
       fi


### PR DESCRIPTION
The previous implementation of the ssh-agent plugin only supported OpenSSH private keys, which are identified by the header "-----BEGIN OPENSSH PRIVATE KEY-----". This limited the plugin's functionality as it couldn't handle keys in other formats, such as PKCS#1 and PKCS#8 (fixes #12743).

Additionally, the previous implementation attempted to use regular expressions on binary files, which could lead to errors and unexpected behavior (fixes #12745).

This commit addresses these limitations by using the `file` command to identify private keys based on their content rather than relying on a specific header or regular expressions. This approach enables the plugin to support all valid private key formats and avoids issues with binary files.

The change improves the usability, flexibility, and robustness of the ssh-agent plugin, allowing users to manage their SSH keys regardless of their format and ensuring consistent behavior across different key types.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Modified `_add_identities` function to use `file` for key identification.
- Removed reliance on OpenSSH-specific header for key detection.

## Other comments:

...
