### PR TITLE
fix(deno): switch to dynamic completions

### DIFF
--- a/plugins/deno/deno.plugin.zsh
+++ b/plugins/deno/deno.plugin.zsh
@@ -25,4 +25,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_deno" ]]; then
   _comps[deno]=_deno
 fi
 
-deno completions zsh >| "$ZSH_CACHE_DIR/completions/_deno" &|
+deno completions zsh --dynamic >| "$ZSH_CACHE_DIR/completions/_deno" &|


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- ? The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Switch from static completions file to dynamic completions for deno.

## Problem:

Completions for most common commands are broken in deno.

Current behavior (run example, but also for test, lint, compile etc.)

- `deno <tab>`: completes to commands and files
- `deno run <tab>`: completes to commands (incorrectly)
- `deno run [file] <tab>`: completes to files

Expected behavior

- `deno <tab>`: completes to commands and files
- `deno run <tab>`: completes to flags and files
- `deno run [file] <tab>`: completes to flags and files

This has been reported before in #10689, and closed because the culprit is in deno, which is correct. It is currently tracked in https://github.com/denoland/deno/issues/25710

I have found the culprit to be default command accepting a secret argument. This is `deno [file]` to run "file" directly. This argument is causing an off-by-one error inside the completions generated by the "clap" crate. The completions all apply to the previous word as a result, hence the current behavior above.

I have not found a culprit why flag completions do not work with static completions.

This is an attempt to workaround the bug in either deno or clap, in generating the correct static completions, that seem to reproduce only for zsh.

## Tested:

I have started using this just now, and it fixes the reported issues. I have not observed any negative behavior so far. It might be worthwhile to use this for a longer period of time, but given completions are largely broken today, I wanted to send the PR early.

## Trade-offs

This spawns deno at every `<tab>`. The performance overhead is not nil.
