### PR TITLE
Fixes #13112 Consolidate symfony, symfony2, and symfony6 plugins into…

### DIFF
--- a/plugins/symfony/README.md
+++ b/plugins/symfony/README.md
@@ -1,9 +1,49 @@
 # Symfony
 
-This plugin provides completion for [Symfony](https://symfony.com/).
+This plugin provides unified completion and aliases for [Symfony](https://symfony.com/) across all versions (Symfony 1.x, 2.x, 3.x, 4.x, 5.x, and 6+).
 
-To use it add symfony to the plugins array in your zshrc file.
+The plugin automatically detects your Symfony version and console location, using:
+- Native completion for Symfony 6.2+ when available
+- Legacy completion for older Symfony versions
+- Automatic console detection (`bin/console`, `app/console`, `console`, or `symfony`)
+
+To use it add `symfony` to the plugins array in your zshrc file.
 
 ```bash
 plugins=(... symfony)
 ```
+
+## Aliases
+
+| Alias         | Command                      | Description                   |
+|---------------|------------------------------|-------------------------------|
+| `sf`          | Auto-detected console path   | Start the symfony console     |
+| `sfcl`        | sf cache:clear               | Clear the cache               |
+| `sfsr`        | sf server:run -vvv           | Run the dev server            |
+| `sfcw`        | sf cache:warmup              | Use the Bundles warmer        |
+| `sfroute`     | sf debug:router              | Show the different routes     |
+| `sfcontainer` | sf debug:container           | List the different services   |
+| `sfgb`        | sf generate:bundle           | Generate a bundle             |
+| `sfgc`        | sf generate:controller       | Generate a controller         |
+| `sfgcom`      | sf generate:command          | Generate a command            |
+| `sfge`        | sf doctrine:generate:entity  | Generate an entity            |
+| `sfsu`        | sf doctrine:schema:update    | Update the schema in Database |
+| `sfdc`        | sf doctrine:database:create  | Create the Database           |
+| `sfdev`       | sf --env=dev                 | Update environment to `dev`   |
+| `sfprod`      | sf --env=prod                | Update environment to `prod`  |
+
+## Supported Commands
+
+The plugin provides completion for all of the following console commands:
+- `sf` (alias)
+- `bin/console`
+- `app/console` 
+- `console`
+- `php bin/console`
+- `php app/console`
+- `php console`
+- `php symfony`
+
+## Migration from other Symfony plugins
+
+This unified plugin replaces the need for separate `symfony2` and `symfony6` plugins. If you were previously using either of those plugins, you can simply replace them with this `symfony` plugin in your `.zshrc` file.

--- a/plugins/symfony/symfony.plugin.zsh
+++ b/plugins/symfony/symfony.plugin.zsh
@@ -1,13 +1,141 @@
-# symfony basic command completion
+# Unified Symfony plugin for all versions
+# Supports Symfony 2, 3, 4, 5, and 6+ with automatic version detection
 
-_symfony_get_command_list () {
-    php symfony | sed "1,/Available tasks/d" | awk 'BEGIN { cat=null; } /^[A-Za-z]+$/ { cat = $1; } /^  :[a-z]+/ { print cat $1; }'
+_symfony_console_path() {
+    if [[ -f "bin/console" ]]; then
+        echo "bin/console"
+    elif [[ -f "app/console" ]]; then
+        echo "app/console"
+    elif [[ -f "console" ]]; then
+        echo "console"
+    elif [[ -f "symfony" ]]; then
+        echo "symfony"
+    else
+        return 1
+    fi
 }
 
-_symfony () {
-  if [ -f symfony ]; then
-    compadd `_symfony_get_command_list`
-  fi
+_symfony_console_command() {
+    local console_path
+    console_path=$(_symfony_console_path)
+    if [[ -n "$console_path" ]]; then
+        if [[ "$console_path" == "symfony" ]]; then
+            echo "php symfony"
+        else
+            echo "php $console_path"
+        fi
+    else
+        return 1
+    fi
 }
 
-compdef _symfony symfony
+_symfony_supports_native_completion() {
+    local console_cmd
+    console_cmd=$(_symfony_console_command)
+    if [[ -n "$console_cmd" ]]; then
+        $console_cmd _complete --no-interaction -szsh -a1 -c1 >/dev/null 2>&1
+        return $?
+    fi
+    return 1
+}
+
+_symfony_legacy_completion() {
+    local console_cmd commands
+    console_cmd=$(_symfony_console_command)
+    if [[ -n "$console_cmd" ]]; then
+        if [[ "$console_cmd" == *"symfony"* ]]; then
+            commands=$(php symfony 2>/dev/null | sed "1,/Available tasks/d" | awk 'BEGIN { cat=null; } /^[A-Za-z]+$/ { cat = $1; } /^  :[a-z]+/ { print cat $1; }')
+        else
+            commands=$($console_cmd --no-ansi 2>/dev/null | sed "1,/Available commands/d" | awk '/^  ?[^ ]+ / { print $1 }')
+        fi
+        compadd ${(f)commands}
+    fi
+}
+
+_symfony_native_completion() {
+    local lastParam flagPrefix requestComp out comp
+    local -a completions
+
+    words=("${=words[1,CURRENT]}") lastParam=${words[-1]}
+
+    setopt local_options BASH_REMATCH
+    if [[ "${lastParam}" =~ '-.*=' ]]; then
+        flagPrefix="-P ${BASH_REMATCH}"
+    fi
+
+    local console_cmd
+    console_cmd=$(_symfony_console_command)
+    if [[ -z "$console_cmd" ]]; then
+        return 1
+    fi
+
+    requestComp="$console_cmd _complete --no-interaction -szsh -a1 -c$((CURRENT-1))" i=""
+    for w in ${words[@]}; do
+        w=$(printf -- '%b' "$w")
+        quote="${w:0:1}"
+        if [ "$quote" = \' ]; then
+            w="${w%\'}"
+            w="${w#\'}"
+        elif [ "$quote" = \" ]; then
+            w="${w%\"}"
+            w="${w#\"}"
+        fi
+        if [ ! -z "$w" ]; then
+            i="${i}-i${w} "
+        fi
+    done
+
+    if [ "${i}" = "" ]; then
+        requestComp="${requestComp} -i\" \""
+    else
+        requestComp="${requestComp} ${i}"
+    fi
+
+    out=$(eval ${requestComp} 2>/dev/null)
+
+    while IFS='\n' read -r comp; do
+        if [ -n "$comp" ]; then
+            comp=${comp//:/\\:}
+            local tab=$(printf '\t')
+            comp=${comp//$tab/:}
+            completions+=${comp}
+        fi
+    done < <(printf "%s\n" "${out[@]}")
+
+    eval _describe "completions" completions $flagPrefix
+    return $?
+}
+
+_symfony() {
+    if _symfony_supports_native_completion; then
+        _symfony_native_completion
+    else
+        _symfony_legacy_completion
+    fi
+}
+
+# Aliases
+alias sf='$(_symfony_console_command)'
+alias sfcl='sf cache:clear'
+alias sfsr='sf server:run -vvv'
+alias sfcw='sf cache:warmup'
+alias sfroute='sf debug:router'
+alias sfcontainer='sf debug:container'
+alias sfgb='sf generate:bundle'
+alias sfgc='sf generate:controller'
+alias sfgcom='sf generate:command'
+alias sfge='sf doctrine:generate:entity'
+alias sfsu='sf doctrine:schema:update'
+alias sfdc='sf doctrine:database:create'
+alias sfdev='sf --env=dev'
+alias sfprod='sf --env=prod'
+
+# Completions for all supported console commands
+compdef _symfony sf
+compdef _symfony 'php app/console'
+compdef _symfony 'php bin/console'
+compdef _symfony 'php console'
+compdef _symfony 'php symfony'
+compdef _symfony 'app/console'
+compdef _symfony 'bin/console'
+compdef _symfony console

--- a/plugins/symfony2/README.md
+++ b/plugins/symfony2/README.md
@@ -1,5 +1,10 @@
 # Symfony2
 
+> **⚠️ DEPRECATION WARNING**  
+> This plugin is deprecated and will be removed in a future release.  
+> **Please migrate to the unified [`symfony`](../symfony/) plugin** which supports all Symfony versions (2.x through 6+).  
+> Simply change `symfony2` to `symfony` in your `.zshrc` plugins list.
+
 This plugin provides completion for [Symfony 2](https://symfony.com/), as well as aliases for frequent Symfony commands.
 
 To use it add symfony2 to the plugins array in your zshrc file.
@@ -7,6 +12,16 @@ To use it add symfony2 to the plugins array in your zshrc file.
 ```bash
 plugins=(... symfony2)
 ```
+
+## Migration
+
+**Recommended:** Use the unified [`symfony`](../symfony/) plugin instead:
+
+```bash
+plugins=(... symfony)  # Replace symfony2 with symfony
+```
+
+The unified plugin provides the same functionality plus automatic version detection and support for all Symfony versions.
 
 ## Aliases
 

--- a/plugins/symfony2/symfony2.plugin.zsh
+++ b/plugins/symfony2/symfony2.plugin.zsh
@@ -1,4 +1,11 @@
 # Symfony2 basic command completion
+#
+# DEPRECATION WARNING: This plugin is deprecated and will be removed in a future release.
+# Please migrate to the unified 'symfony' plugin which supports all Symfony versions.
+# Simply change 'symfony2' to 'symfony' in your .zshrc plugins list.
+#
+echo "⚠️  WARNING: The 'symfony2' plugin is deprecated. Please use the unified 'symfony' plugin instead." >&2
+echo "   Change 'symfony2' to 'symfony' in your .zshrc plugins list." >&2
 
 _symfony_console () {
   echo "php $(find . -maxdepth 2 -mindepth 1 -name 'console' -type f | head -n 1)"

--- a/plugins/symfony6/README.md
+++ b/plugins/symfony6/README.md
@@ -1,5 +1,10 @@
 # Symfony
 
+> **⚠️ DEPRECATION WARNING**  
+> This plugin is deprecated and will be removed in a future release.  
+> **Please migrate to the unified [`symfony`](../symfony/) plugin** which supports all Symfony versions (2.x through 6+).  
+> Simply change `symfony6` to `symfony` in your `.zshrc` plugins list.
+
 This plugin provides native completion for [Symfony](https://symfony.com/), but requires at least Symfony 6.2.
 
 To use it add `symfony6` to the plugins array in your zshrc file.
@@ -7,3 +12,13 @@ To use it add `symfony6` to the plugins array in your zshrc file.
 ```bash
 plugins=(... symfony6)
 ```
+
+## Migration
+
+**Recommended:** Use the unified [`symfony`](../symfony/) plugin instead:
+
+```bash
+plugins=(... symfony)  # Replace symfony6 with symfony
+```
+
+The unified plugin provides the same native completion functionality plus automatic version detection and support for all Symfony versions.

--- a/plugins/symfony6/symfony6.plugin.zsh
+++ b/plugins/symfony6/symfony6.plugin.zsh
@@ -8,6 +8,14 @@
 # https://symfony.com/doc/current/contributing/code/license.html
 
 #
+# DEPRECATION WARNING: This plugin is deprecated and will be removed in a future release.
+# Please migrate to the unified 'symfony' plugin which supports all Symfony versions.
+# Simply change 'symfony6' to 'symfony' in your .zshrc plugins list.
+#
+echo "⚠️  WARNING: The 'symfony6' plugin is deprecated. Please use the unified 'symfony' plugin instead." >&2
+echo "   Change 'symfony6' to 'symfony' in your .zshrc plugins list." >&2
+
+#
 # zsh completions for console
 #
 # References:


### PR DESCRIPTION
## Changes:

- Extracted Symfony-related aliases and functions from the symfony2-6 plugin into a dedicated symfony plugin.
- Renamed the plugin to reflect broader Symfony support beyond version 2.
- Updated relevant documentation and plugin structure for clarity and compatibility.

## Other comments:
This PR resolves [#13112](https://github.com/ohmyzsh/ohmyzsh/issues/13112) by improving the naming and scope of the plugin to better reflect current Symfony usage. The change makes it more intuitive for users looking for Symfony support regardless of framework version.
Let me know if you'd like me to keep the old name as an alias or include a migration note.
