### PR TITLE
Add `pat` alias to use Tinker in Laravel

### DIFF
--- a/plugins/laravel/README.md
+++ b/plugins/laravel/README.md
@@ -10,6 +10,7 @@ plugins=(... laravel)
 |:-:|:-:|
 | `artisan`  | `php artisan`  |
 | `pas`  | `php artisan serve` |
+| `pat`  | `php artisan tink` |
 | `pats`  | `php artisan test` |
 
 ## Database

--- a/plugins/laravel/laravel.plugin.zsh
+++ b/plugins/laravel/laravel.plugin.zsh
@@ -5,6 +5,7 @@ alias bob='php artisan bob::build'
 # Development
 alias pas='php artisan serve'
 alias pats='php artisan test'
+alias pat='php artisan tink'
 
 # Database
 alias pam='php artisan migrate'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added `pat` alias to use Tinker in Laravel