### PR TITLE
feat(ansible): updated plugin ansible to current ansible-core tools, removed broken & unnecessary functions

### DIFF
--- a/plugins/ansible/README.md
+++ b/plugins/ansible/README.md
@@ -1,6 +1,7 @@
 # ansible plugin
 
-The `ansible plugin` adds several aliases for useful [ansible](https://docs.ansible.com/ansible/latest/index.html) commands and [aliases](#aliases).
+The `ansible plugin` adds several aliases for useful
+[ansible](https://docs.ansible.com/ansible/latest/index.html) commands and [aliases](#aliases).
 
 To use it, add `ansible` to the plugins array of your zshrc file:
 
@@ -10,22 +11,19 @@ plugins=(... ansible)
 
 ## Aliases
 
-| Command                                    | Description                                                         |
-|:-------------------------------------------|:--------------------------------------------------------------------|
-| `ansible-version` / `aver`                 | Show the version on ansible installed in this host                  |
-| `ansible-role-init <role name>` / `arinit` | Creates the Ansible Role as per Ansible Galaxy standard             |
-| `a`                                        | command `ansible`                                                   |
-| `aconf`                                    | command `ansible-config`                                            |
-| `acon`                                     | command `ansible-console`                                           |
-| `ainv`                                     | command `ansible-inventory`                                         |
-| `aplaybook`                                | command `ansible-playbook`                                          |
-| `adoc`                                     | command `ansible-doc`                                               |
-| `agal`                                     | command `ansible-galaxy`                                            |
-| `apull`                                    | command `ansible-pull`                                              |
-| `aval`                                     | command `ansible-vault`                                             |
+| Command             | Description                 |
+| :------------------ | :-------------------------- |
+| `a`                 | command `ansible`           |
+| `acon`              | command `ansible-console`   |
+| `aconf`             | command `ansible-config`    |
+| `adoc`              | command `ansible-doc`       |
+| `agal`              | command `ansible-galaxy`    |
+| `ainv`              | command `ansible-inventory` |
+| `aplb`, `aplaybook` | command `ansible-playbook`  |
+| `apull`             | command `ansible-pull`      |
+| `atest`             | command `ansible-test`      |
+| `aval`              | command `ansible-vault`     |
 
 ## Maintainer
 
-### [Deepankumar](https://github.com/deepan10)
-
-[https://github.com/deepan10/oh-my-zsh/tree/features/ansible-plugin](https://github.com/deepan10/oh-my-zsh/tree/features/ansible-plugin)
+### [PascalKont](https://github.com/PascalKont)

--- a/plugins/ansible/README.md
+++ b/plugins/ansible/README.md
@@ -21,7 +21,7 @@ plugins=(... ansible)
 | `ainv`              | command `ansible-inventory` |
 | `aplb`, `aplaybook` | command `ansible-playbook`  |
 | `apull`             | command `ansible-pull`      |
-| `atest`             | command `ansible-test`      |
+| `ates`              | command `ansible-test`      |
 | `aval`              | command `ansible-vault`     |
 
 ## Maintainer

--- a/plugins/ansible/ansible.plugin.zsh
+++ b/plugins/ansible/ansible.plugin.zsh
@@ -8,5 +8,5 @@ alias ainv='ansible-inventory '
 alias aplaybook='ansible-playbook ' # this long version of the playbook alias is kept for backwards compatibility
 alias aplb='ansible-playbook ' # cannot use aplay because of collision with 'aplay' command for playing audio files
 alias apull='ansible-pull '
-alias atest='ansible-test '
+alias ates='ansible-test '
 alias aval='ansible-vault '

--- a/plugins/ansible/ansible.plugin.zsh
+++ b/plugins/ansible/ansible.plugin.zsh
@@ -1,28 +1,12 @@
-# Functions
-function ansible-version() {
-    ansible --version
-}
-
-function ansible-role-init() {
-    if [[ -n "$1" ]]; then
-        echo "Ansible Role : $1 Creating...."
-        ansible-galaxy init "$1"
-        tree "$1"
-    else
-        echo "Usage : ansible-role-init <role name>"
-        echo "Example : ansible-role-init role1"
-    fi
-}
-
 # Alias
 alias a='ansible '
-alias aconf='ansible-config '
 alias acon='ansible-console '
-alias aver='ansible-version'
-alias arinit='ansible-role-init'
-alias aplaybook='ansible-playbook '
-alias ainv='ansible-inventory '
+alias aconf='ansible-config '
 alias adoc='ansible-doc '
 alias agal='ansible-galaxy '
+alias ainv='ansible-inventory '
+alias aplaybook='ansible-playbook ' # this long version of the playbook alias is kept for backwards compatibility
+alias aplb='ansible-playbook ' # cannot use aplay because of collision with 'aplay' command for playing audio files
 alias apull='ansible-pull '
-alias aval='ansible-vault'
+alias atest='ansible-test '
+alias aval='ansible-vault '


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- updated aliases to reflect current binaries that ship with ansible-core
  -  added new alias `ates='ansible-test '`
- (re)added a short version of ansible-playbook `aplb='ansible-playbook '`, without reintroducing a collision 
  - #7604
  - #7617 
- reordered list of aliases in alphabetical order
- removed broken function `ansible-role-init`, the command is no longer working and since it hasn't been fixed in a long time, I removed it. 
I don't see how this is useful anyways. It is not a command you use often.
The fixed line would need to be `ansible-galaxy init role $1`
- removed unnecessary function `aver`.

## Other comments:

There is also the topic of single char alias collisions #10859 regarding `alias a='ansible '`
My suggestions for a new alias:
- an
- abl

But i don't want to introduce such a change with a proposal that i'm not confident in.
