### PR TITLE
feat(bazel): add bzlmod integrity gen function

### DIFF
--- a/plugins/bazel/README.md
+++ b/plugins/bazel/README.md
@@ -1,6 +1,7 @@
 # Bazel plugin
 
-This plugin adds completion and aliases for [bazel](https://bazel.build), an open-source build and test tool that scalably supports multi-language and multi-platform projects.
+This plugin adds completion and aliases for [bazel](https://bazel.build), an open-source build and test tool
+that scalably supports multi-language and multi-platform projects.
 
 To use it, add `bazel` to the plugins array in your zshrc file:
 
@@ -14,15 +15,15 @@ The plugin has a copy of [the completion script from the git repository][1].
 
 ## Aliases
 
-| Alias   | Command                                | Description                                            |
-| ------- | -------------------------------------- | ------------------------------------------------------ |
-| bzb     | `bazel build`                          | The `bazel build` command                              |
-| bzt     | `bazel test`                           | The `bazel test` command                               |
-| bzr     | `bazel run`                            | The `bazel run` command                                |
-| bzq     | `bazel query`                          | The `bazel query` command                              |
+| Alias | Command       | Description               |
+| ----- | ------------- | ------------------------- |
+| bzb   | `bazel build` | The `bazel build` command |
+| bzt   | `bazel test`  | The `bazel test` command  |
+| bzr   | `bazel run`   | The `bazel run` command   |
+| bzq   | `bazel query` | The `bazel query` command |
 
 ## Functions
 
-| Function | Description                              |
-| -------- | ---------------------------------------- |
-| sri-hash  | Generate SRI hash used by bzlmod |
+| Function | Description                      |
+| -------- | -------------------------------- |
+| sri-hash | Generate SRI hash used by bzlmod |

--- a/plugins/bazel/README.md
+++ b/plugins/bazel/README.md
@@ -25,4 +25,4 @@ The plugin has a copy of [the completion script from the git repository][1].
 
 | Function | Description                              |
 | -------- | ---------------------------------------- |
-| bzlmod_integrety  | Generate bzlmod integrity value |
+| sri-hash  | Generate SRI hash used by bzlmod |

--- a/plugins/bazel/README.md
+++ b/plugins/bazel/README.md
@@ -16,7 +16,13 @@ The plugin has a copy of [the completion script from the git repository][1].
 
 | Alias   | Command                                | Description                                            |
 | ------- | -------------------------------------- | ------------------------------------------------------ |
-| bzb      | `bazel build`                          | The `bazel build` command                              |
-| bzt      | `bazel test`                           | The `bazel test` command                               |
-| bzr      | `bazel run`                            | The `bazel run` command                                |
-| bzq      | `bazel query`                          | The `bazel query` command                              |
+| bzb     | `bazel build`                          | The `bazel build` command                              |
+| bzt     | `bazel test`                           | The `bazel test` command                               |
+| bzr     | `bazel run`                            | The `bazel run` command                                |
+| bzq     | `bazel query`                          | The `bazel query` command                              |
+
+## Functions
+
+| Function | Description                              |
+| -------- | ---------------------------------------- |
+| bzlmod_integrety  | Generate bzlmod integrity value |

--- a/plugins/bazel/bazel.plugin.zsh
+++ b/plugins/bazel/bazel.plugin.zsh
@@ -4,6 +4,6 @@ alias bzt='bazel test'
 alias bzr='bazel run'
 alias bzq='bazel query'
 
-bzlmod_integrety() {
+sri-hash() {
     openssl dgst -sha256 -binary $1 | openssl base64 -A | sed 's/^/sha256-/'
 }

--- a/plugins/bazel/bazel.plugin.zsh
+++ b/plugins/bazel/bazel.plugin.zsh
@@ -3,3 +3,7 @@ alias bzb='bazel build'
 alias bzt='bazel test'
 alias bzr='bazel run'
 alias bzq='bazel query'
+
+bzlmod_integrety() {
+    openssl dgst -sha256 -binary $1 | openssl base64 -A | sed 's/^/sha256-/'
+}


### PR DESCRIPTION
## Standards checklist:

For https://registry.bazel.build/ files and archives use an integrety value to proof that you get the correct artifact. However, getting this value is not that trivial and so far not yet documented. https://github.com/bazelbuild/bazel/issues/17124 is the issue for adding the documentation but is open for about 2 years.

This PR adds the generation as function to the bazel plugin.

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add function for generating bzlmod integrety value
- Fix indention of the markdown table for the aliases

## Other comments:

...
