### PR TITLE
Update docker-compose plugin doc to clarify command selection

### DIFF
--- a/plugins/docker-compose/README.md
+++ b/plugins/docker-compose/README.md
@@ -2,6 +2,8 @@
 
 This plugin provides completion for [docker-compose](https://docs.docker.com/compose/) as well as some
 aliases for frequent docker-compose commands.
+This plugin chooses automatically between the legacy `docker-compose` command and the modern 
+`docker compose` subcommand, preferring `docker-compose` when both are available.
 
 To use it, add docker-compose to the plugins array of your zshrc file:
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added a line to the Docker Compose plugin README to clarify how the command is selected.

## Other comments:

Fixes #12913

Added explanation that the plugin automatically chooses between the legacy `docker-compose` command and the modern `docker compose` subcommand, preferring `docker-compose` when both are available.
I think this clarification is useful, because I'm not the first person struggling to find a plugin for `docker compose`, and eventually ending up on this one named `docker-compose`, whose documentation still uses the old `docker-compose` command but can actually be used with `docker compose` (#12913). This new line in the README makes it clear that the plugin will use `docker compose` if that command is available.
