### PR TITLE
feat(ubuntu): add apt-fast support for faster package management

### DIFF
--- a/plugins/ubuntu/README.md
+++ b/plugins/ubuntu/README.md
@@ -10,10 +10,11 @@ plugins=(... ubuntu)
 
 ## Aliases
 
-Commands that use `$APT` will use `apt` if installed or defer to `apt-get` otherwise.
+Commands that use `$APT` will use `apt-fast` if installed, or `apt` if installed, or defer to `apt-get`
+otherwise.
 
 | Alias   | Command                                                                  | Description                                                                                       |
-|---------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| ------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
 | age     | `sudo $APT`                                                              | Run apt-get with sudo                                                                             |
 | acs     | `apt-cache search`                                                       | Search the apt-cache with the specified criteria                                                  |
 | acsp    | `apt-cache showpkg`                                                      | Shows information about the listed packages                                                       |
@@ -26,7 +27,7 @@ Commands that use `$APT` will use `apt` if installed or defer to `apt-get` other
 | agd     | `sudo $APT dselect-upgrade`                                              | Follows dselect choices for package installation                                                  |
 | agi     | `sudo $APT install <pkg>`                                                | Install the specified package                                                                     |
 | agli    | `apt list --installed`                                                   | List the installed packages                                                                       |
-| aglu    | `sudo apt-get -u upgrade --assume-no`                                    | Run an apt-get upgrade assuming no to all prompts                                                 |
+| aglu    | `apt list --upgradable`                                                  | List available updates only                                                                       |
 | agp     | `sudo $APT purge <pkg>`                                                  | Remove a package including any configuration files                                                |
 | agr     | `sudo $APT remove <pkg>`                                                 | Remove a package                                                                                  |
 | ags     | `$APT source <pkg>`                                                      | Fetch the source for the specified package                                                        |
@@ -36,21 +37,20 @@ Commands that use `$APT` will use `apt` if installed or defer to `apt-get` other
 | agar    | `sudo $APT autoremove`                                                   | Remove automatically installed packages no longer needed                                          |
 | aguu    | `sudo $APT update && sudo $APT upgrade`                                  | Update packages list and upgrade available packages                                               |
 | allpkgs | `dpkg --get-selections \| grep -v deinstall`                             | Print all installed packages                                                                      |
-| kclean  | `sudo aptitude remove -P ?and(~i~nlinux-(ima\|hea) ?not(~n$(uname -r)))` |Remove ALL kernel images and headers EXCEPT the one in use                                         |
+| kclean  | `sudo aptitude remove -P ?and(~i~nlinux-(ima\|hea) ?not(~n$(uname -r)))` | Remove ALL kernel images and headers EXCEPT the one in use                                        |
 | mydeb   | `time dpkg-buildpackage -rfakeroot -us -uc`                              | Create a basic .deb package                                                                       |
 | ppap    | `sudo ppa-purge <ppa>`                                                   | Remove the specified PPA                                                                          |
 
-
 ## Functions
 
-| Function          | Usage                                 |Description                                                               |
-|-------------------|---------------------------------------|--------------------------------------------------------------------------|
+| Function          | Usage                                 | Description                                                              |
+| ----------------- | ------------------------------------- | ------------------------------------------------------------------------ |
 | aar               | `aar ppa:xxxxxx/xxxxxx [packagename]` | apt-add-repository with automatic install/upgrade of the desired package |
 | apt-history       | `apt-history <action>`                | Prints the Apt history of the specified action                           |
 | apt-list-packages | `apt-list-packages`                   | List packages by size                                                    |
 | kerndeb           | `kerndeb`                             | Kernel-package building shortcut                                         |
 
-## Authors:
+## Authors
 
 - [@AlexBio](https://github.com/AlexBio)
 - [@dbb](https://github.com/dbb)
@@ -59,3 +59,4 @@ Commands that use `$APT` will use `apt` if installed or defer to `apt-get` other
 - [Nicolas Jonas](https://nextgenthemes.com)
 - [@loctauxphilippe](https://github.com/loctauxphilippe)
 - [@HaraldNordgren](https://github.com/HaraldNordgren)
+- [@AmrElsayyad](https://github.com/AmrElsayyad)

--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -1,11 +1,22 @@
-(( $+commands[apt] )) && APT=apt || APT=apt-get
+# Detect available package manager (prefer apt-fast > apt > apt-get)
+if (( $+commands[apt-fast] )); then
+    APT=apt-fast
+elif (( $+commands[apt] )); then
+    APT=apt
+else
+    APT=apt-get
+fi
 
 alias acs='apt-cache search'
 
 alias afs='apt-file search --regexp'
 
 # These are apt/apt-get only
-alias ags="$APT source"
+if (( $+commands[apt] )); then
+    alias ags="apt source"
+else
+    alias ags="apt-get source"
+fi
 
 alias acp='apt-cache policy'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

• Enhanced the ubuntu plugin to detect and use apt-fast when available, providing faster package operations
• Maintains backward compatibility by falling back to apt or apt-get when apt-fast is not installed

## Other comments:

### Test plan

- [x] Test with apt-fast installed - verify aliases use apt-fast
- [x] Test without apt-fast but with apt - verify aliases use apt  
- [x] Test on older systems with only apt-get - verify aliases use apt-get
- [x] Verify all existing aliases continue to work as expected