### PR TITLE
Make the perl plugin activate perlbrew

### DIFF
--- a/plugins/perl/perl.plugin.zsh
+++ b/plugins/perl/perl.plugin.zsh
@@ -54,3 +54,29 @@ pgs() { # [find] [replace] [filename]
 prep() { # [pattern] [filename unless STDOUT]
     perl -nle 'print if /'"$1"'/;' $2
 }
+
+# If the 'perlbrew' function isn't defined, perlbrew isn't setup.
+if ! typeset -f perlbrew > /dev/null; then
+  # Has PERLBREW_ROOT been set prior, and is it a valid directory?  If so, store
+  # value
+  if [[ -n "${PERLBREW_ROOT}" && -d "{{PERLBREW_ROOT}" ]]; then
+    perlbrew_root="${PERLBREW_ROOT}"
+  fi
+
+  # If perlbrew_root isn't set yet, then set the default path
+  if [[ -z "${perlbrew_root}" ]]; then
+    perlbrew_root="${HOME}/perl5/perlbrew"
+  fi
+
+  # If we can find perlbrew's 'bashrc' (yes, I know!)...
+  if [[ -d "${perlbrew_root}" && -f "${perlbrew_root}/etc/bashrc" ]]; then
+    # and if NO_AUTO_ADD isn't set
+    if [[ -z "${PERLBREW_NO_AUTO_ADD}" ]]; then
+      # Initialize perlbrew
+      source "${perlbrew_root}/etc/bashrc"
+    fi
+  fi
+
+  # Clear our temporary variable
+  unset perlbrew_root
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- The current perl plugin defines a number of aliases for 'perlbrew' but doesn't in itself actually activate perlbrew; this PR adds (optional) perlbrew activation to the plugin.  It will check if the 'perlbrew' function is defined; and if not, attempt to source the activation code included in perlbrew.  The perlbrew root directory can be defined by the standard PERLBREW_ROOT variable; and then entire activation can be disabled by setting PERLBREW_NO_AUTO_ADD to some value before sourcing oh-my-zsh.

## Other comments:

Yes, the perlbrew code being sourced is actually named "bashrc"; but it appears to work correctly in zsh to the best of my knowledge and testing.
