### PR TITLE
fix(1password)!: remove v1 support

### DIFF
--- a/plugins/1password/_opswd
+++ b/plugins/1password/_opswd
@@ -6,14 +6,4 @@ function _opswd() {
   [[ -z "$services" ]] || compadd -a -- services
 }
 
-# TODO: 2022-03-26: Remove support for op CLI 1
-autoload -Uz is-at-least
-is-at-least 2.0.0 $(op --version) || {
-  function _opswd() {
-    local -a services
-    services=("${(@f)$(op list items --categories Login 2>/dev/null | op get item - --fields title 2>/dev/null)}")
-    [[ -z "$services" ]] || compadd -a -- services
-  }
-}
-
 _opswd "$@"

--- a/plugins/1password/opswd
+++ b/plugins/1password/opswd
@@ -46,45 +46,4 @@ function opswd() {
   (sleep 20 && clipcopy </dev/null 2>/dev/null) &!
 }
 
-# TODO: 2022-03-26: Remove support for op CLI 1
-autoload -Uz is-at-least
-is-at-least 2.0.0 $(op --version) || {
-  print -ru2 ${(%):-"%F{yellow}opswd: usage with op version $(op --version) is deprecated. Upgrade to CLI 2 and reload zsh.
-For instructions, see https://developer.1password.com/docs/cli/upgrade.%f"}
-
-  # opswd puts the password of the named service into the clipboard. If there's a
-  # one time password, it will be copied into the clipboard after 10 seconds. The
-  # clipboard is cleared after another 20 seconds.
-  function opswd() {
-    if [[ $# -lt 1 ]]; then
-      echo "Usage: opswd <service>"
-      return 1
-    fi
-
-    local service=$1
-
-    # If not logged in, print error and return
-    op list users > /dev/null || return
-
-    local password
-    # Copy the password to the clipboard
-    if ! password=$(op get item "$service" --fields password 2>/dev/null); then
-      echo "error: could not obtain password for $service"
-      return 1
-    fi
-
-    echo -n "$password" | clipcopy
-    echo "✔ password for $service copied to clipboard"
-
-    # If there's a one time password, copy it to the clipboard after 5 seconds
-    local totp
-    if totp=$(op get totp "$service" 2>/dev/null) && [[ -n "$totp" ]]; then
-      sleep 10 && echo -n "$totp" | clipcopy
-      echo "✔ TOTP for $service copied to clipboard"
-    fi
-
-    (sleep 20 && clipcopy </dev/null 2>/dev/null) &!
-  }
-}
-
 opswd "$@"


### PR DESCRIPTION
BREAKING CHANGE: `op` v1 support has been removed. Please migrate to v2 if you are affected by this change.