### PR TITLE
pbfile plugin: Copies files to the macOS pasteboard for pasting with Cmd+V in Finder, messengers, and other apps.

### DIFF
--- a/plugins/pbfile/README.md
+++ b/plugins/pbfile/README.md
@@ -1,0 +1,20 @@
+# pbfile plugin
+
+Copies files to the macOS pasteboard for pasting with Cmd+V in Finder, messengers, and other apps.
+
+To use it, add `pbfile` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... pbfile)
+```
+
+## Usage
+
+- `pbfile <file>`: copies the given file to the pasteboard for pasting as an attachment.
+
+## Examples
+
+```zsh
+pbfile document.pdf
+pbfile config.json
+```

--- a/plugins/pbfile/pbfile.plugin.zsh
+++ b/plugins/pbfile/pbfile.plugin.zsh
@@ -1,0 +1,19 @@
+# Check if running on macOS
+if [[ "$OSTYPE" != darwin* ]]; then
+  return
+fi
+
+function pbfile() {
+  if [[ $# -ne 1 ]]; then
+    echo "Usage: pbfile <file>"
+    return 1
+  fi
+  
+  if [[ ! -e "$1" ]]; then
+    echo "File not found: $1"
+    return 1
+  fi
+  
+  osascript -e "tell application \"Finder\" to set the clipboard to (POSIX file \"$(realpath "$1")\")"
+  echo "Copied $1 to pasteboard"
+}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- New pbfile plugin

## Other comments:

...
