### PR TITLE
Add YTD plugin for Oh-My-Zsh

### DIFF
--- a/plugins/ytd/README.md
+++ b/plugins/ytd/README.md
@@ -1,0 +1,36 @@
+# YTD Zsh Plugin
+
+A Zsh plugin designed primarily for musicians, producers, and DJs.  
+This plugin allows you to quickly download any YouTube video or music track in the **highest quality audio
+format**, directly as a track.  
+Normally this process takes several steps, but with this plugin, you can get your track in just a few seconds.
+
+## Usage
+
+```bash
+ytd "youtube-music-link"
+```
+
+## Installation
+
+1. Clone this project into your Oh-My-Zsh custom plugins folder:
+
+git clone https://github.com/aniltugrulturker/ohmyzsh.git $ZSH_CUSTOM/plugins/ytd
+
+2. Navigate to the plugin directory(optional):
+
+cd $ZSH_CUSTOM/plugins/ytd
+
+3. Add ytd to your .zshrc plugins list:
+
+plugins(... ytd)
+
+4. Reload Zsh:
+
+source ~/.zshrc
+
+## Features
+
+Download YouTube videos or music tracks in high-quality audio.
+
+Quick and simple usage for DJs, producers, and music enthusiasts.

--- a/plugins/ytd/ytd.plugin.zsh
+++ b/plugins/ytd/ytd.plugin.zsh
@@ -1,0 +1,17 @@
+#!/bin/zsh
+# ytd: YouTube ses indirici Oh My Zsh plugin
+
+ytd() {
+    if [[ -z "$1" ]]; then
+        echo "Kullanım: ytd <YouTube linki>"
+        return 1
+    fi
+
+    # İndirme klasörü
+    DIR="$HOME"
+    mkdir -p "$DIR"
+
+    # yt-dlp ile mp3 olarak indir
+    yt-dlp -f bestaudio --extract-audio --audio-format mp3 --no-playlist -o "$DIR/%(title)s.%(ext)s" "$1"
+}
+


### PR DESCRIPTION
This PR adds a Zsh plugin for YTD that allows quick downloading of 
YouTube videos or music tracks in high-quality audio.

Usage:
ytd "youtube-link"

Installation instructions are included in the plugin's README.
