### PR TITLE
fix(clipboard): strip carriage returns from PowerShell output on WSL

### DIFF
--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -59,7 +59,7 @@ function detect-clipboard() {
     function clippaste() { cat /dev/clipboard; }
   elif (( $+commands[clip.exe] )) && (( $+commands[powershell.exe] )); then
     function clipcopy() { cat "${1:-/dev/stdin}" | clip.exe; }
-    function clippaste() { powershell.exe -noprofile -command Get-Clipboard; }
+    function clippaste() { powershell.exe -noprofile -command Get-Clipboard | tr -d '\r'; }
   elif [ -n "${WAYLAND_DISPLAY:-}" ] && (( ${+commands[wl-copy]} )) && (( ${+commands[wl-paste]} )); then
     function clipcopy() { cat "${1:-/dev/stdin}" | wl-copy &>/dev/null &|; }
     function clippaste() { wl-paste --no-newline; }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

On WSL, `clippaste` uses `powershell.exe Get-Clipboard` which outputs `\r\n` line endings. Command substitution strips `\n` but not `\r`, so clipboard content gets `^M` tacked on. Noticed it in vi-mode where `xp` pastes the character with `^M` appended.

Piping through `tr -d \r\` strips the carriage returns.

## Other comments:

Fixes #13331