### PR TITLE
feat(1password): automatic secret injection for specific commands

### DIFF
--- a/plugins/1password/1password.plugin.zsh
+++ b/plugins/1password/1password.plugin.zsh
@@ -22,28 +22,28 @@ OP_RUN_WRAPPER_SYMBOL="🔑"
 
 # Currently we take a simple approach and set aliases to override each command, this could be done with functions instead
 # Also ignoring the option to specify specific environment files with the `--env-file` flag
-set_op_aliases() {
+function set_op_aliases() {
   for cmd in "${OP_RUN_WRAPPER_CMDS[@]}"; do
     alias "$cmd"="op run -- $cmd"
   done
 }
 
-unset_op_aliases() {
+function unset_op_aliases() {
   for cmd in "${OP_RUN_WRAPPER_CMDS[@]}"; do
     unalias "$cmd" 2>/dev/null
   done
 }
 
-set_prompt() {
+function set_prompt() {
   OP_RUN_WRAPPER_ORIGINAL_PROMPT=$PROMPT
   export PROMPT="(${OP_RUN_WRAPPER_SYMBOL}) ${PROMPT}"
 }
 
-unset_prompt() {
+function unset_prompt() {
   export PROMPT="${OP_RUN_WRAPPER_ORIGINAL_PROMPT}"
 }
  
-toggle_secrets_injection() {
+function toggle_secrets_injection() {
   if [[ -z "${OP_RUN_WRAPPER_CMDS[*]}" ]]; then
     echo "Error: OP_RUN_WRAPPER_CMDS is empty, please update the list of commands which require secrets injection."
     zle reset-prompt

--- a/plugins/1password/1password.plugin.zsh
+++ b/plugins/1password/1password.plugin.zsh
@@ -13,3 +13,55 @@ op completion zsh >| "$ZSH_CACHE_DIR/completions/_op" &|
 
 # Load opswd function
 autoload -Uz opswd
+
+
+# List of commands to inject secrets into before running
+OP_RUN_WRAPPER_CMDS=()
+OP_RUN_WRAPPER_ORIGINAL_PROMPT=$PROMPT
+OP_RUN_WRAPPER_SYMBOL="🔑"
+
+# Currently we take a simple approach and set aliases to override each command, this could be done with functions instead
+# Also ignoring the option to specify specific environment files with the `--env-file` flag
+set_op_aliases() {
+  for cmd in "${OP_RUN_WRAPPER_CMDS[@]}"; do
+    alias "$cmd"="op run -- $cmd"
+  done
+}
+
+unset_op_aliases() {
+  for cmd in "${OP_RUN_WRAPPER_CMDS[@]}"; do
+    unalias "$cmd" 2>/dev/null
+  done
+}
+
+set_prompt() {
+  OP_RUN_WRAPPER_ORIGINAL_PROMPT=$PROMPT
+  export PROMPT="(${OP_RUN_WRAPPER_SYMBOL}) ${PROMPT}"
+}
+
+unset_prompt() {
+  export PROMPT="${OP_RUN_WRAPPER_ORIGINAL_PROMPT}"
+}
+ 
+toggle_secrets_injection() {
+  if [[ -z "${OP_RUN_WRAPPER_CMDS[*]}" ]]; then
+    echo "Error: OP_RUN_WRAPPER_CMDS is empty, please update the list of commands which require secrets injection."
+    zle reset-prompt
+    return 1
+  fi
+  
+  if [[ -z "$OP_RUN_WRAPPER_ACTIVE" ]]; then
+    export OP_RUN_WRAPPER_ACTIVE=true
+    set_op_aliases   
+    set_prompt    
+  else
+    unset OP_RUN_WRAPPER_ACTIVE
+    unset_op_aliases  
+    unset_prompt     
+  fi
+
+  zle reset-prompt 
+}
+
+zle -N toggle_secrets_injection
+bindkey '^O' toggle_secrets_injection 

--- a/plugins/1password/README.md
+++ b/plugins/1password/README.md
@@ -33,6 +33,30 @@ service you want to get.
 > - [Get started with 1Password CLI 2: Sign in](https://developer.1password.com/docs/cli/get-started#sign-in)
 > - [Sign in to your 1Password account manually](https://developer.1password.com/docs/cli/sign-in-manually)
 
+## Secrets Injection
+
+This plugin wraps specific commands (e.g., terraform, env) with the op run command from 1Password, automatically injecting any relevant secrets already defined in your environment variables. This ensures seamless integration with 1Password to manage sensitive information without needing .env files.
+
+### Key Features
+
+- Automatic 1Password Integration: The plugin automatically loads secrets from your 1Password vaults into the environment for supported commands.
+- Toggle Activation: Easily enable or disable the wrapper with a keybinding (Ctrl+O by default).
+- Command-Specific Behavior: Each supported command (e.g., terraform, env) is wrapped with `op run`, and any secrets defined in your environment are automatically passed into the subprocess.
+
+### Basic Setup
+
+```zsh
+# setup any commands you wish to wrap
+➜  ~ export OP_RUN_WRAPPER_CMDS=(env)
+# define a secret and it's path inside your 1Password vault
+➜  ~ export AWS_ACCESS_KEY_ID="op://vault/secret/atrribute" 
+# enabled injection mode with Ctrl+O, call wrapped command `env` and see result
+(🔑) ➜  ~ env | grep AWS_ACCESS_KEY_ID                      
+AWS_ACCESS_KEY_ID=<concealed by 1Password>
+```
+
+For more information on the `op run` command, check out the official [1Password CLI documentation](https://developer.1password.com/docs/cli/secrets-environment-variables).
+
 ## Requirements
 
 - [1Password CLI 2](https://developer.1password.com/docs/cli/get-started#install)


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- allows users to specify commands to automatically run with `op run -- ` prefix for secrets injection from environment variables
