### PR TITLE
feat(web-search): Add multiple (ai) search engines

### DIFF
--- a/plugins/web-search/README.md
+++ b/plugins/web-search/README.md
@@ -29,6 +29,7 @@ Available search contexts are:
 | `bing`                | `https://www.bing.com/search?q=`                |
 | `google`              | `https://www.google.com/search?q=`              |
 | `brs` or `brave`      | `https://search.brave.com/search?q=`            |
+| `braveai`             | `https://search.brave.com/search?summary=1&q=`  |
 | `yahoo`               | `https://search.yahoo.com/search?p=`            |
 | `ddg` or `duckduckgo` | `https://www.duckduckgo.com/?q=`                |
 | `sp` or `startpage`   | `https://www.startpage.com/do/search?q=`        |
@@ -53,6 +54,12 @@ Available search contexts are:
 | `chatgpt`             | `https://chatgpt.com/?q=`                       |
 | `reddit`              | `https://www.reddit.com/search/?q=`             |
 | `ppai`                | `https://www.perplexity.ai/search/new?q=`       |
+| `claude`              | `https://claude.ai/new?q=`                      |
+| `mistral`             | `https://chat.mistral.ai/chat?q=`              |
+| `mscop`               | `https://www.bing.com/search?showconv=1&sendquery=1&q=` |
+| `you`                 | `https://you.com/search?q=`                     |
+| `youchat`             | `https://you.com/search?tbm=youchat&q=`        |
+| `gmaps`               | `https://www.google.com/maps/search/?api=1&query=` |
 
 Also there are aliases for bang-searching DuckDuckGo:
 

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -10,6 +10,7 @@ function web_search() {
     google          "https://www.google.com/search?q="
     bing            "https://www.bing.com/search?q="
     brave           "https://search.brave.com/search?q="
+    braveai         "https://search.brave.com/search?summary=1&q="
     yahoo           "https://search.yahoo.com/search?p="
     duckduckgo      "https://www.duckduckgo.com/?q="
     startpage       "https://www.startpage.com/do/search?q="
@@ -34,6 +35,12 @@ function web_search() {
     chatgpt         "https://chatgpt.com/?q="
     reddit          "https://www.reddit.com/search/?q="
     ppai            "https://www.perplexity.ai/search/new?q="
+    claude          "https://claude.ai/new?q="
+    mistral         "https://chat.mistral.ai/chat?q="
+    mscop           "https://www.bing.com/search?showconv=1&sendquery=1&q="
+    you             "https://you.com/search?q="
+    youchat         "https://you.com/search?tbm=youchat&q="
+    gmaps           "https://www.google.com/maps/search/?api=1&query="
   )
 
   # check whether the search engine is supported
@@ -63,10 +70,13 @@ function web_search() {
 
 
 alias bing='web_search bing'
+alias brave='web_search brave'
 alias brs='web_search brave'
 alias google='web_search google'
 alias yahoo='web_search yahoo'
+alias duckduckgo='web_search duckduckgo'
 alias ddg='web_search duckduckgo'
+alias startpage='web_search startpage'
 alias sp='web_search startpage'
 alias yandex='web_search yandex'
 alias github='web_search github'
@@ -89,6 +99,13 @@ alias gopkg='web_search gopkg'
 alias chatgpt='web_search chatgpt'
 alias reddit='web_search reddit'
 alias ppai='web_search ppai'
+alias braveai='web_search braveai'
+alias claude='web_search claude'
+alias mistral='web_search mistral'
+alias mscop='web_search mscop'
+alias you='web_search you'
+alias youchat='web_search youchat'
+alias gmaps='web_search gmaps'
 
 #add your own !bang searches here
 alias wiki='web_search duckduckgo \!w'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add multiple (ai) search engines to websearch-plugin
  - ai: Claude, Mistral, Microsoft Copilot, YouChat
  - non-ai: You, Google Maps
- Add missing aliases for `brave`, `duckduckgo` and `startpage`

## Other comments:

- I have limited it to the most important ones from my point of view
