### PR TITLE
fix(git-prompt): Use `--git-common-dir` to load stash count

### DIFF
--- a/plugins/git-prompt/gitstatus.py
+++ b/plugins/git-prompt/gitstatus.py
@@ -23,9 +23,10 @@ def get_tagname_or_hash():
         return hash_
     return None
 
-# Re-use method from https://github.com/magicmonty/bash-git-prompt to get stashs count
+# Re-use method from https://github.com/magicmonty/bash-git-prompt to get stash count
+# Use `--git-common-dir` to avoid problems with git worktrees, which don't have individual stashes
 def get_stash():
-    cmd = Popen(['git', 'rev-parse', '--git-dir'], stdout=PIPE, stderr=PIPE)
+    cmd = Popen(['git', 'rev-parse', '--git-common-dir'], stdout=PIPE, stderr=PIPE)
     so, se = cmd.communicate()
     stash_file = '%s%s' % (so.decode('utf-8').rstrip(), '/logs/refs/stash')
 
@@ -34,7 +35,6 @@ def get_stash():
             return sum(1 for _ in f)
     except IOError:
         return 0
-
 
 # `git status --porcelain --branch` can collect all information
 # branch, remote_branch, untracked, staged, changed, conflicts, ahead, behind


### PR DESCRIPTION
Use `--git-common-dir` to load stash because worktrees don't have individualized stash files, so the current practice of `git rev-parse --git-dir` fails to find the correct file.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- fix(git-prompt): Use `--git-common-dir` to load stash count