### PR TITLE
fix(pyenv): use corect --path argument for init

### DIFF
--- a/plugins/pyenv/pyenv.plugin.zsh
+++ b/plugins/pyenv/pyenv.plugin.zsh
@@ -79,7 +79,7 @@ if [[ $FOUND_PYENV -eq 1 ]]; then
   fi
 
   # Load pyenv
-  eval "$(pyenv init - --no-rehash zsh)"
+  eval "$(pyenv init --path --no-rehash zsh)"
 
   # If pyenv-virtualenv exists, load it
   if [[ "$ZSH_PYENV_VIRTUALENV" != false && "$(pyenv commands)" =~ "virtualenv-init" ]]; then


### PR DESCRIPTION
Fixes `mkdir: Permission Denied` on Ubuntu 25.10 when calling `pyenv init - --no-rehash zsh`
`pyenv init --path --no-rehash zsh` works correctly.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Replaces `pyenv init - --no-rehash zsh` with `pyenv init --path --no-rehash zsh`
