### PR TITLE
feat(git): add `gac` alias for staging and committing untracked files

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -265,6 +265,7 @@ receive further support.
 | `git_develop_branch`     | Returns the name of the “development” branch: `dev`, `devel`, `development` if they exist, `develop` otherwise. |
 | `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise.                                   |
 | `grename <old> <new>`    | Renames branch `<old>` to `<new>`, including on the origin remote.                                              |
+| `gac`                    | Stages and commits an untracked file.                                                                           |
 | `gbda`                   | Deletes all merged branches                                                                                     |
 | `gbds`                   | Deletes all squash-merged branches (**Note: performance degrades with number of branches**)                     |
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -115,6 +115,22 @@ alias gamscp='git am --show-current-patch'
 alias gams='git am --skip'
 alias gap='git apply'
 alias gapt='git apply --3way'
+
+# Adds and commits an untracked file.
+function gac() {
+  if [ $# -lt 2 ]; then
+    echo "Usage: gac <file> <commit message>"
+    return 1
+  fi
+
+  local file="$1"
+  shift
+  local message="$@"
+
+  git add "$file"
+  git commit -m "$message"
+}
+
 alias gbs='git bisect'
 alias gbsb='git bisect bad'
 alias gbsg='git bisect good'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds a function called `gac` for conveniently staging and committing an untracked file in a single command.
- Example Usage:
  - `gac file.txt "Add initial version"` This stages `myfile.txt` and commits it with the message "Add initial version."


## Other comments:
- Handles unquoted commit messages with spaces.
- Provides a usage message if insufficient arguments are provided.