### PR TITLE
fix(af-magic): add logic for virtualenv separator

### DIFF
--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -13,6 +13,8 @@ function afmagic_dashes {
   # the prompt, account for it when returning the number of dashes
   if [[ -n "$python_env" && "$PS1" = *\(${python_env}\)* ]]; then
     echo $(( COLUMNS - ${#python_env} - 3 ))
+  elif [[ -n "$VIRTUAL_ENV_PROMPT" && "$PS1" = *${VIRTUAL_ENV_PROMPT}* ]]; then
+    echo $(( COLUMNS - ${#VIRTUAL_ENV_PROMPT} ))
   else
     echo $COLUMNS
   fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds a fallback method for detecting Python virtualenv prompt for `af-magic` theme separator line. 

## Other comments:
The current method seems to be broken in some cases. The previous version assumes that the name of the virtual environment is the venv directory itself (e.g., `.venv`), but this isn't always the case, as running `uv venv` names the virtualenv based on the directory where it was created.