### PR TITLE
feat: allow backspace correction in update prompt

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -233,10 +233,9 @@ function handle_update() {
     # Ask for confirmation and only update on 'y', 'Y' or Enter
     # Otherwise just show a reminder for how to update
     printf "[oh-my-zsh] Would you like to update? [Y/n] "
-    read -r -k 1 option
-    [[ "$option" = $'\n' ]] || echo
+    read -r option
     case "$option" in
-      [yY$'\n']) update_ohmyzsh ;;
+      [yY]|"") update_ohmyzsh ;;
       [nN]) update_last_updated_file ;&
       *) echo "[oh-my-zsh] You can update manually by running \`omz update\`" ;;
     esac


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Changed `read -r -k 1` to `read -r` in the update prompt so that users can correct their input with backspace before pressing Enter, instead of the input being accepted immediately after a single keypress.

## Other comments:

Previously, when prompted for an update (`[Y/n]`), `read -r -k 1` captured input immediately after one character with no chance to correct a mistake. By switching to `read -r`, users can now type, use backspace to fix typos, and
confirm with Enter. The default behavior (pressing Enter without input) still triggers the update.


No.. 🥺🥺
<img width="515" height="135" alt="image" src="https://github.com/user-attachments/assets/5564e134-79b4-400e-ad2d-1b1e69abbaf4" />
