### PR TITLE
feat(python): add recursive parent directory search for auto_vrun

### DIFF
--- a/plugins/python/README.md
+++ b/plugins/python/README.md
@@ -34,6 +34,7 @@ virtual environments:
   `<venv-name>/bin/activate`, and automatically deactivate it when navigating out of it (keeps venv activated
   in subdirectories).
   - To enable the feature, set `PYTHON_AUTO_VRUN=true` before sourcing oh-my-zsh.
+  - To also search parent directories (useful for monorepos), set `PYTHON_AUTO_VRUN_RECURSIVE=true` as well.
   - The plugin activates the first existing virtual environment, in order, appearing in `$PYTHON_VENV_NAMES`.
     The default virtual environment name is `venv`. To use a different name, set
     `PYTHON_VENV_NAME=<venv-name>`. For example: `PYTHON_VENV_NAME=".venv"`

--- a/plugins/python/python.plugin.zsh
+++ b/plugins/python/python.plugin.zsh
@@ -113,8 +113,21 @@ if [[ "$PYTHON_AUTO_VRUN" == "true" ]]; then
         # make sure we're not in a venv already
         (( $+functions[deactivate] )) && deactivate > /dev/null 2>&1
         source $file > /dev/null 2>&1
-        break
+        return
       done
+
+      # Search parent directories if recursive mode is enabled
+      if [[ "$PYTHON_AUTO_VRUN_RECURSIVE" == "true" ]]; then
+        local search_dir="$PWD:h"
+        while [[ "$search_dir" != "/" && "$search_dir" != "." ]]; do
+          for file in "${search_dir}/"${^PYTHON_VENV_NAMES[@]}"/bin/activate"(N.); do
+            (( $+functions[deactivate] )) && deactivate > /dev/null 2>&1
+            source $file > /dev/null 2>&1
+            return
+          done
+          search_dir="${search_dir:h}"
+        done
+      fi
     fi
   }
   add-zsh-hook chpwd auto_vrun


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `PYTHON_AUTO_VRUN_RECURSIVE` option to search parent directories for virtual environments
- Update README.md with documentation for the new option

## Other comments:

### Motivation

In **monorepo** setups, the virtual environment is typically placed at the repository root (e.g., `/project/.venv`), while developers often work in subdirectories (e.g., `/project/packages/foo`). Currently, `auto_vrun` only searches the current directory for venv, which means it won't activate when entering subdirectories.

This change adds an optional `PYTHON_AUTO_VRUN_RECURSIVE=true` setting that searches parent directories for virtual environments.

### Backward Compatibility

This change is **fully backward compatible**:
- The new behavior is **opt-in** and requires explicitly setting `PYTHON_AUTO_VRUN_RECURSIVE=true`
- Existing users with only `PYTHON_AUTO_VRUN=true` will see no change in behavior

### Usage

```zsh
PYTHON_AUTO_VRUN=true
PYTHON_AUTO_VRUN_RECURSIVE=true  # optional: also search parent directories
```

### Feedback Welcome

I'm very open to suggestions for improvements. If there's a better approach or naming convention, I'm happy to make changes.