### PR TITLE
Explains how to identify which git completion file takes precedence

### DIFF
--- a/plugins/git-extras/README.md
+++ b/plugins/git-extras/README.md
@@ -10,7 +10,13 @@ plugins=(... git-extras)
 
 ## Setup notes
 
-The completions work by augmenting the `_git` completion provided by `zsh`. This only works with the `zsh`-provided `_git`, not the `_git` provided by `git` itself. If you have both `zsh` and `git` installed, you need to make sure that the `zsh`-provided `_git` takes precedence.
+The completions work by augmenting the `_git` completion provided by `zsh`. This only works with the `zsh`-provided `_git`, not the `_git` provided by `git` itself. If you have both `zsh` and `git` installed, you need to make sure that the `zsh` provided `_git` takes precedence.
+
+To find out where the `_git` completions are installed and which one has precedence:
+
+1. `ls /usr/share/zsh/functions/Completion/Unix/_git` # if present, the `zsh` provided `_git` completion is present.
+2. `ls /usr/share/git/completion/git-completion.zsh`  # if present, the `git` provided `_git` completion is present. And why wouldn't it be?
+3. `which _git` # will show the path of the _git completion that is currently being used by your shell, indicating which one has precedence.
 
 ### OS X Homebrew Setup
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Documentation: Shows how to find out which _git completion takes precedence.