### PR TITLE
feat(dotenv): add named pipe (FIFO) support for 1Password Environments

### DIFF
--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -78,6 +78,14 @@ change.
 NOTE: if a directory is found in both the allowed and disallowed lists, the disallowed list
 takes preference, _i.e._ the .env file will never be sourced.
 
+## Named Pipe (FIFO) Support
+
+The plugin supports `.env` files provided as UNIX named pipes (FIFOs) in addition to regular files.
+This is useful when secrets managers like [1Password Environments](https://developer.1password.com/docs/environment/)
+mount `.env` files as named pipes to inject secrets on-the-fly without writing them to disk.
+
+No additional configuration is required — the plugin automatically detects and sources named pipes.
+
 ## Version Control
 
 **It's strongly recommended to add `.env` file to `.gitignore`**, because usually it contains sensitive information such as your credentials, secret keys, passwords etc. You don't want to commit this file, it's supposed to be local only.

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -11,7 +11,7 @@
 ## Functions
 
 source_env() {
-  if [[ ! -f "$ZSH_DOTENV_FILE" ]]; then
+  if [[ ! -f "$ZSH_DOTENV_FILE" ]] && [[ ! -p "$ZSH_DOTENV_FILE" ]]; then
     return
   fi
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add named pipe (FIFO) support to the `source_env` function in `dotenv.plugin.zsh`.
  [1Password Environments](https://developer.1password.com/docs/environments/local-env-file/) and similar secret managers mount `.env` files as UNIX named pipes (FIFOs) rather than regular files. The existing `-f` check rejects these, so a `-p` (named pipe) check is added alongside it.
- Update `README.md` with a section documenting FIFO support.

## Other comments:

This is a one-line logic change (`-f` → `-f || -p`) with zero impact on existing regular-file `.env` workflows. Named pipes behave identically to regular files when read via `source`, so no other code paths need adjustment.

AI tools (Claude) were used to assist with this contribution as QA asisstant.