### PR TITLE
feat(prek): add plugin with aliases for prek commands

### DIFF
--- a/plugins/prek/README.md
+++ b/plugins/prek/README.md
@@ -1,0 +1,119 @@
+# Prek plugin
+
+This plugin adds aliases for common commands of [prek](https://prek.j178.dev/).
+
+**Prek** is a faster, Rust-based drop-in replacement for pre-commit that provides better performance and additional features like workspace support and improved user experience. It's approximately **10x faster** than pre-commit for hook installation and **~7x faster** for execution.
+
+To use this plugin, add it to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... prek)
+```
+
+## About Prek
+
+Prek offers several advantages over pre-commit:
+
+- **~10x faster** installation and ~7x faster execution
+- **Single binary** - no Python or runtime dependencies required
+- **Workspace support** - manage multiple projects with separate configs in monorepos
+- **Better UX** - improved commands like `prek run --directory` and `prek run --last-commit`
+- **Drop-in replacement** - uses the same `.pre-commit-config.yaml` configuration
+
+## Aliases
+
+### Main Command
+
+| Alias | Command | Description |
+| ----- | ------- | ----------- |
+| `pk` | `prek` | The `prek` command |
+
+### Installation & Setup
+
+| Alias | Command | Description |
+| ----- | ------- | ----------- |
+| `pki` | `prek install` | Install the prek git hook |
+| `pkii` | `prek install --install-hooks` | Install the git hook and hook environments in one command |
+| `pkih` | `prek install-hooks` | Install hook environments for all hooks in config |
+
+### Running Hooks
+
+| Alias | Command | Description |
+| ----- | ------- | ----------- |
+| `pkr` | `prek run` | Run hooks on staged files |
+| `pkra` | `prek run --all-files` | Run hooks on all files in the repository |
+| `pkrf` | `prek run --files` | Run hooks on specific files |
+| `pkrl` | `prek run --last-commit` | Run hooks on files changed in the last commit |
+| `pkrd` | `prek run --directory` | Run hooks on files in a specific directory |
+
+### Management
+
+| Alias | Command | Description |
+| ----- | ------- | ----------- |
+| `pku` | `prek uninstall` | Uninstall the prek git hook |
+| `pkl` | `prek list` | List all available hooks and their descriptions |
+
+### Updates
+
+| Alias | Command | Description |
+| ----- | ------- | ----------- |
+| `pkau` | `prek auto-update` | Auto-update config to the latest repo versions |
+| `pksu` | `prek self update` | Update prek itself to the latest version |
+
+### Configuration
+
+| Alias | Command | Description |
+| ----- | ------- | ----------- |
+| `pkvc` | `prek validate-config` | Validate `.pre-commit-config.yaml` file |
+| `pkvm` | `prek validate-manifest` | Validate `.pre-commit-hooks.yaml` file |
+| `pksc` | `prek sample-config` | Produce a sample `.pre-commit-config.yaml` file |
+
+### Cache Management
+
+| Alias | Command | Description |
+| ----- | ------- | ----------- |
+| `pkcd` | `prek cache dir` | Show the location of the prek cache |
+| `pkcgc` | `prek cache gc` | Clean unused cached repositories and environments |
+| `pkcc` | `prek cache clean` | Remove all prek cached data |
+
+## Usage Examples
+
+```zsh
+# Install prek hooks
+pki
+
+# Run hooks on all files
+pkra
+
+# Run hooks on files changed in the last commit
+pkrl
+
+# Run a specific hook
+pkr ruff
+
+# Run hooks on files in a specific directory
+pkrd src/
+
+# Update hooks to latest versions
+pkau
+
+# Clean up unused cache
+pkcgc
+```
+
+## Installation
+
+First, install prek itself:
+
+```zsh
+# Using uv (recommended)
+uv tool install prek
+
+# Using pip
+pip install prek
+
+# Using Homebrew
+brew install prek
+```
+
+For more installation options, see the [prek installation guide](https://prek.j178.dev/installation/).

--- a/plugins/prek/prek.plugin.zsh
+++ b/plugins/prek/prek.plugin.zsh
@@ -1,0 +1,37 @@
+# Prek plugin for Oh My Zsh
+# Description: Adds aliases for prek, a faster drop-in replacement for pre-commit
+# Author: Based on the pre-commit plugin structure
+# Repository: https://github.com/j178/prek
+
+# Main command
+alias pk='prek'
+
+# Installation & Setup
+alias pki='prek install'
+alias pkii='prek install --install-hooks'
+alias pkih='prek install-hooks'
+
+# Running Hooks
+alias pkr='prek run'
+alias pkra='prek run --all-files'
+alias pkrf='prek run --files'
+alias pkrl='prek run --last-commit'
+alias pkrd='prek run --directory'
+
+# Management
+alias pku='prek uninstall'
+alias pkl='prek list'
+
+# Updates
+alias pkau='prek auto-update'
+alias pksu='prek self update'
+
+# Configuration
+alias pkvc='prek validate-config'
+alias pkvm='prek validate-manifest'
+alias pksc='prek sample-config'
+
+# Cache Management
+alias pkcd='prek cache dir'
+alias pkcgc='prek cache gc'
+alias pkcc='prek cache clean'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added a new plugin for `prek`, a Rust-based drop-in replacement for the `pre-commit` tool, to Oh My Zsh's plugin collection.
- Created `prek.plugin.zsh` defining 20+ aliases for common prek commands covering installation, running hooks, updating, configuration validation, cache management, and more.
- Included comprehensive documentation (`README.md`).
- Followed the structure, style, and conventions of the existing `pre-commit` Oh My Zsh plugin for consistency.

## Other comments:

This plugin addresses usability and performance improvements for developers using pre-commit hooks by enabling faster hook installation and execution through prek. It is fully compatible with existing `.pre-commit-config.yaml` files, making migration easy.

The addition enhances the Oh My Zsh ecosystem by offering an up-to-date, performance-optimized alternative without breaking existing workflows.