### PR TITLE
Rename claude alias to claudeai to avoid conflict with Claude CLI

### DIFF
--- a/plugins/web-search/README.md
+++ b/plugins/web-search/README.md
@@ -52,7 +52,7 @@ Available search contexts are:
 | `packagist`           | `https://packagist.org/?query=`                 |
 | `gopkg`               | `https://pkg.go.dev/search?m=package&q=`        |
 | `chatgpt`             | `https://chatgpt.com/?q=`                       |
-| `claude`              | `https://claude.ai/new?q=`                      |
+| `claudeai`            | `https://claude.ai/new?q=`                      |
 | `grok`                | `https://grok.com/?q=`                          |
 | `reddit`              | `https://www.reddit.com/search/?q=`             |
 | `ppai`                | `https://www.perplexity.ai/search/new?q=`       |

--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -34,7 +34,7 @@ function web_search() {
     gopkg           "https://pkg.go.dev/search?m=package&q="
     chatgpt         "https://chatgpt.com/?q="
     grok            "https://grok.com/?q="
-    claude          "https://claude.ai/new?q="
+    claudeai        "https://claude.ai/new?q="
     reddit          "https://www.reddit.com/search/?q="
     ppai            "https://www.perplexity.ai/search/new?q="
   )


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.


## Context and Reasoning
The alias `claude`, added in [PR #13222](https://github.com/ohmyzsh/ohmyzsh/pull/13222), causes unintended behaviour for users who have the Claude CLI installed locally. When running the claude command, instead of launching the CLI as expected, it opens a browser via the web_search plugin.

```shell
➜  which claude
claude: aliased to web_search claude
```

## Changes:

Renamed the alias to `claudeai`.