### PR TITLE
feat(git): add gstam for git stash push --message

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -195,6 +195,8 @@ plugins=(... git)
 | `gstp`                 | `git stash pop`                                                                                                                 |
 | `gsta`                 | On Git >= 2.13: `git stash push`                                                                                                |
 | `gsta`                 | On Git < 2.13: `git stash save`                                                                                                 |
+| `gstam`                | On Git >= 2.13: `git stash push --message`                                                                                                |
+| `gstam`                | On Git < 2.13: `git stash save`                                                                                                 |
 | `gsts`                 | `git stash show --patch`                                                                                                        |
 | `gst`                  | `git status`                                                                                                                    |
 | `gss`                  | `git status --short`                                                                                                            |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -391,6 +391,9 @@ alias gstp='git stash pop'
 is-at-least 2.13 "$git_version" \
   && alias gsta='git stash push' \
   || alias gsta='git stash save'
+is-at-least 2.13 "$git_version" \
+  && alias gstam='git stash push --message' \
+  || alias gstam='git stash save'
 alias gsts='git stash show --patch'
 alias gst='git status'
 alias gss='git status --short'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add a new alias "gstam" in plugins/git/git.plugin.zsh
- improve plugins/git/README.md for the new alias

## Other comments:

I think `gstam` for `git stash push --message` is the best and short alias.
