### PR TITLE
ci(dependencies): update job permissions and change commits to chore

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -4,14 +4,13 @@ on:
   schedule:
     - cron: "0 6 * * 0"
 
-permissions:
-  contents: write
-
 jobs:
   check:
     name: Check for updates
     runs-on: ubuntu-latest
     if: github.repository == 'ohmyzsh/ohmyzsh'
+    permissions:
+      contents: write # this is needed to push commits and branches
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2

--- a/.github/workflows/dependencies/updater.py
+++ b/.github/workflows/dependencies/updater.py
@@ -238,7 +238,7 @@ class Dependency:
                             # Create GitHub PR
                             GitHub.create_pr(
                                 branch,
-                                f"feat({self.name}): update to version {new_version}",
+                                f"chore({self.name}): update to version {new_version}",
                                 f"""## Description
 
 Update for **{self.desc}**: update to version [{new_version}]({status["head_url"]}).
@@ -423,7 +423,7 @@ class Git:
                 f"user.email={user_email}",
                 "commit",
                 "-m",
-                f"feat({scope}): update to {version}",
+                f"chore({scope}): update to {version}",
             ],
             stage="CreateCommit",
             env=clean_env,


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `content:write` permissions to job level instead of workflow
- Change conventional commit type to `chore` -- `feat` pollutes the changelog, and usually an update doesn't introduce anything significant for our users.

