### PR TITLE
Updated Python plugin: accepts multiple venv names

### DIFF
--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -36,4 +36,5 @@ virtual environments:
   - To enable the feature, set `export PYTHON_AUTO_VRUN=true` before sourcing oh-my-zsh.
   - Plugin activates first virtual environment in lexicographic order whose name begins with `<venv-name>`.
     The default virtual environment name is `venv`. To use a different name, set
-    `export PYTHON_VENV_NAME=<venv-name>`. For example: `export PYTHON_VENV_NAME=".venv"`
+    `export PYTHON_VENV_NAME=("<venv-name>" "venv-name2")`. For example:
+    `export PYTHON_VENV_NAME=(".venv" "venv" ".env" "env")`


### PR DESCRIPTION
- Refined automatic virtual environment activation (`auto_vrun`):
  - Enhanced support for dynamic activation of virtual environments from a list.

- Updated `vrun` function:
  - Enabled activation of the first valid virtual environment from a list of potential names.
  - Improved feedback with clear error messages when no valid environment is found.

- Enhanced `mkv` function:
  - Added support for multiple potential virtual environment names using `PYTHON_VENV_NAME` as a list.
  - Simplified path handling with explicit construction using `${PWD}`.
  - Improved error messaging and direct activation of newly created environments.

- This is my first pull request ever so please let me know if there are any issues with the changes or request.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
