### PR TITLE
docs: add a space after ellipsis in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ configuration.
 
 Sounds boring. Let's try again.
 
-**Oh My Zsh will not make you a 10x developer...but you may feel like one.**
+**Oh My Zsh will not make you a 10x developer... but you may feel like one.**
 
 Once installed, your terminal shell will become the talk of the town _or your money back!_ With each keystroke
 in your command prompt, you'll take advantage of the hundreds of powerful plugins and beautiful themes.
 Strangers will come up to you in cafés and ask you, _"that is amazing! are you some sort of genius?"_
 
-Finally, you'll begin to get the sort of attention that you have always felt you deserved. ...or maybe you'll
+Finally, you'll begin to get the sort of attention that you have always felt you deserved. ... or maybe you'll
 use the time that you're saving to start flossing more often. 😬
 
 To learn more, visit [ohmyz.sh](https://ohmyz.sh), follow [@ohmyzsh](https://x.com/ohmyzsh) on X (formerly
@@ -215,7 +215,7 @@ If you're feeling feisty, you can let the computer select one randomly for you e
 terminal window.
 
 ```sh
-ZSH_THEME="random" # (...please let it be pie... please be some pie..)
+ZSH_THEME="random" # (... please let it be pie... please be some pie..)
 ```
 
 And if you want to pick a random theme from a list of your favorite themes:


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add a space after every ellipsis in README.md

## Other comments:

I checked the commit history and found that this has never been modified. Please feel free to ask for changes if something isn't right.
