### PR TITLE
Perf/aws faster profile loading

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -42,7 +42,7 @@ function asp() {
   export AWS_PROFILE=$1
   export AWS_EB_PROFILE=$1
 
-  export AWS_PROFILE_REGION=$(aws configure get region)
+  export AWS_PROFILE_REGION=$(_aws_get_profile_region "$1")
 
   _aws_update_state
 
@@ -264,6 +264,34 @@ function aws_profiles() {
   else
     aws --no-cli-pager configure list-profiles 2>/dev/null
   fi
+}
+
+# Fast region lookup by parsing config file directly, with fallback to AWS CLI
+function _aws_get_profile_region() {
+  local profile="${1:-$AWS_PROFILE}"
+  local config_file="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+  local region=""
+
+  # Try fast config file parsing first
+  if [[ -r "$config_file" ]]; then
+    region=$(awk -v profile="$profile" '
+      /^\[/ {
+        in_profile = 0
+        s = $0; sub(/^\[[ ]*/, "", s); sub(/[ ]*\].*/, "", s)
+        if (profile == "default" ? (s == "default" || s == "profile default") \
+            : sub(/^profile[ ]+/, "", s) && s == profile)
+          in_profile = 1
+      }
+      in_profile && /^[ ]*region[ ]*=/ { sub(/^[ ]*region[ ]*=[ ]*/, ""); sub(/[ ]*$/, ""); print; exit }
+    ' "$config_file")
+  fi
+
+  # Fallback to AWS CLI if fast method didn't find region
+  if [[ -z "$region" ]]; then
+    region=$(aws configure get region --profile "$profile" 2>/dev/null)
+  fi
+
+  echo "$region"
 }
 
 function _aws_regions() {

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -239,9 +239,31 @@ function aws_regions() {
 }
 
 function aws_profiles() {
-  aws --no-cli-pager configure list-profiles 2> /dev/null && return
-  [[ -r "${AWS_CONFIG_FILE:-$HOME/.aws/config}" ]] || return 1
-  grep --color=never -Eo '\[.*\]' "${AWS_CONFIG_FILE:-$HOME/.aws/config}" | sed -E 's/^[[:space:]]*\[(profile)?[[:space:]]*([^[:space:]]+)\][[:space:]]*$/\2/g'
+  local config_file="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+  local credentials_file="${AWS_SHARED_CREDENTIALS_FILE:-$HOME/.aws/credentials}"
+  local profiles=()
+
+  # Parse config file: only match [default] and [profile ...] sections,
+  # skipping [sso-session ...], [services ...], and other non-profile sections
+  if [[ -r "$config_file" ]]; then
+    profiles+=($(grep --color=never -E '^\[[ ]*(default|profile[ ]+)' "$config_file" \
+      | sed -nE 's/^\[[ ]*(profile[ ]+)?([^]]+[^ ])[ ]*\]$/\2/p'))
+  fi
+
+  # Parse credentials file (profiles have [name] format, no "profile" prefix)
+  if [[ -r "$credentials_file" ]]; then
+    profiles+=($(grep --color=never -Eo '\[.*\]' "$credentials_file" \
+      | sed -nE 's/^[[:space:]]*\[([^[:space:]]+)[[:space:]]*\]$/\1/p'))
+  fi
+
+  # Return unique profiles, or fall back to AWS CLI.
+  # Note: profiles only visible via AWS CLI (e.g. config plugins, SSO) will
+  # be missed when config files have entries. Intentional for performance.
+  if [[ ${#profiles[@]} -gt 0 ]]; then
+    printf '%s\n' "${profiles[@]}" | sort -u
+  else
+    aws --no-cli-pager configure list-profiles 2>/dev/null
+  fi
 }
 
 function _aws_regions() {


### PR DESCRIPTION
  ## Standards checklist:

  - [x] The PR title is descriptive.
  - [x] The PR doesn't replicate another PR which is already open.
  - [x] I have read the contribution guide and followed all the instructions.
  - [x] The code follows the code style guide detailed in the wiki.
  - [x] The code is mine or it's from somewhere with an MIT-compatible license.
  - [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
  - [x] The code is efficient, to the best of my ability, and does not waste computer resources.
  - [x] The code is stable and I have tested it myself, to the best of my abilities.
  - [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

  ## Changes:

  - Speed up `aws_profiles` by parsing `~/.aws/config` and `~/.aws/credentials` directly instead of invoking `aws configure list-profiles`, which has significant Python startup overhead

```
before:
( repeat 10; do; aws --no-cli-pager configure list-profiles > /dev/null 2>&1;   3.38s user 1.47s system 48% cpu 9.976 total

after:
( repeat 10; do; aws_profiles > /dev/null; done; )  0.03s user 0.08s system 54% cpu 0.199 total
```

  - Add `_aws_get_profile_region` helper to speed up region lookup in `asp` by parsing the config file directly instead of invoking `aws configure get region`

```
before:
( repeat 10; do; aws configure get region --profile MY_PROFILE > /dev/null; done; )  3.93s user 1.75s system 44% cpu 12.654 total

after:
( repeat 10; do; awk -v profile="MY_PROFILE"  ~/.aws/config > /dev/null; done; )  0.01s user 0.03s system 29% cpu 0.125 total
```

  - Both changes fall back to AWS CLI if the fast method fails, ensuring reliability

  ## Other comments:

  **AI Disclosure:** I used Claude Code to assist with this contribution. The problem (slow `asp` command due to AWS CLI startup overhead) was identified by me, and I worked with Claude to develop and refine the solution. I understand how the code works:

  - `aws_profiles` now uses grep/sed to parse section headers from both config files, filters out `sso-session` entries, deduplicates with `sort -u`, and falls back to AWS CLI if no profiles are found
  - `_aws_get_profile_region` uses awk to find the matching profile section and extract the region value, falling back to AWS CLI if not found

  I have tested both changes locally and verified the output matches `aws configure list-profiles` and `aws configure get region`.