### PR TITLE
Adding gdno for git diff name only to list changed files

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -205,6 +205,7 @@ alias gdct='git describe --tags $(git rev-list --tags --max-count=1)'
 alias gd='git diff'
 alias gdca='git diff --cached'
 alias gdcw='git diff --cached --word-diff'
+alias gdno='git diff --name-only'
 alias gds='git diff --staged'
 alias gdw='git diff --word-diff'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x ] The PR title is descriptive.
- [ x ] The PR doesn't replicate another PR which is already open.
- [ x ] I have read the contribution guide and followed all the instructions.
- [ x ] The code follows the code style guide detailed in the wiki.
- [ x ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x ] The code is stable and I have tested it myself, to the best of my abilities.
- [ x ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
 Adds gdno alias for the git plugin, git diff --name-only lists the changed files
- [...]

## Other comments:

...
