### PR TITLE
feat(virtualenvwrapper): add proper distributive-specific virtualenvwrapper.sh paths

### DIFF
--- a/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
+++ b/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh
@@ -4,6 +4,7 @@ function {
       $commands[virtualenvwrapper.sh] \
       /usr/share/virtualenvwrapper/virtualenvwrapper{_lazy,}.sh \
       /usr/local/bin/virtualenvwrapper{_lazy,}.sh \
+      /usr/bin/virtualenvwrapper{_lazy,}.sh \
       /etc/bash_completion.d/virtualenvwrapper \
       /usr/share/bash-completion/completions/virtualenvwrapper \
       $HOME/.local/bin/virtualenvwrapper.sh


### PR DESCRIPTION
If virtualenvwrapper was installed into Arch Linux with pacman -- here are the proper paths (see https://archlinux.org/packages/extra/any/python-virtualenvwrapper/files/)

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add Arch Linux vendor-specific pathes for virtualenvwrapper[_lazy].sh

Closes https://github.com/ohmyzsh/ohmyzsh/issues/13583