### PR TITLE
fix(uninstall): keep ~/.zshrc if no backup exists

### DIFF
--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -22,9 +22,14 @@ if [ -d ~/.oh-my-zsh ]; then
 fi
 
 if [ -e ~/.zshrc ]; then
-  ZSHRC_SAVE=~/.zshrc.omz-uninstalled-$(date +%Y-%m-%d_%H-%M-%S)
-  echo "Found ~/.zshrc -- Renaming to ${ZSHRC_SAVE}"
-  mv ~/.zshrc "${ZSHRC_SAVE}"
+  ZSHRC_ORIG=~/.zshrc.pre-oh-my-zsh
+  if [ -e "$ZSHRC_ORIG" ]; then
+    ZSHRC_SAVE=~/.zshrc.omz-uninstalled-$(date +%Y-%m-%d_%H-%M-%S)
+    echo "Found ~/.zshrc -- Renaming to ${ZSHRC_SAVE}"
+    mv ~/.zshrc "${ZSHRC_SAVE}"
+  else
+    echo "Found ~/.zshrc but no backup config detected -- leaving it untouched"
+  fi
 fi
 
 echo "Looking for original zsh config..."


### PR DESCRIPTION
Fixes #13156

### Current behavior
- During uninstall, ~/.zshrc is always renamed, even when no ~/.zshrc.pre-oh-my-zsh backup exists.
- This leaves the user without an active ~/.zshrc, which looks like their config has been deleted.

### New behavior
- If a backup (~/.zshrc.pre-oh-my-zsh) exists, ~/.zshrc is renamed and the backup is restored (same as before).
- If no backup exists, the current ~/.zshrc is left untouched to prevent user confusion.

### Why
This improves UX and prevents users from losing their configuration unexpectedly.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Updated `tools/uninstall.sh` to keep `~/.zshrc` untouched if no backup exists.

## Other comments:

...
