### PR TITLE
fix(tmux): better `tmux` detection

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -1,4 +1,4 @@
-if ! (( $+commands[tmux] )); then
+if ! command -v tmux >/dev/null; then
   print "zsh tmux plugin: tmux not found. Please install tmux before using this plugin." >&2
   return 1
 fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

I have tmux installed by brew on linux and this plugin can't detect it. 

```
# aensidhe @ thinkpad in ~ [11:16:31] C:1
$ $+commands[tmux]
zsh: command not found: 1

# aensidhe @ thinkpad in ~ [11:18:43] C:127
$ which tmux
/home/linuxbrew/.linuxbrew/bin/tmux
```
