### PR TITLE
docs(volta): fix typo

### DIFF
--- a/plugins/volta/volta.plugin.zsh
+++ b/plugins/volta/volta.plugin.zsh
@@ -4,7 +4,7 @@ if (( ! $+commands[volta] )); then
 fi
 
 # If the completion file doesn't exist yet, we need to autoload it and
-# bind it to `deno`. Otherwise, compinit will have already done that.
+# bind it to `volta`. Otherwise, compinit will have already done that.
 if [[ ! -f "$ZSH_CACHE_DIR/completions/_volta" ]]; then
   typeset -g -A _comps
   autoload -Uz _volta


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- fix the comment typo which doesn't match the plugin name

## Other comments:

...
