### PR TITLE
fix: preserve user .zshrc when no backup exists during uninstall

### DIFF
--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -35,6 +35,12 @@ if [ -e "$ZSHRC_ORIG" ]; then
   echo "Your original zsh config was restored."
 else
   echo "No original zsh config found"
+  if [ -e "${ZSHRC_SAVE}" ]; then
+    echo "Restoring your current config and removing Oh My Zsh lines..."
+    grep -v 'source.*oh-my-zsh\.sh' "${ZSHRC_SAVE}" > ~/.zshrc
+    echo "Your config was restored with Oh My Zsh lines removed."
+    echo "Original file saved at: ${ZSHRC_SAVE}"
+  fi
 fi
 
 echo "Thanks for trying out Oh My Zsh. It's been uninstalled."


### PR DESCRIPTION
## Description

Fixes #13156
Fixes #13328

Currently, when uninstalling Oh My Zsh, if no original backup (.zshrc.pre-oh-my-zsh) exists, the user's .zshrc is deleted permanently. This happens when users installed Oh My Zsh years ago on a different machine.

## Changes

- When no original backup exists, restore the current .zshrc with Oh My Zsh lines removed
- Use grep to filter out 'source.*oh-my-zsh.sh' lines
- Keep the timestamped backup file for safety

## Impact

Users will no longer lose their .zshrc configuration when uninstalling, even if the original backup doesn't exist.

## Example

Before: .zshrc deleted, no backup available
After: .zshrc restored with Oh My Zsh lines removed

## Standards checklist

- [x] The PR title is descriptive
- [x] The PR doesn't replicate another PR which is already open
- [x] The code follows the code style guide
- [x] The code is stable and tested