### PR TITLE
feat(vscode): add support for Cursor editor in vscode plugin

### DIFF
--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -1,7 +1,6 @@
 # VS Code
 
-This plugin provides useful aliases to simplify the interaction between the command line and VS Code or
-VSCodium editor.
+This plugin provides useful aliases to simplify the interaction between the command line and VS Code, VSCodium, or Cursor editor.
 
 To start using it, add the `vscode` plugin to your `plugins` array in `~/.zshrc`:
 
@@ -18,6 +17,7 @@ You can install either:
 - VS Code (code)
 - VS Code Insiders (code-insiders)
 - VSCodium (codium)
+- Cursor (cursor)
 
 ### MacOS
 
@@ -33,6 +33,10 @@ open the Command Palette via (F1 or ⇧⌘P) and type shell command to find the 
 
 > Shell Command: Install 'codium' command in PATH
 
+For Cursor, open the Command Palette via (F1 or ⌘⇧P) and type shell command to find the Shell Command:
+
+> Shell Command: Install 'cursor' command in PATH
+
 ## Using multiple flavours
 
 If for any reason, you ever require to use multiple flavours of VS Code i.e. VS Code (stable) and VS Code
@@ -43,7 +47,7 @@ executable.
 ```zsh
 ZSH_THEME=...
 
-# Choose between one [code, code-insiders or codium]
+# Choose between one [code, code-insiders, codium, or cursor]
 # The following line will make the plugin to open VS Code Insiders
 # Invalid entries will be ignored, no aliases will be added
 VSCODE=code-insiders

--- a/plugins/vscode/vscode.plugin.zsh
+++ b/plugins/vscode/vscode.plugin.zsh
@@ -1,4 +1,4 @@
-# VS Code (stable / insiders) / VSCodium zsh plugin
+# VS Code (stable / insiders) / VSCodium / Cursor zsh plugin
 # Authors:
 #   https://github.com/MarsiBarsi (original author)
 #   https://github.com/babakks
@@ -19,6 +19,8 @@ if [[ -z "$VSCODE" ]]; then
     VSCODE=code-insiders
   elif which codium &>/dev/null; then
     VSCODE=codium
+  elif which cursor &>/dev/null; then
+    VSCODE=cursor
   else
     return
   fi


### PR DESCRIPTION
Here's a PR message for your changes:

---

## Title:
**Add Cursor IDE support to vscode plugin**

## Description:

This PR adds support for Cursor IDE to the vscode plugin, allowing users to use all existing plugin aliases and functions with Cursor.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added Cursor IDE (`cursor`) detection to the plugin's auto-detection logic
- Updated plugin header comment to include Cursor alongside VS Code and VSCodium
- Updated README.md to document Cursor as a supported editor
- Added macOS setup instructions for installing the `cursor` command in PATH
- Updated configuration examples to include `cursor` as a valid option

## Other comments:

Cursor is a popular AI-powered code editor built on VS Code that uses the same command-line interface (`cursor`) as VS Code uses `code`. This addition allows Cursor users to benefit from all the existing vscode plugin aliases (`vsc`, `vsca`, `vscd`, `vscg`, etc.) without any additional configuration.

The detection priority order is maintained as: `code` → `code-insiders` → `codium` → `cursor`, ensuring backward compatibility while adding support for the new editor.

No new aliases are introduced; the plugin reuses all existing functionality with Cursor when detected or manually configured via `VSCODE=cursor`.