### PR TITLE
Rename .NET Core to .NET in README

### DIFF
--- a/plugins/dotnet/README.md
+++ b/plugins/dotnet/README.md
@@ -1,6 +1,6 @@
-# .NET Core CLI plugin
+# .NET CLI plugin
 
-This plugin provides completion and useful aliases for [.NET Core CLI](https://dotnet.microsoft.com/).
+This plugin provides completion and useful aliases for [.NET CLI](https://dotnet.microsoft.com/).
 
 To use it, add `dotnet` to the plugins array in your zshrc file.
 


### PR DESCRIPTION
Time to drop the Core suffix. It's been called only .NET for five years now.