### PR TITLE
Add aws-cost command for quick AWS cost overview

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -35,6 +35,9 @@ plugins=(... aws)
 
 * `aws_change_access_key`: changes the AWS access key of a profile.
 
+* `aws-cost`: displays a quick overview of AWS costs including current month spending, 
+  cost breakdown by service, and comparison with previous periods.
+
 * `aws_profiles`: lists the available profiles in the  `$AWS_CONFIG_FILE` (default: `~/.aws/config`).
   Used to provide completion for the `asp` function.
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add aws-cost function that displays current AWS costs in a formatted table
- Shows costs for yesterday, last 7 days, current month, and last month
- Displays top 5 services with cost breakdown and percentages
- Includes month-over-month cost comparison
- Uses AWS Cost Explorer API for accurate cost data
- Updated README with aws-cost documentation

## Other comments:

I've always found myself needed a quick way to check cost, so I've added this for consideration.
