### PR TITLE
feat(macos): add support for Ghostty terminal

### DIFF
--- a/plugins/macos/README.md
+++ b/plugins/macos/README.md
@@ -13,6 +13,7 @@ plugins=(... macos)
 - [iTerm2](https://iterm2.com/)
 - [Hyper](https://hyper.is/)
 - [Tabby](https://tabby.sh/)
+- [Ghostty](https://ghostty.org)
 
 ## Commands
 

--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -86,6 +86,12 @@ EOF
         tell process "Tabby" to keystroke "t" using command down
       end tell
 EOF
+  elif [[ "$the_app" == 'ghostty' ]]; then
+    osascript >/dev/null <<EOF
+      tell application "System Events"
+        tell process "Ghostty" to keystroke "t" using command down
+      end tell
+EOF
   else
     echo "$0: unsupported terminal app: $the_app" >&2
     return 1
@@ -138,6 +144,12 @@ EOF
     osascript >/dev/null <<EOF
       tell application "System Events"
         tell process "Tabby" to keystroke "D" using command down
+      end tell
+EOF
+  elif [[ "$the_app" == 'ghostty' ]]; then
+    osascript >/dev/null <<EOF
+      tell application "System Events"
+        tell process "Ghostty" to keystroke "D" using command down
       end tell
 EOF
   else
@@ -193,6 +205,12 @@ EOF
     osascript >/dev/null <<EOF
       tell application "System Events"
         tell process "Tabby" to keystroke "d" using command down
+      end tell
+EOF
+  elif [[ "$the_app" == 'ghostty' ]]; then
+    osascript >/dev/null <<EOF
+      tell application "System Events"
+        tell process "Ghostty" to keystroke "d" using command down
       end tell
 EOF
   else


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added support for Ghostty terminal for the `macos` plugin.

## Other comments:

Tested locally for `tab`, `split_tab` and `vsplit_tab`. 