### PR TITLE
feat(gradle): Aliased to `gradlew` as well as `gradle`.

### DIFF
--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -11,17 +11,25 @@ plugins=(... gradle)
 ## Usage
 
 This plugin creates a function called `gradle-or-gradlew`, which is aliased
-to `gradle`, which is used to determine whether the current project directory
-has a gradlew file. If `gradlew` is present it will be used, otherwise `gradle`
-is used instead. Gradle tasks can be executed directly without regard for
-whether it is `gradle` or `gradlew`. It also supports being called from
-any directory inside the root project directory.
+to `gradle` and `gradlew`. This function is is used to determine whether the
+current project directory has a `gradlew` wrapper file. If this file is present
+it will be used, otherwise the `gradle` binary from the system environment is
+used instead. Gradle tasks can be executed directly without regard for whether
+it is the environment `gradle` or the `gradlew` wrapper being invoked. It also
+supports being called from any directory inside the root directory of a Gradle
+project.
 
 Examples:
 
 ```zsh
+# Enter project directory
+cd /my/gradle/project
+# Will call `gradlew` if present or `gradle` if not
 gradle test
-gradle build
+# Enter a sub-directory of the project directory
+cd my/sub/directory
+# Will call `gradlew` from `/my/gradle/project` if present or `gradle` if not
+gradlew build
 ```
 
 ## Completion

--- a/plugins/gradle/gradle.plugin.zsh
+++ b/plugins/gradle/gradle.plugin.zsh
@@ -13,9 +13,9 @@ function gradle-or-gradlew() {
     dir="${dir:h}"
   done
 
-  # if gradlew found, run it instead of gradle
+  # if local gradle wrapper found, run it instead of gradle
   if [[ -f "$project_root/gradlew" ]]; then
-    echo "executing gradlew instead of gradle"
+    echo "executing local gradle wrapper instead of gradle"
     "$project_root/gradlew" "$@"
   else
     command gradle "$@"
@@ -23,4 +23,5 @@ function gradle-or-gradlew() {
 }
 
 alias gradle=gradle-or-gradlew
+alias gradlew=gradle-or-gradlew
 compdef _gradle gradle-or-gradlew


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Aliased `gradlew` to `gradle-or-gradlew` as well as `gradle` in the `gradle` plugin.
- Added this change to the `README.md`.
- Also cleaned/reworded up the `README.md` a touch.

## Other comments:

The logic behind adding this alias is that `gradlew` is a common substitute for `gradle` inside of projects that use the Gradle wrapper. A user is likely to attempt to type `gradlew` out of muscle memory and, with the `gradle` plugin enabled, assume they can drop the leading `./` and just use the plugin aliases (since the function is called `gradle-or-gradlew`).

This alias does not clash with other system-level commands/aliases as `gradlew` is not a common alias. The wrapper script needs to be prefixed with `./` to function.