### PR TITLE
feat(plugin): add plugin to easily save aliases and functions

### DIFF
--- a/plugins/fishysave/README.md
+++ b/plugins/fishysave/README.md
@@ -1,0 +1,27 @@
+## fishysave
+
+Plugin to save and update functions and aliases directly from shell, reminiscent of the fish "funcsave" feature.
+
+## Install
+
+add fishysave to the plugins array of your zshrc file:
+```bash
+# ~/.zshrc
+plugins=(... fishysave)
+
+```
+
+## Usage
+
+```bash
+# Save an alias
+alias lsal="ls -al"
+fishysave lsal
+
+# Save a function
+function lsa() {
+    ls -al
+}
+fishysave lsa
+
+```

--- a/plugins/fishysave/fishysave.plugin.zsh
+++ b/plugins/fishysave/fishysave.plugin.zsh
@@ -1,0 +1,39 @@
+local base_dir="${ZSH_SAVE_DIR:-$HOME/.zshrc_fishy}"
+
+function fishysave() {
+  local name="$1"
+
+  local base_dir="${ZSH_SAVE_DIR:-$HOME/.zshrc_fishy}"
+  local alias_dir="$base_dir/aliases"
+  local func_dir="$base_dir/functions"
+  
+  if [[ -z "$name" ]]; then
+    echo "No parameter provided"
+    echo "Usage: save <alias or function>"
+    return 1
+  fi
+
+  if alias "$name" &>/dev/null; then
+    local alias_def
+    alias_def=$(alias "$name")
+
+    echo "alias $alias_def" > "$alias_dir/$name.zsh"
+    echo "Alias $name saved to $alias_dir/$name.zsh"
+  elif whence -w "$name" | grep -q function; then
+    local func_def
+    func_def=$(functions "$name")
+    echo "$func_def" > "$func_dir/$name.zsh"
+    echo "Function $name saved to $func_dir/$name.zsh"
+  else
+    echo "Couldn't find a declared function or alias named '$name'"
+    return 2
+  fi
+}
+
+mkdir -p "$base_dir/aliases" "$base_dir/functions"
+
+setopt localoptions nullglob
+
+for file in "$base_dir"/aliases/*.zsh "$base_dir"/functions/*.zsh; do
+  [[ -f $file ]] && source "$file"
+done


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add a new plugin named fishysave

## Other comments:

## Use case

I've migrated to zsh from fish, and one feature I've been missing is to think about a customization to my shell experience and implement it right away. I know I can ```alias lsal="ls -al >> ~/.zshrc``` but that doesnt cover the case in which I want to keep refining that addition to my shell, and it's unorganized too, because it all gets mixed up.
With this plugin I can create a complex shell alias or function, and in any other moment just update it, either using fishysave command again or even editing it on the function folder.
I've been using this for a little while as a custom plugin and I found it very pleasing for my usecase.
