### PR TITLE
Fix unquoted path expansions in thefuck plugin

### DIFF
--- a/plugins/thefuck/thefuck.plugin.zsh
+++ b/plugins/thefuck/thefuck.plugin.zsh
@@ -5,8 +5,8 @@ if [[ -z $commands[thefuck] ]]; then
 fi
 
 # Register alias
-[[ ! -a $ZSH_CACHE_DIR/thefuck ]] && thefuck --alias > $ZSH_CACHE_DIR/thefuck
-source $ZSH_CACHE_DIR/thefuck
+[[ ! -a "$ZSH_CACHE_DIR/thefuck" ]] && thefuck --alias > "$ZSH_CACHE_DIR/thefuck"
+source "$ZSH_CACHE_DIR/thefuck"
 
 fuck-command-line() {
     local FUCK="$(THEFUCK_REQUIRE_CONFIRMATION=0 thefuck $(fc -ln -1 | tail -n 1) 2> /dev/null)"


### PR DESCRIPTION
ZSH_CACHE_DIR wasnt quoted in thefuck plugin, would break if the path has spaces in it