### PR TITLE
fix(af-magic): fix virtual env prompt fallback to take into account parentheses

### DIFF
--- a/themes/af-magic.zsh-theme
+++ b/themes/af-magic.zsh-theme
@@ -14,7 +14,7 @@ function afmagic_dashes {
   if [[ -n "$python_env" && "$PS1" = *\(${python_env}\)* ]]; then
     echo $(( COLUMNS - ${#python_env} - 3 ))
   elif [[ -n "$VIRTUAL_ENV_PROMPT" && "$PS1" = *${VIRTUAL_ENV_PROMPT}* ]]; then
-    echo $(( COLUMNS - ${#VIRTUAL_ENV_PROMPT} ))
+    echo $(( COLUMNS - ${#VIRTUAL_ENV_PROMPT} - 3 ))
   else
     echo $COLUMNS
   fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes dash calculation for Python virtualenv prompt for `af-magic` theme separator line.

## Other comments:

Additional fix for #12875, where now I noticed that the prompt was still broken without the subtraction of the parentheses.
