### PR TITLE
fix(open_command,wsl): Escape cmd.exe special chars for URLs in open_command when using WSL

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -23,6 +23,7 @@ function open_command() {
     linux*)   [[ "$(uname -r)" != *icrosoft* ]] && open_cmd='nohup xdg-open' || {
                 open_cmd='cmd.exe /c start ""'
                 [[ -e "$1" ]] && { 1="$(wslpath -w "${1:a}")" || return 1 }
+                [[ "$1" = (http|https)://* ]] && { 1="$(echo "$1" | sed -E 's/([&|()<>^])/^\1/g')" || return 1 }
               } ;;
     msys*)    open_cmd='start ""' ;;
     *)        echo "Platform $OSTYPE not supported"

--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -23,7 +23,9 @@ function open_command() {
     linux*)   [[ "$(uname -r)" != *icrosoft* ]] && open_cmd='nohup xdg-open' || {
                 open_cmd='cmd.exe /c start ""'
                 [[ -e "$1" ]] && { 1="$(wslpath -w "${1:a}")" || return 1 }
-                [[ "$1" = (http|https)://* ]] && { 1="$(echo "$1" | sed -E 's/([&|()<>^])/^\1/g')" || return 1 }
+                [[ "$1" = (http|https)://* ]] && {
+                  1="$(echo "$1" | sed -E 's/([&|()<>^])/^\1/g')" || return 1
+                }
               } ;;
     msys*)    open_cmd='start ""' ;;
     *)        echo "Platform $OSTYPE not supported"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below: N/A

## Context

Use `open_command` on WSL to open a URL in the browser.

```zsh
open_command "https://example.com/test?arg=value&key=value"
```

Currently, this is executed with `cmd.exe`, which considers `&` (amongst others) as special characters that are not escaped.
The result of this is that the actual URL that is opened is truncated at the first special character. 
A prevalent case where this occurs is with multiple URL arguments, as shown in the above example.

## Changes:

- If detecting WSL, look for URLs (using the same definition for using `BROWSER`), and escape any of the following characters: `&|()<>^` with the `^` escape character (for cmd.exe)

## Questions for reviewers

* I am making use of `sed -E` here, are there any requirements about if `sed` with extended regular expressions is an expected dependency or not?
