### PR TITLE
feat(laravel): add alias for `optimize:clear`

### DIFF
--- a/plugins/laravel/README.md
+++ b/plugins/laravel/README.md
@@ -49,6 +49,7 @@ plugins=(... laravel)
 | `pacoc`  |  `php artisan config:clear` |
 | `pavic`  |  `php artisan view:clear` |
 | `paroc`  |  `php artisan route:clear` |
+| `paopc`  |  `php artisan optimize:clear` |
 
 ## Queues
 

--- a/plugins/laravel/laravel.plugin.zsh
+++ b/plugins/laravel/laravel.plugin.zsh
@@ -36,6 +36,8 @@ alias pacac='php artisan cache:clear'
 alias pacoc='php artisan config:clear'
 alias pavic='php artisan view:clear'
 alias paroc='php artisan route:clear'
+alias paopc='php artisan optimize:clear'
+
 
 # queues
 alias paqf='php artisan queue:failed'

--- a/plugins/laravel/laravel.plugin.zsh
+++ b/plugins/laravel/laravel.plugin.zsh
@@ -38,7 +38,6 @@ alias pavic='php artisan view:clear'
 alias paroc='php artisan route:clear'
 alias paopc='php artisan optimize:clear'
 
-
 # queues
 alias paqf='php artisan queue:failed'
 alias paqft='php artisan queue:failed-table'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added alias paopc for the php artisan optimize:clear command in the Laravel plugin.

## Other comments:
This alias provides a quick way to clear all cached data, streamlining the process and ensuring that the application runs with the latest configuration and optimized settings.

...
