### PR TITLE
fix(agnoster): print white text over black for light theme only

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -35,8 +35,14 @@
 CURRENT_BG='NONE'
 
 case ${SOLARIZED_THEME:-dark} in
-    light) CURRENT_FG='white';;
-    *)     CURRENT_FG='black';;
+    light)
+      CURRENT_FG='white'
+      CURRENT_DEFAULT_FG='white'
+      ;;
+    *)
+      CURRENT_FG='black'
+      CURRENT_DEFAULT_FG='default'
+      ;;
 esac
 
 ### Theme Configuration Initialization
@@ -48,7 +54,7 @@ esac
 : ${AGNOSTER_DIR_BG:=blue}
 
 # user@host
-: ${AGNOSTER_CONTEXT_FG:=white}
+: ${AGNOSTER_CONTEXT_FG:=${CURRENT_DEFAULT_FG}}
 : ${AGNOSTER_CONTEXT_BG:=black}
 
 # Git related
@@ -85,7 +91,7 @@ esac
 : ${AGNOSTER_STATUS_RETVAL_FG:=red}
 : ${AGNOSTER_STATUS_ROOT_FG:=yellow}
 : ${AGNOSTER_STATUS_JOB_FG:=cyan}
-: ${AGNOSTER_STATUS_FG:=white}
+: ${AGNOSTER_STATUS_FG:=${CURRENT_DEFAULT_FG}}
 : ${AGNOSTER_STATUS_BG:=black}
 
 ## Non-Color settings - set to 'true' to enable


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Print white text over black only when `SOLARIZED_THEME` is set to `light`

## Other comments:

Changes introduced by #12525 changes `AGNOSTER_CONTEXT_FG` and `AGNOSTER_STATUS_FG` text color from default to white under default configuration, which makes a difference when terminal default text color is not white.
This should be achieved by setting `SOLARIZED_THEME` to `light` or modifying `AGNOSTER_CONTEXT_FG` and `AGNOSTER_STATUS_FG` manually in .zshrc.
cc @Kekun @carlosala 