### PR TITLE
feat(archlinux): add paru to AUR helpers

### DIFF
--- a/plugins/archlinux/README.md
+++ b/plugins/archlinux/README.md
@@ -155,6 +155,30 @@ upgrades were available. Use `pacman -Que` instead.
 | yasu    | `yay -Syu --no-confirm`        | Same as `yaupg`, but without confirmation                         |
 | upgrade[¹](#f1) | `yay -Syu`             | Sync with repositories before upgrading packages                  |
 
+#### Paru
+
+| Alias    | Command                         | Description                                                       |
+|----------|---------------------------------|-------------------------------------------------------------------|
+| parclean | `paru -Sc`                      | Clean out old and unused caches and packages                      |
+| parclr   | `paru -Scc`                     | Remove all files from the cache                                   |
+| parin    | `paru -S`                       | Install packages from the repositories                            |
+| parins   | `paru -U`                       | Install a package from a local file                               |
+| parinsd  | `paru -S --asdeps`              | Install packages as dependencies of another package               |
+| parloc   | `paru -Qi`                      | Display information about a package in the local database         |
+| parlocs  | `paru -Qs`                      | Search for packages in the local database                         |
+| parlst   | `paru -Qe`                      | List installed packages including from AUR (tagged as "local")    |
+| parmir   | `paru -Syy`                     | Force refresh of all package lists after updating mirrorlist      |
+| parorph  | `paru -Qtd`                     | Remove orphans using paru                                         |
+| pare     | `paru -R`                       | Remove packages, keeping its settings and dependencies            |
+| parem    | `paru -Rns`                     | Remove packages, including its settings and unneeded dependencies |
+| parep    | `paru -Si`                      | Display information about a package in the repositories           |
+| pareps   | `paru -Ss`                      | Search for packages in the repositories                           |
+| parupd   | `paru -Sy`                      | Update and refresh local package, ABS and AUR databases           |
+| parupg   | `paru -Syu`                     | Sync with repositories before upgrading packages                  |
+| parsu    | `paru -Syu --no-confirm`        | Same as `parupg`, but without confirmation                        |
+| upgrade[¹](#f1) | `paru -Syu`              | Sync with repositories before upgrading packages                  |
+
+
 ---
 
 <span id="f1">¹</span>

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -177,7 +177,6 @@ if (( $+commands[yay] )); then
 fi
 
 if (( $+commands[paru] )); then
-  alias parconf='paru -Pg'
   alias parclean='paru -Sc'
   alias parclr='paru -Scc'
   alias parupg='paru -Syu'

--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -176,6 +176,27 @@ if (( $+commands[yay] )); then
   alias yaupd="yay -Sy"
 fi
 
+if (( $+commands[paru] )); then
+  alias parconf='paru -Pg'
+  alias parclean='paru -Sc'
+  alias parclr='paru -Scc'
+  alias parupg='paru -Syu'
+  alias parsu='paru -Syu --noconfirm'
+  alias parin='paru -S'
+  alias parins='paru -U'
+  alias pare='paru -R'
+  alias parem='paru -Rns'
+  alias parep='paru -Si'
+  alias pareps='paru -Ss'
+  alias parloc='paru -Qi'
+  alias parlocs='paru -Qs'
+  alias parlst='paru -Qe'
+  alias parorph='paru -Qtd'
+  alias parinsd='paru -S --asdeps'
+  alias parmir='paru -Syy'
+  alias parupd="paru -Sy"
+fi
+
 # Check Arch Linux PGP Keyring before System Upgrade to prevent failure.
 function upgrade() {
   echo ":: Checking Arch Linux PGP Keyring..."
@@ -189,7 +210,9 @@ function upgrade() {
     echo " Arch Linux PGP Keyring is up to date."
     echo " Proceeding with full system upgrade."
   fi
-  if (( $+commands[yay] )); then
+  if (( $+commands[paru] )); then
+    paru -Syu
+  elif (( $+commands[yay] )); then
     yay -Syu
   elif (( $+commands[trizen] )); then
     trizen -Syu


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add aliases for [paru](https://github.com/Morganamilo/paru) - an AUR helper written in Rust by one of the most frequent Pacman contributors.

## Other comments:

...
