### PR TITLE
docs(common-aliases): fix tar.gz command in README

### DIFF
--- a/plugins/common-aliases/README.md
+++ b/plugins/common-aliases/README.md
@@ -114,13 +114,13 @@ that file will be open with `acroread`.
 
 ### Listing files inside a packed file
 
-| Alias  | Command    | Description                       |
-| ------ | ---------- | --------------------------------- |
-| zip    | `unzip -l` | Lists files inside a .zip file    |
-| rar    | `unrar l`  | Lists files inside a .rar file    |
-| tar    | `tar tf`   | Lists files inside a .tar file    |
-| tar.gz | `echo`     | Lists files inside a .tar.gz file |
-| ace    | `unace l`  | Lists files inside a .ace file    |
+| Alias  | Command      | Description                       |
+| ------ | ------------ | --------------------------------- |
+| zip    | `unzip -l`   | Lists files inside a .zip file    |
+| rar    | `unrar l`    | Lists files inside a .rar file    |
+| tar    | `tar tf`     | Lists files inside a .tar file    |
+| tar.gz | `tar -ztf`   | Lists files inside a .tar.gz file |
+| ace    | `unace l`    | Lists files inside a .ace file    |
 
 ### Some other features
 


### PR DESCRIPTION
- Replace incorrect 'echo' command with 'tar -ztf' for listing tar.gz files
- This provides the correct command for users to list contents of gzip-compressed tar archives

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [...]

## Other comments:

...
