### PR TITLE
refactor(bundler): Remove bundle_install

### DIFF
--- a/plugins/bundler/README.md
+++ b/plugins/bundler/README.md
@@ -11,18 +11,18 @@ plugins=(... bundler)
 
 ## Aliases
 
-| Alias  | Command                              | Description                                                                              |
-|--------|--------------------------------------|------------------------------------------------------------------------------------------|
-| `ba`   | `bundle add`                         | Add gem to the Gemfile and run bundle install                                            |
-| `bck`  | `bundle check`                       | Verifies if dependencies are satisfied by installed gems                                 |
-| `bcn`  | `bundle clean`                       | Cleans up unused gems in your bundler directory                                          |
-| `be`   | `bundle exec`                        | Execute a command in the context of the bundle                                           |
-| `bi`   | `bundle install --jobs=<core_count>` | Install the dependencies specified in your Gemfile (using all cores in bundler >= 1.4.0) |
-| `bl`   | `bundle list`                        | List all the gems in the bundle                                                          |
-| `bo`   | `bundle open`                        | Opens the source directory for a gem in your bundle                                      |
-| `bout` | `bundle outdated`                    | List installed gems with newer versions available                                        |
-| `bp`   | `bundle package`                     | Package your needed .gem files into your application                                     |
-| `bu`   | `bundle update`                      | Update your gems to the latest available versions                                        |
+| Alias  | Command           | Description                                              |
+| ------ | ----------------- | -------------------------------------------------------- |
+| `ba`   | `bundle add`      | Add gem to the Gemfile and run bundle install            |
+| `bck`  | `bundle check`    | Verifies if dependencies are satisfied by installed gems |
+| `bcn`  | `bundle clean`    | Cleans up unused gems in your bundler directory          |
+| `be`   | `bundle exec`     | Execute a command in the context of the bundle           |
+| `bi`   | `bundle install`  | Install the dependencies specified in your Gemfile       |
+| `bl`   | `bundle list`     | List all the gems in the bundle                          |
+| `bo`   | `bundle open`     | Opens the source directory for a gem in your bundle      |
+| `bout` | `bundle outdated` | List installed gems with newer versions available        |
+| `bp`   | `bundle package`  | Package your needed .gem files into your application     |
+| `bu`   | `bundle update`   | Update your gems to the latest available versions        |
 
 ## Gem wrapper
 

--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -4,44 +4,12 @@ alias ba="bundle add"
 alias bck="bundle check"
 alias bcn="bundle clean"
 alias be="bundle exec"
-alias bi="bundle_install"
+alias bi="bundle install"
 alias bl="bundle list"
 alias bo="bundle open"
 alias bout="bundle outdated"
 alias bp="bundle package"
 alias bu="bundle update"
-
-## Functions
-
-bundle_install() {
-  # Bail out if bundler is not installed
-  if (( ! $+commands[bundle] )); then
-    echo "Bundler is not installed"
-    return 1
-  fi
-
-  # Bail out if not in a bundled project
-  if ! _within-bundled-project; then
-    echo "Can't 'bundle install' outside a bundled project"
-    return 1
-  fi
-
-  # Check the bundler version is at least 1.4.0
-  autoload -Uz is-at-least
-  local bundler_version=$(bundle version | cut -d' ' -f3)
-  if ! is-at-least 1.4.0 "$bundler_version"; then
-    bundle install "$@"
-    return $?
-  fi
-
-  # If bundler is at least 1.4.0, use all the CPU cores to bundle install
-  if [[ "$OSTYPE" = (darwin|freebsd)* ]]; then
-    local cores_num="$(sysctl -n hw.ncpu)"
-  else
-    local cores_num="$(nproc)"
-  fi
-  BUNDLE_JOBS="$cores_num" bundle install "$@"
-}
 
 ## Gem wrapper
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Remove the `bundle_install` function, which should only be needed for deprecated Bundler versions (4 years and older)

## Other comments:

- `commands[bundle]` check: The shell should provide feedback for unrecognized commands
- `_within-bundled-project` check: Bundler returns `Could not locate Gemfile`
- `1.4.0` check: It's 12+ years old and beyond deprecated
- `BUNDLE_JOBS`: It's been enabled by default for all platforms since `2.3` (the first non-deprecated -but still legacy- version, 4+ years old), and before that, for non-Windows

Supported versions (from https://bundler.io/man/bundle-install.1.html):

<img width="325" height="505" alt="Screenshot 2026-03-06 at 08 39 57" src="https://github.com/user-attachments/assets/ad0aafba-f2cd-480d-9a73-68965e6c8f91" />
