### PR TITLE
feat: exegol aliases

### DIFF
--- a/plugins/exegol/README.md
+++ b/plugins/exegol/README.md
@@ -1,0 +1,30 @@
+# Exegol plugin
+
+The Exegol plugin provides useful aliases
+
+To use it, add `exegol` to the plugins array of your zshrc file:
+
+```zsh
+plugins=(... exegol)
+```
+
+## Aliases
+
+| Alias   | Command                          | Description                                               |
+| :------ | :------------------------------- | :-------------------------------------------------------- |
+| `e`     | `exegol`                         | Shorthand for exegol command                              |
+| `ei`    | `exegol info`                    | Displays exegol information                               |
+| `eu`    | `exegol update`                  | Updates exegol to the latest version                      |
+| `es`    | `exegol start`                   | Starts an Exegol instance                                 |
+| `esn`   | `exegol start [default] nightly` | Starts a nightly Exegol instance                          |
+| `esf`   | `exegol start [default] full`    | Starts a full Exegol instance                             |
+| `esf!`  | `esf --privileged`               | Starts a full Exegol instance with privileged access      |
+| `esn!`  | `esn --privileged`               | Starts a nightly Exegol instance with privileged access   |
+| `etmpn` | `exegol exec --tmp nightly`      | Executes a command in a temporary nightly Exegol instance |
+| `etmpf` | `exegol exec --tmp full`         | Executes a command in a temporary full Exegol instance    |
+| `estp`  | `exegol stop`                    | Stops an Exegol instance                                  |
+| `estpa` | `exegol stop --all`              | Stops all Exegol instances                                |
+| `erm`   | `exegol remove`                  | Removes an Exegol instance                                |
+| `erm!`  | `exegol remove --force`          | Removes an Exegol instance forcefully                     |
+| `erma`  | `exegol remove --all`            | Removes all Exegol instances                              |
+| `erma!` | `exegol remove --force --all`    | Removes all Exegol instances forcefully                   |

--- a/plugins/exegol/exegol.plugin.zsh
+++ b/plugins/exegol/exegol.plugin.zsh
@@ -1,0 +1,55 @@
+# Return immediately if exegol is not found
+if (( ! ${+commands[exegol]} )); then
+  echo OK
+fi
+
+alias e='exegol'
+alias ei='exegol info'
+alias eu='exegol update'
+
+alias es='exegol start'
+function esn() {
+  local only_dashes=true
+  for arg in "$@"; do
+    if [[ ! "$arg" == -* ]]; then
+      only_dashes=false
+      break
+    fi
+  done
+
+  if [[ "$#" == 0 ]] || $only_dashes; then
+    # If all arguments are dashes or empty, use default name
+    exegol start default nightly "$@"
+  else
+    exegol start "$@" nightly
+  fi
+}
+function esf() {
+  local only_dashes=true
+  for arg in "$@"; do
+    if [[ ! "$arg" == -* ]]; then
+      only_dashes=false
+      break
+    fi
+  done
+
+  if [[ "$#" == 0 ]] || $only_dashes; then
+    # If all arguments are dashes or empty, use default name
+    exegol start default full "$@"
+  else
+    exegol start "$@" full
+  fi
+}
+alias esf!='esf --privileged'
+alias esn!='esn --privileged'
+
+alias etmpn='exegol exec --tmp nightly'
+alias etmpf='exegol exec --tmp full'
+
+alias estp='exegol stop'
+alias estpa='exegol stop --all'
+
+alias erm='exegol remove'
+alias erm!='exegol remove --force'
+alias erma='exegol remove --all'
+alias erma!='exegol remove --force --all'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds useful aliases for [Exegol](https://github.com/ThePorgs/Exegol) (a _community-driven hacking environment_).

## Other comments:

For now `esn` and `esf` functions are a bit weird because of the exegol argument logic... Feel free if you have a better idea to handle them :)
