### PR TITLE
feat(theme): Make agnoster support conda environment

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -314,6 +314,9 @@ prompt_dir() {
 
 # Virtualenv: current working virtualenv
 prompt_virtualenv() {
+  if [ -n "$CONDA_DEFAULT_ENV" ]; then
+    prompt_segment magenta $CURRENT_FG "🐍 $CONDA_DEFAULT_ENV"
+  fi
   if [[ -n "$VIRTUAL_ENV" && -n "$VIRTUAL_ENV_DISABLE_PROMPT" ]]; then
     prompt_segment "$AGNOSTER_VENV_BG" "$AGNOSTER_VENV_FG" "(${VIRTUAL_ENV:t:gs/%/%%})"
   fi
@@ -354,9 +357,9 @@ prompt_aws() {
 build_prompt() {
   RETVAL=$?
   prompt_status
-  prompt_virtualenv
   prompt_aws
   prompt_context
+  prompt_virtualenv
   prompt_dir
   prompt_git
   prompt_bzr

--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -357,9 +357,9 @@ prompt_aws() {
 build_prompt() {
   RETVAL=$?
   prompt_status
+  prompt_virtualenv
   prompt_aws
   prompt_context
-  prompt_virtualenv
   prompt_dir
   prompt_git
   prompt_bzr


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add a agnoster subtheme on conda supported

## Other comments:

effect:

(Sorry, I can't upload pictures right now...)

such as:

```shell
 zcx@zcx-workpc  🐍 ecloud  ~/.oh-my-zsh/themes   master  conda deactivate
 zcx@zcx-workpc  🐍 base  ~/.oh-my-zsh/themes   master  conda deactivate
 zcx@zcx-workpc  ~/.oh-my-zsh/themes   master  vim ../.zshrc
```
