### PR TITLE
'resetlaunchpad' alias to reset Launchpad layout

### DIFF
--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -17,6 +17,9 @@ function ofd {
 alias showfiles="defaults write com.apple.finder AppleShowAllFiles -bool true && killall Finder"
 alias hidefiles="defaults write com.apple.finder AppleShowAllFiles -bool false && killall Finder"
 
+# Reset Launchpad layout (defaults method does not work in MacOS 15.2+)
+alias resetlaunchpad='defaults write com.apple.dock ResetLaunchPad -bool true && rm -rf /private/$(getconf DARWIN_USER_DIR)/com.apple.dock.launchpad && killall Dock'
+
 # Bluetooth restart
 function btrestart() {
   sudo kextunload -b com.apple.iokit.BroadcomBluetoothHostControllerUSBTransport


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added a `resetlaunchpad` alias to reset Launchpad layout to the `macos` plugin
- Included the new method to reset Launchpad layout on MacOS 15.2+

## Added code:
```bash
# Reset Launchpad layout (defaults method does not work in MacOS 15.2+)
alias resetlaunchpad='defaults write com.apple.dock ResetLaunchPad -bool true && rm -rf /private/$(getconf DARWIN_USER_DIR)/com.apple.dock.launchpad && killall Dock'
```
