### PR TITLE
"Add act and runpy aliases to Python plugin"

### DIFF
--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -18,8 +18,8 @@ plugins=(... python)
 | `pygrep <text>`  | Looks for `text` in `*.py` files in the current directory, recursively                 |
 | `pyuserpaths`    | Add user site-packages folders to `PYTHONPATH`, for Python 2 and 3                     |
 | `pyserver`       | Starts an HTTP server on the current directory (use `--directory` for a different one) |
-| `act`            | Activate the local environment                                                         |
-| `pyr`          | Run `main.py`                                                                          |
+| `pya`            | Activate the local environment                                                         |
+| `pyr`            | Run `main.py`                                                                          |
 
 ## Virtual environments
 

--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -19,7 +19,7 @@ plugins=(... python)
 | `pyuserpaths`    | Add user site-packages folders to `PYTHONPATH`, for Python 2 and 3                     |
 | `pyserver`       | Starts an HTTP server on the current directory (use `--directory` for a different one) |
 | `act`            | Activate the local environment                                                         |
-| `runpy`          | Run `main.py`                                                                          |
+| `pyr`          | Run `main.py`                                                                          |
 
 ## Virtual environments
 

--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -18,6 +18,8 @@ plugins=(... python)
 | `pygrep <text>`  | Looks for `text` in `*.py` files in the current directory, recursively                 |
 | `pyuserpaths`    | Add user site-packages folders to `PYTHONPATH`, for Python 2 and 3                     |
 | `pyserver`       | Starts an HTTP server on the current directory (use `--directory` for a different one) |
+| `act`            | Activate the local environment                                                         |
+| `runpy`          | Run `main.py`                                                                          |
 
 ## Virtual environments
 

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -124,4 +124,4 @@ fi
 # Activate the local environment
 alias act='source venv/bin/activate'
 # run main.py 
-alias runpy='python main.py'
+alias pyr='python main.py'

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -120,3 +120,8 @@ if [[ "$PYTHON_AUTO_VRUN" == "true" ]]; then
   add-zsh-hook chpwd auto_vrun
   auto_vrun
 fi
+
+# Activate the local environment
+alias act='source venv/bin/activate'
+# run main.py 
+alias runpy='python main.py'

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -122,6 +122,6 @@ if [[ "$PYTHON_AUTO_VRUN" == "true" ]]; then
 fi
 
 # Activate the local environment
-alias act='source venv/bin/activate'
+alias pya='source venv/bin/activate'
 # run main.py 
 alias pyr='python main.py'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added the `act` alias to quickly activate a Python virtual environment.
- Added the `runpy` alias to easily run `main.py` with Python.

## Other comments:

- These aliases simplify the workflow for Python developers by reducing the number of commands needed to activate virtual environments and run the main script.
- The aliases do not duplicate existing functionality and should be useful for most Python projects that use virtual environments.
