### PR TITLE
FIX[#13616]: tools/update.sh -- remove redundant variable and local declaration

### DIFF
--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 set +u # disable nounset
 
-local ret=0 # exit code
+ret=0 # exit code
 
 # Protect against running with shells other than zsh
 if [ -z "$ZSH_VERSION" ]; then


### PR DESCRIPTION
# NIT: tools/update.sh -- fix minor redundant variable declaration

Issue #13616 

## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Removed `local` keyword from `ret=0` declaration at line 4 of `tools/upgrade.sh`. The `local` builtin is only valid inside a function — using it at script (top-level) scope is incorrect. `zsh` silently accepts it as an extension, which masked the bug; running the script with `sh` exposed the error.
- Removed a duplicate `local ret=0` declaration at line 228 (now line 226) of the same file. This declaration was unreachable dead code — `ret` was already declared and in scope from the top of the script, making this a redundant re-declaration with no effect.

## Other comments:

The `local` misuse was discovered by accidentally running `tools/upgrade.sh` with `sh upgrade.sh` instead of `zsh upgrade.sh`. The POSIX `sh` shell correctly rejects `local` outside of a function, surfacing the issue. Because `zsh` silently promotes `local` at script scope to a normal variable assignment, the bug had no visible impact in normal use — but it represents incorrect shell scripting practice.

AI disclosure: Claude Code (claude-sonnet-4-6) assisted in drafting this PR description.