### PR TITLE
feat(ubuntu): add apti alias with recommended packages

### DIFF
--- a/plugins/ubuntu/ubuntu.plugin.zsh
+++ b/plugins/ubuntu/ubuntu.plugin.zsh
@@ -135,4 +135,6 @@ function apt-list-packages {
   grep -v deinstall | \
   sort -n | \
   awk '{print $1" "$2}'
+# Install package with recommended AND suggested packages
+alias apti='apt install -o APT::Install-Recommends="true" -o APT::Install-Suggests="true"'
 }


### PR DESCRIPTION
## Description
Adds `apti` alias to install packages with **recommended** and **suggested** packages.

```bash
apti package-name