### PR TITLE
Remove echo from gradle plugin

### DIFF
--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -15,7 +15,6 @@ function gradle-or-gradlew() {
 
   # if gradlew found, run it instead of gradle
   if [[ -f "$project_root/gradlew" ]]; then
-    echo "executing gradlew instead of gradle"
     "$project_root/gradlew" "$@"
   else
     command gradle "$@"


### PR DESCRIPTION
When using this plugin and running e.g. `gradle --quiet`, the echo statement would print to stdout. I figured that I could make it respect the `--quiet` flag (and possibly various other situations in which echoing isn't expected to print to stdout), but as a much simpler approach it can also be removed altogether unless there is a reason to keep it.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] ~If the code introduces new aliases, I provide a valid use case for all plugin users down below.~

## Other comments:

I don't know who maintains the gradle plugin, so I'm not sure who to mention.