### PR TITLE
Fixes #13052: support legacy and new procs completion command

### DIFF
--- a/plugins/procs/procs.plugin.zsh
+++ b/plugins/procs/procs.plugin.zsh
@@ -3,11 +3,16 @@ if (( ! $+commands[procs] )); then
 fi
 
 # If the completion file doesn't exist yet, we need to autoload it and
-# bind it to `minikube`. Otherwise, compinit will have already done that.
+# bind it to `procs`. Otherwise, compinit will have already done that.
 if [[ ! -f "$ZSH_CACHE_DIR/completions/_procs" ]]; then
   typeset -g -A _comps
   autoload -Uz _procs
   _comps[procs]=_procs
 fi
 
-procs --gen-completion-out zsh >| "$ZSH_CACHE_DIR/completions/_procs" &|
+# Check which flag is supported by the installed version of procs
+if procs --help 2>&1 | grep -q -- "--gen-completion-out"; then
+  procs --gen-completion-out zsh >| "$ZSH_CACHE_DIR/completions/_procs" &|
+else
+  procs --completion-out zsh >| "$ZSH_CACHE_DIR/completions/_procs" &|
+fi

--- a/plugins/procs/procs.plugin.zsh
+++ b/plugins/procs/procs.plugin.zsh
@@ -10,9 +10,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_procs" ]]; then
   _comps[procs]=_procs
 fi
 
-# Check which flag is supported by the installed version of procs
-if procs --help 2>&1 | grep -q -- "--gen-completion-out"; then
-  procs --gen-completion-out zsh >| "$ZSH_CACHE_DIR/completions/_procs" &|
-else
-  procs --completion-out zsh >| "$ZSH_CACHE_DIR/completions/_procs" &|
-fi
+{
+  autoload -Uz is-at-least
+  local _version=$(procs --version)
+  if is-at-least "0.14" "${_version#procs }"; then
+    procs --gen-completion-out zsh >| "$ZSH_CACHE_DIR/completions/_procs"
+  else
+    procs --completion-out zsh >| "$ZSH_CACHE_DIR/completions/_procs"
+  fi
+} &|


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Update cache completion to support newer versions of procs
- Update comment that suggests it is bound to minikube (artifact from copied boilerplate)

## Other comments:

Fixes #13052 