### PR TITLE
Fix function call typo in the dnf5 plugin

### DIFF
--- a/plugins/dnf/_dnf5
+++ b/plugins/dnf/_dnf5
@@ -38,7 +38,7 @@ _dnf5_rpm_files() {
 
 _dnf5_packages_or_rpms() {
   if [[ "$words[CURRENT]" = (*/*|\~*) ]]; then # if looks like a path name
-    _dnf_rpm_files
+    _dnf5_rpm_files
   else
     _dnf5_packages "$@"
   fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fix `_dnf_rpm_files` to `_dnf5_rpm_files` to match actual function definition

Fixes #13037