### PR TITLE
fix(lib): handle Unicode characters in git branch names

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -104,7 +104,7 @@ function _omz_git_prompt_status() {
   status_lines=("${(@f)${status_text}}")
 
   # If the tracking line exists, get and parse it
-  if [[ "$status_lines[1]" =~ "^## [^ ]+ \[(.*)\]" ]]; then
+  if [[ "$status_lines[1]" =~ "^## [^[:space:]]+ \[(.*)\]" ]]; then
     local branch_statuses
     branch_statuses=("${(@s/,/)match}")
     for branch_status in $branch_statuses; do


### PR DESCRIPTION
Fixes #13330

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Replace [^ ]+ with [^[:space:]]+ in regex pattern to properly handle Unicode characters like Chinese characters in git branch names.


## Other comments:

Before Fix: _omz_git_prompt_status:65: regex matching error: illegal byte sequence
After Fix: Function works correctly with Unicode branch names
  Test Case:

     1 │# Create branch with Chinese characters
     2 │git checkout -b "中文-1.0.0-中文"
     3 │
     4 │# Git status output (no longer causes error):
     5 │## 中文-1.0.0-中文
     6 │M  test.txt
     7 │
     8 │# Function now works without errors:
     9 │_omz_git_prompt_status  # Returns empty string (no status info) - no error!
