### PR TITLE
feat(extract): Support .pk{3,4,7} alias file extensions

### DIFF
--- a/plugins/extract/README.md
+++ b/plugins/extract/README.md
@@ -17,7 +17,6 @@ plugins=(... extract)
 | Extension         | Description                             |
 | :---------------- | :-------------------------------------- |
 | `7z`              | 7zip file                               |
-| `Z`               | Z archive (LZW)                         |
 | `apk`             | Android app file                        |
 | `aar`             | Android library file                    |
 | `bz2`             | Bzip2 file                              |
@@ -60,6 +59,7 @@ plugins=(... extract)
 | `whl`             | Python wheel file                       |
 | `xpi`             | Mozilla XPI module file                 |
 | `xz`              | LZMA2 archive                           |
+| `Z`               | Z archive (LZW)                         |
 | `zip`             | Zip archive                             |
 | `zlib`            | zlib archive                            |
 | `zst`             | Zstandard file (zstd)                   |

--- a/plugins/extract/README.md
+++ b/plugins/extract/README.md
@@ -14,53 +14,56 @@ plugins=(... extract)
 
 ## Supported file extensions
 
-| Extension         | Description                          |
-| :---------------- | :----------------------------------- |
-| `7z`              | 7zip file                            |
-| `Z`               | Z archive (LZW)                      |
-| `apk`             | Android app file                     |
-| `aar`             | Android library file                 |
-| `bz2`             | Bzip2 file                           |
-| `cab`             | Microsoft cabinet archive            |
-| `cpio`            | Cpio archive                         |
-| `deb`             | Debian package                       |
-| `ear`             | Enterprise Application aRchive       |
-| `exe`             | Windows executable file              |
-| `gz`              | Gzip file                            |
-| `ipa`             | iOS app package                      |
-| `ipsw`            | iOS firmware file                    |
-| `jar`             | Java Archive                         |
-| `lrz`             | LRZ archive                          |
-| `lz4`             | LZ4 archive                          |
-| `lzma`            | LZMA archive                         |
-| `obscpio`         | cpio archive used on OBS             |
-| `rar`             | WinRAR archive                       |
-| `rpm`             | RPM package                          |
-| `sublime-package` | Sublime Text package                 |
-| `tar`             | Tarball                              |
-| `tar.bz2`         | Tarball with bzip2 compression       |
-| `tar.gz`          | Tarball with gzip compression        |
-| `tar.lrz`         | Tarball with lrzip compression       |
-| `tar.lz`          | Tarball with lzip compression        |
-| `tar.lz4`         | Tarball with lz4 compression         |
-| `tar.xz`          | Tarball with lzma2 compression       |
-| `tar.zma`         | Tarball with lzma compression        |
-| `tar.zst`         | Tarball with zstd compression        |
-| `tbz`             | Tarball with bzip compression        |
-| `tbz2`            | Tarball with bzip2 compression       |
-| `tgz`             | Tarball with gzip compression        |
-| `tlz`             | Tarball with lzma compression        |
-| `txz`             | Tarball with lzma2 compression       |
-| `tzst`            | Tarball with zstd compression        |
-| `vsix`            | VS Code extension zip file           |
-| `war`             | Web Application archive (Java-based) |
-| `whl`             | Python wheel file                    |
-| `xpi`             | Mozilla XPI module file              |
-| `xz`              | LZMA2 archive                        |
-| `zip`             | Zip archive                          |
-| `zlib`            | zlib archive                         |
-| `zst`             | Zstandard file (zstd)                |
-| `zpaq`            | Zpaq file                            |
+| Extension         | Description                             |
+| :---------------- | :-------------------------------------- |
+| `7z`              | 7zip file                               |
+| `Z`               | Z archive (LZW)                         |
+| `apk`             | Android app file                        |
+| `aar`             | Android library file                    |
+| `bz2`             | Bzip2 file                              |
+| `cab`             | Microsoft cabinet archive               |
+| `cpio`            | Cpio archive                            |
+| `deb`             | Debian package                          |
+| `ear`             | Enterprise Application aRchive          |
+| `exe`             | Windows executable file                 |
+| `gz`              | Gzip file                               |
+| `ipa`             | iOS app package                         |
+| `ipsw`            | iOS firmware file                       |
+| `jar`             | Java Archive                            |
+| `lrz`             | LRZ archive                             |
+| `lz4`             | LZ4 archive                             |
+| `lzma`            | LZMA archive                            |
+| `obscpio`         | cpio archive used on OBS                |
+| `pk3`             | Renamed Zip archive used by Quake games |
+| `pk4`             | Renamed Zip archive used by Quake games |
+| `pk7`             | Renamed 7zip file used by Quake games   |
+| `rar`             | WinRAR archive                          |
+| `rpm`             | RPM package                             |
+| `sublime-package` | Sublime Text package                    |
+| `tar`             | Tarball                                 |
+| `tar.bz2`         | Tarball with bzip2 compression          |
+| `tar.gz`          | Tarball with gzip compression           |
+| `tar.lrz`         | Tarball with lrzip compression          |
+| `tar.lz`          | Tarball with lzip compression           |
+| `tar.lz4`         | Tarball with lz4 compression            |
+| `tar.xz`          | Tarball with lzma2 compression          |
+| `tar.zma`         | Tarball with lzma compression           |
+| `tar.zst`         | Tarball with zstd compression           |
+| `tbz`             | Tarball with bzip compression           |
+| `tbz2`            | Tarball with bzip2 compression          |
+| `tgz`             | Tarball with gzip compression           |
+| `tlz`             | Tarball with lzma compression           |
+| `txz`             | Tarball with lzma2 compression          |
+| `tzst`            | Tarball with zstd compression           |
+| `vsix`            | VS Code extension zip file              |
+| `war`             | Web Application archive (Java-based)    |
+| `whl`             | Python wheel file                       |
+| `xpi`             | Mozilla XPI module file                 |
+| `xz`              | LZMA2 archive                           |
+| `zip`             | Zip archive                             |
+| `zlib`            | zlib archive                            |
+| `zst`             | Zstandard file (zstd)                   |
+| `zpaq`            | Zpaq file                               |
 
 See [list of archive formats](https://en.wikipedia.org/wiki/List_of_archive_formats) for more information
 regarding archive formats.

--- a/plugins/extract/_extract
+++ b/plugins/extract/_extract
@@ -19,6 +19,9 @@ local -a exts=(
   lz4
   lzma
   obscpio
+  pk3
+  pk4
+  pk7
   rar
   rpm
   sublime-package

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -76,11 +76,11 @@ EOF
       (*.lz4) lz4 -d "$full_path" ;;
       (*.lzma) unlzma "$full_path" ;;
       (*.z) uncompress "$full_path" ;;
-      (*.zip|*.war|*.jar|*.ear|*.sublime-package|*.ipa|*.ipsw|*.xpi|*.apk|*.aar|*.whl|*.vsix|*.crx) unzip "$full_path" ;;
+      (*.zip|*.war|*.jar|*.ear|*.sublime-package|*.ipa|*.ipsw|*.xpi|*.apk|*.aar|*.whl|*.vsix|*.crx|*.pk3|*.pk4) unzip "$full_path" ;;
       (*.rar) unrar x -ad "$full_path" ;;
       (*.rpm)
         rpm2cpio "$full_path" | cpio --quiet -id ;;
-      (*.7z | *.7z.[0-9]*) 7za x "$full_path" ;;
+      (*.7z | *.7z.[0-9]* | *.pk7) 7za x "$full_path" ;;
       (*.deb)
         command mkdir -p "control" "data"
         ar vx "$full_path" > /dev/null


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

7a0aa439e81e5fbc345bd25072ec975efdf07630

feat(extract): Add support for file extension aliases .pk{3,4,7} which are just renamed zip/7zip files.

File extensions .pk3 and .pk4 are renamed zip archives and the file extension .pk7 is a renamed 7zip file. They can be handled in the same way as zip and 7zip files.

https://doomwiki.org/wiki/PK3  
https://doomwiki.org/wiki/PK4

---

0c7b74a0f6846a4b9ef36695a910a8fd70af2113

chore(extract): Fix alphabetical sorting of supported file extensions in README.md having been case sensitive.

Previously the sorting was case sensitive (A-Z then a-z) in `README.md` but not in the completions file `_extract`, now both are case insensitive.