### PR TITLE
fix(vi-mode): re-render cursor after exisiting visual mode (ohmyzsh#11705)

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -31,24 +31,32 @@ function _vi-mode-set-cursor-shape-for-keymap() {
   # https://vt100.net/docs/vt510-rm/DECSCUSR
   local _shape=0
   case "${1:-${VI_KEYMAP:-main}}" in
-    main)    _shape=$VI_MODE_CURSOR_INSERT ;; # vi insert: line
-    viins)   _shape=$VI_MODE_CURSOR_INSERT ;; # vi insert: line
-    isearch) _shape=$VI_MODE_CURSOR_INSERT ;; # inc search: line
-    command) _shape=$VI_MODE_CURSOR_INSERT ;; # read a command name
-    vicmd)   _shape=$VI_MODE_CURSOR_NORMAL ;; # vi cmd: block
-    visual)  _shape=$VI_MODE_CURSOR_VISUAL ;; # vi visual mode: block
-    viopp)   _shape=$VI_MODE_CURSOR_OPPEND ;; # vi operation pending: blinking block
-    *)       _shape=0 ;;
+    main)        _shape=$VI_MODE_CURSOR_INSERT ;; # vi insert: line
+    viins)       _shape=$VI_MODE_CURSOR_INSERT ;; # vi insert: line
+    isearch)     _shape=$VI_MODE_CURSOR_INSERT ;; # inc search: line
+    command)     _shape=$VI_MODE_CURSOR_INSERT ;; # read a command name
+    vicmd)       _shape=$VI_MODE_CURSOR_NORMAL ;; # vi cmd: block
+    visual)      _shape=$VI_MODE_CURSOR_VISUAL ;; # vi visual mode: block
+    visual-line) _shape=$VI_MODE_CURSOR_VISUAL ;; # vi visual line mode: block
+    viopp)       _shape=$VI_MODE_CURSOR_OPPEND ;; # vi operation pending: blinking block
+    *)           _shape=0 ;;
   esac
   printf $'\e[%d q' "${_shape}"
 }
 
-function _visual-mode {
-  typeset -g VI_KEYMAP=visual
-  _vi-mode-set-cursor-shape-for-keymap "$VI_KEYMAP"
-  zle .visual-mode
+function zle-line-pre-redraw() {
+  if [[ "$REGION_ACTIVE" -eq 0 && ("$VI_KEYMAP" == visual || "$VI_KEYMAP" == visual-line) ]]; then
+    typeset -g VI_KEYMAP=$KEYMAP
+    _vi-mode-set-cursor-shape-for-keymap "$VI_KEYMAP"
+  elif [[ "$REGION_ACTIVE" -eq 1 && "$VI_KEYMAP" != "visual" ]]; then
+    typeset -g VI_KEYMAP=visual
+    _vi-mode-set-cursor-shape-for-keymap "$VI_KEYMAP"
+  elif [[ "$REGION_ACTIVE" -eq 2 && "$VI_KEYMAP" != "visual-line" ]]; then
+    typeset -g VI_KEYMAP=visual-line
+    _vi-mode-set-cursor-shape-for-keymap "$VI_KEYMAP"
+  fi
 }
-zle -N visual-mode _visual-mode
+zle -N zle-line-pre-redraw
 
 function _vi-mode-should-reset-prompt() {
   # If $VI_MODE_RESET_PROMPT_ON_MODE_CHANGE is unset (default), dynamically


### PR DESCRIPTION
Redraw the cursor after exiting visual or visual line mode.

Fixes 11705.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki. 
_I didn't see a wiki or a style guide but did try follow this [style indication](https://github.com/KevinWMatthews/ohmyzsh/blob/master/CONTRIBUTING.md#style) in `CONTRIBUTING.md`_
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Following [this suggestion](https://github.com/ohmyzsh/ohmyzsh/issues/11705#issuecomment-1557342576) from #11705:
- remove the `visual-mode` widget
- add a `zli-line-pre-redraw` hook ([special widget](https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#Special-Widgets))

This hook checks the highlight state, and if necessary updates the local understanding of the keymap and changes the cursor shape.

## Other comments:

This contribution is AI-assisted, and I take full responsibility for the code in this PR. (To be honest, I hadn't planned on learning anything about zsh but it with some help it isn't so bad :) ).

My current understanding is that zsh doesn't maintain a separate keycode for vi's visual and visual-line modes, but instead highlights part of the text. The `vi-mode` plugin emulates these vi modes by checking current highlight state and the current key.

The [REGION_ACTIVE](https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#index-REGION_005fACTIVE) variable indicates which characters/regions are to be highlighted, and it has values of:
- 0: no highlight
- 1: character/region highlight active
- 2: line highlight active

Note that the rprompt is not modified to indicate when visual mode is active. I think this could be a useful feature but is outside the scope of this PR. I plan to create a separate issue and post a follow-up PR for this. (edit: see #13625 and #13626).