### PR TITLE
fix(alias-finder): Typo for equals

### DIFF
--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -47,7 +47,7 @@ alias-finder() {
 
     if [[ $exact == true ]]; then
       break # because exact case is only one
-    elif [[ $longer = true ]]; then
+    elif [[ $longer == true ]]; then
       break # because above grep command already found every longer aliases during first cycle
     fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- There's typo that I made. "=" should be replaced with "==".
