### PR TITLE
brew: always eval \`brew shellenv\` to keep env vars current even if brew is on PATH; update README

### DIFF
--- a/plugins/brew/README.md
+++ b/plugins/brew/README.md
@@ -10,12 +10,17 @@ plugins=(... brew)
 
 ## Shellenv
 
-If `brew` is not found in the PATH, this plugin will attempt to find it in common locations, and execute
-`brew shellenv` to set the environment appropriately. This plugin will also export
-`HOMEBREW_PREFIX="$(brew --prefix)"` if not previously defined for convenience.
+This plugin evaluates Homebrew's shell environment on load to ensure `PATH`, `MANPATH`, `INFOPATH`, and other
+Homebrew variables are up to date:
 
-In case you installed `brew` in a non-common location, you can still set `BREW_LOCATION` variable pointing to
-the `brew` binary before sourcing `oh-my-zsh.sh` and it'll set up the environment.
+```zsh
+eval "$(brew shellenv)"
+```
+
+If `brew` is not already on `PATH`, the plugin will attempt to find it in common locations and run
+`brew shellenv` from there. You can also set a `BREW_LOCATION` variable pointing to the `brew` binary before
+loading Oh My Zsh to override detection. This plugin will also export `HOMEBREW_PREFIX="$(brew --prefix)"`
+if not previously defined for convenience.
 
 ## Aliases
 

--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -1,4 +1,7 @@
-if (( ! $+commands[brew] )); then
+if (( $+commands[brew] )); then
+  # Brew is already on PATH; still evaluate shellenv to ensure env vars are current
+  eval "$(brew shellenv)"
+else
   if [[ -n "$BREW_LOCATION" ]]; then
     if [[ ! -x "$BREW_LOCATION" ]]; then
       echo "[oh-my-zsh] $BREW_LOCATION is not executable"
@@ -16,9 +19,7 @@ if (( ! $+commands[brew] )); then
     return
   fi
 
-  # Only add Homebrew installation to PATH, MANPATH, and INFOPATH if brew is
-  # not already on the path, to prevent duplicate entries. This aligns with
-  # the behavior of the brew installer.sh post-install steps.
+  # Evaluate Homebrew shell environment from discovered brew binary
   eval "$("$BREW_LOCATION" shellenv)"
   unset BREW_LOCATION
 fi


### PR DESCRIPTION
- What: Always evaluate brew shellenv on plugin load, ensuring PATH, MANPATH, INFOPATH, and other Homebrew environment variables remain up to date. Update README shellenv section to reflect behavior.

- Why: Aligns with brew guidance and addresses cases where env vars change after upgrades or relocations; avoids stale env while keeping detection for non-PATH installs.

- Notes: Respects BREW_LOCATION override; still exports HOMEBREW_PREFIX if unset.