### PR TITLE
Revert "feat(ssh-agent): add keys regardless of filename (#12741)"

### DIFF
--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -39,16 +39,13 @@ function _add_identities() {
     return
   fi
 
-  # If no keys specified in zstyle, add default keys.
-  # Mimics calling ssh-add with no arguments.
-  if [[ ${#identities[@]} -eq 0 ]]; then
-    # Iterate over files in .ssh folder.
-    for file in "$HOME/.ssh"/*; do
-      # Check if file is a regular file and starts with "-----BEGIN OPENSSH PRIVATE KEY-----".
-      if [[ -f "$file" && $(command head -n 1 "$file") =~ ^-----BEGIN\ OPENSSH\ PRIVATE\ KEY----- ]]; then
-        # Add filename (without path) to identities array.
-        identities+=("${file##*/}")
-      fi
+  # add default keys if no identities were set up via zstyle
+  # this is to mimic the call to ssh-add with no identities
+  if [[ ${#identities} -eq 0 ]]; then
+    # key list found on `ssh-add` man page's DESCRIPTION section
+    for id in id_rsa id_dsa id_ecdsa id_ed25519 id_ed25519_sk identity; do
+      # check if file exists
+      [[ -f "$HOME/.ssh/$id" ]] && identities+=($id)
     done
   fi
 


### PR DESCRIPTION
This reverts commit d2d5155d41cbe183ef172fef1e83a29d116a5af6.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Revert #12741 that brought several regressions.
From now on `identities` option has to be used to avoid loading undesired keys.