### PR TITLE
Update suse.plugin.zsh - alias collision for zcl

### DIFF
--- a/plugins/suse/suse.plugin.zsh
+++ b/plugins/suse/suse.plugin.zsh
@@ -38,7 +38,7 @@ alias zwp='zypper --no-refresh wp'
 
 #Repositories commands
 alias zar='sudo zypper ar'
-alias zcl='sudo zypper clean'
+alias zcc='sudo zypper clean'
 alias zlr='zypper lr'
 alias zmr='sudo zypper mr'
 alias znr='sudo zypper nr'


### PR DESCRIPTION
fix duplicate entry for alias 'zcl'

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- fix duplicate entry for alias 'zcl'

## Other comments:

#10859 this is also open PR for almost 3years now, my PR is minimal in terms of edit, literally 3 characters, perhaps we can hasten the PR by that, thanks.