### PR TITLE
fix(mvn): Handle directories in <relativePath>

### DIFF
--- a/plugins/mvn/mvn.plugin.zsh
+++ b/plugins/mvn/mvn.plugin.zsh
@@ -101,8 +101,14 @@ function listMavenCompletions {
       new_file="../pom.xml"
     fi
 
-    # if file doesn't exist break
     file="${file:h}/${new_file}"
+
+    # if the file points to a directory, assume it is a pom.xml in that directory
+    if [[ -d "$file" ]]; then
+      file="${file}/pom.xml"
+    fi
+
+    # if file doesn't exist break
     if ! [[ -e "$file" ]]; then
       break
     fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] ~If the code introduces new aliases, I provide a valid use case for all plugin users down below.~

## Changes:

Maven also supports putting a directory into `<relativePath>`, however, the current version of the plugin only supports references to files and produce the following error with directories:

```
sed: read error on XXXXXXXX: Is a directory
```

This PR fixes that.

## Other comments:

Not sure who maintains the mvn plugin so I guess cc @mcornella from the git history?
