### PR TITLE
feat(run0): add run0 plugin

### DIFF
--- a/plugins/run0/README.md
+++ b/plugins/run0/README.md
@@ -1,0 +1,61 @@
+# run0
+
+Easily prefix your current or previous commands with `run0` by pressing <kbd>esc</kbd> twice.
+
+To use it, add `run0` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... run0)
+```
+
+## Usage
+
+### Current typed commands
+
+Say you have typed a long command and forgot to add `run0` in front:
+
+```console
+$ apt-get install build-essential
+```
+
+By pressing the <kbd>esc</kbd> key twice, you will have the same command with `run0` prefixed without typing:
+
+```console
+$ run0 apt-get install build-essential
+```
+
+### Previous executed commands
+
+Say you want to delete a system file and denied:
+
+```console
+$ rm some-system-file.txt
+-su: some-system-file.txt: Permission denied
+$
+```
+
+By pressing the <kbd>esc</kbd> key twice, you will have the same command with `run0` prefixed without typing:
+
+```console
+$ rm some-system-file.txt
+-su: some-system-file.txt: Permission denied
+$ run0 rm some-system-file.txt
+Password:
+$
+```
+
+The same happens for file editing, as told before.
+
+## Key binding
+
+By default, the `run0` plugin uses <kbd>Esc</kbd><kbd>Esc</kbd> as the trigger.
+If you want to change it, you can use the `bindkey` command to bind it to a different key:
+
+```sh
+bindkey -M emacs '<seq>' run0-command-line
+bindkey -M vicmd '<seq>' run0-command-line
+bindkey -M viins '<seq>' run0-command-line
+```
+
+where `<seq>` is the sequence you want to use. You can find the keyboard sequence
+by running `cat` and pressing the keyboard combination you want to use.

--- a/plugins/run0/run0.plugin.zsh
+++ b/plugins/run0/run0.plugin.zsh
@@ -1,0 +1,44 @@
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+# run0 will be inserted before the command
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+# * Daniel Braunwarth <oss@braunwarth.dev>
+#
+# ------------------------------------------------------------------------------
+
+__run0-replace-buffer() {
+  local old=$1 new=$2 space=${2:+ }
+
+  # if the cursor is positioned in the $old part of the text, make
+  # the substitution and leave the cursor after the $new text
+  if [[ $CURSOR -le ${#old} ]]; then
+    BUFFER="${new}${space}${BUFFER#$old }"
+    CURSOR=${#new}
+  # otherwise just replace $old with $new in the text before the cursor
+  else
+    LBUFFER="${new}${space}${LBUFFER#$old }"
+  fi
+}
+
+run0-command-line() {
+  # If line is empty, get the last run command from history
+  [[ -z $BUFFER ]] && LBUFFER="$(fc -ln -1)"
+
+  case "$BUFFER" in
+    run0\ *) __run0-replace-buffer "run0" "" ;;
+    *) LBUFFER="run0 $LBUFFER" ;;
+  esac
+}
+
+zle -N run0-command-line
+
+# Defined shortcut keys: [Esc] [Esc]
+bindkey -M emacs '\e\e' run0-command-line
+bindkey -M vicmd '\e\e' run0-command-line
+bindkey -M viins '\e\e' run0-command-line


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add run0 plugin

## Other comments:

Derived from the sudo plugin but without the editor support, because run0 doesn't support this (yet) 
