### PR TITLE
fix(chruby): update brew sourcing for Apple Silicon

### DIFF
--- a/plugins/chruby/chruby.plugin.zsh
+++ b/plugins/chruby/chruby.plugin.zsh
@@ -16,14 +16,15 @@ _source-from-omz-settings() {
 }
 
 _source-from-homebrew() {
-  (( $+commands[brew] )) || return 1
-
   local _brew_prefix
   # check default brew prefix
-  if [[ -h /usr/local/opt/chruby ]];then
-    _brew_prefix="/usr/local/opt/chruby"
+  if [[ -h /opt/homebrew/opt/chruby ]]; then
+    _brew_prefix="/opt/homebrew/opt/chruby"
   else
     # ok , it is not default prefix
+    # check to see if brew command is available
+    (( $+commands[brew] )) || return 1
+
     # this call to brew is expensive ( about 400 ms ), so at least let's make it only once
     _brew_prefix=$(brew --prefix chruby)
   fi

--- a/plugins/chruby/chruby.plugin.zsh
+++ b/plugins/chruby/chruby.plugin.zsh
@@ -16,15 +16,16 @@ _source-from-omz-settings() {
 }
 
 _source-from-homebrew() {
+  (( $+commands[brew] )) || return 1
+
   local _brew_prefix
   # check default brew prefix
-  if [[ -h /opt/homebrew/opt/chruby ]]; then
+  if [[ -h /usr/local/opt/chruby ]];then
+    _brew_prefix="/usr/local/opt/chruby"
+  elif [[ -h /opt/homebrew/opt/chruby ]]; then
     _brew_prefix="/opt/homebrew/opt/chruby"
   else
     # ok , it is not default prefix
-    # check to see if brew command is available
-    (( $+commands[brew] )) || return 1
-
     # this call to brew is expensive ( about 400 ms ), so at least let's make it only once
     _brew_prefix=$(brew --prefix chruby)
   fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes (and hopefully speeds up) the `chruby` plugin loading process on Apple Silicon macs where the default Homebrew prefix is `/opt/homebrew`

cc @mcornella @carlosala 