### PR TITLE
Add kate-admin-helper plugin to securely edit files with elevated privileges

### DIFF
--- a/plugins/kate-admin-helper/README.md
+++ b/plugins/kate-admin-helper/README.md
@@ -1,0 +1,40 @@
+# kate-admin-helper
+
+This plugin provides an automatic privilege elevation helper for **Kate** (KDE text editor) when opening files in zsh.
+
+When opening files that the user does not have write access to, the plugin automatically uses the `admin://` KIO protocol, allowing **Kate** to request privilege elevation via Polkit.  
+This avoids running the entire **Kate** process as root and follows modern KDE security practices.
+
+If privilege elevation is needed, a message will be shown, and the user will be prompted to authenticate with their password through Polkit.
+
+## Installation
+
+Add `kate-admin-helper` to your plugin list in `~/.zshrc`:
+
+```zsh
+plugins=(
+  ...
+  kate-admin-helper
+)
+```
+
+## Usage
+
+Open files as usual:
+
+```zsh
+kate /etc/hosts
+kt /etc/fstab /etc/ssh/sshd_config
+```
+
+If the file requires elevated privileges to edit, it will be opened automatically with `admin://`.  
+A colored message will inform you that privilege elevation is needed, and a Polkit prompt will ask for your password.
+
+The `kt` command is also available and behaves the same way.
+
+## Requirements
+
+- **Kate** installed
+- **kio-admin** installed
+- A running **Polkit authentication agent** (e.g., `polkit-kde-agent-5` or `polkit-kde-agent-6`)
+- `pkexec` available to create new files if needed

--- a/plugins/kate-admin-helper/kate-admin-helper.plugin.zsh
+++ b/plugins/kate-admin-helper/kate-admin-helper.plugin.zsh
@@ -1,0 +1,60 @@
+# Kate admin helper
+
+# Color definitions (standard and portable)
+RED="$(printf '\033[0;31m')"
+GREEN="$(printf '\033[0;32m')"
+YELLOW="$(printf '\033[1;33m')"
+RESET="$(printf '\033[0m')"
+
+kt_internal() {
+  if [[ $# -eq 0 ]]; then
+    echo -e "${RED}Usage: kt <file1> [file2 ...]${RESET}"
+    return 1
+  fi
+
+  for file in "$@"; do
+    local abs_path
+    abs_path="$(realpath -m "$file")"
+
+    if [[ -e "$file" ]]; then
+      # File exists
+      if [[ -w "$file" ]]; then
+        echo -e "${GREEN}Opening '$file' normally...${RESET}"
+        command kate "$file"
+      else
+        echo -e "${YELLOW}No write permission for '$file', opening with admin://...${RESET}"
+        command kate "admin://$abs_path"
+      fi
+    else
+      # File does not exist, check parent directory
+      local parent_dir
+      parent_dir="$(dirname "$abs_path")"
+
+      if [[ -w "$parent_dir" ]]; then
+        echo -e "${GREEN}Opening new file '$file' normally...${RESET}"
+        command kate "$file"
+      else
+        echo -e "${YELLOW}File '$file' does not exist and no write permission for directory '$parent_dir', creating it with sudo...${RESET}"
+        if pkexec touch "$abs_path"; then
+          echo -e "${GREEN}File '$file' created successfully.${RESET}"
+          command kate "admin://$abs_path"
+        else
+          echo -e "${RED}Failed to create file '$file'.${RESET}"
+        fi
+      fi
+    fi
+  done
+}
+
+# Allow kt command: calls the internal logic
+kt() {
+  kt_internal "$@"
+}
+
+# Allow kate command: uses the same internal logic as kt
+kate() {
+  kt_internal "$@"
+}
+
+# Remove any previous alias for kate to avoid conflicts
+unalias kate 2>/dev/null


### PR DESCRIPTION
This plugin provides automatic privilege elevation for the Kate editor using the `admin://` KIO protocol.

It detects whether the user has write access to a file, and if not, opens the file using `admin://`, prompting for authentication via Polkit. This allows safe editing of system files without running the entire Kate process as root, following modern KDE security recommendations.

The plugin also supports new files: if a file does not exist and the user lacks permission to create it, it uses `pkexec` to create the file first, ensuring a seamless experience.

It offers both `kate` and `kt` commands with the same behavior.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added `kate-admin-helper` plugin
- Enables safe editing of files requiring elevated permissions via `admin://`
- Adds `kt` alias alongside `kate` for convenience
- Provides user feedback and password prompt when privilege elevation is needed

## Use cases:

- Editing system files like `/etc/hosts`, `/etc/fstab`, or config files owned by root
- Automatically handles write checks and privilege elevation without requiring users to remember to prefix paths with `admin://`

## Other comments:

Tested on openSUSE Tumbleweed with KDE Plasma 6, using `kio-admin` and `polkit-kde-agent-6`. Works as expected.
