### PR TITLE
Fix btrestart macos monterey

### DIFF
--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -19,8 +19,17 @@ alias hidefiles="defaults write com.apple.finder AppleShowAllFiles -bool false &
 
 # Bluetooth restart
 function btrestart() {
-  sudo kextunload -b com.apple.iokit.BroadcomBluetoothHostControllerUSBTransport
-  sudo kextload -b com.apple.iokit.BroadcomBluetoothHostControllerUSBTransport
+  # Kill audio and bluetooth processes
+  pgrep audio | xargs sudo kill 2>/dev/null || true
+  pgrep bluetooth | xargs sudo kill 2>/dev/null || true
+
+  # Restart bluetooth services using launchctl
+  sudo launchctl list | grep -i blue | awk '{ print $3 }' | xargs sudo launchctl stop 2>/dev/null || true
+  sudo launchctl list | grep -i blue | awk '{ print $3 }' | xargs sudo launchctl start 2>/dev/null || true
+  
+  # Restart audio services using launchctl
+  sudo launchctl list | grep -i audio | awk '{ print $3 }' | xargs sudo launchctl stop 2>/dev/null || true
+  sudo launchctl list | grep -i audio | awk '{ print $3 }' | xargs sudo launchctl start 2>/dev/null || true
 }
 
 function _omz_macos_get_frontmost_app() {

--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -19,17 +19,9 @@ alias hidefiles="defaults write com.apple.finder AppleShowAllFiles -bool false &
 
 # Bluetooth restart
 function btrestart() {
-  # Kill audio and bluetooth processes
-  pgrep audio | xargs sudo kill 2>/dev/null || true
-  pgrep bluetooth | xargs sudo kill 2>/dev/null || true
-
-  # Restart bluetooth services using launchctl
-  sudo launchctl list | grep -i blue | awk '{ print $3 }' | xargs sudo launchctl stop 2>/dev/null || true
-  sudo launchctl list | grep -i blue | awk '{ print $3 }' | xargs sudo launchctl start 2>/dev/null || true
-  
-  # Restart audio services using launchctl
-  sudo launchctl list | grep -i audio | awk '{ print $3 }' | xargs sudo launchctl stop 2>/dev/null || true
-  sudo launchctl list | grep -i audio | awk '{ print $3 }' | xargs sudo launchctl start 2>/dev/null || true
+  echo "Restarting Bluetooth daemon..."
+  sudo pkill bluetoothd
+  echo "Bluetooth daemon restarted."
 }
 
 function _omz_macos_get_frontmost_app() {


### PR DESCRIPTION
Fixes #10934

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Replace complex launchctl approach with simple pkill bluetoothd
- macOS automatically restarts bluetoothd when killed
- Much more maintainable and future-proof
- Reduces from 6 commands to 1 command
- Less prone to OS changes and service discovery issues
- Cleaner, more readable implementation

## Other comments:

This should be compatible with Jaguar 10.2+