### PR TITLE
Add  AWS CDK plugin with aliases and autocompletion

### DIFF
--- a/plugins/cdk/cdk.plugin.zsh
+++ b/plugins/cdk/cdk.plugin.zsh
@@ -1,0 +1,12 @@
+# AWS CDK plugin for Oh My Zsh
+
+# aliases
+alias cdkls='cdk ls'
+alias cdkd='cdk deploy'
+alias cdks='cdk synth'
+alias cdkdiff='cdk diff'
+
+# load CDK completion if available
+if command -v cdk >/dev/null 2>&1; then
+  eval "$(cdk completion zsh)"
+fi


### PR DESCRIPTION
Fixes #11816

Adds a cdk plugin that provides basic aliases and autocompletion support for the AWS CDK CLI. The plugin can be enabled by adding cdk to the plugins list in .zshrc.
