### PR TITLE
Update macos.plugin.zsh - Made it possible to alias `man` to `man-preview`

### DIFF
--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -271,7 +271,7 @@ function man-preview() {
   [[ $# -eq 0 ]] && >&2 echo "Usage: $0 command1 [command2 ...]" && return 1
 
   local page
-  for page in "${(@f)"$(man -w $@)"}"; do
+  for page in "${(@f)"$(command man -w $@)"}"; do
     command mandoc -Tpdf $page | open -f -a Preview
   done
 }


### PR DESCRIPTION
Now it's possible to set `man` as an alias to `man-preview` without causing recursion issues.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Changed `for page in "${(@f)"$(man -w $@)"}"` to `for page in "${(@f)"$(command man -w $@)"}"`
