### PR TITLE
feat(fnm): add autostart option to setup fnm env

### DIFF
--- a/plugins/fnm/README.md
+++ b/plugins/fnm/README.md
@@ -2,8 +2,34 @@
 
 This plugin adds autocompletion for [fnm](https://github.com/Schniz/fnm) - a Node.js version manager.
 
-To use it, add `fnm` to the plugins array in your zshrc file:
+To use it, add `fnm` to the plugins array in your `.zshrc` file:
 
 ```zsh
 plugins=(... fnm)
 ```
+
+## Configuration
+
+These settings should go in your `.zshrc` file, before Oh My Zsh is sourced.
+
+### Autostart
+
+If set, the plugin will automatically start fnm for the session, running the `fnm env`:
+
+```zsh
+zstyle ':omz:plugins:fnm' autostart yes
+```
+
+Default: `no` (disabled)
+
+### Use on cd
+
+If set, the Node.js version will be switched based on the requirements of the current directory (recommended):
+
+```zsh
+zstyle ':omz:plugins:fnm' use-on-cd yes
+```
+
+Default: `yes` (enabled)
+
+Check out the [official documentation](https://github.com/Schniz/fnm/blob/master/docs/commands.md) for the available fnm variables.

--- a/plugins/fnm/fnm.plugin.zsh
+++ b/plugins/fnm/fnm.plugin.zsh
@@ -11,3 +11,11 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_fnm" ]]; then
 fi
 
 fnm completions --shell=zsh >| "$ZSH_CACHE_DIR/completions/_fnm" &|
+
+if zstyle -t ':omz:plugins:fnm' autostart; then
+  local -a fnm_env_cmd
+  if zstyle -T ':omz:plugins:fnm' use-on-cd; then
+    fnm_env_cmd+=("--use-on-cd")
+  fi
+  eval "$(fnm env --shell=zsh $fnm_env_cmd)"
+fi


### PR DESCRIPTION
Add new setting `ZSH_FNM_AUTOSTART` to be able to automatic setup the `fnm env`.  
Default set to `false` to avoid breaking existing setup.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Other comments:

It would be ideal to have it enabled by default, but it can current break existing setups. The `fnm env` also adds to `$PATH`, so we must not duplicate it.

I think this https://github.com/Schniz/fnm/pull/1309 would solve it.
