### PR TITLE
feat(git): add alias listing latest branches

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -268,6 +268,7 @@ receive further support.
 | `grename <old> <new>`    | Renames branch `<old>` to `<new>`, including on the origin remote.                                              |
 | `gbda`                   | Deletes all merged branches                                                                                     |
 | `gbds`                   | Deletes all squash-merged branches (**Note: performance degrades with number of branches**)                     |
+| `glb`                    | List latest switched to branches (default 10, can use glb X to get latest X branches)
 
 ### Work in Progress (WIP)
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -71,6 +71,12 @@ function grename() {
   fi
 }
 
+# List latest X (default 10) used branches
+glb() {
+    local count=${1:-10}
+    git reflog | grep 'checkout: moving' | awk '{print $8}' | awk '!seen[$0]++' | head -n "$count"
+}
+
 #
 # Functions Work in Progress (WIP)
 # (sorted alphabetically by function name)


### PR DESCRIPTION
add glb function to git plugin which
allows listing the latest X branches (10 by default) make it easy to work with multiple branches
when it is hard remembering the names

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add a function to the git plugin that allows listing the latest used branches
This is useful in cases where you work on multiple branches and don't remember the names 
making it hard to going between multiple branches


## Other comments:

...
