### PR TITLE
feat(ssh): Add sub-commands to the SSH plugin to support port forwarding and proxy.

### DIFF
--- a/plugins/ssh/ssh.plugin.zsh
+++ b/plugins/ssh/ssh.plugin.zsh
@@ -51,3 +51,62 @@ function ssh_unload_key {
     ssh-add -d "$keyfile"
   fi
 }
+
+############################################################
+# Port forwarding
+function ssh_port_forward {
+  if [[ $# -lt 2 ]]; then
+    echo "Usage: ssh port-forward <local_port>:<remote_port> user@host [ssh options]"
+    return 1
+  fi
+  local ports="$1"
+  shift
+  local local_port="${ports%%:*}"
+  local remote_port="${ports##*:}"
+  if [[ -z "$local_port" || -z "$remote_port" ]]; then
+    echo "Invalid port format. Use local_port:remote_port"
+    return 1
+  fi
+  command ssh -N -L "${local_port}:127.0.0.1:${remote_port}" "$@"
+}
+
+############################################################
+# SSH SOCKS proxy
+function ssh_proxy {
+  local local_port="$1"
+  if [[ -z "$local_port" ]]; then
+    echo "Usage: ssh proxy <local_port> user@host [ssh options]"
+    return 1
+  fi
+  shift
+  if [[ -z "$local_port" || "$local_port" != <-> ]]; then
+    echo "Invalid port. Use a numeric local port."
+    return 1
+  fi
+  if [[ $# -lt 1 ]]; then
+    echo "Usage: ssh proxy local_port user@host [ssh options]"
+    return 1
+  fi
+
+  command ssh -D "${local_port}" -N "$@"
+}
+
+############################################################
+# Configure ssh command to support custom subcommands
+function ssh {
+  case "$1" in
+    port-forward|pf)
+      shift
+      ssh_port_forward "$@"
+      return $?
+      ;;
+    proxy|px)
+      shift
+      ssh_proxy "$@"
+      return $?
+      ;;
+    *)
+      command ssh "$@"
+      ;;
+  esac
+}


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add `port-forward`, `pf`, and `proxy`, `px` in the ssh plugin as a sub-command for ssh

## Other comments:

...
