### PR TITLE
New git alias: gpff (git pull --ff-only)

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -121,6 +121,7 @@ plugins=(... git)
 | `gmtl`                 | `git mergetool --no-prompt`                                                                                                     |
 | `gmtlvim`              | `git mergetool --no-prompt --tool=vimdiff`                                                                                      |
 | `gl`                   | `git pull`                                                                                                                      |
+| `gpff`                 | `git pull --ff-only`                                                                                                                      |
 | `gpr`                  | `git pull --rebase`                                                                                                             |
 | `gprv`                 | `git pull --rebase -v`                                                                                                          |
 | `gpra`                 | `git pull --rebase --autostash`                                                                                                 |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -263,6 +263,7 @@ alias gmtl='git mergetool --no-prompt'
 alias gmtlvim='git mergetool --no-prompt --tool=vimdiff'
 
 alias gl='git pull'
+alias gpff='git pull --ff-only'
 alias gpr='git pull --rebase'
 alias gprv='git pull --rebase -v'
 alias gpra='git pull --rebase --autostash'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Adds a new git alias `gpff = git pull --ff-only`. There is already an alias for `gmff = git merge --ff-only` and this change makes the git aliases more consistent and predictable, without interfering with other aliases.

## Other comments:

IMHO `git pull --ff-only` is very useful when you want to be sure you do not have accidental changes in your local branch.
