### PR TITLE
feat(uv): add uv='noglob uv' alias

### DIFF
--- a/plugins/uv/uv.plugin.zsh
+++ b/plugins/uv/uv.plugin.zsh
@@ -3,6 +3,8 @@ if (( ! ${+commands[uv]} )); then
   return
 fi
 
+alias uv="noglob uv"
+
 alias uva='uv add'
 alias uvexp='uv export --format requirements-txt --no-hashes --output-file requirements.txt --quiet'
 alias uvl='uv lock'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Adds `alias uv="noglob pip"` for the uv plugin , [following the `pip` plugin](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/pip/pip.plugin.zsh#L85-L89). This is especially useful when installing modules with extras: e.g. `pip install module[extra]`

