### PR TITLE
fix(bgnotify): Use lsappinfo and add support of Ghostty and Alacritty terminals

### DIFF
--- a/plugins/bgnotify/bgnotify.plugin.zsh
+++ b/plugins/bgnotify/bgnotify.plugin.zsh
@@ -60,8 +60,10 @@ function bgnotify_formatted {
 }
 
 function bgnotify_appid {
-  if (( ${+commands[osascript]} )); then
-    osascript -e "tell application id \"$(bgnotify_programid)\"  to get the {id, frontmost, id of front window, visible of front window}" 2>/dev/null
+  if (( ${+commands[lsappinfo]} )); then
+    lsappinfo info -only bundleid "$(lsappinfo front)" | awk -F= '{print $2}' | tr -d '"' 2>/dev/null
+  elif (( ${+commands[osascript]} )); then
+    osascript -e "tell application id \"$(bgnotify_programid)\" to get the {id, frontmost, id of front window, visible of front window}" 2>/dev/null
   elif [[ -n $WAYLAND_DISPLAY ]] && ([[ -n $SWAYSOCK ]] || [[ -n $I3SOCK ]]) && (( ${+commands[swaymsg]} )); then # wayland+sway
     local app_id=$(bgnotify_find_sway_appid)
     [[ -n "$app_id" ]] && echo "$app_id" || echo $EPOCHSECONDS
@@ -108,6 +110,7 @@ function bgnotify_programid {
   case "$TERM_PROGRAM" in
     iTerm.app) echo 'com.googlecode.iterm2' ;;
     Apple_Terminal) echo 'com.apple.terminal' ;;
+    ghostty) echo 'com.mitchellh.ghostty' ;;
   esac
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Recently I tried to migrate from iTerm to Ghostty terminal. I noticed `bgnotify` doesn't work for Ghostty at all, so I tried to dig into that problem.

So the issue is `osascript` fails to detect the app id for Ghostty (probably for other apps too) with this error:

```
➜ osascript -e "tell application id \"com.mitchellh.ghostty\" to get the {id, frontmost, id of front window, visible of front window}"
71:73: execution error: Ghostty got an error: Can’t get id of window 1. (-1728)

➜ osascript -e 'tell application id "com.mitchellh.ghostty" to properties of front window'
47:57: execution error: Ghostty got an error: Can’t get every property of window 1. (-1728)

➜ osascript -e 'tell application id "com.mitchellh.ghostty" to get {id, frontmost}'
com.mitchellh.ghostty, true
```

I fixed that by using `lsappinfo` command, and it now works for iTerm, Ghostty, Alacritty and probably more other terminals.

## Other comments:

Works well for me.

In case of Alacritty, `TERM_PROGRAM` is empty string, so `bgnotify_programid` only adds Ghostty.
