### PR TITLE
vi-mode: Document additional text objects

### DIFF
--- a/plugins/vi-mode/README.md
+++ b/plugins/vi-mode/README.md
@@ -46,7 +46,7 @@ hasn't been defined by theme, *Insert mode* is not displayed by default.
 
 You can change these indicators by setting the `MODE_INDICATOR` (*Normal mode*) and
 `INSERT_MODE_INDICATORS` (*Insert mode*) variables.
-This settings support Prompt Expansion sequences. For example:
+These settings support Prompt Expansion sequences. For example:
 
 ```zsh
 MODE_INDICATOR="%F{white}+%f"
@@ -156,6 +156,27 @@ NOTE: this used to be bound to `v`. That is now the default (`visual-mode`).
 NOTE: delete/kill commands (`dd`, `D`, `c{motion}`, `C`, `x`,`X`) and yank commands
 (`y`, `Y`) will copy to the clipboard. Contents can then be put back using paste commands
 (`P`, `p`).
+
+## Text objects
+
+Standard text objects are supported with `i` ("inside") and `a` ("around"), e.g., for words; thus, you can select the word the cursor is in with `viw`, or delete the current word, including surrounding spaces, with `daw`.
+
+For other text objects, you can rely on the built-in functionality of Zsh and enable it accordingly.
+For example, for quoted strings, you can copy the commented snippet of <https://sourceforge.net/p/zsh/code/ci/master/tree/Functions/Zle/select-quoted>: place this in your `.zsrhc` file, e.g., after sourcing oh-my-zsh:
+
+```sh
+autoload -U select-quoted
+zle -N select-quoted
+for m in visual viopp; do
+    for c in {a,i}{\',\",\`}; do
+        bindkey -M $m $c select-quoted
+    done
+done
+```
+
+Now, in normal mode, you can select everything inside a double-quoted string with `vi"`.
+Note that this works even if you're not already inside a quoted string.
+For example, you can replace everything inside a single-quoted string in the current line, from wherever the cursor is, with `ci'`.
 
 ## Known issues
 


### PR DESCRIPTION
This documents how to enable additional text objects, e.g., quoted strings, using standard Zsh features.

I was searching for this functionality and found https://github.com/ohmyzsh/ohmyzsh/issues/12343 that put me in the right direction.

I guess it's worthwhile to document it.

This also fixes a small grammar mistake.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- This documents how to enable additional text objects, e.g., quoted strings, using standard Zsh features. It also fixes a small grammar mistake.

## Other comments:

I was searching for this functionality and found https://github.com/ohmyzsh/ohmyzsh/issues/12343 that put me in the right direction.

I guess it's worthwhile to document it.
