### PR TITLE
feat(docker): Add 'dxgcit', grepping version of 'dxcit'

### DIFF
--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -77,10 +77,16 @@ If you use Podman's Docker wrapper, you need to enable legacy completion. See ab
 | drs     | `docker container restart`    | Restart one or more containers                                                           |
 | dsta    | `docker stop $(docker ps -q)` | Stop all running containers                                                              |
 | dstp    | `docker container stop`       | Stop one or more running containers                                                      |
-| dsts    | `docker stats`                | Display real-time streaming statistics for containers                                                    |
+| dsts    | `docker stats`                | Display real-time streaming statistics for containers                                    |
 | dtop    | `docker top`                  | Display the running processes of a container                                             |
 | dvi     | `docker volume inspect`       | Display detailed information about one or more volumes                                   |
 | dvls    | `docker volume ls`            | List all the volumes known to docker                                                     |
 | dvprune | `docker volume prune`         | Cleanup dangling volumes                                                                 |
 | dxc     | `docker container exec`       | Run a new command in a running container                                                 |
 | dxcit   | `docker container exec -it`   | Run a new command in a running container in an interactive shell                         |
+
+## Functions
+
+| Command                     | Description                                                                                           |
+| :-------------------------- | :---------------------------------------------------------------------------------------------------- |
+| `dxgcit <pattern> <cmd...>` | Run a new command in a running container selected via pattern matching on the image or container name |


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added the `dxgcit` alias, which is `dxcit` but with a `grep` for the name of the container or image instead of requiring the full name correctly.

## Other comments:

The idea is that I often find myself needing to execute side commands / shells in an existing Docker container that was spawned ephemerally (with a random-generated name, even running with `docker run --rm`…). Having to do `dps` and copy-paste the image name is repetitive and clunky (and does not work well with history).

In order to be able to use just one command without needing mouse or complex pipelines, I added `dxgcit <pattern> <command...>`, which is essentially a safe equivalent to `dxcit "$(dps | grep <pattern> | cut -d ' ' -f 1)" <command...>`.

This way, e.g., if I know that my current work container is spawned from image `work-A` (as it usually happens), I can reuse `dxgcit work-A bash` from the shell history.