### PR TITLE
fix(colored-man-pages): quote array expansion in `colored` function

### DIFF
--- a/plugins/colored-man-pages/colored-man-pages.plugin.zsh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.zsh
@@ -43,7 +43,7 @@ function colored() {
     environment+=( PATH="${__colored_man_pages_dir}:$PATH" )
   fi
 
-  command env $environment "$@"
+  command env "${environment[@]}" "$@"
 }
 
 # Colorize man and dman/debman (from debian-goodies)


### PR DESCRIPTION
## Problem

When `man` is invoked with the `GLOB_SUBST` zsh option enabled, the `colored` function errors with:

```
colored:19: bad pattern: LESS_TERMCAP_ue=^[[00m
```

## Root cause

In `colored-man-pages.plugin.zsh`, line 46:

```zsh
command env $environment "$@"
```

The `$environment` array is unquoted. With `GLOB_SUBST` set, zsh performs glob expansion on the expanded values. The `LESS_TERMCAP_*` values contain ANSI escape sequences with `[` (e.g. `ESC[00m`), which zsh interprets as glob patterns, triggering a `bad pattern` error.

`GLOB_SUBST` is not a default zsh option and oh-my-zsh does not set it, so this only affects users who enable it themselves. It was introduced in #9437.

## Fix

```zsh
command env "${environment[@]}" "$@"
```

Quoting the array expansion prevents glob interpretation of the values.

---

*AI-assisted: diagnosed and fix authored with Claude, reviewed and tested manually.*