### PR TITLE
feat(grep): Use ggrep via Homebrew if it is installed

### DIFF
--- a/lib/grep.zsh
+++ b/lib/grep.zsh
@@ -5,8 +5,14 @@ __GREP_ALIAS_CACHES=("$__GREP_CACHE_FILE"(Nm-1))
 if [[ -n "$__GREP_ALIAS_CACHES" ]]; then
     source "$__GREP_CACHE_FILE"
 else
+    # If ggrep via Homebrew is not available, use system grep
+    if [[ -n "$HOMEBREW_PREFIX" && -x "$HOMEBREW_PREFIX/bin/ggrep" ]]; then
+        GREP="ggrep"
+    else
+        GREP="grep"
+    fi
     grep-flags-available() {
-        command grep "$@" "" &>/dev/null <<< ""
+        command $GREP "$@" "" &>/dev/null <<< ""
     }
 
     # Ignore these folders (if the necessary grep flags are available)
@@ -23,9 +29,9 @@ else
 
     if [[ -n "$GREP_OPTIONS" ]]; then
         # export grep, egrep and fgrep settings
-        alias grep="grep $GREP_OPTIONS"
-        alias egrep="grep -E"
-        alias fgrep="grep -F"
+        alias grep="$GREP $GREP_OPTIONS"
+        alias egrep="$GREP -E"
+        alias fgrep="$GREP -F"
 
         # write to cache file if cache directory is writable
         if [[ -w "$ZSH_CACHE_DIR" ]]; then
@@ -34,7 +40,7 @@ else
     fi
 
     # Clean up
-    unset GREP_OPTIONS EXC_FOLDERS
+    unset GREP GREP_OPTIONS EXC_FOLDERS
     unfunction grep-flags-available
 fi
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- This checks if `ggrep` (GNU Grep) is installed via Homebrew and uses that for the grep aliases

## Other comments:

I am willing to admit that this may not get merged due to forcing the user into using grep installed via Homebrew, which at time of writing is `ggrep (GNU grep) 3.12`, over the native macOS version which is `grep (BSD grep, GNU compatible) 2.6.0-FreeBSD`. This PR is mainly for my own uses, as I was sick of lacking `-P` for more powerful regex grepping and lacking colored output when using `grep`.
