### PR TITLE
feat(clipboard): tmux: send clipboard to client when using clipcopy

### DIFF
--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -82,7 +82,7 @@ function detect-clipboard() {
     function clipcopy() { cat "${1:-/dev/stdin}" | termux-clipboard-set; }
     function clippaste() { termux-clipboard-get; }
   elif [ -n "${TMUX:-}" ] && (( ${+commands[tmux]} )); then
-    function clipcopy() { tmux load-buffer "${1:--}"; }
+    function clipcopy() { tmux load-buffer -w "${1:--}"; }
     function clippaste() { tmux save-buffer -; }
   else
     function _retry_clipboard_detection_or_fail() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

By adding `-w`, we can get `load-buffer` (and `clipcopy`) to also send the copied buffer to the client, allowing for easy copying tmux buffers into the local client, which is useful in scenarios such as ssh+tmux remote sessions.

From [`man tmux`](https://www.man7.org/linux/man-pages/man1/tmux.1.html):

```man
load-buffer [-w] [-b buffer-name] [-t target-client] path
             (alias: loadb)
       Load the contents of the specified paste buffer from path.  If -w is given, the buffer is also sent to the clipboard
       for target-client using the xterm(1) escape sequence, if possible.  If path is ‘-’, the contents are read from stdin.
```

