### PR TITLE
fix(rust): call `rustc` through `rustup run`

### DIFF
--- a/plugins/rust/rust.plugin.zsh
+++ b/plugins/rust/rust.plugin.zsh
@@ -22,5 +22,5 @@ fi
 rustup completions zsh >| "$ZSH_CACHE_DIR/completions/_rustup" &|
 cat >| "$ZSH_CACHE_DIR/completions/_cargo" <<'EOF'
 #compdef cargo
-source "$(rustc +${${(z)$(rustup default)}[1]} --print sysroot)"/share/zsh/site-functions/_cargo
+source "$(rustup run ${${(z)$(rustup default)}[1]} rustc --print sysroot)"/share/zsh/site-functions/_cargo
 EOF


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

On recent versions of `rustc`, the `+toolchain` option has disapear. To prevent the command from issuing an empty string, call `rustc` through `rustup run rustc`.

