### PR TITLE
kubectl: Add alias plugin for kubectl auth can-i --list

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -178,6 +178,9 @@ alias kej='kubectl edit job'
 alias kdj='kubectl describe job'
 alias kdelj='kubectl delete job'
 
+# Check allowed action
+alias kacil='kubectl auth can-i --list'
+
 # Utility print functions (json / yaml)
 function _build_kubectl_out_alias {
   setopt localoptions norcexpandparam


### PR DESCRIPTION
This shortcut is useful to check allowed action. It's common to execute this command when checking kubernetes security.

GitHub issue:
https://github.com/ohmyzsh/ohmyzsh/issues/13076

Example output:

```
➜ kubectl auth can-i --list=true
Resources                                       Non-Resource URLs   Resource Names   Verbs
*.*                                             []                  []               [*]
                                                [*]                 []               [*]
selfsubjectreviews.authentication.k8s.io        []                  []               [create]
selfsubjectaccessreviews.authorization.k8s.io   []                  []               [create]
selfsubjectrulesreviews.authorization.k8s.io    []                  []               [create]
                                                [/api/*]            []               [get]
                                                [/api]              []               [get]
                                                [/apis/*]           []               [get]
                                                [/apis]             []               [get]
                                                [/healthz]          []               [get]
                                                [/healthz]          []               [get]
                                                [/livez]            []               [get]
                                                [/livez]            []               [get]
                                                [/openapi/*]        []               [get]
                                                [/openapi]          []               [get]
                                                [/readyz]           []               [get]
                                                [/readyz]           []               [get]
                                                [/version/]         []               [get]
                                                [/version/]         []               [get]
                                                [/version]          []               [get]
                                                [/version]          []               [get]

```

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.