### PR TITLE
Fix zsh completion for aws plugin.

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -296,6 +296,7 @@ fi
 # AWS CLI v2 comes with its own autocompletion. Check if that is there, otherwise fall back
 if command -v aws_completer &> /dev/null; then
   autoload -Uz bashcompinit && bashcompinit
+  autoload -Uz compinit && compinit
   complete -C aws_completer aws
 else
   function _awscli-homebrew-installed() {


### PR DESCRIPTION
This is following the documentation for completion from aws here https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-completion.html. I imagine this may work if other plugins are executed before this that perform this action already, but it was broken for me.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fix zsh completion for aws plugin.

## Other comments:

This is following the documentation for completion from aws here
https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-completion.html. I
imagine this may work if other plugins are executed before this that perform
this action already, but it was broken for me.