### PR TITLE
feat(zellij): add zellij plugin with aliases, functions, and completions

### DIFF
--- a/plugins/zellij/README.md
+++ b/plugins/zellij/README.md
@@ -45,10 +45,11 @@ taken by another alias, function, or command, it is silently skipped.
 
 | Function (default) | Function (with `z`) | Command                            | Description            |
 | ------------------- | ------------------- | ---------------------------------- | ---------------------- |
-| `zja`               | `za`                | `zellij attach`                    | Attach to a session    |
-| `zjd`               | `zd`                | `zellij delete-session`            | Delete a session       |
-| `zjk`               | `zk`                | `zellij kill-session`              | Kill a session         |
-| `zjas`              | `zas`               | `zellij action switch-session`     | Switch to a session    |
+| `zja`               | `za`                | `zellij attach`                    | Attach to a session              |
+| `zjd`               | `zd`                | `zellij delete-session`            | Delete a session (exited only)   |
+| `zjdf`              | `zdf`               | `zellij delete-session --force`    | Force-delete any session         |
+| `zjk`               | `zk`                | `zellij kill-session`              | Kill a session                   |
+| `zjas`              | `zas`               | `zellij action switch-session`     | Switch to a session              |
 
 The following convenience functions are always available (unless the name is already taken):
 

--- a/plugins/zellij/zellij.plugin.zsh
+++ b/plugins/zellij/zellij.plugin.zsh
@@ -64,6 +64,11 @@ if ! _omz_zellij_taken "${_zellij_short_prefix}d"; then
   _zellij_exited_session_targets+=("${_zellij_short_prefix}d")
 fi
 
+if ! _omz_zellij_taken "${_zellij_short_prefix}df"; then
+  eval "${_zellij_short_prefix}df() { command zellij delete-session --force \"\$@\"; }"
+  _zellij_all_session_targets+=("${_zellij_short_prefix}df")
+fi
+
 if ! _omz_zellij_taken "${_zellij_short_prefix}k"; then
   eval "${_zellij_short_prefix}k() { command zellij kill-session \"\$@\"; }"
   _zellij_running_session_targets+=("${_zellij_short_prefix}k")
@@ -92,6 +97,7 @@ if ! _omz_zellij_taken "${_zellij_short_prefix}h"; then
       '${_zellij_short_prefix}s:zellij -s <name>'
       '${_zellij_short_prefix}a:zellij attach <session>'
       '${_zellij_short_prefix}d:zellij delete-session <session>'
+      '${_zellij_short_prefix}df:zellij delete-session --force <session>'
       '${_zellij_short_prefix}k:zellij kill-session <session>'
       '${_zellij_short_prefix}da:zellij delete-all-sessions'
       '${_zellij_short_prefix}ka:zellij kill-all-sessions'


### PR DESCRIPTION
## Summary

- Add new `zellij` plugin with aliases and shell functions for common zellij commands
- Support dynamic prefix (`zj` default, `z` with `ZSH_ZELLIJ_PREFIX_Z=true`)
- When `z` is already taken (e.g. by zoxide), only the root alias falls back to `zj` — sub-commands keep the shorter `z` prefix (`zl`, `za`, `zk`, `zd`, …)
- All aliases and functions check for conflicts before defining, silently skipping if the name is taken
- Convenience functions `zr`, `zrf`, `ze` for quick run/edit commands
- Session-aware tab completions for attach (all sessions), kill (running), and delete (exited)
- Completion cache: synchronous on first load, background regeneration when the zellij binary is updated
- `ad` alias for `zellij action detach`, `as` function for `zellij action switch-session`
- `h` help function that lists only actively registered aliases/functions
- Use `list-sessions --short` (zellij ≥0.44) for session name extraction with sed fallback

## Test plan

- [x] Verify `plugins=(zellij)` loads without errors
- [x] Verify default prefix (`zj`) aliases work: `zj`, `zjl`, `zjs`, `zja`, `zjd`, `zjk`
- [x] Set `ZSH_ZELLIJ_PREFIX_Z=true` and verify `z` prefix aliases: `z`, `zl`, `zs`, `za`, `zd`, `zk`
- [x] With zoxide (`z`) loaded before zellij, verify root alias falls back to `zj` while sub-commands use `z` prefix
- [x] Verify `zr`, `zrf`, `ze` convenience functions work
- [x] Verify tab completion works for `zellij` and aliased commands
- [x] Verify session-aware completions for attach/kill/delete functions
- [x] Verify `zjad` / `zad` runs `zellij action detach`
- [x] Verify `zjas` / `zas` runs `zellij action switch-session` with session tab completion
- [x] Verify `zjh` / `zh` prints help table showing only registered aliases (skipped conflicts hidden)
- [x] Verify session name completion uses `--short` on zellij ≥0.44
- [x] Verify session name completion falls back to sed parsing on zellij <0.44

## AI-assisted contribution disclosure

- **Plugin script (`zellij.plugin.zsh`)**: Generated with GPT 5.4 (thinking mode), then reviewed and tested manually
- **README, commit messages, and PR**: Written with Claude Code (claude-opus-4-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)