### PR TITLE
bug(asdf): don't add $ASDF_DATA_DIR/shims to the path if already present

### DIFF
--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -1,7 +1,9 @@
 (( ! $+commands[asdf] )) && return
 
 export ASDF_DATA_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}"
-path=("$ASDF_DATA_DIR/shims" $path)
+
+# Only add to the path if not already present
+(($path[(Ie)$ASDF_DATA_DIR/shims])) || path=("$ASDF_DATA_DIR/shims" $path)
 
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `asdf`. Otherwise, compinit will have already done that.

--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -2,8 +2,8 @@
 
 export ASDF_DATA_DIR="${ASDF_DATA_DIR:-$HOME/.asdf}"
 
-# Only add to the path if not already present
-(($path[(Ie)$ASDF_DATA_DIR/shims])) || path=("$ASDF_DATA_DIR/shims" $path)
+# Add shims to the front of the path, removing if already present.
+path=("$ASDF_DATA_DIR/shims" ${path:#$ASDF_DATA_DIR/shims})
 
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `asdf`. Otherwise, compinit will have already done that.


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

-  don't add `$ASDF_DATA_DIR/shims` to the path if already present

## Other comments:

This is just a minor change to prevent `$ASDF_DATA_DIR/shims` from being added to the path multiple times (for example, if you `exec zsh`, your shims directory will keep getting added).

@RobLoach