### PR TITLE
fix: prevent .zshrc deletion during uninstall when no backup exists

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -341,6 +341,11 @@ setup_zshrc() {
     # Skip this if the user doesn't want to replace an existing .zshrc
     if [ "$KEEP_ZSHRC" = yes ]; then
       echo "${FMT_YELLOW}Found ${zdot}/.zshrc.${FMT_RESET} ${FMT_GREEN}Keeping...${FMT_RESET}"
+      # Still create a backup for uninstall safety, but don't overwrite the existing .zshrc
+      if [ ! -e "$OLD_ZSHRC" ]; then
+        echo "${FMT_GREEN}Creating backup at ${OLD_ZSHRC} for safe uninstall${FMT_RESET}"
+        cp "$zdot/.zshrc" "$OLD_ZSHRC"
+      fi
       return
     fi
     

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -35,6 +35,19 @@ if [ -e "$ZSHRC_ORIG" ]; then
   echo "Your original zsh config was restored."
 else
   echo "No original zsh config found"
+  # Check if we have a backup from this uninstall session
+  if [ -e ~/.zshrc.omz-uninstalled-* ]; then
+    echo "However, your .zshrc was backed up during this uninstall."
+    echo "Restoring it automatically..."
+    # Find the most recent backup and restore it
+    LATEST_BACKUP=$(ls -t ~/.zshrc.omz-uninstalled-* 2>/dev/null | head -1)
+    if [ -n "$LATEST_BACKUP" ]; then
+      mv "$LATEST_BACKUP" ~/.zshrc
+      echo "Your .zshrc has been restored from backup."
+    fi
+  else
+    echo "No backup found. You may need to recreate your .zshrc configuration."
+  fi
 fi
 
 echo "Thanks for trying out Oh My Zsh. It's been uninstalled."


### PR DESCRIPTION
Fixes #13156

- Enhanced uninstall script to automatically restore .zshrc from uninstall backup when no original backup (.zshrc.pre-oh-my-zsh) exists
- Improved install script to create backup even when KEEP_ZSHRC=yes
- Added better user feedback and error handling
- Prevents data loss for users who installed with --keep-zshrc option

The issue occurred when users installed oh-my-zsh with KEEP_ZSHRC=yes (keeping their existing .zshrc), which didn't create a backup. During uninstall, their .zshrc would be deleted with no backup to restore.

Now the uninstall process:
1. Creates a timestamped backup of current .zshrc
2. Looks for original backup (.zshrc.pre-oh-my-zsh)
3. If found, restores the original
4. If not found, automatically restores from the uninstall backup
5. Provides clear feedback to the user

This ensures users never lose their .zshrc configuration during uninstall.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

