### PR TITLE
Added new --prune-tags to git fetch alias

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -90,7 +90,7 @@ plugins=(... git)
 | `gdnolock`             | `git diff $@ ":(exclude)package-lock.json" ":(exclude)\*.lock"`                                                                 |
 | `gdt`                  | `git diff-tree --no-commit-id --name-only -r`                                                                                   |
 | `gf`                   | `git fetch`                                                                                                                     |
-| `gfa`                  | `git fetch --all --tags --prune`                                                                                                       |
+| `gfa`                  | `git fetch --all --tags --prune --prune-tags --jobs=10`                                                                         |
 | `gfo`                  | `git fetch origin`                                                                                                              |
 | `gg`                   | `git gui citool`                                                                                                                |
 | `gga`                  | `git gui citool --amend`                                                                                                        |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -219,10 +219,17 @@ compdef _git gdnolock=git-diff
 
 alias gdt='git diff-tree --no-commit-id --name-only -r'
 alias gf='git fetch'
+
+# --prune-tags was added in git 2.17
 # --jobs=<n> was added in git 2.8
-is-at-least 2.8 "$git_version" \
-  && alias gfa='git fetch --all --tags --prune --jobs=10' \
-  || alias gfa='git fetch --all --tags --prune'
+if is-at-least 2.17 "$git_version"; then
+  alias gfa='git fetch --all --tags --prune --prune-tags --jobs=10'
+elif is-at-least 2.8 "$git_version"; then
+  alias gfa='git fetch --all --tags --prune --jobs=10'
+else
+  alias gfa='git fetch --all --tags --prune'
+fi
+
 alias gfo='git fetch origin'
 alias gg='git gui citool'
 alias gga='git gui citool --amend'


### PR DESCRIPTION
## Standards checklist:

Appended the "new" `--prune-tags` option to `git fetch` (`gfa`) alias.  
It is available since git version 2.17.
See [documentation](https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---prune-tags) for it.

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Extend the alias `gfa` with "new" `--prune-tags` option

