### PR TITLE
docs(jj): clarify git async-prompt limitation with wrapper functions

### DIFF
--- a/plugins/jj/README.md
+++ b/plugins/jj/README.md
@@ -77,6 +77,15 @@ _my_theme_vcs_info() {
 PROMPT='$(_my_theme_vcs_info) $'
 ```
 
+> **Note:** When using a wrapper function around `git_prompt_info`, the git async prompt feature
+> (enabled by default on Zsh ≥5.0.6) will not work because it only detects the literal pattern
+> `$(git_prompt_info)` in prompt variables. To fix this, either:
+>
+> - Disable git async prompt: `zstyle ':omz:alpha:lib:git' async-prompt no`
+> - Force async handlers to always register: `zstyle ':omz:alpha:lib:git' async-prompt force`
+>
+> See [issue #13555](https://github.com/ohmyzsh/ohmyzsh/issues/13555) for details.
+
 You can find an example
 [here](https://github.com/nasso/omzsh/blob/e439e494f22f4fd4ef1b6cb64626255f4b341c1b/themes/sunakayu.zsh-theme).
 


### PR DESCRIPTION
## Summary

This PR adds documentation to clarify a known limitation when using the recommended jj/git wrapper function pattern with Oh My Zsh's async git prompt feature.

## Issue

When wrapping `git_prompt_info` in a custom function (as shown in the jj plugin README for jj/git fallback), the git async prompt feature (enabled by default on Zsh ≥5.0.6) fails to detect the usage and doesn't register async handlers. This causes `git_prompt_info` to return nothing.

The async detection code in `lib/git.zsh` (lines 165-175) uses string pattern matching to detect `$(git_prompt_info)` or backticks directly in prompt variables. When wrapped like `$(_my_theme_vcs_info)`, the pattern doesn't match.

## Changes

Added a note to the jj plugin README explaining:
- The limitation when using wrapper functions with async prompt
- Two workarounds:
  - Disable git async prompt: `zstyle ':omz:alpha:lib:git' async-prompt no`
  - Force async handlers to always register: `zstyle ':omz:alpha:lib:git' async-prompt force`
- Link to the issue for additional context

## Testing

- Verified the markdown renders correctly
- Confirmed the workarounds are accurate based on the implementation in `lib/git.zsh`

Fixes #13555