### PR TITLE
fix(poetry-env): switch venv between poetry dirs

### DIFF
--- a/plugins/poetry-env/poetry-env.plugin.zsh
+++ b/plugins/poetry-env/poetry-env.plugin.zsh
@@ -6,11 +6,10 @@ _togglePoetryShell() {
   fi
 
   # Deactivate the current environment if moving out of a Poetry directory or into a different Poetry directory
-  if [[ $poetry_active -eq 1 ]] && [[ $in_poetry_dir -eq 0 ]] \
-    && [[ "$PWD" != "$poetry_dir"* ]]; then
+  if [[ $poetry_active -eq 1 ]] && { [[ $in_poetry_dir -eq 0 ]] || [[ "$PWD" != "$poetry_dir"* ]]; }; then
     export poetry_active=0
     unset poetry_dir
-    (( $+functions[deactivate] )) && deactivate
+    deactivate
   fi
 
   # Activate the environment if in a Poetry directory and no environment is currently active

--- a/plugins/poetry-env/poetry-env.plugin.zsh
+++ b/plugins/poetry-env/poetry-env.plugin.zsh
@@ -9,7 +9,7 @@ _togglePoetryShell() {
   if [[ $poetry_active -eq 1 ]] && { [[ $in_poetry_dir -eq 0 ]] || [[ "$PWD" != "$poetry_dir"* ]]; }; then
     export poetry_active=0
     unset poetry_dir
-    deactivate
+    (( $+functions[deactivate] )) && deactivate
   fi
 
   # Activate the environment if in a Poetry directory and no environment is currently active


### PR DESCRIPTION
Properly deactivate shell if you move directly from one poetry env to another otherwise you get stuck in the old virtual env unless you hit a non-poetry directory first which would trigger the deactivate command.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Changed && to || to properly trigger deactivation. 
