### PR TITLE
feat: add the rustup completion script

### DIFF
--- a/plugins/rustup/README.md
+++ b/plugins/rustup/README.md
@@ -1,0 +1,9 @@
+# Buf plugin
+
+This plugin adds completion for [rustup](https://github.com/rust-lang/rustup), the Rust toolchain installer.
+
+To use it, add `rustup` to the plugins array in you rustup file:
+
+```zsh
+plugins=(... rustup)
+```

--- a/plugins/rustup/rustup.plugin.zsh
+++ b/plugins/rustup/rustup.plugin.zsh
@@ -1,0 +1,14 @@
+# Autocompletion for the rustup CLI (rustup).
+if (( !$+commands[rustup] )); then
+  return
+fi
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `rustup`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_rustup" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _rustup
+  _comps[rustup]=_rustup
+fi
+
+# Generate and load rustup completion
+rustup completions zsh >! "$ZSH_CACHE_DIR/completions/_rustup" &|


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Introduce [rustup](https://github.com/rust-lang/rustup) plugin

## Other comments:

...
