### PR TITLE
fix(appearance): ensure arg separation in `test-ls-args`

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -40,9 +40,9 @@ if [[ -z "$LS_COLORS" ]]; then
 fi
 
 function test-ls-args {
-  local cmd="$1"  # ls, gls, colorls, ...
-  shift            # remove the command, leaving only the arguments
-  command "$cmd" "$@" /dev/null &>/dev/null
+  # Usage: test-ls-args cmd args...
+  # e.g. test-ls-args gls --color
+  command "$@" /dev/null &>/dev/null
 }
 
 # Find the option for using colors in ls, depending on the version


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Use `shift` + `"$@"` instead of `"$args"` in `test-ls-args` to pass flags separately. 
- Code quality improvement, no functional change.

## Other comments:

Issue spotted with GitHub Copilot.