### PR TITLE
fix(git): Revert deprecation notice for gg* aliases

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -239,9 +239,6 @@ receive further support.
 | `gap`    | `git add --patch`                                         | New alias: `gapa`                                     |
 | `gcl`    | `git config --list`                                       | New alias: `gcf`                                      |
 | `gdt`    | `git difftool`                                            | No replacement                                        |
-| `ggpull` | `git pull origin $(git_current_branch)`                   | New function: `ggl` (`ggpull` is now aliased to this) |
-| `ggpur`  | `git pull --rebase origin $(git_current_branch)`          | New function: `ggu` (`ggpur` is now aliased to this)  |
-| `ggpush` | `git push origin $(git_current_branch)`                   | New function: `ggp` (`ggpush` is now aliased to this) |
 
 ## Functions
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -102,6 +102,7 @@ function ggpnp() {
 }
 compdef _git ggpnp=git-checkout
 
+alias ggpur='ggu'
 alias g='git'
 alias ga='git add'
 alias gaa='git add --all'
@@ -281,6 +282,7 @@ alias gprom='git pull --rebase origin $(git_main_branch)'
 alias gpromi='git pull --rebase=interactive origin $(git_main_branch)'
 alias gprum='git pull --rebase upstream $(git_main_branch)'
 alias gprumi='git pull --rebase=interactive upstream $(git_main_branch)'
+alias ggpull='git pull origin "$(git_current_branch)"'
 
 function ggl() {
   if [[ $# != 0 ]] && [[ $# != 1 ]]; then
@@ -324,6 +326,7 @@ is-at-least 2.30 "$git_version" \
 alias gpv='git push --verbose'
 alias gpoat='git push origin --all && git push origin --tags'
 alias gpod='git push origin --delete'
+alias ggpush='git push origin "$(git_current_branch)"'
 
 function ggp() {
   if [[ $# != 0 ]] && [[ $# != 1 ]]; then
@@ -420,9 +423,6 @@ unset git_version
 local old_name new_name
 for old_name new_name (
   current_branch  git_current_branch
-  ggpull          ggl
-  ggpur           ggu
-  ggpush          ggp
 ); do
   aliases[$old_name]="
     print -Pu2 \"%F{yellow}[oh-my-zsh] '%F{red}${old_name}%F{yellow}' is deprecated, using '%F{green}${new_name}%F{yellow}' instead.%f\"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Revert deprecation notice for `gg*` aliases

## Other comments:

Should I do `alias ggpush='ggp'` or are they incompatible?
