### PR TITLE
Safer uninstall: preserve .zshrc by removing only Oh My Zsh lines instead of overwriting

### DIFF
--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -22,19 +22,34 @@ if [ -d ~/.oh-my-zsh ]; then
 fi
 
 if [ -e ~/.zshrc ]; then
-  ZSHRC_SAVE=~/.zshrc.omz-uninstalled-$(date +%Y-%m-%d_%H-%M-%S)
-  echo "Found ~/.zshrc -- Renaming to ${ZSHRC_SAVE}"
-  mv ~/.zshrc "${ZSHRC_SAVE}"
+  BACKUP=~/.zshrc.backup-$(date +%Y-%m-%d_%H-%M-%S)
+  echo "Backing up your current ~/.zshrc to ${BACKUP}"
+  cp ~/.zshrc "${BACKUP}"
+
+  # Remove only oh-my-zsh related lines
+  if grep -q 'oh-my-zsh.sh' ~/.zshrc; then
+    sed -i '/oh-my-zsh.sh/d' ~/.zshrc
+    echo "Removed Oh My Zsh initialization from ~/.zshrc"
+  fi
+
+  if grep -q 'plugins=(' ~/.zshrc; then
+    sed -i '/plugins=(/d' ~/.zshrc
+    echo "Removed Oh My Zsh plugin line from ~/.zshrc"
+  fi
+
+  if grep -q 'ZSH_THEME=' ~/.zshrc; then
+    sed -i '/ZSH_THEME=/d' ~/.zshrc
+    echo "Removed Oh My Zsh theme setting from ~/.zshrc"
+  fi
 fi
 
 echo "Looking for original zsh config..."
 ZSHRC_ORIG=~/.zshrc.pre-oh-my-zsh
 if [ -e "$ZSHRC_ORIG" ]; then
-  echo "Found $ZSHRC_ORIG -- Restoring to ~/.zshrc"
-  mv "$ZSHRC_ORIG" ~/.zshrc
-  echo "Your original zsh config was restored."
+  echo "Found $ZSHRC_ORIG (not restoring automatically)."
+  echo "You can restore it manually if needed: cp $ZSHRC_ORIG ~/.zshrc"
 else
-  echo "No original zsh config found"
+  echo "No original zsh config found. Your current ~/.zshrc was cleaned."
 fi
 
 echo "Thanks for trying out Oh My Zsh. It's been uninstalled."


### PR DESCRIPTION
## Summary

Currently, `tools/uninstall.sh` renames the user’s existing `~/.zshrc` and restores `~/.zshrc.pre-oh-my-zsh` if it exists.  
This can cause **loss of years of user configuration, tokens, and customizations**, since the old `pre-oh-my-zsh` file may be outdated.

## Changes Made

- Always back up the current `~/.zshrc` to `~/.zshrc.backup-<timestamp>`.
- Instead of restoring the pre-oh-my-zsh config, the script **removes only the lines injected by Oh My Zsh**:
  - `source $ZSH/oh-my-zsh.sh`
  - `plugins=(...)`
  - `ZSH_THEME=...`
- Leaves all user aliases, tokens, and custom configs intact.
- If a pre-oh-my-zsh config exists, notify the user but **do not auto-restore it**.

## Benefits

- Prevents accidental data loss of user’s shell settings.
- Provides a safer, less destructive uninstall process.
- Gives users the option to manually restore their old config if desired.

## Related Issue

Fixes #13328
