### PR TITLE
fix(dpoggi): ensure correct Ghostty rendering

### DIFF
--- a/themes/dpoggi.zsh-theme
+++ b/themes/dpoggi.zsh-theme
@@ -1,10 +1,7 @@
 if [ $UID -eq 0 ]; then NCOLOR="red"; else NCOLOR="green"; fi
 local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 
-PROMPT='%{$fg[$NCOLOR]%}%n%{$reset_color%}@%{$fg[cyan]%}%m\
-%{$reset_color%}:%{$fg[magenta]%}%~\
-$(git_prompt_info) \
-%{$fg[red]%}%(!.#.»)%{$reset_color%} '
+PROMPT='%{$fg[$NCOLOR]%}%n%{$reset_color%}@%{$fg[cyan]%}%m%{$reset_color%}:%{$fg[magenta]%}%~$(git_prompt_info) %{$fg[red]%}%(!.#.»)%{$reset_color%} '
 PROMPT2='%{$fg[red]%}\ %{$reset_color%}'
 RPS1='${return_code}'
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Summary

The `dpoggi` theme's `PROMPT` definition uses `\<newline>` (backslash followed by a literal newline) within a single-quoted string as line continuations. Zsh's prompt expansion consumes both characters, so the prompt has always rendered as a **single line** — matching the [wiki preview](https://user-images.githubusercontent.com/49100982/108254790-7fd4ef00-716c-11eb-821e-d11fba0c4f10.jpg).

## Problem

Ghostty 1.3.0 introduced updated shell integration that inserts [OSC 133 semantic prompt markers](https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md) after each newline in `PS1` to support features like click-to-move-cursor and `jump_to_prompt`. This breaks the `\<newline>` continuation pattern — the inserted marker sits between `\` and the newline, so zsh no longer treats them as a continuation pair. The result is a prompt that unexpectedly renders across multiple lines.

This is the same class of issue reported for the `jreese` theme in [ghostty-org/ghostty#11712](https://github.com/ghostty-org/ghostty/discussions/11712) and for bash prompts in [ghostty-org/ghostty#11267](https://github.com/ghostty-org/ghostty/discussions/11267).

## Fix

Collapse the `PROMPT` assignment to a single line. This produces **identical output** in all terminals (verified in iTerm2, Terminal.app, tmux, zellij, and Ghostty) while avoiding the fragile `\<newline>` pattern that shell integration can disrupt.

## Before / After

No visual change. The prompt renders the same as it always has:

```
user@host:~/path(branch⚡) »
```

## AI disclosure

PR description and code change were prepared with the help of an AI coding assistant (Claude). The issue was identified, diagnosed, and tested by the contributor.