### PR TITLE
fix(cli): support `noexec` environments

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -193,7 +193,7 @@ EOF
     return 1
   fi
 
-  "$ZSH/tools/changelog.sh" "$version" "${2:-}" "$format"
+  ZSH="$ZSH" command zsh -f "$ZSH/tools/changelog.sh" "$version" "${2:-}" "$format"
 }
 
 function _omz::plugin {

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -254,7 +254,7 @@ if LANG= git pull --quiet --rebase $remote $branch; then
 
     # Print changelog to the terminal
     if [[ $interactive == true && $verbose_mode == default ]]; then
-      "$ZSH/tools/changelog.sh" HEAD "$last_commit"
+      ZSH="$ZSH" command zsh -f "$ZSH/tools/changelog.sh" HEAD "$last_commit"
     fi
 
     if [[ $verbose_mode != silent ]]; then


### PR DESCRIPTION
Closes #13032

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Ensure that `omz update` can be called in `noexec` environments.
Closes #13032 