### PR TITLE
python: Add variant of mkv command with system site packages

### DIFF
--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -27,6 +27,8 @@ virtual environments:
 - `mkv [name]`: make a new virtual environment called `name` (default: if set `$PYTHON_VENV_NAME`, else
   `venv`) in the current directory.
 
+- `mkvs [name]`: same as `mkvs`, but uses system site packages by adding `--system-site-packages` argument.
+
 - `vrun [name]`: Activate the virtual environment called `name` (default: if set `$PYTHON_VENV_NAME`, else
   `venv`) in the current directory.
 

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -81,6 +81,18 @@ function mkv() {
   vrun "${name}"
 }
 
+# Create a new virtual environment using the specified name.
+# If none specified, use $PYTHON_VENV_NAME
+# Use system site packages
+function mkvs() {
+  local name="${1:-$PYTHON_VENV_NAME}"
+  local venvpath="${name:P}"
+
+  python3 -m venv --system-site-packages "${name}" || return
+  echo >&2 "Created venv with system site packages in '${venvpath}'"
+  vrun "${name}"
+}
+
 if [[ "$PYTHON_AUTO_VRUN" == "true" ]]; then
   # Automatically activate venv when changing dir
   function auto_vrun() {


### PR DESCRIPTION
Sometimes it's useful to include system site packages and use virtual environments to add additional packages without editing system site using either system package manager or pip.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added `mkvs`, a variant of `mkv` which uses system site packages in the virtual environment
