### PR TITLE
Fix link to prek's source repository

### DIFF
--- a/plugins/pre-commit/README.md
+++ b/plugins/pre-commit/README.md
@@ -1,7 +1,7 @@
 # Pre-commit plugin
 
 This plugin adds aliases for common commands of [pre-commit](https://pre-commit.com/).
-It also supports [prek](https://github.com/prek/prek) as a drop-in replacement.
+It also supports [prek](https://github.com/j178/prek) as a drop-in replacement.
 If `prek` is available, it will be used; otherwise, `pre-commit` is used as fallback.
 
 To use this plugin, add it to the plugins array in your zshrc file:


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes the link to the "prek" command's source in the readme for the "pre-commit" plugin.

## Other comments:

No AI was used in this.
