### PR TITLE
feat: terragrunt plugin, clone of opentofu plugin

### DIFF
--- a/plugins/terragrunt/README.md
+++ b/plugins/terragrunt/README.md
@@ -1,0 +1,62 @@
+# Terragrunt plugin
+
+Terragrunt is a thin wrapper for opentofu/terraform that provides extra tools
+and features to enhance the management of Infrastructure as Code (IaC) using
+opentofu/terraform. Ths plugin adds completion for `terragrunt` command, as well
+as aliases and a prompt function.
+
+To use it, add `terragrunt` to the plugins array of your `~/.zshrc` file:
+
+```shell
+plugins=(... terragrunt)
+```
+
+## Requirements
+
+- [Terragrunt](https://terragrunt.gruntwork.io//)
+
+## Aliases
+
+| Alias  | Command                              |
+|--------|--------------------------------------|
+| `tg`   | `terragrunt`                               |
+| `tga`  | `terragrunt -- apply`                 |
+| `tgaa` | `terragrunt -- apply -auto-approve`   |
+| `tgc`  | `terragrunt -- console`               |
+| `tgd`  | `terragrunt -- destroy`               |
+| `tgd!` | `terragrunt -- destroy -auto-approve` |
+| `tgf`  | `terragrunt -- fmt`                   |
+| `tgfr` | `terragrunt -- fmt -recursive`        |
+| `tgi`  | `terragrunt -- init`                  |
+| `tgo`  | `terragrunt -- output`                |
+| `tgp`  | `terragrunt -- plan`                  |
+| `tgv`  | `terragrunt -- validate`              |
+| `tgs`  | `terragrunt -- state`                 |
+| `tgsh` | `terragrunt -- show`                  |
+| `tgr`  | `terragrunt -- refresh`               |
+| `tgt`  | `terragrunt -- test`                  |
+| `tgws` | `terragrunt -- workspace`             |
+
+## Prompt functions
+
+- `terragrunt_prompt_info`: shows the current workspace when in a Terragrunt project directory.
+
+- `terragrunt_version_prompt_info`: shows the current version of the `terragrunt` command.
+
+To use them, add them to a `PROMPT` variable in your theme or `.zshrc` file:
+
+```sh
+PROMPT='$(terragrunt_prompt_info)'
+RPROMPT='$(terragrunt_version_prompt_info)'
+```
+
+You can also specify the PREFIX and SUFFIX strings for both functions, with the following variables:
+
+```sh
+# for terragrunt_prompt_info
+ZSH_THEME_TERRAGRUNT_PROMPT_PREFIX="%{$fg[white]%}"
+ZSH_THEME_TERRAGRUNT_PROMPT_SUFFIX="%{$reset_color%}"
+# for terragrunt_version_prompt_info
+ZSH_THEME_TERRAGRUNT_VERSION_PROMPT_PREFIX="%{$fg[white]%}"
+ZSH_THEME_TERRAGRUNT_VERSION_PROMPT_SUFFIX="%{$reset_color%}"
+```

--- a/plugins/terragrunt/terragrunt.plugin.zsh
+++ b/plugins/terragrunt/terragrunt.plugin.zsh
@@ -1,0 +1,52 @@
+# set up the terragrunt completion (compatible for zsh)
+autoload -Uz bashcompinit && bashcompinit
+complete -C terragrunt terragrunt
+
+# terragrunt workspace prompt function
+function terragrunt_prompt_info() {
+ # only show the workspace name if we're in an openterragrunt project
+ # i.e. if a .terragrunt-cache directory exists within the hierarchy
+ local dir="$PWD"
+ while [[ ! -d "${dir}/.terragrunt-cache" ]]; do
+  [[ "$dir" != / ]] || return 0 # stop at the root directory
+  dir="${dir:h}"        # get the parent directory
+ done
+
+ # Run the command and capture the full line of output
+ local full_output
+ full_output="$(terragrunt run -- workspace show)"
+
+ # Use Zsh parameter expansion to keep only the part after the last space.
+ # The '##* ' pattern performs a "greedy" removal of everything up to
+ # and including the final space in the string.
+ local workspace="${full_output##* }"
+
+ # make sure to escape % signs in the workspace name to prevent command injection
+ echo "${ZSH_THEME_terragrunt_PROMPT_PREFIX-[}${workspace:gs/%/%%}${ZSH_THEME_terragrunt_PROMPT_SUFFIX-]}"
+}
+
+# terragrunt version prompt function
+function terragrunt_version_prompt_info() {
+ # get the output of `terragrunt --version` in a single line, and get the second word after splitting by a space
+ local terragrunt_version=${${(s: :)$(terragrunt --version)}[3]}
+ # make sure to escape % signs in the version string to prevent command injection
+ echo "${ZSH_THEME_terragrunt_VERSION_PROMPT_PREFIX-[}${terragrunt_version:gs/%/%%}${ZSH_THEME_terragrunt_VERSION_PROMPT_SUFFIX-]}"
+}
+
+alias tg='terragrunt'
+alias tga='terragrunt -- run apply'
+alias tgaa='terragrunt -- run apply -auto-approve'
+alias tgc='terragrunt -- run console'
+alias tgd='terragrunt -- run destroy'
+alias tgd!='terragrunt -- run destroy -auto-approve'
+alias tgf='terragrunt -- run fmt'
+alias tgfr='terragrunt -- run fmt -recursive'
+alias tgi='terragrunt -- run init'
+alias tgo='terragrunt -- run output'
+alias tgp='terragrunt -- run plan'
+alias tgv='terragrunt -- run validate'
+alias tgs='terragrunt -- run state'
+alias tgsh='terragrunt -- run show'
+alias tgr='terragrunt -- run refresh'
+alias tgt='terragrunt -- run test'
+alias tgws='terragrunt -- run workspace'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- create new plugin for terragrunt
- clone of opentofu plugin with minor changes

## Other comments:

The code introduces new alias that follow the same pattern as terraform plugin (tf*) and opentofu plugin (tt*) but for terragrunt (tg*)
