### PR TITLE
fix(vagrant-prompt): make `vagrant_prompt_info` generic for any state

### DIFF
--- a/plugins/vagrant-prompt/README.md
+++ b/plugins/vagrant-prompt/README.md
@@ -17,11 +17,15 @@ To display Vagrant info on your prompt add the `vagrant_prompt_info` to the
 `$PROMPT` or `$RPROMPT` variable in your theme. Example:
 
 ```zsh
-PROMPT='%{$fg[$NCOLOR]%}%B%n%b%{$reset_color%}:%{$fg[blue]%}%B%c/%b%{$reset_color%} $(vagrant_prompt_info)$(svn_prompt_info)$(git_prompt_info)%(!.#.$) '
+PROMPT="$PROMPT"' $(vagrant_prompt_info)'
+# or
+RPROMPT='$(vagrant_prompt_info)'
 ```
 
-`vagrant_prompt_info` makes use of some custom variables. This is an example
-definition:
+### Customization
+
+`vagrant_prompt_info` makes use of the following custom variables, which can be set in your
+`.zshrc` file:
 
 ```zsh
 ZSH_THEME_VAGRANT_PROMPT_PREFIX="%{$fg_bold[blue]%}["
@@ -31,3 +35,18 @@ ZSH_THEME_VAGRANT_PROMPT_POWEROFF="%{$fg_no_bold[red]%}●"
 ZSH_THEME_VAGRANT_PROMPT_SUSPENDED="%{$fg_no_bold[yellow]%}●"
 ZSH_THEME_VAGRANT_PROMPT_NOT_CREATED="%{$fg_no_bold[white]%}○"
 ```
+
+### State to variable mapping
+
+The plugin uses the output reported by `vagrant status` to print whichever symbol matches,
+according to the following table:
+
+| State       | Symbol                                 |
+| ----------- | -------------------------------------- |
+| running     | `ZSH_THEME_VAGRANT_PROMPT_RUNNING`     |
+| not running | `ZSH_THEME_VAGRANT_PROMPT_POWEROFF`    |
+| poweroff    | `ZSH_THEME_VAGRANT_PROMPT_POWEROFF`    |
+| paused      | `ZSH_THEME_VAGRANT_PROMPT_SUSPENDED`   |
+| saved       | `ZSH_THEME_VAGRANT_PROMPT_SUSPENDED`   |
+| suspended   | `ZSH_THEME_VAGRANT_PROMPT_SUSPENDED`   |
+| not created | `ZSH_THEME_VAGRANT_PROMPT_NOT_CREATED` |

--- a/plugins/vagrant-prompt/vagrant-prompt.plugin.zsh
+++ b/plugins/vagrant-prompt/vagrant-prompt.plugin.zsh
@@ -1,16 +1,18 @@
 function vagrant_prompt_info() {
-  local vm_states vm_state
-  if [[ -d .vagrant && -f Vagrantfile ]]; then
-    vm_states=(${(f)"$(vagrant status 2> /dev/null | sed -nE 's/^.*(saved|poweroff|running|not created) \([[:alnum:]_]+\)$/\1/p')"})
-    printf '%s' $ZSH_THEME_VAGRANT_PROMPT_PREFIX
-    for vm_state in $vm_states; do
-      case "$vm_state" in
-        saved) printf '%s' $ZSH_THEME_VAGRANT_PROMPT_SUSPENDED ;;
-        running) printf '%s' $ZSH_THEME_VAGRANT_PROMPT_RUNNING ;;
-        poweroff) printf '%s' $ZSH_THEME_VAGRANT_PROMPT_POWEROFF ;;
-        "not created") printf '%s' $ZSH_THEME_VAGRANT_PROMPT_NOT_CREATED ;;
-      esac
-    done
-    printf '%s' $ZSH_THEME_VAGRANT_PROMPT_SUFFIX
+  if [[ ! -d .vagrant || ! -f Vagrantfile ]]; then
+    return
   fi
+
+  local vm_states vm_state
+  vm_states=(${(f)"$(vagrant status 2> /dev/null | sed -nE 's/^[^ ]* *([[:alnum:] ]*) \([[:alnum:]_]+\)$/\1/p')"})
+  printf '%s' $ZSH_THEME_VAGRANT_PROMPT_PREFIX
+  for vm_state in $vm_states; do
+    case "$vm_state" in
+      running) printf '%s' $ZSH_THEME_VAGRANT_PROMPT_RUNNING ;;
+      "not running"|poweroff) printf '%s' $ZSH_THEME_VAGRANT_PROMPT_POWEROFF ;;
+      paused|saved|suspended) printf '%s' $ZSH_THEME_VAGRANT_PROMPT_SUSPENDED ;;
+      "not created") printf '%s' $ZSH_THEME_VAGRANT_PROMPT_NOT_CREATED ;;
+    esac
+  done
+  printf '%s' $ZSH_THEME_VAGRANT_PROMPT_SUFFIX
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixed the `sed` parser to get any possible state reported by `vagrant status`
- Updated the state to variable mapping
- Documented changes

Fixes #12193
