### PR TITLE
fix(git): make aliases ggu, ggl, gp, ggfl, ggp more correct

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -280,10 +280,11 @@ alias gpra='git pull --rebase --autostash'
 alias gprav='git pull --rebase --autostash -v'
 
 function ggu() {
-  [[ "$#" != 1 ]] && local b="$(git_current_branch)"
-  git pull --rebase origin "${b:=$1}"
+  local b
+  [[ "$#" != 1 ]] && b="$(git_current_branch)"
+  git pull --rebase origin "${b:-$1}"
 }
-compdef _git ggu=git-checkout
+compdef _git ggu=git-pull
 
 alias gprom='git pull --rebase origin $(git_main_branch)'
 alias gpromi='git pull --rebase=interactive origin $(git_main_branch)'
@@ -295,11 +296,12 @@ function ggl() {
   if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
     git pull origin "${*}"
   else
-    [[ "$#" == 0 ]] && local b="$(git_current_branch)"
-    git pull origin "${b:=$1}"
+    local b
+    [[ "$#" == 0 ]] && b="$(git_current_branch)"
+    git pull origin "${b:-$1}"
   fi
 }
-compdef _git ggl=git-checkout
+compdef _git ggl=git-pull
 
 alias gluc='git pull upstream $(git_current_branch)'
 alias glum='git pull upstream $(git_main_branch)'
@@ -307,10 +309,11 @@ alias gp='git push'
 alias gpd='git push --dry-run'
 
 function ggf() {
-  [[ "$#" != 1 ]] && local b="$(git_current_branch)"
-  git push --force origin "${b:=$1}"
+  local b
+  [[ "$#" != 1 ]] && b="$(git_current_branch)"
+  git push --force origin "${b:-$1}"
 }
-compdef _git ggf=git-checkout
+compdef _git ggf=git-push
 
 alias gpf!='git push --force'
 is-at-least 2.30 "$git_version" \
@@ -318,10 +321,11 @@ is-at-least 2.30 "$git_version" \
   || alias gpf='git push --force-with-lease'
 
 function ggfl() {
-  [[ "$#" != 1 ]] && local b="$(git_current_branch)"
-  git push --force-with-lease origin "${b:=$1}"
+  local b
+  [[ "$#" != 1 ]] && b="$(git_current_branch)"
+  git push --force-with-lease origin "${b:-$1}"
 }
-compdef _git ggfl=git-checkout
+compdef _git ggfl=git-push
 
 alias gpsup='git push --set-upstream origin $(git_current_branch)'
 is-at-least 2.30 "$git_version" \
@@ -336,11 +340,12 @@ function ggp() {
   if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
     git push origin "${*}"
   else
-    [[ "$#" == 0 ]] && local b="$(git_current_branch)"
-    git push origin "${b:=$1}"
+    local b
+    [[ "$#" == 0 ]] && b="$(git_current_branch)"
+    git push origin "${b:-$1}"
   fi
 }
-compdef _git ggp=git-checkout
+compdef _git ggp=git-push
 
 alias gpu='git push upstream'
 alias grb='git rebase'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- correct `compdef` functions
- force local variable
- do not reassign variable when falling back (change `:=` to `:-`)

## Other comments:

Current behavior of `ggp` has a bug:

```
# run with a typo
$ ggp --forge
error: unknown option `forge'

# then run correctly after the typo
$ ggp --force
error: unknown option `forge'
```

the typo ends up "cached", because `b` is
1) potentially assigned in the expression `${b:=$1}`, and
2) not declared `local` there

Also, any global value of `b` would be used in `${b:=$1}`, so the bug can be triggered by anything in the environment.

This seems to be the same issue for 5 functions.
All those functions seem to have the wrong function declared for compdef as well.
