### PR TITLE
feat(direnv-p10k): Add a new plugin for direnv specifically for fixing the giant instant prompt warning for powerlevel10k theme users

### DIFF
--- a/plugins/direnv-p10k/README.md
+++ b/plugins/direnv-p10k/README.md
@@ -1,0 +1,17 @@
+# direnv plugin
+
+This plugin creates the [Direnv](https://direnv.net/) hook.
+
+This hook is tweaked to prevent issues with the powerlevel10k theme's instant prompt feature by not adding the direnv hook to precmd_functions
+
+To use it, add `direnv-p10k` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... direnv-p10k)
+```
+
+## Requirements
+
+In order to make this work, you will need to have direnv installed.
+
+More info on the usage and install: https://github.com/direnv/direnv

--- a/plugins/direnv-p10k/direnv-p10k.plugin.zsh
+++ b/plugins/direnv-p10k/direnv-p10k.plugin.zsh
@@ -1,0 +1,15 @@
+# If direnv is not found, don't continue and print a warning
+if (( ! $+commands[direnv] )); then
+  echo "Warning: direnv not found. Please install direnv and ensure it's in your PATH before using this plugin."
+  return
+fi
+
+_direnv_hook() {
+  trap -- '' SIGINT;
+  eval "$(direnv export zsh)";
+  trap - SIGINT;
+}
+typeset -ag chpwd_functions;
+if [[ -z "${chpwd_functions[(r)_direnv_hook]+1}" ]]; then
+  chpwd_functions=( _direnv_hook ${chpwd_functions[@]} )
+fi


### PR DESCRIPTION
Hello,

I tweaked the direnv plugin to help out powerlevel10k users who use the instant prompt feature.

Based on research I did for direnv/direnv#68 I found the `precmd_functions` hook to be a nuisance when using powerlevel10k theme's instant prompt feature.

Summary:
Direnv generates output any time it loads environment variables from a `.envrc` file. This causes powerlevel10k users with instant prompt enabled to receive a giant warning message on every shell start where the shell is starting and presenting a prompt inside a directory with a `.envrc` file. Because `precmd_functions` runs before every prompt, having the direnv hook included in the array causes this issue.

This plugin is functionally identical to the existing plugin except that the `precmd_functions` hook is removed.

This is provided as a separate plugin to allow this to ONLY affect powerlevel10k users, as `precmd_functions` is still a valid hook and no issues stem from its use outside of the context of using the powerlevel10k theme's instant prompt feature.

TO REPRODUCE THE ISSUE:

1. Install oh-my-zsh and direnv
2. Install powerlevel10k theme and run `p10k configure`
3. Enable instant prompt
5. Set powerlevel10k as your oh-my-zsh theme
6. Create a `.envrc` file in any directory with some variables to export upon entry to the directory
7. Run `direnv allow` in the directory, then go out and back in to ensure that the variables load. You should see output from direnv indicating it loaded the file in the directory.
8. Enable the direnv oh-my-zsh plugin in `~/.zshrc`
9. Open a Finder (MacOS), Nautilus (GNOME), or Dolphin or Konqueror (KDE) (or the appropriate file manager for your system) window and navigate to one directory above where the `.envrc` file is located.
10. From the above screen, launch a new terminal (or terminal tab) using whatever method is appropriate to ensure that the terminal starts in the directory where the `.envrc` is located. For MacOS/Finder this is cmd+right click the directory with the `.envrc` file -> Services -> New Terminal at Folder
11. Observe the message which appears from p10k warning you to disable output during terminal initialization or turn off instant prompt
12. In `~/.zshrc`, disable the direnv plugin, enable the direnv-p10k plugin (this plugin)
13. Perform the steps 9, 10 and 11 as before, opening a new terminal or terminal tab in the directory where the `.envrc` file is located.
14. Observe no warning message is printed -- NOTE direnv has not loaded the .envrc file at this point.
  * To load .envrc, simply run `cd .`

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Creates a copy of direnv plugin without the `precmd_functions` related lines

## Other comments:


