### PR TITLE
Plugin Battery : add watts delivered by charger

### DIFF
--- a/plugins/battery/README.md
+++ b/plugins/battery/README.md
@@ -19,6 +19,12 @@ For example:
 BATTERY_CHARGING="⚡️"
 ```
 
+You can see the power of your charger using the following setting (MacOS only)
+
+```zsh
+BATTERY_SHOW_WATTS=true
+```
+
 ## Requirements
 
 - On Linux, you must have the `acpi` or `acpitool` commands installed on your operating system.

--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -17,8 +17,13 @@
 # Modified to add support for OpenBSD     #
 ###########################################
 
+: ${BATTERY_SHOW_WATTS:=false}
+
 
 if [[ "$OSTYPE" = darwin* ]]; then
+  function get_charger_power() {
+    echo "$(ioreg -rc AppleSmartBattery | grep -o '"Watts"=[0-9]\+' | head -1 | grep -o '[0-9]\+')W "
+  }
   function battery_is_charging() {
     ioreg -rc AppleSmartBattery | command grep -q '^.*"ExternalConnected"\ =\ Yes'
   }
@@ -58,7 +63,10 @@ if [[ "$OSTYPE" = darwin* ]]; then
       fi
       echo "%{$fg[$color]%}[${battery_pct}%%]%{$reset_color%}"
     else
-      echo "${BATTERY_CHARGING-⚡️}"
+      if [[ "${BATTERY_SHOW_WATTS}" = "true" ]] ; then
+        watts=$(get_charger_power)
+      fi
+      echo "${watts}${BATTERY_CHARGING-⚡️}"
     fi
   }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- BATTERY_SHOW_WATTS for battery plugin

## Other comments:

I'm always curious how much my charger deliver, i've introduced a variable into the plugin.
