### PR TITLE
branch: output branch names with '/' correctly

### DIFF
--- a/plugins/branch/branch.plugin.zsh
+++ b/plugins/branch/branch.plugin.zsh
@@ -8,7 +8,7 @@ function branch_prompt_info() {
   while [[ "$dir" != '/' ]]; do
     # Found .git directory
     if [[ -d "${dir}/.git" ]]; then
-      branch="${"$(<"${dir}/.git/HEAD")"##*/}"
+      branch="${"$(<"${dir}/.git/HEAD")"##ref: refs/heads/}"
       echo '±' "${branch:gs/%/%%}"
       return
     fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

Changes:
- Delete until the known `.git/HEAD` current branch prefix instead of until the last "/" in the branch name

## Other comments:

Fixes https://github.com/ohmyzsh/ohmyzsh/issues/13062
