### PR TITLE
fix(gitfast): update alias config regexp to '^alias\.'

### DIFF
--- a/plugins/gitfast/_git
+++ b/plugins/gitfast/_git
@@ -173,7 +173,7 @@ __git_zsh_cmd_common ()
 __git_zsh_cmd_alias ()
 {
 	local -a list
-	list=(${${(0)"$(git config -z --get-regexp '^alias\.*')"}#alias.})
+	list=(${${(0)"$(git config -z --get-regexp '^alias\.')"}#alias.})
 	list=(${(f)"$(printf "%s:alias for '%s'\n" ${(f@)list})"})
 	_describe -t alias-commands 'aliases' list && _ret=0
 }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
<!-- === GH HISTORY FORMAT FENCE === --> <!--
- %s
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
- fix(gitfast): update alias config regexp to '^alias\\.'
<!-- === GH HISTORY FENCE === -->

## Other comments:
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->

I have a custom alias-helper.* section in my config, and the old regexp
captured them too.

[1] https://git.tsundere.moe/Frederick888/frederick-settings/-/blob/303ffaa3d465640031dbd06a81d77975f749d955/.gitconfig#L9-37


<!-- === GH HISTORY FENCE === -->
