### PR TITLE
fix: asdf completion && clean up old completion code

### DIFF
--- a/plugins/asdf/README.md
+++ b/plugins/asdf/README.md
@@ -1,39 +1,39 @@
-## asdf
+# asdf
 
 Adds integration with [asdf](https://github.com/asdf-vm/asdf), the extendable version manager, with support for Ruby, Node.js, Elixir, Erlang and more.
 
-### Installation
+## Installation
 
-1. [Download asdf](https://asdf-vm.com/guide/getting-started.html#_1-install-asdf):
-
-  ```sh
-  # For macos via homebrew
-  brew install asdf
-```
-
-For OS's where asdf isn't directly available to download via the package manager, follow [this](https://asdf-vm.com/guide/getting-started.html#install-asdf) section.
-
-2. [Enable asdf](https://asdf-vm.com/guide/getting-started.html#_3-install-asdf) by adding it to your `plugins` definition in `~/.zshrc`.
-
-  ```sh
-  plugins=(asdf)
-  ```
-
-### Usage
-
-See the [asdf plugin documentation](https://asdf-vm.com/guide/getting-started.html#_4-install-a-plugin) for information on how to use asdf:
+1. [Install](https://asdf-vm.com/guide/getting-started.html#_1-install-asdf) asdf and ensure that's it's discoverable on `$PATH`;
+2. Enable it by adding it to your `plugins` definition in `~/.zshrc`:
 
 ```sh
-asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+plugins=(asdf)
+```
+
+## Usage
+
+Refer to the [asdf plugin documentation](https://asdf-vm.com/guide/getting-started.html#_4-install-a-plugin) for information on how to add a plugin and install the many runtime versions for it.
+
+Example for installing the nodejs plugin and the many runtimes for it:
+
+```sh
+# Add plugin to asdf
+asdf plugin add nodejs 
+
+# Install the latest available nodejs runtime version
 asdf install nodejs latest
 
-# Set the latest version
+# Install nodejs v16.5.0 runtime version
+asdf install nodejs 16.5.0
+
+# Set the latest version in .tools-version in the current working directory
 asdf set nodejs latest
 
-# Set globally to a pinned version 
+# Set a version globally that will apply to all directories under $HOME
 asdf set -u nodejs 16.5.0
 ```
 
-### Maintainer
+## Maintainer
 
 - [@RobLoach](https://github.com/RobLoach)

--- a/plugins/asdf/README.md
+++ b/plugins/asdf/README.md
@@ -4,27 +4,34 @@ Adds integration with [asdf](https://github.com/asdf-vm/asdf), the extendable ve
 
 ### Installation
 
-1. [Download asdf](https://asdf-vm.com/guide/getting-started.html#_2-download-asdf) by running the following:
+1. [Download asdf](https://asdf-vm.com/guide/getting-started.html#_1-install-asdf):
 
-  ```
-  git clone https://github.com/asdf-vm/asdf.git ~/.asdf
-  ```
+  ```sh
+  # For macos via homebrew
+  brew install asdf
+```
+
+For OS's where asdf isn't directly available to download via the package manager, follow [this](https://asdf-vm.com/guide/getting-started.html#install-asdf) section.
 
 2. [Enable asdf](https://asdf-vm.com/guide/getting-started.html#_3-install-asdf) by adding it to your `plugins` definition in `~/.zshrc`.
 
-  ```
+  ```sh
   plugins=(asdf)
   ```
 
 ### Usage
 
-See the [asdf documentation](https://asdf-vm.com/guide/getting-started.html#_4-install-a-plugin) for information on how to use asdf:
+See the [asdf plugin documentation](https://asdf-vm.com/guide/getting-started.html#_4-install-a-plugin) for information on how to use asdf:
 
-```
+```sh
 asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
 asdf install nodejs latest
-asdf global nodejs latest
-asdf local nodejs latest
+
+# Set the latest version
+asdf set nodejs latest
+
+# Set globally to a pinned version 
+asdf set -u nodejs 16.5.0
 ```
 
 ### Maintainer

--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -2,12 +2,47 @@ if (( $+commands[asdf] )); then
   export ASDF_DATA_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}"
   path=("$ASDF_DATA_DIR/shims" $path)
 
-  # Create the completion file if it doesn't exist.
+  # If the completion file doesn't exist yet, we need to autoload it and
+  # bind it to `asdf`. Otherwise, compinit will have already done that.
   if [[ ! -f "$ZSH_CACHE_DIR/completions/_asdf" ]]; then
-    asdf completion zsh >| "$ZSH_CACHE_DIR/completions/_asdf" &|
+    typeset -g -A _comps
+    autoload -Uz _asdf
+    _comps[asdf]=_asdf
   fi
+  asdf completion zsh >| "$ZSH_CACHE_DIR/completions/_asdf" &|
 
-  autoload -Uz _asdf
-  compdef _asdf asdf
+  return
+fi
 
+# TODO:(2025-02-12): remove deprecated asdf <0.16 code
+
+# Find where asdf should be installed
+ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
+ASDF_COMPLETIONS="$ASDF_DIR/completions"
+
+if [[ ! -f "$ASDF_DIR/asdf.sh" || ! -f "$ASDF_COMPLETIONS/_asdf" ]]; then
+  # If not found, check for archlinux/AUR package (/opt/asdf-vm/)
+  if [[ -f "/opt/asdf-vm/asdf.sh" ]]; then
+    ASDF_DIR="/opt/asdf-vm"
+    ASDF_COMPLETIONS="$ASDF_DIR"
+  # If not found, check for Homebrew package
+  elif (( $+commands[brew] )); then
+    _ASDF_PREFIX="$(brew --prefix asdf)"
+    ASDF_DIR="${_ASDF_PREFIX}/libexec"
+    ASDF_COMPLETIONS="${_ASDF_PREFIX}/share/zsh/site-functions"
+    unset _ASDF_PREFIX
+  else
+    return
+  fi
+fi
+
+# Load command
+if [[ -f "$ASDF_DIR/asdf.sh" ]]; then
+  source "$ASDF_DIR/asdf.sh"
+  # Load completions
+  if [[ -f "$ASDF_COMPLETIONS/_asdf" ]]; then
+    fpath+=("$ASDF_COMPLETIONS")
+    autoload -Uz _asdf
+    compdef _asdf asdf # compdef is already loaded before loading plugins
+  fi
 fi

--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -10,5 +10,4 @@ if (( $+commands[asdf] )); then
   autoload -Uz _asdf
   compdef _asdf asdf
 
-  return
 fi

--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -2,47 +2,13 @@ if (( $+commands[asdf] )); then
   export ASDF_DATA_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}"
   path=("$ASDF_DATA_DIR/shims" $path)
 
-  # If the completion file doesn't exist yet, we need to autoload it and
-  # bind it to `asdf`. Otherwise, compinit will have already done that.
+  # Create the completion file if it doesn't exist.
   if [[ ! -f "$ZSH_CACHE_DIR/completions/_asdf" ]]; then
-    typeset -g -A _comps
-    autoload -Uz _asdf
-    _comps[asdf]=_asdf
+    asdf completion zsh >| "$ZSH_CACHE_DIR/completions/_asdf" &|
   fi
-  asdf completion zsh >| "$ZSH_CACHE_DIR/completions/_asdf" &|
+
+  autoload -Uz _asdf
+  compdef _asdf asdf
 
   return
-fi
-
-# TODO:(2025-02-12): remove deprecated asdf <0.16 code
-
-# Find where asdf should be installed
-ASDF_DIR="${ASDF_DIR:-$HOME/.asdf}"
-ASDF_COMPLETIONS="$ASDF_DIR/completions"
-
-if [[ ! -f "$ASDF_DIR/asdf.sh" || ! -f "$ASDF_COMPLETIONS/_asdf" ]]; then
-  # If not found, check for archlinux/AUR package (/opt/asdf-vm/)
-  if [[ -f "/opt/asdf-vm/asdf.sh" ]]; then
-    ASDF_DIR="/opt/asdf-vm"
-    ASDF_COMPLETIONS="$ASDF_DIR"
-  # If not found, check for Homebrew package
-  elif (( $+commands[brew] )); then
-    _ASDF_PREFIX="$(brew --prefix asdf)"
-    ASDF_DIR="${_ASDF_PREFIX}/libexec"
-    ASDF_COMPLETIONS="${_ASDF_PREFIX}/share/zsh/site-functions"
-    unset _ASDF_PREFIX
-  else
-    return
-  fi
-fi
-
-# Load command
-if [[ -f "$ASDF_DIR/asdf.sh" ]]; then
-  source "$ASDF_DIR/asdf.sh"
-  # Load completions
-  if [[ -f "$ASDF_COMPLETIONS/_asdf" ]]; then
-    fpath+=("$ASDF_COMPLETIONS")
-    autoload -Uz _asdf
-    compdef _asdf asdf # compdef is already loaded before loading plugins
-  fi
 fi


### PR DESCRIPTION
## Standards checklist:
<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- fix autoloading for asdf completion
- clean up redundant code (for < v0.16)
- update docs

## Other comments:
Closes https://github.com/ohmyzsh/ohmyzsh/issues/13025