### PR TITLE
feat(jj): add `jja` alias for `jj abandon`

### DIFF
--- a/plugins/jj/README.md
+++ b/plugins/jj/README.md
@@ -12,6 +12,7 @@ plugins=(... jj)
 
 | Alias  | Command                       |
 | ------ | ----------------------------- |
+| jja    | `jj abandon`                  |
 | jjb    | `jj bookmark`                 |
 | jjbc   | `jj bookmark create`          |
 | jjbd   | `jj bookmark delete`          |

--- a/plugins/jj/jj.plugin.zsh
+++ b/plugins/jj/jj.plugin.zsh
@@ -34,6 +34,7 @@ function jj_prompt_template() {
 }
 
 # Aliases (sorted alphabetically)
+alias jja='jj abandon'
 alias jjb='jj bookmark'
 alias jjbc='jj bookmark create'
 alias jjbd='jj bookmark delete'


### PR DESCRIPTION
Fixes #13508

  ## Standards checklist:

  - [x] The PR title is descriptive.
  - [x] The PR doesn't replicate another PR which is already open.
  - [x] I have read the contribution guide and followed all the instructions.
  - [x] The code follows the code style guide detailed in the wiki.
  - [x] The code is mine or it's from somewhere with an MIT-compatible license.
  - [x] The code is efficient, to the best of my ability, and does not waste computer resources.
  - [x] The code is stable and I have tested it myself, to the best of my abilities.
  - [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

  ## Changes:

  - Added `jja` alias for `jj abandon` in `plugins/jj/jj.plugin.zsh`
  - Updated `plugins/jj/README.md` to document the new alias

  ## Other comments:

  The `jj abandon` command is frequently used when working with Jujutsu repositories to discard unwanted revisions. The `jja` alias follows the existing naming pattern in the plugin (e.g., `jjc` for `jj commit`, `jjd` for `jj diff`).
  
  ---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=132382032