### PR TITLE
doc:Added a Note stating User also needs to install tldr

### DIFF
--- a/plugins/tldr/README.md
+++ b/plugins/tldr/README.md
@@ -13,3 +13,6 @@ plugins=(... tldr)
 | Shortcut                           | Description                                                                |
 |------------------------------------|----------------------------------------------------------------------------|
 | <kbd>Esc</kbd> + tldr              | add tldr before the previous command to see the tldr page for this command |
+
+## Note
+You also need to install ```tldr```.


### PR DESCRIPTION
I think it is a good idea to keep uniformity as many other plugins do mention if a package is need to installed separately as well or not.

## Changes:

- I added a new Note saying that tldr needs to be installed
