### PR TITLE
feat(docker): add docker desktop aliases

### DIFF
--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -79,3 +79,9 @@ zstyle ':omz:plugins:docker' legacy-completion yes
 | dvprune | `docker volume prune`         | Cleanup dangling volumes                                                                 |
 | dxc     | `docker container exec`       | Run a new command in a running container                                                 |
 | dxcit   | `docker container exec -it`   | Run a new command in a running container in an interactive shell                         |
+| ddeng   | `docker desktop engine`       | Commands to list and switch containers (Windows only)                                    |
+| ddres   | `docker desktop restart`      | Restart Docker Desktop                                                                   |
+| ddst    | `docker desktop start`        | Start Docker Desktop                                                                     |
+| ddsts   | `docker desktop status`       | Display Docker Desktop's status                                                          |
+| ddstp   | `docker desktop stop`         | Stop Docker Desktop                                                                      |
+| ddver   | `docker desktop version`      | Show the Docker Desktop version information                                              |

--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -34,6 +34,13 @@ alias dvls='docker volume ls'
 alias dvprune='docker volume prune'
 alias dxc='docker container exec'
 alias dxcit='docker container exec -it'
+alias ddeng='docker desktop engine'
+alias ddres='docker desktop restart'
+alias ddst='docker desktop start'
+alias ddsts='docker desktop status'
+alias ddstp='docker desktop stop'
+alias ddver='docker desktop version'
+
 
 if (( ! $+commands[docker] )); then
   return


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add aliases for `docker desktop` CLI commands, currently in Beta, using [docs from Docker website](https://docs.docker.com/reference/cli/docker/desktop/) as reference

## Other comments:

I've searched the codebase for the aliases being added for existing usage and no results were found.
