### PR TITLE
Add prek support to pre-commit plugin

### DIFF
--- a/plugins/pre-commit/README.md
+++ b/plugins/pre-commit/README.md
@@ -1,6 +1,8 @@
 # Pre-commit plugin
 
 This plugin adds aliases for common commands of [pre-commit](https://pre-commit.com/).
+It also supports [prek](https://github.com/prek/prek) as a drop-in replacement.
+If `prek` is available, it will be used; otherwise, `pre-commit` is used as fallback.
 
 To use this plugin, add it to the plugins array in your zshrc file:
 
@@ -10,10 +12,11 @@ plugins=(... pre-commit)
 
 ## Aliases
 
-| Alias   | Command                                | Description                                            |
-| ------- | -------------------------------------- | ------------------------------------------------------ |
-| prc     | `pre-commit`                           | The `pre-commit` command                               |
-| prcau   | `pre-commit autoupdate`                | Update hooks automatically                             |
-| prcr    | `pre-commit run`                       | The `pre-commit run` command                           |
-| prcra   | `pre-commit run --all-files`           | Run pre-commit hooks on all files                      |
-| prcrf   | `pre-commit run --files`               | Run pre-commit hooks on a given list of files          |
+| Alias | Command                                                | Description                                   |
+| ----- | ------------------------------------------------------ | --------------------------------------------- |
+| prc   | `prek` or `pre-commit`                                 | The pre-commit command                        |
+| prcau | `prek auto-update` or `pre-commit autoupdate`          | Update hooks automatically                    |
+| prcr  | `prek run` or `pre-commit run`                         | The pre-commit run command                    |
+| prcra | `prek run --all-files` or `pre-commit run --all-files` | Run pre-commit hooks on all files             |
+| prcrf | `prek run --files` or `pre-commit run --files`         | Run pre-commit hooks on a given list of files |
+

--- a/plugins/pre-commit/pre-commit.plugin.zsh
+++ b/plugins/pre-commit/pre-commit.plugin.zsh
@@ -1,8 +1,17 @@
-# Aliases for pre-commit
-alias prc='pre-commit'
+# Aliases for pre-commit (uses prek if available, else pre-commit)
+if command -v prek &> /dev/null; then
+    _prc_cmd='prek'
+    _prc_autoupdate='auto-update'
+else
+    _prc_cmd='pre-commit'
+    _prc_autoupdate='autoupdate'
+fi
 
-alias prcau='pre-commit autoupdate'
+alias prc="$_prc_cmd"
 
-alias prcr='pre-commit run'
-alias prcra='pre-commit run --all-files'
-alias prcrf='pre-commit run --files'
+alias prcau="$_prc_cmd $_prc_autoupdate"
+
+alias prcr="$_prc_cmd run"
+alias prcra="$_prc_cmd run --all-files"
+alias prcrf="$_prc_cmd run --files"
+


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open. (see comment below)
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

https://prek.j178.dev/ is a reimagined version of pre-commit, built in Rust. It is designed to be a faster, dependency-free and drop-in alternative for it, while also providing some additional long-requested features.

As I don't want to remember which tool is actually installed and add a new plugin for a drop in replacement, instead I extend the existing aliases to do this. It first detects if prek (the faster tool) is available and falls back to pre-commit if not.

This is an alternative to https://github.com/ohmyzsh/ohmyzsh/pull/13432 adding a new plugin.

## Other comments:

...
