### PR TITLE
feat(jj): add alias for new bookmark advance command

### DIFF
--- a/plugins/jj/README.md
+++ b/plugins/jj/README.md
@@ -14,6 +14,7 @@ plugins=(... jj)
 | ------ | ----------------------------- |
 | jja    | `jj abandon`                  |
 | jjb    | `jj bookmark`                 |
+| jjba   | `jj bookmark advance`         |
 | jjbc   | `jj bookmark create`          |
 | jjbd   | `jj bookmark delete`          |
 | jjbf   | `jj bookmark forget`          |

--- a/plugins/jj/jj.plugin.zsh
+++ b/plugins/jj/jj.plugin.zsh
@@ -36,6 +36,7 @@ function jj_prompt_template() {
 # Aliases (sorted alphabetically)
 alias jja='jj abandon'
 alias jjb='jj bookmark'
+alias jjba='jj bookmark advance'
 alias jjbc='jj bookmark create'
 alias jjbd='jj bookmark delete'
 alias jjbf='jj bookmark forget'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `jjba` aliases for the recently introduced `jj bookmark advance` command: https://docs.jj-vcs.dev/latest/cli-reference/#jj-bookmark-advance

## Other comments:

Jujutsu recently introduced the `jj bookmark advance` command for the very common flow of advancing bookmarks to the latest change. Since this is a very common operation to do, an alias to speed this up is a helpful addition to the plugin.

@nasso