### PR TITLE
feat(conda): add environment tab completion for cna and cnrn

### DIFF
--- a/plugins/conda/README.md
+++ b/plugins/conda/README.md
@@ -1,6 +1,6 @@
 # conda plugin
 
-The conda plugin provides [aliases](#aliases) for `conda`, usually installed via [anaconda](https://www.anaconda.com/) or [miniconda](https://docs.conda.io/en/latest/miniconda.html).
+The conda plugin provides [aliases](#aliases) and [completion](#completion) for `conda`, usually installed via [anaconda](https://www.anaconda.com/) or [miniconda](https://docs.conda.io/en/latest/miniconda.html).
 
 To use it, add `conda` to the plugins array in your zshrc file:
 
@@ -35,3 +35,10 @@ plugins=(... conda)
 | `cnu`    | `conda update`                          | Update conda package manager                                                    |
 | `cnua`   | `conda update --all`                    | Update all installed packages                                                   |
 | `cnuc`   | `conda update conda`                    | Update conda package manager                                                    |
+
+## Completion
+
+Tab completion is available for the following commands by fetching the list of conda environments:
+
+- `cna`: completes environment names for `conda activate`
+- `cnrn`: completes environment names for `conda remove -y --all -n`

--- a/plugins/conda/conda.plugin.zsh
+++ b/plugins/conda/conda.plugin.zsh
@@ -1,4 +1,10 @@
-alias cna='conda activate'
+if (( ! $+commands[conda] )); then
+  return
+fi
+
+cna()  { conda activate "$@"; }
+cnrn() { conda remove -y --all -n "$@"; }
+
 alias cnab='conda activate base'
 alias cncf='conda env create -f'
 alias cncn='conda create -y -n'
@@ -14,10 +20,22 @@ alias cnl='conda list'
 alias cnle='conda list --export'
 alias cnles='conda list --explicit > spec-file.txt'
 alias cnr='conda remove'
-alias cnrn='conda remove -y --all -n'
 alias cnrp='conda remove -y --all -p'
 alias cnry='conda remove -y'
 alias cnsr='conda search'
 alias cnu='conda update'
 alias cnua='conda update --all'
 alias cnuc='conda update conda'
+
+_omz_conda_envs() {
+  emulate -L zsh
+  local -a envs
+  envs=("${(@f)$(conda env list 2>/dev/null \
+    | sed -nE '/^#/d;/^[[:space:]]*$/d;s/^[[:space:]]*([^[:space:]]+).*/\1/p' \
+    | sed '/^base$/d')}")
+  (( ${#envs[@]} )) && compadd -Q -a envs
+}
+
+if (( $+functions[compdef] )); then
+  compdef _omz_conda_envs cna cnrn
+fi


### PR DESCRIPTION
## Summary
- Add conda command check to exit early if conda is not installed
- Convert `cna` and `cnrn` from aliases to functions to support argument passing
- Add `_omz_conda_envs` completion function that fetches conda environments and provides tab completion for `cna` (activate) and `cnrn` (remove by name) commands
- Update README to document the new completion feature

## AI-assisted contribution disclosure
- Plugin script (`conda.plugin.zsh`): Generated with GPT 5.4 (thinking mode), then reviewed and tested manually
- README, commit messages, and PR: Written with Claude Code (claude-opus-4-6)

## Test plan
- [x] Verify plugin exits early when conda is not installed
- [x] Verify `cna <TAB>` shows available conda environments (excluding base)
- [x] Verify `cnrn <TAB>` shows available conda environments (excluding base)
- [x] Verify `cna envname` activates the specified environment
- [x] Verify all aliases still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)