### PR TITLE
feat(hcloud): add plugin for Hetzner Cloud CLI

### DIFF
--- a/plugins/hcloud/README.md
+++ b/plugins/hcloud/README.md
@@ -1,0 +1,143 @@
+# hcloud plugin
+
+This plugin adds completion for the [Hetzner Cloud CLI](https://github.com/hetznercloud/cli),
+as well as some aliases for common hcloud commands.
+
+To use it, add `hcloud` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... hcloud)
+```
+
+## Aliases
+
+| Alias      | Command                                   | Description                                                   |
+| :--------- | :---------------------------------------- | :------------------------------------------------------------ |
+| hc         | `hcloud`                                  | The hcloud command                                            |
+|            |                                           | **Context Management**                                        |
+| hcctx      | `hcloud context`                          | Manage contexts                                               |
+| hcctxls    | `hcloud context list`                     | List all contexts                                             |
+| hcctxu     | `hcloud context use`                      | Use a context                                                 |
+| hcctxc     | `hcloud context create`                   | Create a new context                                          |
+| hcctxd     | `hcloud context delete`                   | Delete a context                                              |
+| hcctxa     | `hcloud context active`                   | Show active context                                           |
+|            |                                           | **Server Management**                                         |
+| hcs        | `hcloud server`                           | Manage servers                                                |
+| hcsl       | `hcloud server list`                      | List all servers                                              |
+| hcsc       | `hcloud server create`                    | Create a server                                               |
+| hcsd       | `hcloud server delete`                    | Delete a server                                               |
+| hcsdesc    | `hcloud server describe`                  | Describe a server                                             |
+| hcspoff    | `hcloud server poweroff`                  | Power off a server                                            |
+| hcspon     | `hcloud server poweron`                   | Power on a server                                             |
+| hcsr       | `hcloud server reboot`                    | Reboot a server                                               |
+| hcsreset   | `hcloud server reset`                     | Reset a server                                                |
+| hcssh      | `hcloud server ssh`                       | SSH into a server                                             |
+| hcse       | `hcloud server enable-rescue`             | Enable rescue mode for a server                               |
+| hcsdr      | `hcloud server disable-rescue`            | Disable rescue mode for a server                              |
+| hcsip      | `hcloud server ip`                        | Manage server IPs                                             |
+| hcsa       | `hcloud server attach-iso`                | Attach an ISO to a server                                     |
+| hcsda      | `hcloud server detach-iso`                | Detach an ISO from a server                                   |
+| hcscip     | `hcloud server change-type`               | Change server type                                            |
+|            |                                           | **Volume Management**                                         |
+| hcv        | `hcloud volume`                           | Manage volumes                                                |
+| hcvl       | `hcloud volume list`                      | List all volumes                                              |
+| hcvc       | `hcloud volume create`                    | Create a volume                                               |
+| hcvd       | `hcloud volume delete`                    | Delete a volume                                               |
+| hcvdesc    | `hcloud volume describe`                  | Describe a volume                                             |
+| hcva       | `hcloud volume attach`                    | Attach a volume to a server                                   |
+| hcvda      | `hcloud volume detach`                    | Detach a volume from a server                                 |
+| hcvr       | `hcloud volume resize`                    | Resize a volume                                               |
+|            |                                           | **Network Management**                                        |
+| hcn        | `hcloud network`                          | Manage networks                                               |
+| hcnl       | `hcloud network list`                     | List all networks                                             |
+| hcnc       | `hcloud network create`                   | Create a network                                              |
+| hcnd       | `hcloud network delete`                   | Delete a network                                              |
+| hcndesc    | `hcloud network describe`                 | Describe a network                                            |
+| hcnas      | `hcloud network add-subnet`               | Add a subnet to a network                                     |
+| hcnds      | `hcloud network delete-subnet`            | Delete a subnet from a network                                |
+| hcnar      | `hcloud network add-route`                | Add a route to a network                                      |
+| hcndr      | `hcloud network delete-route`             | Delete a route from a network                                 |
+|            |                                           | **Floating IP Management**                                    |
+| hcfip      | `hcloud floating-ip`                      | Manage floating IPs                                           |
+| hcfipl     | `hcloud floating-ip list`                 | List all floating IPs                                         |
+| hcfipc     | `hcloud floating-ip create`               | Create a floating IP                                          |
+| hcfipd     | `hcloud floating-ip delete`               | Delete a floating IP                                          |
+| hcfipdesc  | `hcloud floating-ip describe`             | Describe a floating IP                                        |
+| hcfipa     | `hcloud floating-ip assign`               | Assign a floating IP to a server                              |
+| hcfipua    | `hcloud floating-ip unassign`             | Unassign a floating IP from a server                          |
+|            |                                           | **SSH Key Management**                                        |
+| hcsk       | `hcloud ssh-key`                          | Manage SSH keys                                               |
+| hcskl      | `hcloud ssh-key list`                     | List all SSH keys                                             |
+| hcskc      | `hcloud ssh-key create`                   | Create an SSH key                                             |
+| hcskd      | `hcloud ssh-key delete`                   | Delete an SSH key                                             |
+| hcskdesc   | `hcloud ssh-key describe`                 | Describe an SSH key                                           |
+| hcsku      | `hcloud ssh-key update`                   | Update an SSH key                                             |
+|            |                                           | **Image Management**                                          |
+| hci        | `hcloud image`                            | Manage images                                                 |
+| hcil       | `hcloud image list`                       | List all images                                               |
+| hcid       | `hcloud image delete`                     | Delete an image                                               |
+| hcidesc    | `hcloud image describe`                   | Describe an image                                             |
+| hciu       | `hcloud image update`                     | Update an image                                               |
+|            |                                           | **Firewall Management**                                       |
+| hcfw       | `hcloud firewall`                         | Manage firewalls                                              |
+| hcfwl      | `hcloud firewall list`                    | List all firewalls                                            |
+| hcfwc      | `hcloud firewall create`                  | Create a firewall                                             |
+| hcfwd      | `hcloud firewall delete`                  | Delete a firewall                                             |
+| hcfwdesc   | `hcloud firewall describe`                | Describe a firewall                                           |
+| hcfwar     | `hcloud firewall add-rule`                | Add a rule to a firewall                                      |
+| hcfwdr     | `hcloud firewall delete-rule`             | Delete a rule from a firewall                                 |
+| hcfwas     | `hcloud firewall apply-to-resource`       | Apply a firewall to a resource                                |
+| hcfwrs     | `hcloud firewall remove-from-resource`    | Remove a firewall from a resource                             |
+|            |                                           | **Load Balancer Management**                                  |
+| hclb       | `hcloud load-balancer`                    | Manage load balancers                                         |
+| hclbl      | `hcloud load-balancer list`               | List all load balancers                                       |
+| hclbc      | `hcloud load-balancer create`             | Create a load balancer                                        |
+| hclbd      | `hcloud load-balancer delete`             | Delete a load balancer                                        |
+| hclbdesc   | `hcloud load-balancer describe`           | Describe a load balancer                                      |
+| hclbu      | `hcloud load-balancer update`             | Update a load balancer                                        |
+| hclbas     | `hcloud load-balancer add-service`        | Add a service to a load balancer                              |
+| hclbds     | `hcloud load-balancer delete-service`     | Delete a service from a load balancer                         |
+| hclbat     | `hcloud load-balancer add-target`         | Add a target to a load balancer                               |
+| hclbdt     | `hcloud load-balancer delete-target`      | Delete a target from a load balancer                          |
+|            |                                           | **Certificate Management**                                    |
+| hccert     | `hcloud certificate`                      | Manage certificates                                           |
+| hccertl    | `hcloud certificate list`                 | List all certificates                                         |
+| hccertc    | `hcloud certificate create`               | Create a certificate                                          |
+| hccertd    | `hcloud certificate delete`               | Delete a certificate                                          |
+| hccertdesc | `hcloud certificate describe`             | Describe a certificate                                        |
+| hccertu    | `hcloud certificate update`               | Update a certificate                                          |
+|            |                                           | **Datacenter and Location Info**                              |
+| hcdc       | `hcloud datacenter list`                  | List all datacenters                                          |
+| hcloc      | `hcloud location list`                    | List all locations                                            |
+| hcst       | `hcloud server-type list`                 | List all server types                                         |
+| hcit       | `hcloud image list --type system`         | List all system images                                        |
+
+## Requirements
+
+This plugin requires the [Hetzner Cloud CLI](https://github.com/hetznercloud/cli) to be installed.
+
+### Installation
+
+Install the Hetzner Cloud CLI using one of the following methods:
+
+**macOS (Homebrew):**
+```bash
+brew install hcloud
+```
+
+**Linux (from source):**
+```bash
+go install github.com/hetznercloud/cli/cmd/hcloud@latest
+```
+
+**Or download a prebuilt binary from the [releases page](https://github.com/hetznercloud/cli/releases).**
+
+### Setup
+
+After installation, create a context and authenticate:
+
+```bash
+hcloud context create my-project
+```
+
+You'll be prompted to enter your Hetzner Cloud API token, which you can generate in the [Hetzner Cloud Console](https://console.hetzner.cloud/).

--- a/plugins/hcloud/hcloud.plugin.zsh
+++ b/plugins/hcloud/hcloud.plugin.zsh
@@ -1,0 +1,129 @@
+# hcloud plugin for oh-my-zsh
+# Hetzner Cloud CLI: https://github.com/hetznercloud/cli
+
+if (( ! $+commands[hcloud] )); then
+  return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `hcloud`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_hcloud" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _hcloud
+  _comps[hcloud]=_hcloud
+fi
+
+hcloud completion zsh 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_hcloud" &|
+
+# Main alias
+alias hc='hcloud'
+
+# Context management
+alias hcctx='hcloud context'
+alias hcctxls='hcloud context list'
+alias hcctxu='hcloud context use'
+alias hcctxc='hcloud context create'
+alias hcctxd='hcloud context delete'
+alias hcctxa='hcloud context active'
+
+# Server management
+alias hcs='hcloud server'
+alias hcsl='hcloud server list'
+alias hcsc='hcloud server create'
+alias hcsd='hcloud server delete'
+alias hcsdesc='hcloud server describe'
+alias hcspoff='hcloud server poweroff'
+alias hcspon='hcloud server poweron'
+alias hcsr='hcloud server reboot'
+alias hcsreset='hcloud server reset'
+alias hcssh='hcloud server ssh'
+alias hcse='hcloud server enable-rescue'
+alias hcsdr='hcloud server disable-rescue'
+alias hcsip='hcloud server ip'
+
+# Server actions
+alias hcsa='hcloud server attach-iso'
+alias hcsda='hcloud server detach-iso'
+alias hcscip='hcloud server change-type'
+
+# Volume management
+alias hcv='hcloud volume'
+alias hcvl='hcloud volume list'
+alias hcvc='hcloud volume create'
+alias hcvd='hcloud volume delete'
+alias hcvdesc='hcloud volume describe'
+alias hcva='hcloud volume attach'
+alias hcvda='hcloud volume detach'
+alias hcvr='hcloud volume resize'
+
+# Network management
+alias hcn='hcloud network'
+alias hcnl='hcloud network list'
+alias hcnc='hcloud network create'
+alias hcnd='hcloud network delete'
+alias hcndesc='hcloud network describe'
+alias hcnas='hcloud network add-subnet'
+alias hcnds='hcloud network delete-subnet'
+alias hcnar='hcloud network add-route'
+alias hcndr='hcloud network delete-route'
+
+# Floating IP management
+alias hcfip='hcloud floating-ip'
+alias hcfipl='hcloud floating-ip list'
+alias hcfipc='hcloud floating-ip create'
+alias hcfipd='hcloud floating-ip delete'
+alias hcfipdesc='hcloud floating-ip describe'
+alias hcfipa='hcloud floating-ip assign'
+alias hcfipua='hcloud floating-ip unassign'
+
+# SSH key management
+alias hcsk='hcloud ssh-key'
+alias hcskl='hcloud ssh-key list'
+alias hcskc='hcloud ssh-key create'
+alias hcskd='hcloud ssh-key delete'
+alias hcskdesc='hcloud ssh-key describe'
+alias hcsku='hcloud ssh-key update'
+
+# Image management
+alias hci='hcloud image'
+alias hcil='hcloud image list'
+alias hcid='hcloud image delete'
+alias hcidesc='hcloud image describe'
+alias hciu='hcloud image update'
+
+# Firewall management
+alias hcfw='hcloud firewall'
+alias hcfwl='hcloud firewall list'
+alias hcfwc='hcloud firewall create'
+alias hcfwd='hcloud firewall delete'
+alias hcfwdesc='hcloud firewall describe'
+alias hcfwar='hcloud firewall add-rule'
+alias hcfwdr='hcloud firewall delete-rule'
+alias hcfwas='hcloud firewall apply-to-resource'
+alias hcfwrs='hcloud firewall remove-from-resource'
+
+# Load balancer management
+alias hclb='hcloud load-balancer'
+alias hclbl='hcloud load-balancer list'
+alias hclbc='hcloud load-balancer create'
+alias hclbd='hcloud load-balancer delete'
+alias hclbdesc='hcloud load-balancer describe'
+alias hclbu='hcloud load-balancer update'
+alias hclbas='hcloud load-balancer add-service'
+alias hclbds='hcloud load-balancer delete-service'
+alias hclbat='hcloud load-balancer add-target'
+alias hclbdt='hcloud load-balancer delete-target'
+
+# Certificate management
+alias hccert='hcloud certificate'
+alias hccertl='hcloud certificate list'
+alias hccertc='hcloud certificate create'
+alias hccertd='hcloud certificate delete'
+alias hccertdesc='hcloud certificate describe'
+alias hccertu='hcloud certificate update'
+
+# Datacenter and location info
+alias hcdc='hcloud datacenter list'
+alias hcloc='hcloud location list'
+alias hcst='hcloud server-type list'
+alias hcit='hcloud image list --type system'


### PR DESCRIPTION
## Summary

Add a new plugin for the Hetzner Cloud CLI (hcloud) with comprehensive alias support and auto-completion.

## Features

- **Auto-completion support**: Generates and caches hcloud completion for zsh
- **Comprehensive aliases**: Covers all major hcloud commands including:
  - Context management (hcctx, hcctxls, hcctxu, etc.)
  - Server management (hcs, hcsl, hcsc, hcsd, etc.)
  - Volume management (hcv, hcvl, hcvc, etc.)
  - Network management (hcn, hcnl, hcnc, etc.)
  - Floating IP management (hcfip, hcfipl, hcfipc, etc.)
  - SSH key management (hcsk, hcskl, hcskc, etc.)
  - Image management (hci, hcil, hcid, etc.)
  - Firewall management (hcfw, hcfwl, hcfwc, etc.)
  - Load balancer management (hclb, hclbl, hclbc, etc.)
  - Certificate management (hccert, hccertl, hccertc, etc.)
- **Complete documentation**: README with full alias reference and installation instructions

## Implementation Details

The plugin follows Oh My Zsh plugin best practices:
- Checks for hcloud CLI installation before loading
- Uses standard completion caching mechanism
- Returns early if hcloud is not installed
- Includes comprehensive README with usage examples

## Related Links

- Hetzner Cloud CLI: https://github.com/hetznercloud/cli
- Hetzner Cloud Console: https://console.hetzner.cloud/