### PR TITLE
feat(plugin): dockolor - docker ps with color based on status

### DIFF
--- a/plugins/dockolor/README.md
+++ b/plugins/dockolor/README.md
@@ -49,7 +49,7 @@ source ~/.zshrc
 
 ## Usage
 
-- `dockolor` — Same as `docker ps --no-trunc`, but colorized.
-- `dps` — Replaced with `dockolor_dps`, with color.
-- `dpsa` — Replaced with `dockolor_dps -a`, showing all containers, with color.
+- `dockolor` — Same as `docker ps`, but colorized.
+- `dps` — Replaced with `dockolor_dps`, same as `dockolor` or `docker ps`.
+- `dpsa` — Replaced with `dockolor_dps -a`, same as `dockolor -a` or `docker ps -a`.
 

--- a/plugins/dockolor/dockolor.plugin.sh
+++ b/plugins/dockolor/dockolor.plugin.sh
@@ -7,7 +7,7 @@ dockolor_has_awk() {
 }
 
 dockolor_colorize() {
-docker ps "$@" --no-trunc | awk '
+docker ps "$@" | awk '
   BEGIN {
     RED = "\033[0;31m"
     GREEN = "\033[0;32m"
@@ -42,7 +42,7 @@ docker ps "$@" --no-trunc | awk '
 dockolor_dps() {
   if [ "$(dockolor_has_awk)" = false ]; then
     echo "You have installed dockolor but you don't have awk installed"
-    docker ps "$@" --no-trunc
+    docker ps "$@"
   else
     dockolor_colorize "$@"
   fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine, or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable, and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Set a function `dockolor` that colorizes `docker ps` output based on container status. 
- Safely overrides `dps`, `dpsa` alias from [the docker plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/docker) for a more unified Docker experience.
- If `awk` is not installed, the script returns the `docker ps` command has is with a message `You have installed dockolor but you don't have awk installed`.

## Use case

I'm sometime lost in my `docker ps` list, so we can improve the readability of the output just with colored line:

before
![image](https://github.com/user-attachments/assets/7c4fecd2-6e6f-49c7-9d33-7e707e001d0f)

after
![image](https://github.com/user-attachments/assets/314903b5-b05b-4978-8f95-571808cebfd2)

## Other comments:

I first started to do this plugin in go, but for keeping this code simple as possible without unnecessary dependencies, I move it to plain sh.

Tell me if something is wrong, if something need a refactor or else :)
