### PR TITLE
feat(ssh): add ssh_fingerprint function and ssh_fp alias

### DIFF
--- a/plugins/ssh/README.md
+++ b/plugins/ssh/README.md
@@ -14,3 +14,10 @@ plugins=(... ssh)
 - `ssh_rmhkey`: remove host key from known hosts based on a host section name from `.ssh/config`.
 - `ssh_load_key`: load SSH key into agent.
 - `ssh_unload_key`: remove SSH key from agent.
+- `ssh_fingerprint` : calculate fingerprint of specifed key files. It has some options:
+  - `-md5` : Use MD5 fingerprint instead of SHA256
+  - `-n` : Don't colorize using ANSI
+  - `-q` : Don't print filename(s)
+  - If key files are not specified, defaults to `~/.ssh/authorized_keys`
+  - `ssh_fp` is an alias to this function
+

--- a/plugins/ssh/ssh.plugin.zsh
+++ b/plugins/ssh/ssh.plugin.zsh
@@ -78,8 +78,9 @@ function ssh_fingerprint() {
   local f
   for f in "${keyfiles[@]}"; do
     if [[ $quiet != "-q" ]]; then printf "${ansi[1]}$f:${ansi[2]}\n"; fi
-    ssh-keygen -l -E "$fptype" -f "$f"
+    if ! ssh-keygen -l -E "$fptype" -f "$f"; then return $?; fi
   done
+  return 0
 }
 alias ssh_fp='ssh_fingerprint'
 

--- a/plugins/ssh/ssh.plugin.zsh
+++ b/plugins/ssh/ssh.plugin.zsh
@@ -20,7 +20,7 @@ unset _ssh_configfile
 ############################################################
 # Remove host key from known hosts based on a host section
 # name from .ssh/config
-function ssh_rmhkey {
+function ssh_rmhkey() {
   local ssh_configfile="$HOME/.ssh/config"
   local ssh_host="$1"
   if [[ -z "$ssh_host" ]]; then return; fi
@@ -42,7 +42,7 @@ function ssh_load_key() {
 
 ############################################################
 # Remove SSH key from agent
-function ssh_unload_key {
+function ssh_unload_key() {
   local key="$1"
   if [[ -z "$key" ]]; then return; fi
   local keyfile="$HOME/.ssh/$key"
@@ -54,7 +54,7 @@ function ssh_unload_key {
 
 ############################################################
 # Calculate SSH key fingerprint
-function ssh_fingerprint {
+function ssh_fingerprint() {
   local fptype
   local quiet
   local ansi

--- a/plugins/ssh/ssh.plugin.zsh
+++ b/plugins/ssh/ssh.plugin.zsh
@@ -51,3 +51,35 @@ function ssh_unload_key {
     ssh-add -d "$keyfile"
   fi
 }
+
+############################################################
+# Calculate SSH key fingerprint
+function ssh_fingerprint {
+  local fptype
+  local quiet
+  local ansi
+
+  zmodload zsh/zutil
+  zparseopts -D -- md5=fptype q=quiet n=ansi
+  fptype="${fptype[*]}"
+  if [[ -z $fptype ]]; then
+    fptype="sha256"
+  else
+    fptype="${fptype:1}"
+  fi
+  if [[ -z ${ansi[*]} ]]; then
+    ansi=("\e[1;30m" "\e[0m")
+  else
+    ansi=("" "")
+  fi
+
+  local keyfiles=( "$@" )
+  if [[ ${#keyfiles[@]} == 0 ]]; then keyfiles=( "$HOME/.ssh/authorized_keys" ); fi
+  local f
+  for f in "${keyfiles[@]}"; do
+    if [[ $quiet != "-q" ]]; then printf "${ansi[1]}$f:${ansi[2]}\n"; fi
+    ssh-keygen -l -E "$fptype" -f "$f"
+  done
+}
+alias ssh_fp='ssh_fingerprint'
+


### PR DESCRIPTION
Adds a new function `ssh_fingerprint` (and its alias `ssh_fp`) to the `ssh` plugin.

`README.md` has also been updated to reflect the new function.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- New function: `ssh_fingerprint`
- New alias: `ssh_fp`
