### PR TITLE
docs: fix typo in installation instructions for yum plugin

### DIFF
--- a/plugins/yum/README.md
+++ b/plugins/yum/README.md
@@ -22,6 +22,6 @@ plugins=(... yum)
 | yi    | `sudo yum install`                | Install package              |
 | ygi   | `sudo yum groupinstall`           | Install package group        |
 | yr    | `sudo yum remove`                 | Remove package               |
-| ygr   | `sudo yum groupremove`            | Remove pagage group          |
+| ygr   | `sudo yum groupremove`            | Remove package group         |
 | yrl   | `sudo yum remove --remove-leaves` | Remove package and leaves    |
 | yc    | `sudo yum clean all`              | Clean yum cache              |


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

I noticed a small typo in yum plugins readme document and fixed it. 

## Other comments:

nil
