### PR TITLE
feat(kubectl): add aliases for 'kubectl rollout restart'

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -12,7 +12,7 @@ plugins=(... kubectl)
 ## Aliases
 
 | Alias    | Command                                            | Description                                                                                      |
-| :------- | :------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
+|:---------|:---------------------------------------------------|:-------------------------------------------------------------------------------------------------|
 | k        | `kubectl`                                          | The kubectl command                                                                              |
 | kca      | `kubectl --all-namespaces`                         | The kubectl command targeting all namespaces                                                     |
 | kaf      | `kubectl apply -f`                                 | Apply a YML file                                                                                 |
@@ -72,6 +72,8 @@ plugins=(... kubectl)
 | kdeld    | `kubectl delete deployment`                        | Delete the deployment                                                                            |
 | ksd      | `kubectl scale deployment`                         | Scale a deployment                                                                               |
 | krsd     | `kubectl rollout status deployment`                | Check the rollout status of a deployment                                                         |
+| krrd     | `kubectl rollout restart deployment`               | Rollout restart a deployment                                                                     |
+| krrd     | `kubectl rollout restart deploy`                   | Rollout restart a deployment                                                                     |
 | kres     | `kubectl set env $@ REFRESHED_AT=...`              | Recreate all pods in deployment with zero-downtime                                               |
 |          |                                                    | **Rollout management**                                                                           |
 | kgrs     | `kubectl get replicaset`                           | List all ReplicaSets `rs` created by the deployment                                              |
@@ -110,6 +112,7 @@ plugins=(... kubectl)
 | kdelss   | `kubectl delete statefulset`                       | Delete the statefulset                                                                           |
 | ksss     | `kubectl scale statefulset`                        | Scale a statefulset                                                                              |
 | krsss    | `kubectl rollout status statefulset`               | Check the rollout status of a deployment                                                         |
+| krrss    | `kubectl rollout restart statefulset`              | Rollout restart a statefulset                                                                    |
 |          |                                                    | **Service Accounts management**                                                                  |
 | kdsa     | `kubectl describe sa`                              | Describe a service account in details                                                            |
 | kdelsa   | `kubectl delete sa`                                | Delete the service account                                                                       |

--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -12,7 +12,7 @@ plugins=(... kubectl)
 ## Aliases
 
 | Alias    | Command                                            | Description                                                                                      |
-|:---------|:---------------------------------------------------|:-------------------------------------------------------------------------------------------------|
+| :------- | :------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
 | k        | `kubectl`                                          | The kubectl command                                                                              |
 | kca      | `kubectl --all-namespaces`                         | The kubectl command targeting all namespaces                                                     |
 | kaf      | `kubectl apply -f`                                 | Apply a YML file                                                                                 |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -96,6 +96,8 @@ alias kdd='kubectl describe deployment'
 alias kdeld='kubectl delete deployment'
 alias ksd='kubectl scale deployment'
 alias krsd='kubectl rollout status deployment'
+alias krrd='kubectl rollout restart deployment'
+alias krrd='kubectl rollout restart deploy'
 
 function kres(){
   kubectl set env $@ REFRESHED_AT=$(date +%Y%m%d%H%M%S)
@@ -118,6 +120,7 @@ alias kdss='kubectl describe statefulset'
 alias kdelss='kubectl delete statefulset'
 alias ksss='kubectl scale statefulset'
 alias krsss='kubectl rollout status statefulset'
+alias krrss='kubectl rollout restart statefulset'
 
 # Port forwarding
 alias kpf="kubectl port-forward"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Create kubectl aliases for restarting the rollout of Deployment and Statefulset resources.
