### PR TITLE
Add `apple-passwords-otp` plugin

### DIFF
--- a/plugins/apple-passwords-otp/README.md
+++ b/plugins/apple-passwords-otp/README.md
@@ -1,0 +1,26 @@
+## apple-passwords-otp
+
+This plugin adds a function that allows to quickly copy the One-Time-Password (OTP) for a specific domain from
+Apple Passwords to the clipboard.
+
+To use it, add `apple-passwords-otp` to the plugins array of your zshrc file:
+
+```zsh
+plugins=(... apple-passwords-otp)
+```
+
+## Functions
+
+- `otp(domain)` : copies the OTP for the specified domain to the clipboard
+
+## Usage
+
+```bash
+otp domain
+```
+
+## Requirements
+
+This plugin depends on the [Apple Passwords CLI](https://github.com/bendews/apw) tool. It can be installed via
+Homebrew. Other requirements are `jq` to parse json files which can be installed via Homebrew as well. You
+need to have Mac OS Sequoia or later to use this plugin.

--- a/plugins/apple-passwords-otp/apple-passwords-otp.zsh
+++ b/plugins/apple-passwords-otp/apple-passwords-otp.zsh
@@ -1,0 +1,37 @@
+function otp() {
+    if [ -z "$1" ]; then
+        echo "Usage: otp <domain>"
+        return 1
+    fi
+    if ! command -v apw &> /dev/null || ! command -v jq &> /dev/null || ! command -v awk &> /dev/null; then
+        echo "This function requires apw, jq and awk to be installed"
+        return 1
+    fi
+    CODES=$(apw otp get $1 2>/dev/null)
+    STATUS=$?
+    # ✋ If return code 9, not authenticated, run apw auth
+    if [ $STATUS -eq 9 ]; then
+        echo "🔐 Authenticating …"
+        apw auth
+        CODES=$(apw otp get $1)
+    fi
+    # ✋ If return code 3, domain not found, alert user
+    if [ $STATUS -eq 3 ]; then
+        echo "🚫 Domain not found"
+        return 1
+    fi
+    # Grab available OTP codes for domain
+    if [ $(echo $CODES | jq '.results | length') -gt 1 ]; then
+        echo 'Multiple OTP codes found, select username:'
+        echo $CODES | jq -r '.results | to_entries[] | "\(.key + 1). \(.value.username)"'
+        read -k 1 index
+        echo
+        CODE=$(echo $CODES | jq -r ".results[$index - 1].code")
+        tput cuu $(echo $CODES | jq '.results | length' | awk '{print $1 + 2}')
+        tput ed
+    else
+        CODE=$(echo $CODES | jq -r '.results[0].code')
+    fi
+    echo $CODE | pbcopy
+    echo "🔑 OTP code copied to clipboard"
+}


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.


## Changes

* Add `apple-passwords-otp` plugin
