### PR TITLE
fix(history): handle HIST_STAMPS with whitespace in timestamp format

### DIFF
--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -18,10 +18,10 @@ function omz_history {
     print -u2 History file deleted.
   elif [[ $# -eq 0 ]]; then
     # if no arguments provided, show full history starting from 1
-    builtin fc $stamp -l 1
+    builtin fc "${stamp[@]}" -l 1
   else
     # otherwise, run `fc -l` with a custom format
-    builtin fc $stamp -l "$@"
+    builtin fc "${stamp[@]}" -l "$@"
   fi
 }
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- handle HIST_STAMPS with whitespace in timestamp format

## Other comments:

```sh
$ echo $HIST_STAMPS
%y-%d-%m %T
$ which history
history: aliased to omz_history -t '%y-%d-%m %T'
$ typeset -ft omz_history
```
Without fix:
```sh
$ history > /dev/null
+ history.zsh:4 @omz_history:2> local clear list stamp REPLY
+ history.zsh:5 @omz_history:3> zparseopts -E -D 'c=clear' 'l=list' 'f=stamp' 'E=stamp' 'i=stamp' 't:=stamp'
+ history.zsh:7 @omz_history:5> [[ -n '' ]]
+ history.zsh:19 @omz_history:17> [[ 0 -eq 0 ]]
+ history.zsh:21 @omz_history:19> fc -t %y-%d-%m %T -l 1
omz_history:fc:19: event not found: %T
```
With fix:
```sh
$ history > /dev/null
+ history.zsh:4 @omz_history:2> local clear list stamp REPLY
+ history.zsh:5 @omz_history:3> zparseopts -E -D 'c=clear' 'l=list' 'f=stamp' 'E=stamp' 'i=stamp' 't:=stamp'
+ history.zsh:7 @omz_history:5> [[ -n '' ]]
+ history.zsh:19 @omz_history:17> [[ 0 -eq 0 ]]
+ history.zsh:21 @omz_history:19> fc -t '%y-%d-%m %T' -l 1
```