### PR TITLE
fix(alias-finder): Return early on very short command (1-length)

### DIFF
--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -36,7 +36,11 @@ alias-finder() {
     # make filter to find only shorter results than current cmd
     if [[ $cheaper == true ]]; then
       cmdLen=$(echo -n "$cmd" | wc -c)
-      filter="^'{0,1}.{0,$((cmdLen - 1))}="
+      if [[ $cmdLen -le 1 ]]; then
+        return
+      fi
+
+      filter="^'?.{1,$((cmdLen - 1))}'?=" # some aliases is surrounded by single quotes
     fi
 
     alias | grep -E "$filter" | grep -E "=$finder"


### PR DESCRIPTION
…ble part## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fix bug in alias-finder: If the input command's length is 1 or less, return early instead of making an invalid regex format.

## Other comments:

- fixes https://github.com/ohmyzsh/ohmyzsh/issues/13016
