### PR TITLE
doc(web-search): Adds missing rscrate and rsdoc

### DIFF
--- a/plugins/web-search/README.md
+++ b/plugins/web-search/README.md
@@ -56,6 +56,8 @@ Available search contexts are:
 | `grok`                | `https://grok.com/?q=`                          |
 | `reddit`              | `https://www.reddit.com/search/?q=`             |
 | `ppai`                | `https://www.perplexity.ai/search/new?q=`       |
+| `rscrate`             | `https://crates.io/search?q=`                   |
+| `rsdoc`               | `https://docs.rs/releases/search?query=`        |
 
 Also there are aliases for bang-searching DuckDuckGo:
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Updates README.md for the web-search plugin to include the missing rscrate and rsdoc