### PR TITLE
feat(perl): add `perlbrew` auto activation

### DIFF
--- a/plugins/perl/README.md
+++ b/plugins/perl/README.md
@@ -8,30 +8,36 @@ To use it, add `perl` to the plugins array in your zshrc file:
 plugins=(... perl)
 ```
 
+## Perlbrew activation
+
+If the plugin detects that `perlbrew` hasn't been activated, yet there is an installation of it in
+`$PERLBREW_ROOT`, it'll initialize by default. To avoid this behaviour, set `ZSH_PERLBREW_ACTIVATE=false`
+before `source oh-my-zsh.sh` in your zshrc.
+
 ## Aliases
 
-| Aliases       | Command            |  Description                           |
-| :------------ | :----------------- | :------------------------------------- |
-| pbi           | `perlbrew install` | Install specific perl version          |
-| pbl           | `perlbrew list`    | List all perl version installed        |
-| pbo           | `perlbrew off`     | Go back to the system perl             |
-| pbs           | `perlbrew switch`  | Turn it back on                        |
-| pbu           | `perlbrew use`     | Use specific version of perl           |
-| pd            | `perldoc`          | Show the perl documentation            |
-| ple           | `perl -wlne`       | Use perl like awk/sed                  |
-| latest-perl   | `curl ...`         | Show the latest stable release of Perl |
+| Aliases     | Command            | Description                            |
+| :---------- | :----------------- | :------------------------------------- |
+| pbi         | `perlbrew install` | Install specific perl version          |
+| pbl         | `perlbrew list`    | List all perl version installed        |
+| pbo         | `perlbrew off`     | Go back to the system perl             |
+| pbs         | `perlbrew switch`  | Turn it back on                        |
+| pbu         | `perlbrew use`     | Use specific version of perl           |
+| pd          | `perldoc`          | Show the perl documentation            |
+| ple         | `perl -wlne`       | Use perl like awk/sed                  |
+| latest-perl | `curl ...`         | Show the latest stable release of Perl |
 
 ## Functions
 
-* `newpl`: creates a basic Perl script file and opens it with $EDITOR.
+- `newpl`: creates a basic Perl script file and opens it with $EDITOR.
 
-* `pgs`: Perl Global Substitution: `pgs <find_pattern> <replace_pattern> <filename>`
-  Looks for `<find_pattern>` and replaces it with `<replace_pattern>` in `<filename>`.
+- `pgs`: Perl Global Substitution: `pgs <find_pattern> <replace_pattern> <filename>` Looks for
+  `<find_pattern>` and replaces it with `<replace_pattern>` in `<filename>`.
 
-* `prep`: Perl grep, because 'grep -P' is terrible: `prep <pattern> [<filename>]`
-  Lets you work with pipes or files (if no `<filename>` provided, use stdin).
+- `prep`: Perl grep, because 'grep -P' is terrible: `prep <pattern> [<filename>]` Lets you work with pipes or
+  files (if no `<filename>` provided, use stdin).
 
 ## Requirements
 
-In order to make this work, you will need to have perl installed.
-More info on the usage and install: https://www.perl.org/get.html
+In order to make this work, you will need to have perl installed. More info on the usage and install:
+https://www.perl.org/get.html

--- a/plugins/perl/perl.plugin.zsh
+++ b/plugins/perl/perl.plugin.zsh
@@ -54,3 +54,29 @@ pgs() { # [find] [replace] [filename]
 prep() { # [pattern] [filename unless STDOUT]
     perl -nle 'print if /'"$1"'/;' $2
 }
+
+# If the 'perlbrew' function isn't defined, perlbrew isn't setup.
+if ! typeset -f perlbrew > /dev/null; then
+  # Has PERLBREW_ROOT been set prior, and is it a valid directory?  If so, store
+  # value
+  if [[ -n "${PERLBREW_ROOT}" && -d "{{PERLBREW_ROOT}" ]]; then
+    perlbrew_root="${PERLBREW_ROOT}"
+  fi
+
+  # If perlbrew_root isn't set yet, then set the default path
+  if [[ -z "${perlbrew_root}" ]]; then
+    perlbrew_root="${HOME}/perl5/perlbrew"
+  fi
+
+  # If we can find perlbrew's 'bashrc' (yes, I know!)...
+  if [[ -d "${perlbrew_root}" && -f "${perlbrew_root}/etc/bashrc" ]]; then
+    # and if NO_AUTO_ADD isn't set
+    if [[ -z "${PERLBREW_NO_AUTO_ADD}" ]]; then
+      # Initialize perlbrew
+      source "${perlbrew_root}/etc/bashrc"
+    fi
+  fi
+
+  # Clear our temporary variable
+  unset perlbrew_root
+fi

--- a/plugins/perl/perl.plugin.zsh
+++ b/plugins/perl/perl.plugin.zsh
@@ -56,27 +56,10 @@ prep() { # [pattern] [filename unless STDOUT]
 }
 
 # If the 'perlbrew' function isn't defined, perlbrew isn't setup.
-if ! typeset -f perlbrew > /dev/null; then
-  # Has PERLBREW_ROOT been set prior, and is it a valid directory?  If so, store
-  # value
-  if [[ -n "${PERLBREW_ROOT}" && -d "{{PERLBREW_ROOT}" ]]; then
-    perlbrew_root="${PERLBREW_ROOT}"
+if [[ $ZSH_PERLBREW_ACTIVATE != false ]] && (( ! $+functions[perlbrew] )); then
+  local _perlbrew="${PERLBREW_ROOT:-${HOME}/perl5/perlbrew}"
+  if [[ -f "${_perlbrew}/etc/bashrc" ]]; then
+    source "${_perlbrew}/etc/bashrc"
   fi
-
-  # If perlbrew_root isn't set yet, then set the default path
-  if [[ -z "${perlbrew_root}" ]]; then
-    perlbrew_root="${HOME}/perl5/perlbrew"
-  fi
-
-  # If we can find perlbrew's 'bashrc' (yes, I know!)...
-  if [[ -d "${perlbrew_root}" && -f "${perlbrew_root}/etc/bashrc" ]]; then
-    # and if NO_AUTO_ADD isn't set
-    if [[ -z "${PERLBREW_NO_AUTO_ADD}" ]]; then
-      # Initialize perlbrew
-      source "${perlbrew_root}/etc/bashrc"
-    fi
-  fi
-
-  # Clear our temporary variable
-  unset perlbrew_root
+  unset _perlbrew
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add code to perl plugin to activate perlbrew if 'perlbrew' function not defined already 

## Other comments:

Currently, the PERL plugin defines some aliases for perlbrew, but doesn't check or activate perlbrew.  This PR adds (optional) perlbrew activation to the plugin. It will check if the 'perlbrew' function is defined; and if not, attempt to source the activation code included in perlbrew. The perlbrew root directory can be defined by the standard PERLBREW_ROOT variable; and then entire activation can be disabled by setting PERLBREW_NO_AUTO_ADD to some value before sourcing oh-my-zsh.

