### PR TITLE
Add new theme: andr31ab

### DIFF
--- a/themes/andr31ab.zsh-theme
+++ b/themes/andr31ab.zsh-theme
@@ -1,0 +1,8 @@
+PROMPT='%(!.%{$fg_bold[red]%} .%{$fg_bold[green]%} ) '
+PROMPT+='%{$fg[cyan]%}%~%{$reset_color%} $(git_prompt_info)'
+PROMPT+=$'\n→ '
+
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}git:(%{$fg[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}) "
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[yellow]%}✗%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_CLEAN=""


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ✓] The PR title is descriptive.
- [ ✓] The PR doesn't replicate another PR which is already open.
- [ ✓] I have read the contribution guide and followed all the instructions.
- [ ✓] The code follows the code style guide detailed in the wiki.
- [ ✓] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ✓] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ✓] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added a new theme called `andr31ab`
- Minimal, clean prompt
- Shows user/root indicator (green for normal user, red for root)
- Shows current directory in cyan
- Shows git branch and dirty state (✗)
- Two-line prompt with arrow indicator

## Other comments:

- Uses Nerd Font icon for folder (\uf115)
- Tested on default terminal colors and with pywal disabled
- The theme is lightweight, fast, and does not rely on external plugins

screenshot:
<img width="566" height="146" alt="screenshot zsh prompt" src="https://github.com/user-attachments/assets/5645061c-eada-41e4-8edb-4619bc507fcc" />

