### PR TITLE
fix(keychain): use pattern matching to detect version

### DIFF
--- a/plugins/keychain/keychain.plugin.zsh
+++ b/plugins/keychain/keychain.plugin.zsh
@@ -23,7 +23,7 @@ function {
 	local version_string=$(keychain --version 2>&1)
   # start keychain, only use --agents for versions below 2.9.0
 	autoload -Uz is-at-least
-	if [[ "$version_string" =~ 'keychain ([0-9]\.[0-9])' ]] && \
+	if [[ "$version_string" =~ 'keychain ([0-9]+\.[0-9]+)' ]] && \
       is-at-least 2.9 "$match[1]"; then
 		keychain ${^options:-} ${^identities} --host $SHORT_HOST
 	else


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Version string starts with `*`, making Fedora 43 `head` replace with all files and directories inside the current dir. Just changing the strategy to avoid that.