### PR TITLE
virtualenvwrapper plugin fix #112852

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -90,4 +90,9 @@ if [[ ! $DISABLE_VENV_CD -eq 1 ]]; then
   autoload -U add-zsh-hook
   add-zsh-hook chpwd workon_cwd
   [[ $PWD != ~ ]] && workon_cwd
+else
+  if [[ "${chpwd_functions[(Ie)workon_cwd]}" -ne 0 ]]; then
+    autoload -U add-zsh-hook
+    add-zsh-hook -d chpwd workon_cwd
+  fi
 fi


### PR DESCRIPTION
when we're not in enabled mode and `DISABLE_VENV_CD=1`:
  - safely delete the chpwd hook `workon_cwd` if it were previously set up

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- see the diff :)

## Other comments:

- tested only manually

...
