### PR TITLE
Fix unquoted password variable in rbw plugin

### DIFF
--- a/plugins/rbw/rbw.plugin.zsh
+++ b/plugins/rbw/rbw.plugin.zsh
@@ -36,7 +36,7 @@ function rbwpw {
   echo -n "$_random" > "$_cache"
 
   # Use clipcopy to copy the password to the clipboard
-  echo -n $pw | clipcopy
+  echo -n "$pw" | clipcopy
   echo "password for $service copied!"
 
   # Clear the clipboard after 20 seconds, but only if the clipboard hasn't


### PR DESCRIPTION
the password variable in the rbw plugin wasnt quoted, so passwords with spaces would get word split. just added quotes around it