### PR TITLE
fix(asdf): allow plugin to initialize if asdf is installed in ~/.asdf

### DIFF
--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -1,4 +1,7 @@
-(( ! $+commands[asdf] )) && return
+# Only continue if .asdf directory exists (manual install) or fallback logic can apply
+if [[ ! -d "$HOME/.asdf" ]]; then
+  return
+fi
 
 export ASDF_DATA_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}"
 path=("$ASDF_DATA_DIR/shims" $path)


### PR DESCRIPTION
Issue: #13059

Previously, the plugin exited early if the `asdf` command was not already in $PATH:

```bash
(( ! $+commands[asdf] )) && return
```

This broke valid setups where `asdf` is installed manually in ~/.asdf and not yet sourced globally (e.g., via .zshrc). Such installs are still recommended in the official asdf documentation.

This change replaces the early exit with a check for the presence of ~/.asdf, so the plugin only runs if the user has a modern asdf setup, while avoiding premature return before `$PATH` and completions are set up.

This preserves the new plugin behavior (removal of legacy <0.16 logic), while restoring compatibility for the common manual install path.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- update `plugins/asdf/asdf.plugin.zsh`
