### PR TITLE
fix(chruby): fix the `rubies` command output

### DIFF
--- a/plugins/chruby/chruby.plugin.zsh
+++ b/plugins/chruby/chruby.plugin.zsh
@@ -15,6 +15,13 @@ _source-from-omz-settings() {
   fi
 }
 
+_source-from-default-location() {
+  [[ -r /usr/local/share/chruby/chruby.sh ]] || return 1
+
+  source /usr/local/share/chruby/chruby.sh
+  source /usr/local/share/chruby/auto.sh
+}
+
 _source-from-homebrew() {
   (( $+commands[brew] )) || return 1
 
@@ -36,27 +43,14 @@ _source-from-homebrew() {
   source $_brew_prefix/share/chruby/auto.sh
 }
 
-_load-chruby-dirs() {
-  local dir
-  for dir in "$HOME/.rubies" "$PREFIX/opt/rubies"; do
-    if [[ -d "$dir" ]]; then
-      RUBIES+=("$dir")
-    fi
-  done
-}
-
 # Load chruby
-if _source-from-omz-settings; then
-  _load-chruby-dirs
-elif [[ -r "/usr/local/share/chruby/chruby.sh" ]] ; then
-  source /usr/local/share/chruby/chruby.sh
-  source /usr/local/share/chruby/auto.sh
-  _load-chruby-dirs
-elif _source-from-homebrew; then
-  _load-chruby-dirs
-fi
+_source-from-omz-settings || \
+  _source-from-default-location || \
+  _source-from-homebrew
 
-unfunction _source-from-homebrew _source-from-omz-settings _load-chruby-dirs
+unfunction _source-from-homebrew \
+           _source-from-default-location \
+           _source-from-omz-settings
 
 
 ## chruby utility functions and aliases


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Removes redundant `_load-chruby-dirs` function
- Extracts a `_source-from-default-location` function
- Fixes the output of `chruby` and its `rubies` alias

## Context

After updating oh-my-zsh to the latest version, the `chruby` command (and its `rubies` alias) now adds `.rubies` to the output:

```sh
~ λ rubies
 * ruby-3.4.1
   .rubies
```

It used to only display the actual Ruby versions installed (in my case in the default `chruby` `$HOME/.rubies` directory):

```sh
~ λ rubies
 * ruby-3.4.1
```

It was revealed using `git bisect` that the output was broken by [this commit](https://github.com/ohmyzsh/ohmyzsh/commit/5c14474eb2a252ad61e55cf084c5bbe6c1c934b9).
I also noticed that `chruby`'s `share/chruby/chruby.sh` [script](https://github.com/postmodern/chruby/blob/master/share/chruby/chruby.sh), which is `source`d by the plugin ([1](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/chruby/chruby.plugin.zsh#L10), [2](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/chruby/chruby.plugin.zsh#L35), [3](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/chruby/chruby.plugin.zsh#L52)), does [the same thing](https://github.com/postmodern/chruby/blob/master/share/chruby/chruby.sh#L5) of adding directories with Ruby versions installed to the `RUBIES` array:

```sh
for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
  [[ -d "$dir" && -n "$(command ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
done
```

so this plugin's `_load-chruby-dirs` function is essentially doing the same thing the `chruby.sh` script already does for us, but the function is doing it wrong, i.e. `RUBIES+=("$dir")` instead of `RUBIES+=("$dir"/*)`.

This PR fixes the process of loading `chruby` dirs and fixes the output of `chruby` (and its `rubies` alias):

```sh
~ λ rubies
 * ruby-3.4.1
```