### PR TITLE
refactor(alias-finder): Revise alias-finder

### DIFF
--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -33,7 +33,7 @@ alias-finder() {
     # make filter to find only shorter results than current cmd
     if [[ $cheaper == true ]]; then
       cmdLen=$(echo -n "$cmd" | wc -c)
-      filter="^'{0,1}.{0,$((cmdLen - 1))}="
+      filter="^'?.{1,$((cmdLen - 1))}'?=" # some aliases is surrounded by single quotes
     fi
 
     alias | grep -E "$filter" | grep -E "=$finder"

--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -39,10 +39,7 @@ alias-finder() {
     alias | grep -E "$filter" | grep -E "=$finder"
 
     $exact && break # because exact case is only one
-
-    if [[ $longer = true ]]; then
-      break # because above grep command already found every longer aliases during first cycle
-    fi
+    $longer && break # because above grep command already found every longer aliases during first cycle
 
     cmd=$(sed -E 's/ {0,}[^ ]*$//' <<< "$cmd") # remove last word
   done

--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -51,12 +51,14 @@ alias-finder() {
   done
 }
 
+# add hook to run alias-finder before each command
 preexec_alias-finder() {
-  # TODO: Remove backward compatibility (other than zstyle form)
-  zstyle -t ':omz:plugins:alias-finder' autoload && alias-finder $1 || if [[ $ZSH_ALIAS_FINDER_AUTOMATIC = true ]]; then
-    alias-finder $1
-  fi
+  alias-finder "$1"
 }
-
-autoload -U add-zsh-hook
-add-zsh-hook preexec preexec_alias-finder
+if zstyle -t ':omz:plugins:alias-finder' autoload ; then
+  autoload -Uz alias-finder
+  add-zsh-hook preexec preexec_alias-finder
+elif [[ $ZSH_ALIAS_FINDER_AUTOMATIC = true ]]; then # TODO: remove this legacy style support
+  autoload -Uz alias-finder
+  add-zsh-hook preexec preexec_alias-finder
+fi

--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -1,19 +1,18 @@
 alias-finder() {
-  local cmd=" " exact="" longer="" cheaper="" wordEnd="'{0,1}$" finder="" filter=""
+  local cmd=" " exact=false longer=false cheaper=false wordEnd="'?$" finder="" filter=""
 
-  # build command and options
+  # setup options
+  # XXX: This logic has flaw. If user enable options with zstyle, there's no way to disable it.
+  #      It's because same function is used for autoload hook and manual execution.
+  #      I believe manual execution is very minor in use, so I'll keep it as is for now.
   for c in "$@"; do
     case $c in
-      # TODO: Remove backward compatibility (other than zstyle form)
-      # set options if exist
       -e|--exact) exact=true;;
       -l|--longer) longer=true;;
       -c|--cheaper) cheaper=true;;
-      # concatenate cmd
       *) cmd="$cmd$c " ;;
     esac
   done
-
   zstyle -t ':omz:plugins:alias-finder' longer && longer=true
   zstyle -t ':omz:plugins:alias-finder' exact && exact=true
   zstyle -t ':omz:plugins:alias-finder' cheaper && cheaper=true

--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -24,9 +24,7 @@ alias-finder() {
   ## - add escaping character to special characters
   cmd=$(echo -n "$cmd" | tr '\n' ' ' | xargs | tr -s '[:space:]' | sed 's/[].\|$(){}?+*^[]/\\&/g')
 
-  if [[ $longer == true ]]; then
-    wordEnd="" # remove wordEnd to find longer aliases
-  fi
+  $longer && wordEnd=".*$"
 
   # find with alias and grep, removing last word each time until no more words
   while [[ $cmd != "" ]]; do

--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -38,9 +38,9 @@ alias-finder() {
 
     alias | grep -E "$filter" | grep -E "=$finder"
 
-    if [[ $exact == true ]]; then
-      break # because exact case is only one
-    elif [[ $longer = true ]]; then
+    $exact && break # because exact case is only one
+
+    if [[ $longer = true ]]; then
       break # because above grep command already found every longer aliases during first cycle
     fi
 

--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -1,5 +1,5 @@
 alias-finder() {
-  local cmd=" " exact=false longer=false cheaper=false wordEnd="'?$" finder="" filter=""
+  local cmd=" " exact=false longer=false cheaper=false wordStart="^'?" wordEnd="'?$" finder="" filter=""
 
   # setup options
   # XXX: This logic has flaw. If user enable options with zstyle, there's no way to disable it.
@@ -28,7 +28,7 @@ alias-finder() {
 
   # find with alias and grep, removing last word each time until no more words
   while [[ $cmd != "" ]]; do
-    finder="'{0,1}$cmd$wordEnd"
+    finder="$wordStart$cmd$wordEnd"
 
     # make filter to find only shorter results than current cmd
     if [[ $cheaper == true ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

I added some code for alias-finder 19 months ago. As an occasional check, I tried to make the code better.

I thought about splitting into multiple PRs but didn't because it seemed too verbose for this grasp of maintainers. If that way is preferable, please let me know.

All changes were written in each commit message. Here's for you:
  - add-zsh-hook part: Upgrade it with more readable if statements. 4fa13eb463971dd070fe54236bd47c5846b8ba44
  - option setup part: Add documentation for explicit defect of current code. d860c7548f05621c9df8fe315a8d68eae2c9c8c7
  - some if statement: Repace them with && logic operator in case it's short enough. 3a746a7ee152d923812487987a7a0e9618ea7f02 3b550a69f6f9bc2c8466458a8dea6e5d5c93c491 f3d7b15cb33b7adab12d804df4e154486d4d086a
  - fix bug: Add ending single quote for alias like `alias 'gc!'='...'`. 129790826552fcc6f1b3c8f3dd776c6134d99308
  - Name the variable: `finder="'{0,1}$cmd$wordEnd"` --> `finder="$wordStart$cmd$wordEnd"` 92fb85e498d80ea341d15225641d774d8edebce8

## Other comments:


