### PR TITLE
feat(cli) Add flag to `omz plugin list` to show only enabled plugins

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -449,30 +449,22 @@ function _omz::plugin::info {
 
 function _omz::plugin::list {
   local -a custom_plugins builtin_plugins
-  custom_plugins=("$ZSH_CUSTOM"/plugins/*(-/N:t))
-  builtin_plugins=("$ZSH"/plugins/*(-/N:t))
 
-  # If --enabled is provided, filter plugins by what's enabled
+  # If --enabled is provided, only list what's enabled
   if [[ "$1" == "--enabled" ]]; then
-    # echo $plugins[@]
     local plugin
-    local -a new_custom_plugins new_builtin_plugins
-    for plugin in "${custom_plugins[@]}"; do
-      # Spaces are to ensure we don't match substrings of other plugins
-      # This avoids the need for a second, inner loop
-      if [[ "${plugins[@]}" =~ $plugin ]]; then
-        new_custom_plugins+=("$plugin")
+    for plugin in "${plugins[@]}"; do
+      if [[ -d "${ZSH_CUSTOM}/plugins/${plugin}" ]]; then
+        custom_plugins+=("${plugin}")
+      elif [[ -d "${ZSH}/plugins/${plugin}" ]]; then
+        builtin_plugins+=("${plugin}")
       fi
     done
-    custom_plugins=(${new_custom_plugins[@]})
-    for plugin in "${builtin_plugins[@]}"; do
-      # Spaces are to ensure we don't match substrings of other plugins
-      # This avoids the need for a second, inner loop
-      if [[ "${plugins[@]}" =~ $plugin ]]; then
-        new_builtin_plugins+=("$plugin")
-      fi
-    done
-    builtin_plugins=(${new_builtin_plugins[@]})
+  elif [[ -n "$1" ]]; then
+    has_completion=1
+  else
+    custom_plugins=("$ZSH_CUSTOM"/plugins/*(-/N:t))
+    builtin_plugins=("$ZSH"/plugins/*(-/N:t))
   fi
 
   # If the command is being piped, print all found line by line

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -72,6 +72,10 @@ function _omz {
         local -aU plugins
         plugins=("$ZSH"/plugins/*/{_*,*.plugin.zsh}(-.N:h:t) "$ZSH_CUSTOM"/plugins/*/{_*,*.plugin.zsh}(-.N:h:t))
         _describe 'plugin' plugins ;;
+      plugin::list)
+        local -a opts
+        opts=('--enabled:List enabled plugins only')
+        _describe -o 'options' opts ;;
       theme::(set|use))
         local -aU themes
         themes=("$ZSH"/themes/*.zsh-theme(-.N:t:r) "$ZSH_CUSTOM"/**/*.zsh-theme(-.N:r:gs:"$ZSH_CUSTOM"/themes/:::gs:"$ZSH_CUSTOM"/:::))

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -464,8 +464,6 @@ function _omz::plugin::list {
         builtin_plugins+=("${plugin}")
       fi
     done
-  elif [[ -n "$1" ]]; then
-    has_completion=1
   else
     custom_plugins=("$ZSH_CUSTOM"/plugins/*(-/N:t))
     builtin_plugins=("$ZSH"/plugins/*(-/N:t))

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -206,7 +206,7 @@ Available commands:
   disable <plugin> Disable plugin(s)
   enable <plugin>  Enable plugin(s)
   info <plugin>    Get information of a plugin
-  list             List all available Oh My Zsh plugins
+  list [--enabled] List Oh My Zsh plugins
   load <plugin>    Load plugin(s)
 
 EOF
@@ -451,6 +451,29 @@ function _omz::plugin::list {
   local -a custom_plugins builtin_plugins
   custom_plugins=("$ZSH_CUSTOM"/plugins/*(-/N:t))
   builtin_plugins=("$ZSH"/plugins/*(-/N:t))
+
+  # If --enabled is provided, filter plugins by what's enabled
+  if [[ "$1" == "--enabled" ]]; then
+    # echo $plugins[@]
+    local plugin
+    local -a new_custom_plugins new_builtin_plugins
+    for plugin in "${custom_plugins[@]}"; do
+      # Spaces are to ensure we don't match substrings of other plugins
+      # This avoids the need for a second, inner loop
+      if [[ "${plugins[@]}" =~ $plugin ]]; then
+        new_custom_plugins+=("$plugin")
+      fi
+    done
+    custom_plugins=(${new_custom_plugins[@]})
+    for plugin in "${builtin_plugins[@]}"; do
+      # Spaces are to ensure we don't match substrings of other plugins
+      # This avoids the need for a second, inner loop
+      if [[ "${plugins[@]}" =~ $plugin ]]; then
+        new_builtin_plugins+=("$plugin")
+      fi
+    done
+    builtin_plugins=(${new_builtin_plugins[@]})
+  fi
 
   # If the command is being piped, print all found line by line
   if [[ ! -t 1 ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added a flag to `omz plugin list` which allows users to list only enabled plugins by category (built-in vs. custom)

## Other comments:

Should be relatively efficient due to use of regex comparison as opposed to double `for` loops.
