### PR TITLE
feat(molecule): introduce molecule aliases

### DIFF
--- a/plugins/molecule/README.md
+++ b/plugins/molecule/README.md
@@ -15,6 +15,6 @@ plugins=(... molecule)
 | :---- | :---------------- | ---------------------------------------------------------------------------------- |
 | mol   | molecule          | Molecule aids in the development and testing of Ansible roles.                     |
 | mcr   | molecule create   | Use the provisioner to start the instances.                                        |
-| mcv   | molecule converge | Use the provisioner to configure instances (dependency, create, prepare converge). |
+| mcon  | molecule converge | Use the provisioner to configure instances (dependency, create, prepare converge). |
 | mls   | molecule list     | List status of instances.                                                          |
 | mvf   | molecule verify   | Run automated tests against instances.                                             |

--- a/plugins/molecule/molecule.plugin.zsh
+++ b/plugins/molecule/molecule.plugin.zsh
@@ -17,6 +17,6 @@ _MOLECULE_COMPLETE=zsh_source molecule >| "$ZSH_CACHE_DIR/completions/_molecule"
 # molecule: https://docs.ansible.com/projects/molecule/
 alias mol='molecule'
 alias mcr='molecule create'
-alias mcv='molecule converge'
+alias mcon='molecule converge'
 alias mls='molecule list'
 alias mvf='molecule verify'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.
 
## Changes:

- introduce molecule aliases

## Other comments:

The four main commands used during 90% of ansible test development are: create, converge, verify, list.
Therefore i gave them their own aliases and added a general alias (mol) for the plain molecule command.
There are no special use cases for those commands, they are used day to day during development.

Examples:
```
mct -s linux    | molecule create -s linux
mcv -s linux    | molecule converge -s linux
mls -s linux    | molecule list -s linux
mvf -s linux    | molecule verify -s linux
```