### PR TITLE
Fixed issue where the exit code becomes non-zero if DISABLE_AUTO_TITLE=1

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -53,7 +53,7 @@ function omz_termsupport_precmd {
 
 # Runs before executing the command
 function omz_termsupport_preexec {
-  [[ "${DISABLE_AUTO_TITLE:-}" != true ]] || return
+  [[ "${DISABLE_AUTO_TITLE:-}" != true ]] || return 0
 
   emulate -L zsh
   setopt extended_glob


### PR DESCRIPTION
When DISABLE_AUTO_TITLE is set to true, the code shouldn't return with a non-zero exit code. Yet if you don't explicitly return 0, at least on my macbook, the method returns a non-zero exit code.

Here's a quick file to test this behavior:
```zsh
#!/usr/bin/env zsh

# Minimal reproduction of the oh-my-zsh termsupport.zsh return error

# Function that mimics the original buggy behavior
function broken_preexec {
  [[ "${DISABLE_AUTO_TITLE:-}" != true ]] || return  # Missing return code
  echo "This line should run when DISABLE_AUTO_TITLE is false"
}

# Function that mimics the fixed behavior  
function fixed_preexec {
  [[ "${DISABLE_AUTO_TITLE:-}" != true ]] || return 0  # Proper return code
  echo "This line should run when DISABLE_AUTO_TITLE is false"
}

echo "=== Testing with DISABLE_AUTO_TITLE=true ==="

export DISABLE_AUTO_TITLE=true

echo "Testing broken function:"
broken_preexec
echo "Exit code: $?"

echo "Testing fixed function:"
fixed_preexec  
echo "Exit code: $?"

echo "=== Testing with DISABLE_AUTO_TITLE=false ==="

export DISABLE_AUTO_TITLE=false

echo "Testing broken function:"
broken_preexec
echo "Exit code: $?"

echo "Testing fixed function:"
fixed_preexec
echo "Exit code: $?"
``` 