### PR TITLE
feat(mise): add ZSH_MISE_AUTOEXPORT_VERSIONS setting to export MISE_T…

### DIFF
--- a/plugins/mise/README.md
+++ b/plugins/mise/README.md
@@ -30,3 +30,7 @@ mise use -g node@system   Use system node as global default
 mise install node@20.0.0  Install a specific version number
 mise use -g node@20       Use node-20.x as global default
 ```
+
+## Setting
+
+- `ZSH_MISE_AUTOEXPORT_VERSIONS`: if set to `true`, the plugin will register a `chpwd` hook to update environment variable to reflect the current configuration. The variables are constructed from the output of `mise -ls -c`, with the `MISE_TOOL_` prefix, and their value is set to the full version of the tool, e.g., `M̀ISE_TOOL_PYTHON=3.8.20``. This can be used when building prompts.

--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -22,6 +22,20 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_$__mise" ]]; then
   _comps[$__mise]=_$__mise
 fi
 
+
+# $ZSH_MISE_AUTOEXPORT_VERSIONS needs to be set prior to loading the plugin.
+if [[ "$ZSH_MISE_AUTOEXPORT_VERSIONS" = "true" ]]; then
+  _updateMiseVersions() {
+    unset -m "MISE_TOOL_*"
+    eval $(mise ls -c --no-header \
+      | sed 's/^\(\S\+\)\s\+\(\S\+\).*$/export MISE_TOOL_\U\1=\2/')
+  }
+
+  autoload -U add-zsh-hook
+  add-zsh-hook chpwd _updateMiseVersions
+  _updateMiseVersions # Initial call to check the current directory at shell startup
+fi
+
 # Generate and load mise completion
 $__mise completion zsh >| "$ZSH_CACHE_DIR/completions/_$__mise" &|
 unset __mise


### PR DESCRIPTION
…OOL_* variables on directory change

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [?] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [-] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add ZSH_MISE_AUTOEXPORT_VERSIONS setting to export MISE_TOOL_{toolname}

## Other comments:

- This is useful for integrating the relevant version number in shell prompts
- This parses the output of `mise ls` with `sed` and outputs a script string containing a series of `export` that is, you guessed it, `eval`. Happy for other suggestions
- Performance seems OK, but I have a beefy machine (which was slow with Pyenv nonetheless). I have gated the behaviour with a `$ZSH_MISE_AUTOEXPORT_VERSIONS`, which needs to be set to `true ` for this to be enabled.
- Tested with GNU `sed`. It would be worth testing on a Mac / BSD.