### PR TITLE
feat(aws): add SSO login support to acp command

### DIFF
--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -25,7 +25,8 @@ plugins=(... aws)
 * `acp [<profile>] [<mfa_token>]`: in addition to `asp` functionality, it actually changes
    the profile by assuming the role specified in the `<profile>` configuration. It supports
    MFA and sets `$AWS_ACCESS_KEY_ID`, `$AWS_SECRET_ACCESS_KEY` and `$AWS_SESSION_TOKEN`, if
-   obtained. It requires the roles to be configured as per the
+   obtained. It automatically detects and performs SSO login for profiles that use AWS SSO,
+   including source profiles used for role assumption. It requires the roles to be configured as per the
    [official guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html).
    Run `acp` without arguments to clear the profile.
 


### PR DESCRIPTION
Fixes #10004

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add _aws_profile_uses_sso() helper function to detect SSO configuration
- Modify acp() function to automatically perform SSO login when needed
- Support both direct SSO profiles and role profiles with SSO source profiles
- Update README.md to document the new SSO functionality

