### PR TITLE
Feat/visual mode indicator

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -47,13 +47,16 @@ function _vi-mode-set-cursor-shape-for-keymap() {
 function zle-line-pre-redraw() {
   if [[ "$REGION_ACTIVE" -eq 0 && ("$VI_KEYMAP" == visual || "$VI_KEYMAP" == visual-line) ]]; then
     typeset -g VI_KEYMAP=$KEYMAP
-    _vi-mode-set-cursor-shape-for-keymap "$VI_KEYMAP"
+    zle reset-prompt
+    zle -R
   elif [[ "$REGION_ACTIVE" -eq 1 && "$VI_KEYMAP" != "visual" ]]; then
     typeset -g VI_KEYMAP=visual
-    _vi-mode-set-cursor-shape-for-keymap "$VI_KEYMAP"
+    zle reset-prompt
+    zle -R
   elif [[ "$REGION_ACTIVE" -eq 2 && "$VI_KEYMAP" != "visual-line" ]]; then
     typeset -g VI_KEYMAP=visual-line
-    _vi-mode-set-cursor-shape-for-keymap "$VI_KEYMAP"
+    zle reset-prompt
+    zle -R
   fi
 }
 zle -N zle-line-pre-redraw
@@ -171,9 +174,16 @@ fi
 
 # if mode indicator wasn't setup by theme, define default, we'll leave INSERT_MODE_INDICATOR empty by default
 typeset -g MODE_INDICATOR=${MODE_INDICATOR:='%B%F{red}<%b<<%f'}
+typeset -g VISUAL_MODE_INDICATOR=${VISUAL_MODE_INDICATOR:='%B%F{white}<%b<<%f'}
+typeset -g VISUAL_LINE_MODE_INDICATOR=${VISUAL_LINE_MODE_INDICATOR:='%B%F{white}<%b<<%f'}
 
 function vi_mode_prompt_info() {
-  echo "${${VI_KEYMAP/vicmd/$MODE_INDICATOR}/(main|viins)/$INSERT_MODE_INDICATOR}"
+  case "$VI_KEYMAP" in
+    vicmd)       echo "$MODE_INDICATOR" ;;
+    visual)      echo "$VISUAL_MODE_INDICATOR" ;;
+    visual-line) echo "$VISUAL_LINE_MODE_INDICATOR" ;;
+    main|viins)  echo "$INSERT_MODE_INDICATOR" ;;
+  esac
 }
 
 # define right prompt, if it wasn't defined by a theme


### PR DESCRIPTION
## Standards checklist:

Add a customizable indicator for the `vi-mode` plugin's:
- visual mode
- visual line mode

These can be configured with the variables:
- `VISUAL_MODE_INDICATOR`
- `VISUAL_LINE_MODE_INDICATOR`

The default is **<**<< in white, similar to but contrasting normal mode's default setting of **<**<< in the red.

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add two environment variables for configuring the prompt in visual and visual line modes
- extend `vi_mode_prompt_info()` to account for these new prompts
- reset the prompt on mode change, considering that visual mode is tracked by the active region

## Other comments:

I originally used Claude to generate this code, and then reviewed and reduced the change set manually.

Here is an example of the default behavior:
![vi-mode-default](https://github.com/user-attachments/assets/be757211-3054-4607-97c9-c0793ff00a27)

and an example that mirrors vim's behavior (`-- INSERT --`, `-- VISUAL --`, `-- VISUAL LINE --`):
![vi-mode-vi-like](https://github.com/user-attachments/assets/c4a71084-53fe-4e98-860b-79df4058613a)

This latter example exposes a pre-existing bug: that the insert indicator is not cleared when enter is pressed (ticket not yet filed).