### PR TITLE
feat(macos): add low power mode management functions

### DIFF
--- a/plugins/macos/README.md
+++ b/plugins/macos/README.md
@@ -9,6 +9,7 @@ plugins=(... macos)
 ```
 
 ## Supported Terminals
+
 - [iTerm](https://iterm.sourceforge.net/)
 - [iTerm2](https://iterm2.com/)
 - [Hyper](https://hyper.is/)
@@ -17,28 +18,33 @@ plugins=(... macos)
 
 ## Commands
 
-| Command       | Description                                              |
-| :------------ | :------------------------------------------------------- |
-| `tab`         | Open the current directory in a new tab                  |
-| `split_tab`   | Split the current terminal tab horizontally              |
-| `vsplit_tab`  | Split the current terminal tab vertically                |
-| `ofd`         | Open passed directories (or $PWD by default) in Finder   |
-| `pfd`         | Return the path of the frontmost Finder window           |
-| `pfs`         | Return the current Finder selection                      |
-| `cdf`         | `cd` to the current Finder directory                     |
-| `pushdf`      | `pushd` to the current Finder directory                  |
-| `pxd`         | Return the current Xcode project directory               |
-| `cdx`         | `cd` to the current Xcode project directory              |
-| `quick-look`  | Quick-Look a specified file                              |
-| `man-preview` | Open man pages in Preview app                            |
-| `showfiles`   | Show hidden files in Finder                              |
-| `hidefiles`   | Hide the hidden files in Finder                          |
-| `itunes`      | _DEPRECATED_. Use `music` from macOS Catalina on         |
-| `music`       | Control Apple Music. Use `music -h` for usage details    |
-| `spotify`     | Control Spotify and search by artist, album, track…      |
-| `rmdsstore`   | Remove .DS_Store files recursively in a directory        |
-| `btrestart`   | Restart the Bluetooth daemon                             |
-| `freespace`   | Erases purgeable disk space with 0s on the selected disk |
+| Command       | Description                                                    |
+| :------------ | :------------------------------------------------------------- |
+| `tab`         | Open the current directory in a new tab                        |
+| `split_tab`   | Split the current terminal tab horizontally                    |
+| `vsplit_tab`  | Split the current terminal tab vertically                      |
+| `ofd`         | Open passed directories (or $PWD by default) in Finder         |
+| `pfd`         | Return the path of the frontmost Finder window                 |
+| `pfs`         | Return the current Finder selection                            |
+| `cdf`         | `cd` to the current Finder directory                           |
+| `pushdf`      | `pushd` to the current Finder directory                        |
+| `pxd`         | Return the current Xcode project directory                     |
+| `cdx`         | `cd` to the current Xcode project directory                    |
+| `quick-look`  | Quick-Look a specified file                                    |
+| `man-preview` | Open man pages in Preview app                                  |
+| `showfiles`   | Show hidden files in Finder                                    |
+| `hidefiles`   | Hide the hidden files in Finder                                |
+| `itunes`      | _DEPRECATED_. Use `music` from macOS Catalina on               |
+| `music`       | Control Apple Music. Use `music -h` for usage details          |
+| `spotify`     | Control Spotify and search by artist, album, track…            |
+| `lpm`         | Toggle Low Power Mode. Use `lpm on\|off\|status` (macOS 12.0+) |
+| `lpm-on`      | Enable Low Power Mode (macOS 12.0+)                            |
+| `lpm-off`     | Disable Low Power Mode (macOS 12.0+)                           |
+| `lpm-status`  | Check the current Low Power Mode status (macOS 12.0+)          |
+| `lpm-toggle`  | Toggle the current Low Power Mode status (macOS 12.0+)         |
+| `rmdsstore`   | Remove .DS_Store files recursively in a directory              |
+| `btrestart`   | Restart the Bluetooth daemon                                   |
+| `freespace`   | Erases purgeable disk space with 0s on the selected disk       |
 
 ## Acknowledgements
 

--- a/plugins/macos/lpm
+++ b/plugins/macos/lpm
@@ -1,0 +1,68 @@
+function lpm() {
+  local sw_vers=$(sw_vers -productVersion 2>/dev/null)
+
+  autoload is-at-least
+  if [[ -z "$sw_vers" ]] || ! is-at-least 12.0 $sw_vers; then
+    echo "Error: Low Power Mode requires macOS 12.0 (Monterey) or later" >&2
+    echo "Current version: ${sw_vers:-unknown}" >&2
+    return 1
+  fi
+
+  local action="${1:-}"
+
+  # Helper function to get current status (returns 0, 1, or empty string)
+  local get_status() {
+    pmset -g | grep lowpowermode | awk '{print $2}'
+  }
+
+  case "${action}" in
+    on)
+      sudo pmset -a lowpowermode 1
+      ;;
+    off)
+      sudo pmset -a lowpowermode 0
+      ;;
+    status)
+      local lpm_status=$(get_status)
+      if [[ "$lpm_status" == "1" ]]; then
+        echo "enabled"
+      elif [[ "$lpm_status" == "0" ]]; then
+        echo "disabled"
+      else
+        echo "unknown" >&2
+        return 3
+      fi
+      ;;
+    toggle)
+      local lpm_status=$(get_status)
+      if [[ "$lpm_status" == "1" ]]; then
+        sudo pmset -a lowpowermode 0
+      elif [[ "$lpm_status" == "0" ]]; then
+        sudo pmset -a lowpowermode 1
+      else
+        echo "Unable to determine current status to toggle" >&2
+        return 3
+      fi
+      ;;
+    *)
+      echo "usage: lpm on|off|status|toggle" >&2
+      return 2
+      ;;
+  esac
+}
+
+function lpm-off() {
+  lpm off
+}
+
+function lpm-on() {
+  lpm on
+}
+
+function lpm-status() {
+  lpm status
+}
+
+function lpm-toggle() {
+  lpm toggle
+}

--- a/plugins/macos/macos.plugin.zsh
+++ b/plugins/macos/macos.plugin.zsh
@@ -314,3 +314,6 @@ source "${0:h:A}/music"
 
 # Spotify control function
 source "${0:h:A}/spotify"
+
+# low power mode toggle-switch function
+source "${0:h:A}/lpm"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added the following commands:

| Command       | Description                                                    |
| :------------ | :------------------------------------------------------------- |
| `lpm`         | Toggle Low Power Mode. Use `lpm on\|off\|status` (macOS 12.0+) |
| `lpm-on`      | Enable Low Power Mode (macOS 12.0+)                            |
| `lpm-off`     | Disable Low Power Mode (macOS 12.0+)                           |
| `lpm-status`  | Check the current Low Power Mode status (macOS 12.0+)          |
| `lpm-toggle`  | Toggle the current Low Power Mode status (macOS 12.0+)         |
## Other comments:

Followed code style as specified in `.editorconfig`.
The code does not introduce new aliases, but it does introduce a 3 letter command, `lpm` (acronym for `low power mode`). Let me know if we should expand it to something longer. 
