### PR TITLE
chore: add `.zwc` files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ log/
 # editor configs
 .vscode
 .idea
+
+# zcompile cached files
+*.zwc


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Adds compiled `*.zwc` files to `.gitignore`.

## Other comments:

I've found an old PR that also introduced this change along some other things, but it was closed by the submitter #9147.