### PR TITLE
fix(ssh): replace deprecated egrep with grep -E

### DIFF
--- a/plugins/ssh/ssh.plugin.zsh
+++ b/plugins/ssh/ssh.plugin.zsh
@@ -5,7 +5,7 @@
 _ssh_configfile="$HOME/.ssh/config"
 if [[ -f "$_ssh_configfile" ]]; then
   _ssh_hosts=($(
-    egrep '^Host.*' "$_ssh_configfile" |\
+    grep -E '^Host.*' "$_ssh_configfile" |\
     awk '{for (i=2; i<=NF; i++) print $i}' |\
     sort |\
     uniq |\


### PR DESCRIPTION
This pull request replaces the `egrep` command with `grep -E` 
in the `ssh` plugin to prevent warnings.

I searched the repository and issues but did not find any related PRs or open issues 
addressing this.

Tested locally and verified that SSH host autocompletion still works as expected.