### PR TITLE
fix(extract): extract to location of archive file (#13348)

### DIFF
--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -28,7 +28,7 @@ EOF
 
     local success=0
     local file="$1" full_path="${1:A}"
-    local extract_dir="${1:t:r}"
+    local extract_dir="${1:A:r}"
 
     # Remove the .tar extension if the file name is .tar.*
     if [[ $extract_dir =~ '\.tar$' ]]; then


### PR DESCRIPTION
Extract to the same directory as the archive file instead of the current working directory

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Set extract_dir variable to use full path of the archive instead of just the filename

## Other comments:
closes #13348
...
