### PR TITLE
fix: resolve syntax errors in check_for_upgrade.sh when detaching from screen #13291

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -232,7 +232,7 @@ function handle_update() {
 
     # Ask for confirmation and only update on 'y', 'Y' or Enter
     # Otherwise just show a reminder for how to update
-    echo -n "[oh-my-zsh] Would you like to update? [Y/n] "
+    printf "[oh-my-zsh] Would you like to update? [Y/n] "
     read -r -k 1 option
     [[ "$option" = $'\n' ]] || echo
     case "$option" in
@@ -280,7 +280,7 @@ case "$update_mode" in
           return 0
         elif [[ "$EXIT_STATUS" -ne 0 ]]; then
           print -P "\n%F{red}[oh-my-zsh] There was an error updating:%f"
-          printf "\n${fg[yellow]}%s${reset_color}" "$ERROR"
+          printf "\n${fg[yellow]}%s${reset_color}" "${ERROR}"
           return 0
         fi
       } always {


### PR DESCRIPTION
Fixes #13291

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Replace echo -n with printf for better compatibility
- Fix variable quoting in printf statement for ERROR variable
- Resolves syntax errors: 'echo [-n] string' expected and missing quotes

## Other comments:

This should resolve.
