### PR TITLE
fix(mercurial): use "hg identify --template", avoid "hg status" when possible

### DIFF
--- a/plugins/mercurial/README.md
+++ b/plugins/mercurial/README.md
@@ -49,13 +49,25 @@ plugins=(... mercurial)
   PROMPT='${ret_status}%{$fg_bold[green]%}%p %{$fg[cyan]%}%c %{$fg_bold[blue]%}$(git_prompt_info)$(hg_prompt_info)%{$fg_bold[blue]%} % %{$reset_color%}'
   ```
 
-You can also redefine additional vars used in the plugin (after Oh My Zsh is sourced):
+You can define the below variables to customize the prompt, after Oh-My-Zsh is source.  The prompt will be generated in this order:
+
+1. PREFIX variable.
+2. IDENTIFY variable, which is used with "hg identify --template":
+    * Branch name, if not "default".
+    * Bookmarks, if any.  The active bookmark will have '*' appended.
+    * Tags, if any.
+3. Either the DIRTY or CLEAN variables.
+4. SUFFIX variable.
+
+Spaces are only needed to separate non-empty parts, but no space will be inserted before DIRTY or CLEAN.
 
 ```zsh
-ZSH_THEME_HG_PROMPT_PREFIX="%{$fg_bold[magenta]%}hg:(%{$fg[red]%}"
-ZSH_THEME_HG_PROMPT_SUFFIX="%{$reset_color%}"
-ZSH_THEME_HG_PROMPT_DIRTY="%{$fg[magenta]%}) %{$fg[yellow]%}✗%{$reset_color%}"
+ZSH_THEME_HG_PROMPT_PREFIX="%{$fg[magenta]%}hg:(%{$fg[red]%}"
+ZSH_THEME_HG_PROMPT_IDENTIFY='{separate(" ",ifeq(branch,"default","",branch),"{activebookmark}*",tags)}'
+    # See "hg help templates"; the default is $ZSH_THEME_HG_PROMPT_IDENTIFY_DEFAULT.
+ZSH_THEME_HG_PROMPT_DIRTY="%{$fg[magenta]%}) %{$fg_bold[yellow]%}✗"
 ZSH_THEME_HG_PROMPT_CLEAN="%{$fg[magenta]%})"
+ZSH_THEME_HG_PROMPT_SUFFIX="%{$reset_color%}"
 ```
 
 ### Display repo branch and directory status in prompt


### PR DESCRIPTION
Use "hg identify" with a template parameter to generate revision identifiers (branch, bookmarks, tags) because this is faster, more complete, and more customizable.

When DISABLE_UNTRACKED_FILES_DIRTY=true, avoid "hg status" entirely; otherwise, stop once the first untracked file is found.  This should be much faster on really large repositories.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
