### PR TITLE
fix(pipenv): fix auto-shell functionality when cd-ing out

### DIFF
--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -19,7 +19,8 @@ if zstyle -T ':omz:plugins:pipenv' auto-shell; then
     if [[ ! -f "$PWD/Pipfile" ]]; then
       if [[ "$PIPENV_ACTIVE" == 1 ]]; then
         if [[ "$PWD" != "$pipfile_dir"* ]]; then
-          exit
+          unset PIPENV_ACTIVE pipfile_dir
+          deactivate
         fi
       fi
     fi
@@ -28,7 +29,8 @@ if zstyle -T ':omz:plugins:pipenv' auto-shell; then
     if [[ "$PIPENV_ACTIVE" != 1 ]]; then
       if [[ -f "$PWD/Pipfile" ]]; then
         export pipfile_dir="$PWD"
-        pipenv shell
+        source "$(pipenv --venv)/bin/activate"
+        export PIPENV_ACTIVE=1
       fi
     fi
   }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

This change uses traditional `activate` instead of `pipenv shell` so that transitions between pipenv projects happen in the same shell and it's possible to properly deactivate the shell.

Fixes #12184
