### PR TITLE
fix(gpg-agent): Fixed inaccurate README and corrected plugin behavior

### DIFF
--- a/plugins/gpg-agent/README.md
+++ b/plugins/gpg-agent/README.md
@@ -1,6 +1,11 @@
 # gpg-agent
 
-Enables [GPG's gpg-agent](https://www.gnupg.org/documentation/manuals/gnupg/) if it is not running.
+Enables [GPG's gpg-agent](https://www.gnupg.org/documentation/manuals/gnupg/) if it is not running and fixes some common issues.
+
+Issues fixed are:
+
+* The `GPG_TTY` environment variable being set incorrectly or not set at all.
+* SSH agent support being broken when `enable-ssh-support` is enabled.
 
 To use it, add `gpg-agent` to the plugins array of your zshrc file:
 

--- a/plugins/gpg-agent/gpg-agent.plugin.zsh
+++ b/plugins/gpg-agent/gpg-agent.plugin.zsh
@@ -1,8 +1,10 @@
-export GPG_TTY=$TTY
+# Launch gpg-agent ahead of time
+gpgconf --launch gpg-agent
 
 # Fix for passphrase prompt on the correct tty
 # See https://www.gnupg.org/documentation/manuals/gnupg/Agent-Options.html#option-_002d_002denable_002dssh_002dsupport
 function _gpg-agent_update-tty_preexec {
+  export GPG_TTY="${TTY}"
   gpg-connect-agent updatestartuptty /bye &>/dev/null
 }
 autoload -U add-zsh-hook


### PR DESCRIPTION
## Standards checklist: ##

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes: ##

* The `gpg-agent` plugin now launchs the gpg-agent process via `gpgconf --launch gpg-agent` when Zsh first starts up.
* Updated the `README.md` for the `gpg-agent` plugin to better explain what the plugin does.

## Other comments: ##

The README update is to explain what issues the plugin fixes when it is enabled for better transparency about what it's actually doing under the hood.
