### PR TITLE
fix(last-working-dir): use explicit return 0 in early-exit guards

### DIFF
--- a/plugins/last-working-dir/last-working-dir.plugin.zsh
+++ b/plugins/last-working-dir/last-working-dir.plugin.zsh
@@ -23,8 +23,8 @@ lwd() {
 #
 # - This isn't the first time the plugin is loaded
 # - We're not in the $HOME directory (e.g. if terminal opened a different folder)
-[[ -z "$ZSH_LAST_WORKING_DIRECTORY" ]] || return
-[[ "$PWD" == "$HOME" ]] || return
+[[ -z "$ZSH_LAST_WORKING_DIRECTORY" ]] || return 0
+[[ "$PWD" == "$HOME" ]] || return 0
 
 if lwd 2>/dev/null; then
   ZSH_LAST_WORKING_DIRECTORY=1


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
- Replace bare `return` with explicit `return 0` in the two early-exit guards at the bottom of `last-working-dir.plugin.zsh`

## Other comments:
The bare `return` statements inherit the exit code of the last executed command, which can be non-zero depending on the shell environment. Plugin managers that check the exit code of `source` (e.g. zcomet) incorrectly report a sourcing failure as a result, even though the plugin loads and functions correctly. Using `return 0` makes the intent explicit and avoids the false error.

Tested on macOS with Ghostty and Kitty terminals. AI-assisted (Claude helped diagnose the root cause).