### PR TITLE
feat(virtualenv): Use prompt set on virtual env creation 

### DIFF
--- a/plugins/virtualenv/README.md
+++ b/plugins/virtualenv/README.md
@@ -7,8 +7,11 @@ To use it, add `virtualenv` to the plugins array of your zshrc file:
 plugins=(... virtualenv)
 ```
 
-The plugin creates a `virtualenv_prompt_info` function that you can use in your theme, which displays
-the basename of the current `$VIRTUAL_ENV`. It uses two variables to control how that is shown:
+The plugin creates a `virtualenv_prompt_info` function that you can use in your theme. It
+displays the prompt string set when creating the virtual environment (via the `--prompt` option),
+falling back to the basename of the current `$VIRTUAL_ENV`.
+
+It uses two variables to control how that is shown:
 
 - `ZSH_THEME_VIRTUALENV_PREFIX`: sets the prefix of the VIRTUAL_ENV. Defaults to `[`.
 

--- a/plugins/virtualenv/README.md
+++ b/plugins/virtualenv/README.md
@@ -7,9 +7,14 @@ To use it, add `virtualenv` to the plugins array of your zshrc file:
 plugins=(... virtualenv)
 ```
 
-The plugin creates a `virtualenv_prompt_info` function that you can use in your theme. It
-displays the prompt string set when creating the virtual environment (via the `--prompt` option),
-falling back to the basename of the current `$VIRTUAL_ENV`.
+The plugin creates a `virtualenv_prompt_info` function that you can use in your
+theme. It displays the prompt string set in the `$VIRTUAL_ENV_PROMPT`
+environment variable. The `activate` scripts for most Python virtual environment
+implementations set this variable to the value provided via the `--prompt`
+option when creating the virtual environment, or the basename of the environment
+directory if the option was not provided. For implementations that do not set
+`$VIRTUAL_ENV_PROMPT`, the plugin will display the basename of the virtual
+environment directory instead.
 
 It uses two variables to control how that is shown:
 

--- a/plugins/virtualenv/virtualenv.plugin.zsh
+++ b/plugins/virtualenv/virtualenv.plugin.zsh
@@ -1,6 +1,16 @@
 function virtualenv_prompt_info(){
   [[ -n ${VIRTUAL_ENV} ]] || return
-  echo "${ZSH_THEME_VIRTUALENV_PREFIX=[}${VIRTUAL_ENV:t:gs/%/%%}${ZSH_THEME_VIRTUALENV_SUFFIX=]}"
+  # Some versions of virtualenv (e.g the version bundled with 'uv') wrap the
+  # prompt in parentheses with a trailing space.
+  local venv_prompt="${(*)VIRTUAL_ENV_PROMPT:/#%(#b)\((*)\) /${match[1]}}"
+
+  if [ -z ${venv_prompt} ]; then
+    # Older versions of virtualenv do not set VIRTUAL_ENV_PROMPT, so fall back
+    # to the basename of the virtualenv path.
+    venv_prompt="${VIRTUAL_ENV:t}"
+  fi
+
+  echo "${ZSH_THEME_VIRTUALENV_PREFIX=[}${venv_prompt:gs/%/%%}${ZSH_THEME_VIRTUALENV_SUFFIX=]}"
 }
 
 # disables prompt mangling in virtual_env/bin/activate


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (Not applicable)

## Changes:

- Add a setting for the `virtualenv_prompt_info` function to use the prompt string specified when creating the virtual environment, instead of just the basename of the environment.