### PR TITLE
feat(extract): extract to existing directory

### DIFF
--- a/plugins/extract/README.md
+++ b/plugins/extract/README.md
@@ -6,11 +6,14 @@ wide variety of archive filetypes.
 This way you don't have to know what specific command extracts a file, you just do `extract <filename>` and
 the function takes care of the rest.
 
+
 To use it, add `extract` to the plugins array in your zshrc file:
 
 ```zsh
 plugins=(... extract)
 ```
+
+To view a short explanations of the flags in this plugin, type `extract` into your terminal after installation is completed.
 
 ## Supported file extensions
 

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -3,135 +3,126 @@ alias x=extract
 extract() {
   setopt localoptions noautopushd
 
+  # Print explanation if "extract" is called with no args
   if (( $# == 0 )); then
     cat >&2 <<'EOF'
-Usage: extract [-option] [file ...]
+Usage: extract [options] [files...]
 
 Options:
-    -r, --remove    Remove archive after unpacking.
+    -r, --remove    Remove archive(s) after unpacking.
+    -t, --to-directory [DIRECTORY NAME]   Extract into an existing directory.
 EOF
+    return
   fi
+  
+  # needed to set internal states by searching CLI args for flags
+  local remove_archive=0
+  local extract_dir=""
 
-  local remove_archive=1
-  if [[ "$1" == "-r" ]] || [[ "$1" == "--remove" ]]; then
-    remove_archive=0
-    shift
-  fi
+  while : 
+  do
+    if [[ "$1" == "-r" ]] || [[ "$1" == "--remove" ]]; then
+      remove_archive=1
+      shift
+      continue
+    fi
+  
+    # this sets the extraction directory to the argument after the -t flag
+    if [[ "$1" == "-t" ]] || [[ "$1" == "--to-directory" ]]; then
+      shift
+      if [[ ! -d "$1" ]]; then
+        echo "extract: specified output directory $1 is not a valid directory." >&2
+        return
+      fi
+      extract_dir="$1"
+      shift
+      continue
+    fi
+    
+    # if none of the flags were found in the first arg, break the loop
+    break
+  done
+  
+  # variables used for saving the current working directory and the 
+  # directory where the archive will be unpacked
+  local work_dir="$PWD"
 
-  local pwd="$PWD"
   while (( $# > 0 )); do
+    
     if [[ ! -f "$1" ]]; then
       echo "extract: '$1' is not a valid file" >&2
       shift
       continue
     fi
-
-    local success=0
-    local file="$1" full_path="${1:A}"
-    local extract_dir="${1:t:r}"
-
-    # Remove the .tar extension if the file name is .tar.*
-    if [[ $extract_dir =~ '\.tar$' ]]; then
-      extract_dir="${extract_dir:r}"
+  
+    if [[ $extract_dir == "" ]]; then
+      extract_dir="$PWD"
     fi
-
-    # If there's a file or directory with the same name as the archive
-    # add a random string to the end of the extract directory
-    if [[ -e "$extract_dir" ]]; then
-      local rnd="${(L)"${$(( [##36]$RANDOM*$RANDOM ))}":1:5}"
-      extract_dir="${extract_dir}-${rnd}"
-    fi
-
-    # Create an extraction directory based on the file name
-    command mkdir -p "$extract_dir"
+  
+    local file="$1" 
+    local full_path="${1:A}"
+    
     builtin cd -q "$extract_dir"
     echo "extract: extracting to $extract_dir" >&2
-
+    
+    local success=0
     case "${file:l}" in
       (*.tar.gz|*.tgz)
         (( $+commands[pigz] )) && { tar -I pigz -xvf "$full_path" } || tar zxvf "$full_path" ;;
-      (*.tar.bz2|*.tbz|*.tbz2)
-        (( $+commands[pbzip2] )) && { tar -I pbzip2 -xvf "$full_path" } || tar xvjf "$full_path" ;;
-      (*.tar.xz|*.txz)
-        (( $+commands[pixz] )) && { tar -I pixz -xvf "$full_path" } || {
-        tar --xz --help &> /dev/null \
-        && tar --xz -xvf "$full_path" \
-        || xzcat "$full_path" | tar xvf - } ;;
-      (*.tar.zma|*.tlz)
-        tar --lzma --help &> /dev/null \
-        && tar --lzma -xvf "$full_path" \
-        || lzcat "$full_path" | tar xvf - ;;
-      (*.tar.zst|*.tzst)
-        tar --zstd --help &> /dev/null \
-        && tar --zstd -xvf "$full_path" \
-        || zstdcat "$full_path" | tar xvf - ;;
-      (*.tar) tar xvf "$full_path" ;;
-      (*.tar.lz) (( $+commands[lzip] )) && tar xvf "$full_path" ;;
-      (*.tar.lz4) lz4 -c -d "$full_path" | tar xvf - ;;
-      (*.tar.lrz) (( $+commands[lrzuntar] )) && lrzuntar "$full_path" ;;
-      (*.gz) (( $+commands[pigz] )) && pigz -cdk "$full_path" > "${file:t:r}" || gunzip -ck "$full_path" > "${file:t:r}" ;;
-      (*.bz2) (( $+commands[pbzip2] )) && pbzip2 -d "$full_path" || bunzip2 "$full_path" ;;
-      (*.xz) unxz "$full_path" ;;
-      (*.lrz) (( $+commands[lrunzip] )) && lrunzip "$full_path" ;;
-      (*.lz4) lz4 -d "$full_path" ;;
-      (*.lzma) unlzma "$full_path" ;;
-      (*.z) uncompress "$full_path" ;;
-      (*.zip|*.war|*.jar|*.ear|*.sublime-package|*.ipa|*.ipsw|*.xpi|*.apk|*.aar|*.whl|*.vsix|*.crx) unzip "$full_path" ;;
-      (*.rar) unrar x -ad "$full_path" ;;
-      (*.rpm)
-        rpm2cpio "$full_path" | cpio --quiet -id ;;
-      (*.7z | *.7z.[0-9]*) 7za x "$full_path" ;;
-      (*.deb)
-        command mkdir -p "control" "data"
-        ar vx "$full_path" > /dev/null
-        builtin cd -q control; extract ../control.tar.*
-        builtin cd -q ../data; extract ../data.tar.*
-        builtin cd -q ..; command rm *.tar.* debian-binary ;;
-      (*.zst) unzstd --stdout "$full_path" > "${file:t:r}" ;;
-      (*.cab|*.exe) cabextract "$full_path" ;;
-      (*.cpio|*.obscpio) cpio -idmvF "$full_path" ;;
-      (*.zpaq) zpaq x "$full_path" ;;
-      (*.zlib) zlib-flate -uncompress < "$full_path" > "${file:r}" ;;
-      (*)
-        echo "extract: '$file' cannot be extracted" >&2
-        success=1 ;;
-    esac
-
+        (*.tar.bz2|*.tbz|*.tbz2)
+          (( $+commands[pbzip2] )) && { tar -I pbzip2 -xvf "$full_path" } || tar xvjf "$full_path" ;;
+          (*.tar.xz|*.txz)
+            (( $+commands[pixz] )) && { tar -I pixz -xvf "$full_path" } || {
+              tar --xz --help &> /dev/null \
+              && tar --xz -xvf "$full_path" \
+              || xzcat "$full_path" | tar xvf - } ;;
+          (*.tar.zma|*.tlz)
+            tar --lzma --help &> /dev/null \
+              && tar --lzma -xvf "$full_path" \
+              || lzcat "$full_path" | tar xvf - ;;
+          (*.tar.zst|*.tzst)
+            tar --zstd --help &> /dev/null \
+              && tar --zstd -xvf "$full_path" \
+              || zstdcat "$full_path" | tar xvf - ;;
+          (*.tar) tar xvf "$full_path" ;;
+          (*.tar.lz) (( $+commands[lzip] )) && tar xvf "$full_path" ;;
+          (*.tar.lz4) lz4 -c -d "$full_path" | tar xvf - ;;
+          (*.tar.lrz) (( $+commands[lrzuntar] )) && lrzuntar "$full_path" ;;
+          (*.gz) (( $+commands[pigz] )) && pigz -cdk "$full_path" > "${file:t:r}" || gunzip -ck "$full_path" > "${file:t:r}" ;;
+          (*.bz2) (( $+commands[pbzip2] )) && pbzip2 -d "$full_path" || bunzip2 "$full_path" ;;
+          (*.xz) unxz "$full_path" ;;
+          (*.lrz) (( $+commands[lrunzip] )) && lrunzip "$full_path" ;;
+          (*.lz4) lz4 -d "$full_path" ;;
+          (*.lzma) unlzma "$full_path" ;;
+          (*.z) uncompress "$full_path" ;;
+          (*.zip|*.war|*.jar|*.ear|*.sublime-package|*.ipa|*.ipsw|*.xpi|*.apk|*.aar|*.whl|*.vsix|*.crx) unzip "$full_path" ;;
+          (*.rar) unrar x -ad "$full_path" ;;
+          (*.rpm)
+            rpm2cpio "$full_path" | cpio --quiet -id ;;
+          (*.7z | *.7z.[0-9]*) 7za x "$full_path" ;;
+          (*.deb)
+            command mkdir -p "control" "data"
+            ar vx "$full_path" > /dev/null
+            builtin cd -q control; extract ../control.tar.*
+            builtin cd -q ../data; extract ../data.tar.*
+            builtin cd -q ..; command rm *.tar.* debian-binary ;;
+          (*.zst) unzstd --stdout "$full_path" > "${file:t:r}" ;;
+          (*.cab|*.exe) cabextract "$full_path" ;;
+          (*.cpio|*.obscpio) cpio -idmvF "$full_path" ;;
+          (*.zpaq) zpaq x "$full_path" ;;
+          (*.zlib) zlib-flate -uncompress < "$full_path" > "${file:r}" ;;
+          (*)
+            echo "extract: '$file' cannot be extracted" >&2
+            success=1 ;;
+      esac # end case
+      
+    
     (( success = success > 0 ? success : $? ))
-    (( success == 0 && remove_archive == 0 )) && command rm "$full_path"
-    shift
+    (( success == 0 && remove_archive == 1 )) && command rm "$full_path"
 
     # Go back to original working directory
-    builtin cd -q "$pwd"
-
-    # If content of extract dir is a single directory, move its contents up
-    # Glob flags:
-    # - D: include files starting with .
-    # - N: no error if directory is empty
-    # - Y2: at most give 2 files
-    local -a content
-    content=("${extract_dir}"/*(DNY2))
-    if [[ ${#content} -eq 1 && -e "${content[1]}" ]]; then
-      # The extracted file/folder (${content[1]}) may have the same name as $extract_dir
-      # If so, we need to rename it to avoid conflicts in a 3-step process
-      #
-      # 1. Move and rename the extracted file/folder to a temporary random name
-      # 2. Delete the empty folder
-      # 3. Rename the extracted file/folder to the original name
-      if [[ "${content[1]:t}" == "$extract_dir" ]]; then
-        # =(:) gives /tmp/zsh<random>, with :t it gives zsh<random>
-        local tmp_name==(:); tmp_name="${tmp_name:t}"
-        command mv "${content[1]}" "$tmp_name" \
-        && command rmdir "$extract_dir" \
-        && command mv "$tmp_name" "$extract_dir"
-      # Otherwise, if the extracted folder name already exists in the current
-      # directory (because of a previous file / folder), keep the extract_dir
-      elif [[ ! -e "${content[1]:t}" ]]; then
-        command mv "${content[1]}" . \
-        && command rmdir "$extract_dir"
-      fi
-    elif [[ ${#content} -eq 0 ]]; then
-      command rmdir "$extract_dir"
-    fi
+    builtin cd -q "${work_dir}"
+    
+    shift
   done
 }

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -32,7 +32,7 @@ EOF
       shift
       if [[ ! -d "$1" ]]; then
         echo "extract: specified output directory $1 is not a valid directory." >&2
-        return
+        return 1
       fi
       extract_dir="$1"
       shift


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (N/A)

## Changes:

Closes issue #13090.

- using the "-t" and "--to-directory" flag and specifying a directory, you can now extract to a specific (existing) directory 
- removed the functionality which flatten the output directory (for now), would need to be re-implemented, maybe with a "-f" or "--flatten" flag
- changed the README to give some instructions on how to view the help page for the `extract` command

## Other comments:
None.
