### PR TITLE
Added file checks on music and spotify scripts for use with zinit

### DIFF
--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -310,7 +310,7 @@ _freespace() {
 compdef _freespace freespace
 
 # Music / iTunes control function
-source "${0:h:A}/music"
+[[ -f "${0:h:A}/music" ]] && source "${0:h:A}/music"
 
 # Spotify control function
-source "${0:h:A}/spotify"
+[[ -f "${0:h:A}/spotify" ]] && source "${0:h:A}/spotify"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added file checks on the `music` and `spotify` files when sourced, since pulling this extension in via zinit does not pull in `music` or `spotify`. Thus, the check ensures that the file exists before sourcing.

## Other comments:

...
