### PR TITLE
feat(web-search): add Mozilla Developer Network search query

### DIFF
--- a/plugins/web-search/README.md
+++ b/plugins/web-search/README.md
@@ -53,6 +53,7 @@ Available search contexts are:
 | `chatgpt`             | `https://chatgpt.com/?q=`                       |
 | `reddit`              | `https://www.reddit.com/search/?q=`             |
 | `ppai`                | `https://www.perplexity.ai/search/new?q=`       |
+| `mdn`                 | `https://developer.mozilla.org/search?q=`       |
 
 Also there are aliases for bang-searching DuckDuckGo:
 

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -34,6 +34,7 @@ function web_search() {
     chatgpt         "https://chatgpt.com/?q="
     reddit          "https://www.reddit.com/search/?q="
     ppai            "https://www.perplexity.ai/search/new?q="
+    mdn             "https://developer.mozilla.org/search?q="
   )
 
   # check whether the search engine is supported
@@ -89,6 +90,7 @@ alias gopkg='web_search gopkg'
 alias chatgpt='web_search chatgpt'
 alias reddit='web_search reddit'
 alias ppai='web_search ppai'
+alias mdn='web_search mdn'
 
 #add your own !bang searches here
 alias wiki='web_search duckduckgo \!w'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add mdn (Mozilla Developer Network) search with a new alias.

## Other comments:

I cannot find an existing alias for mdn on the web. This new alias seems harmless and helpful to those who search mdn often. mdn is a valuable resource for backend and frontend developers.

