### PR TITLE
feat(clipboard): add simple osc52 support

### DIFF
--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -84,6 +84,17 @@ function detect-clipboard() {
   elif [ -n "${TMUX:-}" ] && (( ${+commands[tmux]} )); then
     function clipcopy() { tmux load-buffer "${1:--}"; }
     function clippaste() { tmux save-buffer -; }
+  elif [[ "$TERM" == "xterm"* || "$TERM" == "screen"* || "$TERM" == "tmux"* ]]; then
+    # OSC 52 support
+    function clipcopy() {
+      local data
+      data=$(cat "${1:-/dev/stdin}" | base64 | tr -d '\n')
+      printf "\033]52;c;%s\a" "$data" > /dev/tty
+    }
+    function clippaste() {
+      echo "OSC 52 does not support pasting from the clipboard."
+      return 1
+    }
   else
     function _retry_clipboard_detection_or_fail() {
       local clipcmd="${1}"; shift

--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -87,8 +87,8 @@ function detect-clipboard() {
   elif [[ "$TERM" == "xterm"* || "$TERM" == "screen"* || "$TERM" == "tmux"* ]]; then
     # OSC 52 support
     function clipcopy() {
-      local data
-      data=$(cat "${1:-/dev/stdin}" | base64 | tr -d '\n')
+      local content_tocopy
+      content_tocopy=$(cat "${1:-/dev/stdin}" | base64 | tr -d '\n')
       printf "\033]52;c;%s\a" "$data" > /dev/tty
     }
     function clippaste() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add osc52 support for `lib/clipboard`, so when we copy content on server, there will be the same content on the clipboard 

