### PR TITLE
ci(deps): ensure push permissions are available

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -39,7 +39,6 @@ jobs:
           GIT_APP_NAME: ohmyzsh[bot]
           GIT_APP_EMAIL: 54982679+ohmyzsh[bot]@users.noreply.github.com
           TMP_DIR: ${{ runner.temp }}
-          DRY_RUN: 1
         run: |
           pip install -r .github/workflows/dependencies/requirements.txt
           python3 .github/workflows/dependencies/updater.py


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

In #13232 we restricted the permissions of the dependencies workflow. Nevertheless, write permissions are required since we are pushing to the repo from `GITHUB_TOKEN`. The GitHub App has no push permissions.
I'm not fully sure if this is the best way to tackle this, maybe we could provide the app with higher permissions, but this option seems more granular.
