### PR TITLE
fix(installer): handle sudo shims that don't support -k flag

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -473,7 +473,10 @@ EOF
   # be prompted for the password either way, so this shouldn't cause any issues.
   #
   if user_can_sudo; then
-    sudo -k chsh -s "$zsh" "$USER"  # -k forces the password prompt
+    # Use -k to invalidate cached credentials (forces password prompt).
+    # Some sudo shims (e.g. doas-sudo-shim on Alpine) don't support -k,
+    # so fall back to running without it.
+    sudo -k chsh -s "$zsh" "$USER" 2>/dev/null || sudo chsh -s "$zsh" "$USER"
   else
     chsh -s "$zsh" "$USER"          # run chsh normally
   fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- On Alpine Linux with `doas-sudo-shim`, `sudo -k chsh ...` fails because the shim doesn't support the `-k` option (`unrecognized option: k`).
- Changed line 476 to try `sudo -k chsh ...` first, and if that fails (exit code != 0), fall back to `sudo chsh ...` without `-k`.
- This preserves the `-k` behavior on systems with real sudo while supporting sudo shims that lack `-k`.

## AI Disclosure

This PR was created with AI assistance (Claude). The fix logic was straightforward - add a fallback when `-k` is unsupported.

## Other comments:

Fixes #13475