### PR TITLE
docs(per-directory-history): add variable docs

### DIFF
--- a/plugins/per-directory-history/README.md
+++ b/plugins/per-directory-history/README.md
@@ -35,6 +35,7 @@ toggle set the `PER_DIRECTORY_HISTORY_TOGGLE` environment variable.
   function above (default `^G`)
 * `PER_DIRECTORY_HISTORY_PRINT_MODE_CHANGE` is a variable which toggles whether
   the current mode is printed to the screen following a mode change (default `true`)
+* `HISTORY_START_WITH_GLOBAL` is a global variable that defines how to start the plugin: global or local (default `false`)
 
 ## History
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add HISTORY_START_WITH_GLOBAL to the documentation to enable `per-directory-history` to start in global history mode (defaults to local history).

## Other comments
- reference to the variable https://github.com/jimhester/per-directory-history/blame/6363a60d2b63383eea4b42c1e115ff6c72a5cda9/per-directory-history.zsh#L60

