### PR TITLE
fix(alias-finder): use `?` over `{0,1}` to support BSD

### DIFF
--- a/plugins/alias-finder/alias-finder.plugin.zsh
+++ b/plugins/alias-finder/alias-finder.plugin.zsh
@@ -1,5 +1,5 @@
 alias-finder() {
-  local cmd=" " exact="" longer="" cheaper="" wordEnd="'{0,1}$" finder="" filter=""
+  local cmd=" " exact="" longer="" cheaper="" wordEnd="'?$" finder="" filter=""
 
   # build command and options
   for c in "$@"; do
@@ -31,7 +31,7 @@ alias-finder() {
 
   # find with alias and grep, removing last word each time until no more words
   while [[ $cmd != "" ]]; do
-    finder="'{0,1}$cmd$wordEnd"
+    finder="'?$cmd$wordEnd"
 
     # make filter to find only shorter results than current cmd
     if [[ $cheaper == true ]]; then


### PR DESCRIPTION
Closes #13416

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Prefer `?` to `{0,1}`, to ensure compatibility with BSD grep as well.