### PR TITLE
fix(dash): urlencode special parameters like `:` in query

### DIFF
--- a/plugins/dash/dash.plugin.zsh
+++ b/plugins/dash/dash.plugin.zsh
@@ -1,5 +1,5 @@
 # Usage: dash [keyword:]query
-dash() { open -a Dash.app dash://"$*" }
+dash() { open -a Dash.app "dash://$(omz_urlencode -r $*)" }
 compdef _dash dash
 
 _dash() {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes

In macOS, using queries such as `dash php:enum` does not open Dash.app, possibly due to colon character being interpreted as a port. Confirmed in macOS Sequoia.

URL-encoding the parameter (: -> %3A) makes this work again.

Fixes https://discord.com/channels/642496866407284746/809850042575093760/1308076125456437300

