### PR TITLE
Update functions.zsh

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -9,7 +9,7 @@ function uninstall_oh_my_zsh() {
 }
 
 function upgrade_oh_my_zsh() {
-  echo >&2 "${fg[yellow]}Note: \`$0\` is deprecated. Use \`omz update\` instead.$reset_color"
+  echo >&2 "${fg[yellow]}Note: \`$0\` is deprecated. Using \`omz update\` instead.$reset_color"
   omz update
 }
 


### PR DESCRIPTION
Explicitly state wrapper function is redirecting to 'omz update' and not running any deprecated code.