### PR TITLE
Fix git async prompt when git_prompt_info is wrapped

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -147,12 +147,16 @@ local _style
 if zstyle -t ':omz:alpha:lib:git' async-prompt \
   || { is-at-least 5.0.6 && zstyle -T ':omz:alpha:lib:git' async-prompt }; then
   function git_prompt_info() {
+    # Support wrapper calls like $(_my_git_prompt_info) by lazily registering
+    # the async handler on first invocation.
+    _omz_register_handler _omz_git_prompt_info
     if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}" ]]; then
       echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}"
     fi
   }
 
   function git_prompt_status() {
+    _omz_register_handler _omz_git_prompt_status
     if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}" ]]; then
       echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}"
     fi


### PR DESCRIPTION
Fixes #13555.

When async prompt is enabled, `git_prompt_info` and `git_prompt_status` can return empty output if they are called through wrapper functions, because async handlers are only registered when literal `$(git_prompt_info)` / `$(git_prompt_status)` is found in prompt variables.

This change lazily registers the corresponding async handlers on first function invocation, so wrapper usage still works with async prompt enabled.