### PR TITLE
refactor(mise)!: Remove rtx support and hook-env

### DIFF
--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -1,27 +1,17 @@
-# TODO: 2024-01-03 remove rtx support
-local __mise=mise
 if (( ! $+commands[mise] )); then
-  if (( $+commands[rtx] )); then
-    __mise=rtx
-  else
-    return
-  fi
+  return
 fi
 
 # Load mise hooks
-eval "$($__mise activate zsh)"
-
-# Hook mise into current environment
-eval "$($__mise hook-env -s zsh)"
+eval "$(mise activate zsh)"
 
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `mise`. Otherwise, compinit will have already done that.
-if [[ ! -f "$ZSH_CACHE_DIR/completions/_$__mise" ]]; then
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_mise" ]]; then
   typeset -g -A _comps
-  autoload -Uz _$__mise
-  _comps[$__mise]=_$__mise
+  autoload -Uz _mise
+  _comps[mise]=_mise
 fi
 
 # Generate and load mise completion
-$__mise completion zsh >| "$ZSH_CACHE_DIR/completions/_$__mise" &|
-unset __mise
+mise completion zsh >| "$ZSH_CACHE_DIR/completions/_mise" &|


### PR DESCRIPTION
BREAKING CHANGE: `rtx` support has been removed. Please visit https://mise.jdx.dev/rtx.html for migration instructions.

`mise activate` already calls `hook-env` (unless `--no-hook-env` is given).

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open. (Partially replicates an early (but closed) effort: https://github.com/ohmyzsh/ohmyzsh/pull/12225)
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [N/A] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- mise: remove `rtx` support
- mise: remove the `hook-env` call (which is already part of `activate`)
