### PR TITLE
feat(hcloud): add hcloud_prompt_info function

### DIFF
--- a/plugins/hcloud/README.md
+++ b/plugins/hcloud/README.md
@@ -112,6 +112,37 @@ plugins=(... hcloud)
 | hcst       | `hcloud server-type list`                 | List all server types                                         |
 | hcit       | `hcloud image list --type system`         | List all system images                                        |
 
+## Prompt function
+
+This plugin provides `hcloud_prompt_info` which can be added to your prompt to display the current Hetzner Cloud context.
+
+- If `HCLOUD_TOKEN` environment variable is set, it displays `HCLOUD_TOKEN` (indicating direct token usage)
+- Otherwise, it displays the active context name
+
+### Usage
+
+Add `$(hcloud_prompt_info)` to your `PROMPT` or `RPROMPT` in your `.zshrc`:
+
+```zsh
+RPROMPT='$(hcloud_prompt_info)'
+```
+
+### Theme variables
+
+| Variable                       | Default         | Description                                      |
+| :----------------------------- | :-------------- | :----------------------------------------------- |
+| `ZSH_THEME_HCLOUD_PREFIX`      | `<hcloud:`      | Prefix before the context name                   |
+| `ZSH_THEME_HCLOUD_SUFFIX`      | `>`             | Suffix after the context name                    |
+| `ZSH_THEME_HCLOUD_TOKEN_TEXT`  | `HCLOUD_TOKEN`  | Text shown when `HCLOUD_TOKEN` env var is set    |
+
+### Example with custom styling
+
+```zsh
+ZSH_THEME_HCLOUD_PREFIX="%{$fg[blue]%}hcloud:("
+ZSH_THEME_HCLOUD_SUFFIX=")%{$reset_color%}"
+RPROMPT='$(hcloud_prompt_info)'
+```
+
 ## Requirements
 
 This plugin requires the [Hetzner Cloud CLI](https://github.com/hetznercloud/cli) to be installed.

--- a/plugins/hcloud/hcloud.plugin.zsh
+++ b/plugins/hcloud/hcloud.plugin.zsh
@@ -127,3 +127,20 @@ alias hcdc='hcloud datacenter list'
 alias hcloc='hcloud location list'
 alias hcst='hcloud server-type list'
 alias hcit='hcloud image list --type system'
+
+# Prompt function to display current hcloud context
+# Usage: add $(hcloud_prompt_info) to your PROMPT or RPROMPT
+function hcloud_prompt_info() {
+  # Check if HCLOUD_TOKEN is set (overrides context)
+  if [[ -n "$HCLOUD_TOKEN" ]]; then
+    echo "${ZSH_THEME_HCLOUD_PREFIX=<hcloud:}${ZSH_THEME_HCLOUD_TOKEN_TEXT=HCLOUD_TOKEN}${ZSH_THEME_HCLOUD_SUFFIX=>}"
+    return
+  fi
+
+  # Get active context
+  local context
+  context=$(hcloud context active 2>/dev/null)
+  [[ -n "$context" ]] || return
+
+  echo "${ZSH_THEME_HCLOUD_PREFIX=<hcloud:}${context}${ZSH_THEME_HCLOUD_SUFFIX=>}"
+}


### PR DESCRIPTION
## Summary

Add a `hcloud_prompt_info` function to display the current Hetzner Cloud context in the shell prompt.

- Shows `HCLOUD_TOKEN` when the environment variable is set (indicating direct token usage)
- Shows the active context name otherwise
- Supports customization via `ZSH_THEME_HCLOUD_*` variables

This follows the pattern used by other plugins like `aws` and `kubectx`.

Suggested by @jooola in #13473.