### PR TITLE
Fix async status registration by declaring it prior to registration

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -39,73 +39,6 @@ function _omz_git_prompt_info() {
   echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref:gs/%/%%}${upstream:gs/%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
 }
 
-# Use async version if setting is enabled, or unset but zsh version is at least 5.0.6.
-# This avoids async prompt issues caused by previous zsh versions:
-# - https://github.com/ohmyzsh/ohmyzsh/issues/12331
-# - https://github.com/ohmyzsh/ohmyzsh/issues/12360
-# TODO(2024-06-12): @mcornella remove workaround when CentOS 7 reaches EOL
-local _style
-if zstyle -t ':omz:alpha:lib:git' async-prompt \
-  || { is-at-least 5.0.6 && zstyle -T ':omz:alpha:lib:git' async-prompt }; then
-  function git_prompt_info() {
-    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}" ]]; then
-      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}"
-    fi
-  }
-
-  function git_prompt_status() {
-    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}" ]]; then
-      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}"
-    fi
-  }
-
-  # Conditionally register the async handler, only if it's needed in $PROMPT
-  # or any of the other prompt variables
-  function _defer_async_git_register() {
-    # Check if git_prompt_info is used in a prompt variable
-    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPROMPT}:${RPS1}:${RPS2}:${RPS3}:${RPS4}" in
-    *(\$\(git_prompt_info\)|\`git_prompt_info\`)*)
-      _omz_register_handler _omz_git_prompt_info
-      ;;
-    esac
-
-    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPROMPT}:${RPS1}:${RPS2}:${RPS3}:${RPS4}" in
-    *(\$\(git_prompt_status\)|\`git_prompt_status\`)*)
-      _omz_register_handler _omz_git_prompt_status
-      ;;
-    esac
-
-    add-zsh-hook -d precmd _defer_async_git_register
-    unset -f _defer_async_git_register
-  }
-
-  # Register the async handler first. This needs to be done before
-  # the async request prompt is run
-  precmd_functions=(_defer_async_git_register $precmd_functions)
-elif zstyle -s ':omz:alpha:lib:git' async-prompt _style && [[ $_style == "force" ]]; then
-  function git_prompt_info() {
-    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}" ]]; then
-      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}"
-    fi
-  }
-
-  function git_prompt_status() {
-    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}" ]]; then
-      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}"
-    fi
-  }
-
-  _omz_register_handler _omz_git_prompt_info
-  _omz_register_handler _omz_git_prompt_status
-else
-  function git_prompt_info() {
-    _omz_git_prompt_info
-  }
-  function git_prompt_status() {
-    _omz_git_prompt_status
-  }
-fi
-
 # Checks if working tree is dirty
 function parse_git_dirty() {
   local STATUS
@@ -365,3 +298,70 @@ function git_repo_name() {
     echo ${repo_path:t}
   fi
 }
+
+# Use async version if setting is enabled, or unset but zsh version is at least 5.0.6.
+# This avoids async prompt issues caused by previous zsh versions:
+# - https://github.com/ohmyzsh/ohmyzsh/issues/12331
+# - https://github.com/ohmyzsh/ohmyzsh/issues/12360
+# TODO(2024-06-12): @mcornella remove workaround when CentOS 7 reaches EOL
+local _style
+if zstyle -t ':omz:alpha:lib:git' async-prompt \
+  || { is-at-least 5.0.6 && zstyle -T ':omz:alpha:lib:git' async-prompt }; then
+  function git_prompt_info() {
+    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}" ]]; then
+      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}"
+    fi
+  }
+
+  function git_prompt_status() {
+    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}" ]]; then
+      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}"
+    fi
+  }
+
+  # Conditionally register the async handler, only if it's needed in $PROMPT
+  # or any of the other prompt variables
+  function _defer_async_git_register() {
+    # Check if git_prompt_info is used in a prompt variable
+    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPROMPT}:${RPS1}:${RPS2}:${RPS3}:${RPS4}" in
+    *(\$\(git_prompt_info\)|\`git_prompt_info\`)*)
+      _omz_register_handler _omz_git_prompt_info
+      ;;
+    esac
+
+    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPROMPT}:${RPS1}:${RPS2}:${RPS3}:${RPS4}" in
+    *(\$\(git_prompt_status\)|\`git_prompt_status\`)*)
+      _omz_register_handler _omz_git_prompt_status
+      ;;
+    esac
+
+    add-zsh-hook -d precmd _defer_async_git_register
+    unset -f _defer_async_git_register
+  }
+
+  # Register the async handler first. This needs to be done before
+  # the async request prompt is run
+  precmd_functions=(_defer_async_git_register $precmd_functions)
+elif zstyle -s ':omz:alpha:lib:git' async-prompt _style && [[ $_style == "force" ]]; then
+  function git_prompt_info() {
+    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}" ]]; then
+      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}"
+    fi
+  }
+
+  function git_prompt_status() {
+    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}" ]]; then
+      echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}"
+    fi
+  }
+
+  _omz_register_handler _omz_git_prompt_info
+  _omz_register_handler _omz_git_prompt_status
+else
+  function git_prompt_info() {
+    _omz_git_prompt_info
+  }
+  function git_prompt_status() {
+    _omz_git_prompt_status
+  }
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Move async conditional block to bottom of file to avoid undefined functions

## Other comments:

> If anyone finds that its git prompt does not appear they can set before `source oh-my-zsh.sh` the following snippet:
>
> ```sh
> zstyle ':omz:alpha:lib:git' async-prompt force
> ```
>
> This was introduced in `2a109d30afe4ab164a946c307abc3d2a444a42ad`

 _Originally posted by @carlosala in [#12328](https://github.com/ohmyzsh/ohmyzsh/issues/12328#issuecomment-2400576507)_

This fix does not work because `git_prompt_status` is defined after `_omz_register_handler` is called thereby skipping registration. The simplest fix seemed like moving the conditional to bottom but I am open to alternatives
