### PR TITLE
fix: 🐛 rename claude alias to claudeai to avoid CLI conflict

### DIFF
--- a/plugins/web-search/web-search.plugin.zsh
+++ b/plugins/web-search/web-search.plugin.zsh
@@ -92,7 +92,7 @@ alias packagist='web_search packagist'
 alias gopkg='web_search gopkg'
 alias chatgpt='web_search chatgpt'
 alias grok='web_search grok'
-alias claude='web_search claude'
+alias claudeai='web_search claudeai'
 alias reddit='web_search reddit'
 alias ppai='web_search ppai'
 


### PR DESCRIPTION
Rename the 'claude' alias to 'claudeai' in the web-search plugin to prevent conflicts with the Claude CLI tool. This ensures users can access both the web search functionality and the Claude CLI without collision.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes the alias issue that was introduced in #13222. Fix was introduced in #13224 but did not fully remove claude alias.

## Other comments:

...
