### PR TITLE
fix(bgnotify): detect if sway is running and not just installed

### DIFF
--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -62,7 +62,7 @@ function bgnotify_formatted {
 function bgnotify_appid {
   if (( ${+commands[osascript]} )); then
     osascript -e "tell application id \"$(bgnotify_programid)\"  to get the {id, frontmost, id of front window, visible of front window}" 2>/dev/null
-  elif [[ -n $WAYLAND_DISPLAY ]] && (( ${+commands[swaymsg]} )); then # wayland+sway
+  elif [[ -n $WAYLAND_DISPLAY ]] && [[ -n $SWAYSOCK ]] && (( ${+commands[swaymsg]} )); then # wayland+sway
     local app_id=$(bgnotify_find_sway_appid)
     [[ -n "$app_id" ]] && echo "$app_id" || echo $EPOCHSECONDS
   elif [[ -z $WAYLAND_DISPLAY ]] && [[ -n $DISPLAY ]] && (( ${+commands[xprop]} )); then

--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -62,7 +62,7 @@ function bgnotify_formatted {
 function bgnotify_appid {
   if (( ${+commands[osascript]} )); then
     osascript -e "tell application id \"$(bgnotify_programid)\"  to get the {id, frontmost, id of front window, visible of front window}" 2>/dev/null
-  elif [[ -n $WAYLAND_DISPLAY ]] && [[ -n $SWAYSOCK ]] && (( ${+commands[swaymsg]} )); then # wayland+sway
+  elif [[ -n $WAYLAND_DISPLAY ]] && ([[ -n $SWAYSOCK ]] || [[ -n $I3SOCK ]]) && (( ${+commands[swaymsg]} )); then # wayland+sway
     local app_id=$(bgnotify_find_sway_appid)
     [[ -n "$app_id" ]] && echo "$app_id" || echo $EPOCHSECONDS
   elif [[ -z $WAYLAND_DISPLAY ]] && [[ -n $DISPLAY ]] && (( ${+commands[xprop]} )); then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Check if sway is actually running before calling swaymsg

## Other comments:

I just tried out hyprland and noticed, that on every new terminal it prints this error:
`00:00:00.007 [ERROR] [swaymsg/main.c:494] Unable to retrieve socket path`
It also prints this error after every command that took longer than the threshold (5 seconds).

Obviously hyprland isn't sway, so it also doesn't have a sway socket. So I changed the code that it doesn't only check if swaymsg is installed, but also if the `$SWAYSOCK` env variable is set, which indicates it is running on sway and swaymsg should work without errors.

It would be even better if it did support hyprland directly, and I might create another PR if I end up switching to hyprland, but for now this at least fixes the error messages everywhere. It also doesn't only fix it for hyprland, but for all other wayland compositors, which all tried to execute swaymsg, which also doesn't work there.
