### PR TITLE
feat(otp): XDG basedir support, or user value for OTP_HOME

### DIFF
--- a/plugins/otp/README.md
+++ b/plugins/otp/README.md
@@ -19,4 +19,6 @@ Provided aliases:
 - `ot`: generates a MFA code based on the given key and copies it to the clipboard
   (on Linux it relies on xsel, on MacOS X it uses pbcopy instead).
 
-The plugin uses `$HOME/.otp` to store its internal files.
+The plugin stores its internal files in `$OTP_HOME`, which can be set in your zshrc.
+If `$OTP_HOME` is not set it defaults to either `$HOME/.otp` or `$XDG_DATA_HOME/otp`,
+depending on whether `~/.otp` already exists, or whether `$XDG_DATA_HOME` is set.

--- a/plugins/otp/otp.plugin.zsh
+++ b/plugins/otp/otp.plugin.zsh
@@ -1,4 +1,10 @@
-export OTP_HOME=~/.otp
+if [[ -z "$OTP_HOME" ]]; then
+  if [[ ! -d "$HOME/.otp" ]] && [[ -n "$XDG_DATA_HOME" ]]; then
+    export OTP_HOME="$XDG_DATA_HOME/otp"
+  else
+    export OTP_HOME=~/.otp
+  fi
+fi
 mkdir -p $OTP_HOME
 
 function ot () {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

otp plugin now uses the following logic for its home:
- If $OTP_HOME is set by the user, use that value
- If ~/.otp dir already exists, use that value
- If XDG_DATA_HOME is set, use $XDG_DATA_HOME/otp
- Else fallback to ~/.otp

## Other comments:

Care was taken to ensure OTP users with an existing `~/.otp` directory are unaffected. This change is necessary to support users who prefer not to have their `$HOME` cluttered and use `$XDG_DATA_HOME` to achieve that. `$XDG_DATA_HOME` is the more appropriate default than `$XDG_CONFIG_HOME` due to the nature of what this plugin stores, but the user could simply `export OTP_HOME=${XDG_CONFIG_HOME:-$HOME/.config}/otp` if they prefer another location.