### PR TITLE
fix(rbw): do not wipe `rbwpw` items if newer are copied

### DIFF
--- a/plugins/rbw/rbw.plugin.zsh
+++ b/plugins/rbw/rbw.plugin.zsh
@@ -29,9 +29,11 @@ function rbwpw {
     echo "$service not found"
     return 1
   fi
+  local _random="$RANDOM"
+  echo -n $_random > $ZSH_CACHE_DIR/rbwpw_cache
   echo -n $pw | clipcopy
   echo "password for $service copied!"
-  {sleep 20 && clipcopy </dev/null 2>/dev/null} &|
+  {sleep 20 && [[ $(<$ZSH_CACHE_DIR/rbwpw_cache) == $_random ]] && clipcopy </dev/null 2>/dev/null} &|
 }
 
 function _rbwpw {

--- a/plugins/rbw/rbw.plugin.zsh
+++ b/plugins/rbw/rbw.plugin.zsh
@@ -29,11 +29,24 @@ function rbwpw {
     echo "$service not found"
     return 1
   fi
-  local _random="$RANDOM"
-  echo -n $_random > $ZSH_CACHE_DIR/rbwpw_cache
+
+  # Generate a random identifier for this call to rbwpw
+  # so we can check if the clipboard content has changed
+  local _random="$RANDOM" _cache="$ZSH_CACHE_DIR/.rbwpw"
+  echo -n "$_random" > "$_cache"
+
+  # Use clipcopy to copy the password to the clipboard
   echo -n $pw | clipcopy
   echo "password for $service copied!"
-  {sleep 20 && [[ $(<$ZSH_CACHE_DIR/rbwpw_cache) == $_random ]] && clipcopy </dev/null 2>/dev/null} &|
+
+  # Clear the clipboard after 20 seconds, but only if the clipboard hasn't
+  # changed (if rbwpw hasn't been called again)
+  {
+    sleep 20 \
+    && [[ "$(<"$_cache")" == "$_random" ]] \
+    && clipcopy </dev/null 2>/dev/null \
+    && command rm -f "$_cache" &>/dev/null
+  } &|
 }
 
 function _rbwpw {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Only wipe `rbwpw` content if it is the latest one to be added. This avoids getting passwords wiped when chaining requests.