### PR TITLE
[#13106] Update keychain plugin to support 2.9.0+ without warnings

### DIFF
--- a/plugins/keychain/keychain.plugin.zsh
+++ b/plugins/keychain/keychain.plugin.zsh
@@ -21,12 +21,9 @@ function {
 
 	# Check keychain version to decide whether to use --agents
 	local version_string=$(keychain --version 2>&1 | head -n 2 | tail -n 1 | cut -d ' ' -f 4)
-	local -a version_parts=(${(s:.:)version_string})
-	local major=${version_parts[1]:-0}
-	local minor=${version_parts[2]:-0}
-
-	# start keychain, only use --agents for versions below 2.9.0
-	if (( major < 2 || (major == 2 && minor < 9) )); then
+  # start keychain, only use --agents for versions below 2.9.0
+	autoload -Uz is-at-least
+	if is-at-least 2.9 "$version_string"; then
 		keychain ${^options:-} --agents ${agents:-gpg} ${^identities} --host $SHORT_HOST
 	else
 		keychain ${^options:-} ${^identities} --host $SHORT_HOST


### PR DESCRIPTION
Keychain versions 2.9.0 and higher removed support for the --agents option and squawk in console constantly if the option isn't removed, now we check to make sure that the keychain version is less than 2.9.0 before passing the argument

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Changed the plugin to only pass --agents on versions lower than 2.9.0 

## Other comments:

I tested this with keychain v 2.9.5 on arch and it seems to work, however i'm not sure if the version output is the same on other operating systems, we could also just change this to not pass the option at all, or only pass the agents option if some flag is set or something, open to suggestions / criticisim
