### PR TITLE
feat(alias-finder): Use ripgrep if possible

### DIFF
--- a/plugins/alias-finder/README.md
+++ b/plugins/alias-finder/README.md
@@ -11,6 +11,8 @@ plugins=(... alias-finder)
 
 To enable it for every single command, set zstyle in your `~/.zshrc`.
 
+If the user has installed `rg`([ripgrep](https://github.com/BurntSushi/ripgrep)), it will be used because it's faster. Otherwise, it will use the `grep` command.
+
 ```zsh
 # ~/.zshrc
 
@@ -28,7 +30,7 @@ When you execute a command alias finder will look at your defined aliases and su
 
 Running the un-aliased `git status` command:
 ```sh
-╭─tim@fox ~/repo/gitopolis ‹main› 
+╭─tim@fox ~/repo/gitopolis ‹main›
 ╰─$ git status
 
 gst='git status'         # <=== shorter suggestion from alias-finder
@@ -40,7 +42,7 @@ nothing to commit, working tree clean
 
 Running a shorter `git st` alias from `.gitconfig` that it suggested :
 ```sh
-╭─tim@fox ~/repo/gitopolis ‹main› 
+╭─tim@fox ~/repo/gitopolis ‹main›
 ╰─$ git st
 gs='git st'         # <=== shorter suggestion from alias-finder
 ## main...origin/main
@@ -48,7 +50,7 @@ gs='git st'         # <=== shorter suggestion from alias-finder
 
 Running the shortest `gs` shell alias that it found:
 ```sh
-╭─tim@fox ~/repo/gitopolis ‹main› 
+╭─tim@fox ~/repo/gitopolis ‹main›
 ╰─$ gs
          # <=== no suggestions alias-finder because this is the shortest
 ## main...origin/main

--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -43,7 +43,11 @@ alias-finder() {
       filter="^'?.{1,$((cmdLen - 1))}'?=" # some aliases is surrounded by single quotes
     fi
 
-    alias | grep -E "$filter" | grep -E "=$finder"
+    if command -v rg >/dev/null 2>&1; then
+      alias | rg "$filter" | rg "=$finder"
+    else
+      alias | grep -E "$filter" | grep -E "=$finder"
+    fi
 
     if [[ $exact == true ]]; then
       break # because exact case is only one

--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -43,7 +43,7 @@ alias-finder() {
       filter="^'?.{1,$((cmdLen - 1))}'?=" # some aliases is surrounded by single quotes
     fi
 
-    if command -v rg >/dev/null 2>&1; then
+    if (( $+commands[rg] )); then
       alias | rg "$filter" | rg "=$finder"
     else
       alias | grep -E "$filter" | grep -E "=$finder"


### PR DESCRIPTION
basic grep is too slow for very long command. ripgrep can easily remediate this issue.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Use ripgrep if possible

## Other comments:

- resolves https://github.com/ohmyzsh/ohmyzsh/issues/13036
- resolves https://github.com/ohmyzsh/ohmyzsh/issues/13039

## How to verify

```sh
❯❯❯ brew install ripgrep
❯❯❯ alias X='echo test && echo test && echo test && echo test && echo test && echo test && echo test && echo test && echo test && echo test'
❯❯❯ alias-finder 'echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "test" && echo "xxx"'
X='echo test && echo test && echo test && echo test && echo test && echo test && echo test && echo test && echo test && echo test'
```

The original grep can't handle this request properly.