### PR TITLE
Fixed poetry-env plugin for Poetry >=2.0.0

### DIFF
--- a/plugins/poetry-env/poetry-env.plugin.zsh
+++ b/plugins/poetry-env/poetry-env.plugin.zsh
@@ -1,7 +1,7 @@
 _togglePoetryShell() {
   # Determine if currently in a Poetry-managed directory
   local in_poetry_dir=0
-  if [[ -f "$PWD/pyproject.toml" ]] && grep -q 'tool.poetry' "$PWD/pyproject.toml"; then
+  if [[ -f "$PWD/pyproject.toml" && -f "$PWD/poetry.lock" ]]; then
     in_poetry_dir=1
   fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixed poetry-env plugin for Poetry versions starting from 2.0.0

## Other comments:
Since version 2.0.0 poetry stopped using '[project.tool]' section in `pyproject.toml`. So the plugin didn't work for the newer poetry version.

With this change, the plugin will check for `pyproject.toml` and `poetry.lock` files to reliably check if it's a poetry project. In my testing, it worked with both poetry versions 1.8.5 and 2.0.1. In my testing, it worked with both poetry versions 1.8.5 and 2.0.1.
