### PR TITLE
feat: support custom prefix in sudo plugin and update README accordingly

### DIFF
--- a/plugins/sudo/README.md
+++ b/plugins/sudo/README.md
@@ -1,30 +1,30 @@
 # sudo
 
-Easily prefix your current or previous commands with `sudo` by pressing <kbd>esc</kbd> twice.
+Easily prefix your current or previous commands with `sudo` (or a custom prefix) by pressing <kbd>esc</kbd> twice.
 
 To use it, add `sudo` to the plugins array in your zshrc file:
 
 ```zsh
 plugins=(... sudo)
-```
+````
 
 ## Usage
 
 ### Current typed commands
 
-Say you have typed a long command and forgot to add `sudo` in front:
+Say you have typed a long command and forgot to add the prefix (default: `sudo`) in front:
 
 ```console
 $ apt-get install build-essential
 ```
 
-By pressing the <kbd>esc</kbd> key twice, you will have the same command with `sudo` prefixed without typing:
+By pressing the <kbd>esc</kbd> key twice, you will have the same command with the prefix (`sudo` by default) added without typing:
 
 ```console
 $ sudo apt-get install build-essential
 ```
 
-The same happens for editing files with your default editor (defined in `$SUDO_EDITOR`, `$VISUAL` or `$EDITOR`, in that order):
+The same happens for editing files with your default editor (defined in `$SUDO_EDITOR`, `$VISUAL`, or `$EDITOR`, in that order):
 
 If the editor defined were `vim`:
 
@@ -32,7 +32,7 @@ If the editor defined were `vim`:
 $ vim /etc/hosts
 ```
 
-By pressing the <kbd>esc</kbd> key twice, you will have the same command with `sudo -e` instead of the editor, that would open that editor with root privileges:
+By pressing the <kbd>esc</kbd> key twice, the command will be replaced with the prefix followed by `-e` (default: `sudo -e`), which opens that editor with root privileges:
 
 ```console
 $ sudo -e /etc/hosts
@@ -40,7 +40,7 @@ $ sudo -e /etc/hosts
 
 ### Previous executed commands
 
-Say you want to delete a system file and denied:
+Say you want to delete a system file and get a permission denied error:
 
 ```console
 $ rm some-system-file.txt
@@ -48,21 +48,20 @@ $ rm some-system-file.txt
 $
 ```
 
-By pressing the <kbd>esc</kbd> key twice, you will have the same command with `sudo` prefixed without typing:
+By pressing the <kbd>esc</kbd> key twice, the plugin will take the last executed command and prefix it with `sudo` (or your configured prefix):
 
 ```console
-$ rm some-system-file.txt
--su: some-system-file.txt: Permission denied
 $ sudo rm some-system-file.txt
 Password:
 $
 ```
 
-The same happens for file editing, as told before.
+The same applies for file editing commands, as described above.
 
 ## Key binding
 
-By default, the `sudo` plugin uses <kbd>Esc</kbd><kbd>Esc</kbd> as the trigger.
+By default, the plugin uses <kbd>Esc</kbd><kbd>Esc</kbd> as the trigger.
+
 If you want to change it, you can use the `bindkey` command to bind it to a different key:
 
 ```sh
@@ -71,5 +70,23 @@ bindkey -M vicmd '<seq>' sudo-command-line
 bindkey -M viins '<seq>' sudo-command-line
 ```
 
-where `<seq>` is the sequence you want to use. You can find the keyboard sequence
-by running `cat` and pressing the keyboard combination you want to use.
+where `<seq>` is the key sequence you want to use. You can find the keyboard sequence by running `cat` and pressing the desired key combination.
+
+## Configuration
+
+You can override the default prefix (`sudo`) by setting the `ZSH_SUDO_PLUGIN_PREFIX` environment variable in your `.zshrc`:
+
+```zsh
+export ZSH_SUDO_PLUGIN_PREFIX="doas"
+```
+
+This will make the plugin prefix commands with `doas` instead of `sudo`.
+
+
+**Important:** If you use a custom prefix different from `sudo`, make sure to create an alias named after that prefix pointing to `sudo`, for example:
+
+```zsh
+alias doas='sudo'
+```
+
+This ensures proper command substitution and consistent behavior.


### PR DESCRIPTION
add configurable prefix support to sudo plugin with alias reminder

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Introduced ZSH_SUDO_PLUGIN_PREFIX variable to allow custom command prefix instead of default 'sudo'
- Updated command substitution logic to handle prefix and prefix -e (sudoedit) properly
- Enhanced README with usage examples and a note about creating alias for custom prefixes
- Maintains default behavior wix is specifiedhen no prefix is specified

## Other comments:

...
