### PR TITLE
Warn user if direnv not found

### DIFF
--- a/plugins/direnv/direnv.plugin.zsh
+++ b/plugins/direnv/direnv.plugin.zsh
@@ -1,5 +1,8 @@
-# Don't continue if direnv is not found
-command -v direnv &>/dev/null || return
+# If direnv is not found, don't continue and print a warning
+if ! command -v direnv &>/dev/null; then
+  echo "Warning: direnv not found. Please install direnv and ensure it's in your PATH before using this plugin."
+  return
+fi
 
 _direnv_hook() {
   trap -- '' SIGINT;

--- a/plugins/direnv/direnv.plugin.zsh
+++ b/plugins/direnv/direnv.plugin.zsh
@@ -1,5 +1,5 @@
 # If direnv is not found, don't continue and print a warning
-if ! command -v direnv &>/dev/null; then
+if (( ! $+commands[direnv] )); then
   echo "Warning: direnv not found. Please install direnv and ensure it's in your PATH before using this plugin."
   return
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Instead of silently not installing the shell hooks, issue a warning (then keep doing nothing).

## Misc:

Follow-up of https://github.com/ohmyzsh/ohmyzsh/pull/8809#issuecomment-612344196 and https://github.com/ohmyzsh/ohmyzsh/issues/12798#issuecomment-2464749859.
