### PR TITLE
feat(terraform): support `TF_DATA_DIR` in `tf_prompt_info`

### DIFF
--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -2,9 +2,9 @@ function tf_prompt_info() {
   # dont show 'default' workspace in home dir
   [[ "$PWD" != ~ ]] || return
   # check if in terraform dir and file exists
-  [[ -d .terraform && -r .terraform/environment ]] || return
+  [[ -d "${TF_DATA_DIR:-.terraform}" && -r "${TF_DATA_DIR:-.terraform}/environment" ]] || return
 
-  local workspace="$(< .terraform/environment)"
+  local workspace="$(< "${TF_DATA_DIR:-.terraform}/environment")"
   echo "${ZSH_THEME_TF_PROMPT_PREFIX-[}${workspace:gs/%/%%}${ZSH_THEME_TF_PROMPT_SUFFIX-]}"
 }
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Enable prompt display with non default terraform data dir

## Other comments:

cc @mcornella