### PR TITLE
fix(git): git_status_prompt respects spaces to properly match prefixes

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -117,7 +117,7 @@ function _omz_git_prompt_status() {
   fi
 
   # For each status prefix, do a regex comparison
-  for status_prefix in ${(k)prefix_constant_map}; do
+  for status_prefix in "${(@k)prefix_constant_map}"; do
     local status_constant="${prefix_constant_map[$status_prefix]}"
     local status_regex=$'(^|\n)'"$status_prefix"
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

`git_status_prompt` was always empty as whitespace around the keys for `$prefix_constant_map` were trimmed. The in list of the for loop must be enclosed in `"` to avoid trimming, which in return requires the iterator specifier to contain an `@` to avoid concatenation of all keys. This is important for the regex to work properly.

## Other comments:

fixes #10909
