### PR TITLE
feat(autojump): add `termux` install path

### DIFF
--- a/plugins/autojump/autojump.plugin.zsh
+++ b/plugins/autojump/autojump.plugin.zsh
@@ -6,6 +6,7 @@ autojump_paths=(
   /run/current-system/sw/share/autojump/autojump.zsh       # NixOS installation
   /etc/profiles/per-user/$USER/share/autojump/autojump.zsh # Home Manager, NixOS with user-scoped packages
   /usr/share/autojump/autojump.zsh                         # Debian and Ubuntu package
+  $PREFIX/share/autojump/autojump.zsh                      # Termux package
   /etc/profile.d/autojump.zsh                              # manual installation
   /etc/profile.d/autojump.sh                               # Gentoo installation
   /usr/local/share/autojump/autojump.zsh                   # FreeBSD installation


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds Termux install path which makes the autojump plugin usable on Termux when relying on autojump installed via the Termux package.

## Other comments:

`$PREFIX` is preferable over `/data/data/com.termux/files/usr` as `$PREFIX` is defined by Termux and not hardcoding it allows forks of Termux with different paths such as `com.termuxfork` to have the support too.

This may accidentally enable autojump to also work on some other $PREFIX using systems

Note: shouldn't the array entries be quoted? I didn't quote the new entry as the older ones aren't quoted either. Is this a bash to zsh difference and zsh can't split strings there?

<details>
<summary>dpkg -L autojump for good measure</summary>

```
/.
/data
/data/data
/data/data/com.termux
/data/data/com.termux/files
/data/data/com.termux/files/usr
/data/data/com.termux/files/usr/bin
/data/data/com.termux/files/usr/bin/autojump
/data/data/com.termux/files/usr/bin/autojump_argparse.py
/data/data/com.termux/files/usr/bin/autojump_data.py
/data/data/com.termux/files/usr/bin/autojump_match.py
/data/data/com.termux/files/usr/bin/autojump_utils.py
/data/data/com.termux/files/usr/etc
/data/data/com.termux/files/usr/etc/profile.d
/data/data/com.termux/files/usr/etc/profile.d/autojump.sh
/data/data/com.termux/files/usr/share
/data/data/com.termux/files/usr/share/autojump
/data/data/com.termux/files/usr/share/autojump/autojump.bash
/data/data/com.termux/files/usr/share/autojump/autojump.fish
/data/data/com.termux/files/usr/share/autojump/autojump.zsh
/data/data/com.termux/files/usr/share/autojump/icon.png
/data/data/com.termux/files/usr/share/doc
/data/data/com.termux/files/usr/share/doc/autojump
/data/data/com.termux/files/usr/share/man
/data/data/com.termux/files/usr/share/man/man1
/data/data/com.termux/files/usr/share/man/man1/autojump.1.gz
/data/data/com.termux/files/usr/share/zsh
/data/data/com.termux/files/usr/share/zsh/site-functions
/data/data/com.termux/files/usr/share/zsh/site-functions/_j
/data/data/com.termux/files/usr/share/doc/autojump/copyright
```

</details>
