### PR TITLE
Fixes command-not-found plugin error caused by a Homebrew update

### DIFF
--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -7,6 +7,7 @@ for file (
   /opt/homebrew/Library/Homebrew/command-not-found/handler.sh
   /usr/local/Homebrew/Library/Homebrew/command-not-found/handler.sh
   /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/command-not-found/handler.sh
+	# Old homebrew implementation
   /opt/homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh
   /usr/local/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh
   /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Changed file paths related to Homebrew due to a change in the file path of the command-not-found shell script. See commit 65a80fb in Homebrew/homebrew-command-not-found for context on the root cause of the issue.

## Issue fixed:
Fixes #13326 