### PR TITLE
feat(command-not-found): added pkgfile presence check for arch

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -1,8 +1,18 @@
 ## Platforms with a built-in command-not-found handler init file
 
+# Arch Linux: required 'pkgfile'
+if [[ -f /etc/arch-release ]]; then
+  if command -v pkgfile >/dev/null 2>&1; then
+    if [[ -f /usr/share/doc/pkgfile/command-not-found.zsh ]]; then
+      source /usr/share/doc/pkgfile/command-not-found.zsh
+      return 0
+    fi
+  else
+    printf "Warning: 'pkgfile' is not installed,\nYou can install it via: sudo pacman -S pkgfile\n" >&2
+  fi
+fi
+
 for file (
-  # Arch Linux. Must have pkgfile installed: https://wiki.archlinux.org/index.php/Pkgfile#Command_not_found
-  /usr/share/doc/pkgfile/command-not-found.zsh
   # Homebrew: https://github.com/Homebrew/homebrew-command-not-found
   /opt/homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh
   /usr/local/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- added check if pkgfile is exist in system for arch, so it will not be confusing for user if he forgot to install it and didn't notice the changes when `source .zshrc`