### PR TITLE
[Bug Fix] Make blinks theme respect user background color in dark mode

### DIFF
--- a/themes/blinks.zsh-theme
+++ b/themes/blinks.zsh-theme
@@ -11,11 +11,11 @@ function _prompt_char() {
 # This theme works with both the "dark" and "light" variants of the
 # Solarized color schema.  Set the SOLARIZED_THEME variable to one of
 # these two values to choose.  If you don't specify, we'll assume you're
-# using the "dark" variant.
+# using neither variant.
 
 case ${SOLARIZED_THEME:-dark} in
     light) bkg=white;;
-    *)     bkg=black;;
+    *)  bkg=default;;
 esac
 
 ZSH_THEME_GIT_PROMPT_PREFIX=" [%{%B%F{blue}%}"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Make blinks theme respect user background color in dark mode

## Other comments:

Tested on my local systems extensively on several different variants of Linux (Arch, Debian, and Ubuntu).

Before fix:
![image](https://github.com/user-attachments/assets/9ca117b9-f8e0-4179-a742-a1ff6c19b76b)

After fix:
![image](https://github.com/user-attachments/assets/145df2c4-cd6b-49c8-b770-23995944e320)
