### PR TITLE
feat(opencode): add completion and alias plugin for opencode

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -1,0 +1,25 @@
+# opencode plugin
+
+This plugin adds several aliases and shell completion for the [`opencode`](https://opencode.ai) command line tool from Anomaly Innovations.
+
+To use it, add `opencode` to the plugins array of your `.zshrc` file:
+
+```zsh
+plugins=(... opencode)
+```
+
+## Installation
+
+See the [opencode docs](https://opencode.ai/docs#install) for installation instructions.
+
+
+## Aliases
+
+|Alias|Command|Description|
+|-|-|-|
+|`oc`|`opencode`|Run the `opencode` command|
+|`ocr`|`opencode run` |Run `opencode` with a message| 
+
+## Completions
+
+This plugin configures shell completion for the `opencode` command.

--- a/plugins/opencode/opencode.plugin.zsh
+++ b/plugins/opencode/opencode.plugin.zsh
@@ -1,0 +1,28 @@
+if ! (( $+commands[opencode] )); then
+  print "zsh opencode plugin: opencode not found. Please install opencode before using this plugin." >&2
+  return 1
+fi
+
+# See `opencode completion`
+_opencode_yargs_completions() {
+  local reply
+  local si=$IFS
+  IFS=$'
+' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" opencode --get-yargs-completions "${words[@]}"))
+  IFS=$si
+  if [[ ${#reply} -gt 0 ]]; then
+    _describe 'values' reply
+  else
+    _default
+  fi
+}
+
+if [[ "'${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
+  _opencode_yargs_completions "$@"
+else
+  compdef _opencode_yargs_completions opencode
+fi
+
+# Aliases
+alias oc="opencode"
+alias ocr="opencode run"

--- a/plugins/opencode/opencode.plugin.zsh
+++ b/plugins/opencode/opencode.plugin.zsh
@@ -1,5 +1,6 @@
 if ! (( $+commands[opencode] )); then
-  print "zsh opencode plugin: opencode not found. Please install opencode before using this plugin." >&2
+  print "zsh opencode plugin: opencode not found. Please install opencode \
+    before using this plugin." >&2
   return 1
 fi
 
@@ -8,7 +9,8 @@ _opencode_yargs_completions() {
   local reply
   local si=$IFS
   IFS=$'
-' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" opencode --get-yargs-completions "${words[@]}"))
+' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" \
+  COMP_POINT="$CURSOR" opencode --get-yargs-completions "${words[@]}"))
   IFS=$si
   if [[ ${#reply} -gt 0 ]]; then
     _describe 'values' reply


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add a shell completion plugin for the [`opencode`](https://opencode.ai) CLI tool
- Add aliases for opencode
- Add plugin README documentation

## Other comments:

Opencode is an MIT-licensed open-source AI coding agent. The `_opencode_yargs_completions` function in this plugin is the output of `opencode completion`. I've copied the function to this plugin script to avoid using `eval`. 

### Alias justification

- `oc` - Alias for `opencode`. Unused by other plugins. This is a shortcut to the main opencode program
- `ocr` - Alias for `opencode run`. Unused by other plugins. This lets users quickly run a opencode query without launching a full TUI.