### PR TITLE
feat(termsupport): add WezTerm window/tab title support (OSC 1, 2)

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -17,7 +17,7 @@ function title {
   : ${2=$1}
 
   case "$TERM" in
-    cygwin|xterm*|putty*|rxvt*|konsole*|ansi|mlterm*|alacritty*|st*|foot*|contour*)
+    wezterm*|cygwin|xterm*|putty*|rxvt*|konsole*|ansi|mlterm*|alacritty*|st*|foot*|contour*)
       print -Pn "\e]2;${2:q}\a" # set window name
       print -Pn "\e]1;${1:q}\a" # set tab name
       ;;

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -17,7 +17,7 @@ function title {
   : ${2=$1}
 
   case "$TERM" in
-    wezterm*|cygwin|xterm*|putty*|rxvt*|konsole*|ansi|mlterm*|alacritty*|st*|foot*|contour*)
+    cygwin|xterm*|putty*|rxvt*|konsole*|ansi|mlterm*|alacritty*|st*|foot*|contour*|wezterm*)
       print -Pn "\e]2;${2:q}\a" # set window name
       print -Pn "\e]1;${1:q}\a" # set tab name
       ;;


### PR DESCRIPTION
This adds TERM=wezterm to the list of supported terminals.
https://wezterm.org/recipes/passing-data.html?h=osc#user-vars

WezTerm uses TERM=xterm-256color by default, but it endorses users to use TERM=wezterm in their configuration:
https://wezterm.org/config/lua/config/term.html

With this patch, oh-my-zsh will still support setting the window and tab name.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add TERM=wezterm to the list of supported terminals in [lib/termsupport.zsh](https://github.com/tobii-dev/ohmyzsh/blob/78cfcccce4ae5c8c551e72e8f32eec11776c0dc6/lib/termsupport.zsh#L20)
