### PR TITLE
style(theme): format prompt_char function for better readability

### DIFF
--- a/themes/dst.zsh-theme
+++ b/themes/dst.zsh-theme
@@ -1,15 +1,17 @@
-
 ZSH_THEME_GIT_PROMPT_PREFIX=" %{$fg[green]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[red]%}!"
 ZSH_THEME_GIT_PROMPT_CLEAN=""
 
 function prompt_char {
-	if [ $UID -eq 0 ]; then echo "%{$fg[red]%}#%{$reset_color%}"; else echo $; fi
+	if [ $UID -eq 0 ]; then
+		echo "%{$fg[red]%}#%{$reset_color%}"
+	else
+		echo $
+	fi
 }
 
-PROMPT='%(?, ,%{$fg[red]%}FAIL%{$reset_color%}
-)
+PROMPT='${$(exit_code=$?; [[ $exit_code -ne 0 && $exit_code -ne 1 ]] && echo "%{$fg[red]%}FAIL%{$reset_color%}")}
 %{$fg[magenta]%}%n%{$reset_color%}@%{$fg[yellow]%}%m%{$reset_color%}: %{$fg_bold[blue]%}%~%{$reset_color%}$(git_prompt_info)
 $(prompt_char) '
 


### PR DESCRIPTION
## Standards checklist:

- ✅ The PR title is descriptive.
- ✅ The PR doesn't replicate another PR which is already open.
- ✅ I have read the contribution guide and followed all the instructions.
- ✅ The code follows the code style guide detailed in the wiki.
- ✅ The code is mine or it's from somewhere with an MIT-compatible license.
- ✅ The code is efficient, to the best of my ability, and does not waste computer resources.
- ✅ The code is stable and I have tested it myself, to the best of my abilities.
- ✅ If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
Updated custom ZSH theme (dst) to avoid false-positive "FAIL" messages when commands exit with code 1 (e.g., ssh -T git@github.com).

<img width="687" alt="Screenshot 2025-04-20 at 2 00 57 PM" src="https://github.com/user-attachments/assets/2efb87b0-33bd-48a6-ad4d-8b200635a125" />

Modified prompt logic to conditionally display FAIL only on non-zero exit codes excluding 1.

<img width="687" alt="Screenshot 2025-04-20 at 2 01 28 PM" src="https://github.com/user-attachments/assets/7fe2b5c0-2ce0-487d-bad4-5ab03ac1a44a" />

This keeps the prompt clean and avoids confusion for commands that are technically successful but return non-zero codes intentionally.

## Other comments:
This change improves usability for developers who use SSH-based Git workflows with GitHub, avoiding misleading failure messages.

Tested locally with different exit scenarios to ensure prompt still reflects real errors properly. Let me know if you'd like a version that also includes a visual SUCCESS indicator.
