### PR TITLE
fix(systemadmin): don't hardcode http20 network interface

### DIFF
--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -94,7 +94,13 @@ function req20() {
 
 # top20 of Using tcpdump port 80 access to view
 function http20() {
-  sudo tcpdump -i eth0 -tnn dst port 80 -c 1000 | awk -F"." '{print $1"."$2"."$3"."$4}' | sort | uniq -c | sort -nr | head -n 20
+  sudo tcpdump -i $(ip route get 1.1.1.1 \
+    | awk '/^1.1.1.1 via / {print $5}') -tnn dst port 80 -c 1000 \
+    | awk -F"." '{print $1"."$2"."$3"."$4}' \
+    | sort \
+    | uniq -c \
+    | sort -nr \
+    | head -n 20
 }
 
 # top20 of Find time_wait connection


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fix: Dynamically determine appropriate network interface for the `http20` function rather than hardcoding it to `eth0`, which is nonexistent on macOS.
- Style: One line per pipeline command in the `http20` function per ohmyzsh [Code Style Guide](https://github.com/ohmyzsh/ohmyzsh/wiki/Code-Style-Guide)

## Other comments:

This change uses the `ip route` command which is commonly installed on Linux and provided by the [iproute2](https://wiki.linuxfoundation.org/networking/iproute2) project. It checks what interface would be used to route to Cloudflare’s 1.1.1.1 DNS service, which although also hardcoded, at least is common across the Internet.

The macOS port of `ip route` is available from [Homebrew](https://brew.sh) by running `brew install iproute2mac`. Although an external dependency, it does at last make the function work on macOS with a command also common on Linux.

For example, on my macOS system, it returns either `en0` (Wi-Fi) or `en7` (the Ethernet slot on my Thunderbolt dock).
