### PR TITLE
feat(zsh_stats): allow showing custom number of results

### DIFF
--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -1,7 +1,7 @@
 function zsh_stats() {
   fc -l 1 \
     | awk '{ CMD[$2]++; count++; } END { for (a in CMD) print CMD[a] " " CMD[a]*100/count "% " a }' \
-    | grep -v "./" | sort -nr | head -n 20 | column -c3 -s " " -t | nl
+    | grep -v "./" | sort -nr | head -n "${1:-20}" | column -c3 -s " " -t | nl
 }
 
 function uninstall_oh_my_zsh() {


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Replaced hardcoded `20` in `zsh_stats` function with a more flexible and intuitive "argument or `20`" logic

## Other comments:

I am still learning this whole contributing thing, so I hope y'all don't mind some possible awkwardness 👉👈. A big project like this probably has to deal with a lot of it anyway
