### PR TITLE
For chucknorris plugin: add note about possibly needing to generate fortune data

### DIFF
--- a/plugins/chucknorris/README.md
+++ b/plugins/chucknorris/README.md
@@ -38,3 +38,7 @@ Last login: Fri Jan 30 23:12:26 on ttys001
 - `cowsay` if using `chuck_cow`
 
 Available via homebrew, apt, ...
+
+> [!NOTE]  
+> In addition to installing `fortune`, it may be necessary to run `strfile $ZSH/plugins/chucknorris/fortunes/chucknorris\n` to write the fortune data to the proper directory.
+> 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

When I installed this plugin and tried to run it, I got an error indicating it could not find the fortune data. The fix was to run `strfile $ZSH/plugins/chucknorris/fortunes/chucknorris\n`.

I would like this to be included in the README for this plugin for the sake of future users.

This PR adds a note:

"In addition to installing `fortune`, it may be necessary to run `strfile $ZSH/plugins/chucknorris/fortunes/chucknorris\n` to write the fortune data to the proper directory."