### PR TITLE
feat(git): add alias for deleting all local branches that do not have a remote branch

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -129,6 +129,7 @@ alias gb='git branch'
 alias gba='git branch --all'
 alias gbd='git branch --delete'
 alias gbD='git branch --delete --force'
+alias gbDnr="gbD \$(diff -B <(gb | sed 's,[[:space:]\*]*,,' | sort) <(gbr | sed 's,[[:space:]\*]*origin/,,' | sort) | sed -n 's/^< //p') 2> /dev/null || echo 'No branches found!!!'" # git branch force-delete no remote
 
 function gbda() {
   git branch --no-color --merged | command grep -vE "^([+*]|\s*($(git_main_branch)|$(git_develop_branch))\s*$)" | command xargs git branch --delete 2>/dev/null


### PR DESCRIPTION
Most often I squash merge my branches into main and then delete the remote on Github. However, this leaves the local branch in my development machine. This command will delete all branches that don't have a matching remote.

I realize this is very destructive and someone could delete a branch they are working on - because it does not have a remote. I would hope that they are experienced enough to not use this command if it doesn't meet their use case.

Only use this if you want to clean up your local branches after all the remotes have been deleted. 

PS: use `gpa` to refresh the remote tracking branches.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add alias for deleting all local branches that do not have a remote branch

## Other comments:

1. squash merge multiple/many PRs
2. delete their associated remote branches on Github by clicking the `Delete Branch` button
3. run `gfa` - this will delete all remote tracking branches that don't have a remote
4. However, my local development branches still exist on my computer. I need a way to clean these up.
    * The alias computes a diff of two lists, a sorted list of local branches and a sorted list of remote branches on the computer
    * Every item in the diff that is from the sorted list of local branches does not have a corresponding remote branch, and can be deleted
    * it uses `gbD` to force-delete the local branch