### PR TITLE
Fix typo: freeBSD to FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Twitter), and join us on [Discord](https://discord.gg/ohmyzsh).
     - [Manual Installation](#manual-installation)
   - [Installation Problems](#installation-problems)
   - [Custom Plugins And Themes](#custom-plugins-and-themes)
-  - [Enable GNU ls In macOS And freeBSD Systems](#enable-gnu-ls-in-macos-and-freebsd-systems)
+  - [Enable GNU ls In macOS And FreeBSD Systems](#enable-gnu-ls-in-macos-and-freebsd-systems)
   - [Skip Aliases](#skip-aliases)
   - [Async git prompt](#async-git-prompt)
 - [Getting Updates](#getting-updates)
@@ -70,7 +70,7 @@ Twitter), and join us on [Discord](https://discord.gg/ohmyzsh).
 | O/S            | Status |
 | :------------- | :----: |
 | Android        |   ✅   |
-| freeBSD        |   ✅   |
+| FreeBSD        |   ✅   |
 | LCARS          |   🛸   |
 | Linux          |   ✅   |
 | macOS          |   ✅   |
@@ -349,7 +349,7 @@ If you have many functions that go well together, you can put them as a `XYZ.plu
 If you would like to override the functionality of a plugin distributed with Oh My Zsh, create a plugin of the
 same name in the `custom/plugins/` directory and it will be loaded instead of the one in `plugins/`.
 
-### Enable GNU ls In macOS And freeBSD Systems
+### Enable GNU ls In macOS And FreeBSD Systems
 
 <a name="enable-gnu-ls"></a>
 


### PR DESCRIPTION
Fixes capitalization of FreeBSD in README. The operating system name should be properly capitalized as FreeBSD rather than freeBSD.