### PR TITLE
feat(yarn): use proper `$PWD` var

### DIFF
--- a/plugins/yarn/_yarn
+++ b/plugins/yarn/_yarn
@@ -111,7 +111,7 @@ _yarn_commands_scripts() {
     packageJson=$(_yarn_find_package_json $opt_args[--cwd])
     binaries=($(builtin cd $opt_args[--cwd] && echo node_modules/.bin/*(x:t)))
   else
-    packageJson=$(_yarn_find_package_json $pwd)
+    packageJson=$(_yarn_find_package_json $PWD)
     binaries=($(echo node_modules/.bin/*(x:t)))
   fi
 
@@ -135,7 +135,7 @@ _yarn_scripts() {
       binaries=($(builtin cd $_yarn_run_cwd && yarn bin | perl -wln -e 'm{^[^:]+: (\S+)$} and print $1'))
     fi
   else
-    packageJson=$(_yarn_find_package_json $pwd)
+    packageJson=$(_yarn_find_package_json $PWD)
     if [[ -d node_modules ]]; then
       binaries=($(echo node_modules/.bin/*(x:t)))
     else


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- plugin used local $pwd var which wasn't set. $PWD seems to be sufficient.

## Issue:

`yarn <tab>` in a javascript project folder resulted in outputting a stream of `usage: dirname string [...]` in a loop.