### PR TITLE
fix(poetry): fix typos and broken markdown table formatting

### DIFF
--- a/plugins/poetry/README.md
+++ b/plugins/poetry/README.md
@@ -10,27 +10,27 @@ plugins=(... poetry)
 
 ## Aliases
 
-| Alias | Command                                            | Description    
+| Alias | Command                                            | Description                                                                             |
 |:----- |--------------------------------------------------- |:--------------------------------------------------------------------------------------- |
 | pad   | `poetry add`                                       | Add packages to `pyproject.toml` and install them                                       |
 | pbld  | `poetry build`                                     | Build the source and wheels archives                                                    |
 | pch   | `poetry check`                                     | Validate the content of the `pyproject.toml` and its consistency with the `poetry.lock` |
 | pcmd  | `poetry list`                                      | Display all the available Poetry commands                                               |
 | pconf | `poetry config --list`                             | Allow you to edit poetry config settings and repositories                               |
-| pexp  | `poetry export --without-hashes > requirements.txt | Export the lock file to `requirements.txt`                                              |
+| pexp  | `poetry export --without-hashes > requirements.txt` | Export the lock file to `requirements.txt`                                              |
 | pin   | `poetry init`                                      | Create a `pyproject.toml` interactively                                                 |
 | pinst | `poetry install`                                   | Read the `pyproject.toml`, resolve the dependencies, and install them                   |
 | plck  | `poetry lock`                                      | Lock the dependencies in `pyproject.toml` without installing                            |
 | pnew  | `poetry new`                                       | Create a directory structure suitable for most Python projects                          |
-| ppath | `poetry env info --path`                           | Get the path of the currently activated virtualenv`                                     |
+| ppath | `poetry env info --path`                           | Get the path of the currently activated virtualenv                                     |
 | pplug | `poetry self show plugins`                         | List all the installed Poetry plugins                                                   |
-| ppub  | `poetry publish`                                   | Publish the builded (`poetry build` command) package to the remote repository           |
+| ppub  | `poetry publish`                                   | Publish the built (`poetry build` command) package to the remote repository           |
 | prm   | `poetry remove`                                    | Remove packages from `pyproject.toml` and uninstall them                                |
 | prun  | `poetry run`                                       | Executes the given command inside the project’s virtualenv                              |
 | psad  | `poetry self add`                                  | Add the Poetry plugin and install dependencies to make it work                          |
 | psh   | `poetry shell`                                     | Spawns a shell within the virtual environment. If one doesn’t exist, it will be created |
 | pshw  | `poetry show`                                      | List all the available dependencies                                                     |
-| pslt  | `poetry show --latest`                             | List lastest version of the dependencies                                                |
+| pslt  | `poetry show --latest`                             | List latest version of the dependencies                                                |
 | psup  | `poetry self update`                               | Update Poetry to the latest version (default) or to the specified version               |
 | psync | `poetry install --sync`                            | Synchronize your environment with the `poetry.lock`                                     |
 | ptree | `poetry show --tree`                               | List the dependencies as tree                                                           |


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixed missing closing `|` in the markdown table header, which caused incorrect rendering
- Fixed missing closing backtick in `pexp` alias command (`poetry export ...`)
- Removed extra backtick in `ppath` alias description (`virtualenv` → `virtualenv`)
- Fixed typo: "builded" → "built" in `ppub` alias description
- Fixed typo: "lastest" → "latest" in `pslt` alias description

## Other comments:

AI tools (GitHub Copilot with Claude) were used to identify the issues. All fixes were manually verified against the rendered markdown output.