### PR TITLE
fix(plugins/copyfile): don't fail with empty filename

### DIFF
--- a/plugins/copyfile/copyfile.plugin.zsh
+++ b/plugins/copyfile/copyfile.plugin.zsh
@@ -1,11 +1,12 @@
-# Copies the contents of a given file to the system or X Windows clipboard
+# Copies the contents of a given file or stdin to the system or X Windows
+# clipboard
 #
-# Usage: copyfile <file>
+# Usage: copyfile [<file>]
 function copyfile {
   emulate -L zsh
 
   clipcopy "${1-}" || {
-    echo "Usage: copyfile <file>"
+    echo "Usage: copyfile [<file>]"
     return 1
   }
 

--- a/plugins/copyfile/copyfile.plugin.zsh
+++ b/plugins/copyfile/copyfile.plugin.zsh
@@ -4,16 +4,10 @@
 function copyfile {
   emulate -L zsh
 
-  if [[ -z "$1" ]]; then
+  clipcopy "${1-}" || {
     echo "Usage: copyfile <file>"
     return 1
-  fi
+  }
 
-  if [[ ! -f "$1" ]]; then
-    echo "Error: '$1' is not a valid file."
-    return 1
-  fi
-
-  clipcopy $1
-  echo ${(%):-"%B$1%b copied to clipboard."}
+  echo ${(%):-"%B${1:-/dev/stdin}%b copied to clipboard."}
 }


### PR DESCRIPTION
clipcopy interprets empty filename as stdin, but the current "error handling" breaks its behavior.

Relevant code: https://github.com/ohmyzsh/ohmyzsh/blob/9e23925b8581d22033f07f1983587412d3761494/lib/clipboard.zsh#L54-L100

This bug was introduced in ohmyzsh/ohmyzsh#13248.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Don't fail when copyfile is invoked with empty filename.

## Other comments:

N/A