### PR TITLE
Add substring matching for pass plugin entry completion

### DIFF
--- a/plugins/pass/_pass
+++ b/plugins/pass/_pass
@@ -125,9 +125,10 @@ _pass_cmd_show () {
 _pass_complete_entries_helper () {
 	local IFS=$'\n'
 	local prefix
-	zstyle -s ":completion:${rootcontext}:" prefix prefix ||
-prefix="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
-  _values -C 'passwords' ${$(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print 2>/dev/null | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' -e 's#\\#\\\\#g' -e 's#:#\\:#g' | sort):-""}
+	zstyle -s ":completion:${rootcontext}:" prefix prefix || prefix="${PASSWORD_STORE_DIR:-$HOME/.password-store}"
+	local -a entries
+	entries=(${$(find -L "$prefix" \( -name .git -o -name .gpg-id \) -prune -o $@ -print 2>/dev/null | sed -e "s#${prefix}/\{0,1\}##" -e 's#\.gpg##' -e 's#\\#\\\\#g' | sort):-""})
+	compadd -M 'l:|=* r:|=*' -a entries
 }
 
 _pass_complete_entries_with_subdirs () {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
- before this change you needed to know the complete path of your password file
- After the change it offers you possible entries which match the entry making the selection of the correct pass much faster.

## Other comments:
AI-assisted
...
