### PR TITLE
feat(jj): enable dynamic completion

### DIFF
--- a/plugins/jj/jj.plugin.zsh
+++ b/plugins/jj/jj.plugin.zsh
@@ -11,7 +11,7 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_jj" ]]; then
   _comps[jj]=_jj
 fi
 
-jj util completion zsh >| "$ZSH_CACHE_DIR/completions/_jj" &|
+COMPLETE=zsh jj >| "$ZSH_CACHE_DIR/completions/_jj" &|
 
 function __jj_prompt_jj() {
   local -a flags


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Use `COMPLETE=zsh jj` to generate dynamic completions

## Other comments:

See: https://jj-vcs.github.io/jj/latest/install-and-setup/#command-line-completion
