### PR TITLE
feat(extract): add unar as fallback for RAR extraction

### DIFF
--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -77,7 +77,15 @@ EOF
       (*.lzma) unlzma "$full_path" ;;
       (*.z) uncompress "$full_path" ;;
       (*.zip|*.war|*.jar|*.ear|*.sublime-package|*.ipa|*.ipsw|*.xpi|*.apk|*.aar|*.whl|*.vsix|*.crx|*.pk3|*.pk4) unzip "$full_path" ;;
-      (*.rar) unrar x -ad "$full_path" ;;
+      (*.rar)
+        if (( $+commands[unrar] )); then
+          unrar x -ad "$full_path"
+        elif (( $+commands[unar] )); then
+          unar -o . "$full_path"
+        else
+          echo "extract: cannot extract RAR files: install unrar or unar" >&2
+          success=1
+        fi ;;
       (*.rpm)
         rpm2cpio "$full_path" | cpio --quiet -id ;;
       (*.7z | *.7z.[0-9]* | *.pk7) 7za x "$full_path" ;;


### PR DESCRIPTION
## Summary

- Add `unar` as a fallback when `unrar` is not available for RAR file extraction
- Preserves backward compatibility by preferring `unrar` if installed
- Shows helpful error message when neither tool is available

Fixes #13460

## Context

`unrar` has been removed from Homebrew due to licensing issues ([Homebrew Discussion #285](https://github.com/orgs/Homebrew/discussions/285)). `unar` is available via `brew install unar` and handles RAR files (among 30+ other formats).

## Changes

```zsh
(*.rar)
  if (( $+commands[unrar] )); then
    unrar x -ad "$full_path"
  elif (( $+commands[unar] )); then
    unar -o . "$full_path"
  else
    echo "extract: cannot extract RAR files: install unrar or unar" >&2
    success=1
  fi ;;
```

## Test plan

- [x] Verified `unar` is called when `unrar` is not available
- [x] Verified correct arguments passed (`unar -o . <path>`)
- [x] Verified error message displays when neither tool is installed
- [x] Verified `unar -o` extraction works correctly