### PR TITLE
zsh-interactive-cd: add option to include hidden directories

### DIFF
--- a/plugins/zsh-interactive-cd/README.md
+++ b/plugins/zsh-interactive-cd/README.md
@@ -19,3 +19,14 @@ This plugin provides an interactive way to change directories in zsh using fzf.
 ## Usage
 
 Press tab for completion as usual, it'll launch fzf automatically. Check fzf’s [readme](https://github.com/junegunn/fzf#search-syntax) for more search syntax usage.
+
+### Hidden Directories
+
+By default, `zsh-interactive-cd` hides directories that start with `.` (dotfolders).  
+
+You can enable hidden directories in the suggestion list by setting:
+
+```zsh
+# Show hidden directories in interactive cd
+export ZIC_SHOW_HIDDEN=true
+```

--- a/plugins/zsh-interactive-cd/zsh-interactive-cd.plugin.zsh
+++ b/plugins/zsh-interactive-cd/zsh-interactive-cd.plugin.zsh
@@ -24,8 +24,11 @@ __zic_matched_subdir_list() {
     fi
     find -L "$dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null \
         | cut -b $(( ${length} + 2 ))- | command sed '/^$/d' | while read -r line; do
-      if [[ "${line[1]}" == "." ]]; then
-        continue
+      # Skip hidden dirs unless explicitly allowed
+      if [[ -z "$ZIC_SHOW_HIDDEN" || "$ZIC_SHOW_HIDDEN" != "true" ]]; then
+        if [[ "${line[1]}" == "." ]]; then
+          continue
+        fi
       fi
       echo "$line"
     done
@@ -40,8 +43,11 @@ __zic_matched_subdir_list() {
       find -L "$dir" -mindepth 1 -maxdepth 1 -type d \
           2>/dev/null | cut -b $(( ${length} + 2 ))- | command sed '/^$/d' \
           | while read -r line; do
-        if [[ "${seg[1]}" != "." && "${line[1]}" == "." ]]; then
-          continue
+        # Skip hidden dirs unless explicitly allowed
+        if [[ -z "$ZIC_SHOW_HIDDEN" || "$ZIC_SHOW_HIDDEN" != "true" ]]; then
+          if [[ "${seg[1]}" != "." && "${line[1]}" == "." ]]; then
+            continue
+          fi
         fi
         if [ "$zic_case_insensitive" = "true" ]; then
           if [[ "$line:u" == "$seg:u"* ]]; then
@@ -60,8 +66,11 @@ __zic_matched_subdir_list() {
       find -L "$dir" -mindepth 1 -maxdepth 1 -type d \
           2>/dev/null | cut -b $(( ${length} + 2 ))- | command sed '/^$/d' \
           | while read -r line; do
-        if [[ "${seg[1]}" != "." && "${line[1]}" == "." ]]; then
-          continue
+        # Skip hidden dirs unless explicitly allowed
+        if [[ -z "$ZIC_SHOW_HIDDEN" || "$ZIC_SHOW_HIDDEN" != "true" ]]; then
+          if [[ "${seg[1]}" != "." && "${line[1]}" == "." ]]; then
+            continue
+          fi
         fi
         if [ "$zic_case_insensitive" = "true" ]; then
           if [[ "$line:u" == *"$seg:u"* ]]; then
@@ -164,11 +173,6 @@ zic-completion() {
 
 [ -z "$__zic_default_completion" ] && {
   binding=$(bindkey '^I')
-  # $binding[(s: :w)2]
-  # The command substitution and following word splitting to determine the
-  # default zle widget for ^I formerly only works if the IFS parameter contains
-  # a space via $binding[(w)2]. Now it specifically splits at spaces, regardless
-  # of IFS.
   [[ $binding =~ 'undefined-key' ]] || __zic_default_completion=$binding[(s: :w)2]
   unset binding
 }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added support for showing hidden directories in the `zsh-interactive-cd` plugin.
- Introduced environment variable `ZIC_SHOW_HIDDEN`:
  - Default (unset): hidden directories are excluded (backward compatible).
  - `ZIC_SHOW_HIDDEN=true`: hidden directories are included in interactive completion.

## Other comments:

This small change makes the plugin more flexible while preserving its default behavior.  
It mirrors how other OMZ plugins expose optional features through environment variables.
