### PR TITLE
feat(theme): Optimize the display effect of conda in the agnoster theme; standardize the code

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -80,6 +80,8 @@ esac
 # VirtualEnv colors
 : ${AGNOSTER_VENV_FG:=black}
 : ${AGNOSTER_VENV_BG:=blue}
+: ${AGNOSTER_CONDA_FG:=${CURRENT_FG}}
+: ${AGNOSTER_CONDA_BG:=magenta}
 
 # AWS Profile colors
 : ${AGNOSTER_AWS_PROD_FG:=yellow}
@@ -314,9 +316,15 @@ prompt_dir() {
 
 # Virtualenv: current working virtualenv
 prompt_virtualenv() {
-  if [ -n "$CONDA_DEFAULT_ENV" ]; then
-    prompt_segment magenta $CURRENT_FG "🐍 $CONDA_DEFAULT_ENV"
+  if [[ -n $CONDA_DEFAULT_ENV && -z $CONDA_ENV_DISABLE_PROMPT ]]; then
+    # You can execute this command to disable conda native prompt.
+    # `conda config --set changeps1 False`
+  
+    local conda_prompt_prefix=${CONDA_PROMPT_PREFIX:-"🐍 "}
+    # local conda_prompt_prefix="$CONDA_PROMPT_PREFIX"
+    prompt_segment "$AGNOSTER_CONDA_BG" "$AGNOSTER_CONDA_FG" "$conda_prompt_prefix$CONDA_DEFAULT_ENV"
   fi
+
   if [[ -n "$VIRTUAL_ENV" && -n "$VIRTUAL_ENV_DISABLE_PROMPT" ]]; then
     prompt_segment "$AGNOSTER_VENV_BG" "$AGNOSTER_VENV_FG" "(${VIRTUAL_ENV:t:gs/%/%%})"
   fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Support disabling conda prompt display via `CONDA_ENV_DISABLE_PROMPT`
- Support customizing the conda prompt prefix via `CONDA_PROMPT_PREFIX`
- Change foreground and background colors to constants, and support defining them via `AGNOSTER_CONDA_BG` and `AGNOSTER_CONDA_FG`
- Add a comment: Command to disable the native conda prompt.