### PR TITLE
fix: include .ssh/config hosts in ssh completion alongside /etc/hosts

### DIFF
--- a/plugins/ssh/ssh.plugin.zsh
+++ b/plugins/ssh/ssh.plugin.zsh
@@ -51,3 +51,22 @@ function ssh_unload_key {
     ssh-add -d "$keyfile"
   fi
 }
+
+# Custom SSH hosts completion: include both /etc/hosts and ~/.ssh/config
+_zsh_ssh_hosts() {
+  local hosts=()
+  # Read hosts from /etc/hosts
+  while read -r ip name _; do
+    [[ -n $name ]] && hosts+=($name)
+  done < /etc/hosts
+
+  # Read Host aliases from ~/.ssh/config
+  local cfg_hosts=(${(f)"$(awk '/^Host[[:space:]]/ { for (i=2; i<=NF; i++) print \$i }' ~/.ssh/config 2>/dev/null)"})
+  hosts+=(${cfg_hosts[@]})
+
+  # Output combined list
+  echo "${hosts[@]}"
+}
+
+# Apply the custom hosts completion function
+zstyle ':completion:*:ssh:*' hosts zsh_ssh_hosts


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
