### PR TITLE
Claude Code Plugin

### DIFF
--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -8,6 +8,33 @@ To use it, add `claude-code` to the plugins array of your zshrc file:
 plugins=(... claude-code)
 ```
 
+## Configuration Variables
+
+Set these in your `~/.zshrc` **before** the plugins line:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ZSH_CLAUDE_DEFAULT_MODEL` | _(unset)_ | Default model applied to all session aliases (e.g., `opus`, `sonnet`, `haiku`, or a full model ID) |
+| `ZSH_CLAUDE_DEFAULT_EFFORT` | _(unset)_ | Default reasoning effort level (`low`, `medium`, `high`, `max`) |
+| `ZSH_CLAUDE_DEFAULT_PERMISSION_MODE` | _(unset)_ | Default permission mode (`acceptEdits`, `bypassPermissions`, `default`, `dontAsk`, `plan`, `auto`) |
+| `ZSH_CLAUDE_AUTO_CONTINUE` | `false` | Auto-resume last conversation on new shell start |
+
+> **How defaults work:** All session-starting aliases (`cl`, `clc`, `clr`, `cln`, `clw`, etc.) automatically
+> inject your configured defaults. If you also pass a flag explicitly (e.g., `cl --model opus`), the explicit
+> flag takes precedence since it appears after the defaults on the command line.
+
+### Example
+
+```zsh
+# ~/.zshrc
+ZSH_CLAUDE_DEFAULT_MODEL="sonnet"
+ZSH_CLAUDE_DEFAULT_EFFORT="high"
+ZSH_CLAUDE_DEFAULT_PERMISSION_MODE="plan"
+ZSH_CLAUDE_AUTO_CONTINUE=false
+
+plugins=(... claude-code)
+```
+
 ## Aliases
 
 ### Core
@@ -56,36 +83,12 @@ plugins=(... claude-code)
 
 | Function | Description | Example |
 |----------|-------------|---------|
-| `clm <model>` | Start with a specific model | `clm opus` |
-| `cle <effort>` | Start with a specific effort level | `cle high` |
-| `clds` | Directory session — create/resume a session named after `$PWD` | `cd my-project && clds` |
+| `clm <model>` | Start with a specific model (also applies effort and permission-mode defaults) | `clm opus` |
+| `cle <effort>` | Start with a specific effort level (also applies model and permission-mode defaults) | `cle high` |
+| `clds` | Directory session — create or resume a session named after `$PWD` | `clds` |
 | `clfp <pr>` | Resume sessions linked to a GitHub PR | `clfp 123` |
-
-
-
-## Configuration Variables
-
-Set these in your `~/.zshrc` before the plugins line:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `ZSH_CLAUDE_DEFAULT_MODEL` | (unset) | Default model for `clm` and `_claude_with_defaults` |
-| `ZSH_CLAUDE_DEFAULT_EFFORT` | (unset) | Default effort level |
-| `ZSH_CLAUDE_DEFAULT_PERMISSION_MODE` | (unset) | Default permission mode (plan/auto/manual) |
-| `ZSH_CLAUDE_AUTO_CONTINUE` | `false` | Auto-continue last session when opening a new shell |
-
-### Example configuration
-
-```zsh
-# ~/.zshrc
-ZSH_CLAUDE_DEFAULT_MODEL="sonnet"
-ZSH_CLAUDE_DEFAULT_EFFORT="high"
-ZSH_CLAUDE_AUTO_CONTINUE=false
-
-plugins=(... claude-code)
-```
 
 ## Tab Completion
 
-- `clm [TAB]` — completes model names (opus, sonnet, haiku)
-- `cle [TAB]` — completes effort levels (low, medium, high, max)
+- `clm [TAB]` — completes model names (`opus`, `sonnet`, `haiku`)
+- `cle [TAB]` — completes effort levels (`low`, `medium`, `high`, `max`)

--- a/plugins/claude-code/claude-code.plugin.zsh
+++ b/plugins/claude-code/claude-code.plugin.zsh
@@ -15,25 +15,25 @@ fi
 : ${ZSH_CLAUDE_DEFAULT_MODEL:=}
 # Default reasoning effort level (low, medium, high, max)
 : ${ZSH_CLAUDE_DEFAULT_EFFORT:=}
-# Default permission mode for claude sessions (e.g., plan, autoaccept)
+# Default permission mode for claude sessions (choices: "acceptEdits", "bypassPermissions", "default", "dontAsk", "plan", "auto")
 : ${ZSH_CLAUDE_DEFAULT_PERMISSION_MODE:=}
 # Auto-resume last conversation on new shell start (true/false)
 : ${ZSH_CLAUDE_AUTO_CONTINUE:=false}
 
 # Core aliases
 
-alias cl='claude'
-alias clc='claude --continue'
-alias clr='claude --resume'
-alias clp='claude -p'
+alias cl='_claude_with_defaults'
+alias clc='_claude_with_defaults --continue'
+alias clr='_claude_with_defaults --resume'
+alias clp='_claude_with_defaults -p'
 alias clv='claude --version'
 alias clu='claude update'
 
 # Session aliases
 
-alias cln='claude -n'
-alias clw='claude -w'
-alias clfork='claude --fork-session'
+alias cln='_claude_with_defaults -n'
+alias clw='_claude_with_defaults -w'
+alias clfork='_claude_with_defaults --fork-session'
 
 # Auth aliases
 
@@ -55,7 +55,10 @@ function clm() {
     return 1
   fi
   shift 2>/dev/null
-  claude --model "$model" "$@"
+  local -a args=()
+  [[ -n "$ZSH_CLAUDE_DEFAULT_EFFORT" ]] && args+=(--effort "$ZSH_CLAUDE_DEFAULT_EFFORT")
+  [[ -n "$ZSH_CLAUDE_DEFAULT_PERMISSION_MODE" ]] && args+=(--permission-mode "$ZSH_CLAUDE_DEFAULT_PERMISSION_MODE")
+  claude --model "$model" "${args[@]}" "$@"
 }
 
 function cle() {
@@ -65,13 +68,16 @@ function cle() {
     return 1
   fi
   shift 2>/dev/null
-  claude --effort "$effort" "$@"
+  local -a args=()
+  [[ -n "$ZSH_CLAUDE_DEFAULT_MODEL" ]] && args+=(--model "$ZSH_CLAUDE_DEFAULT_MODEL")
+  [[ -n "$ZSH_CLAUDE_DEFAULT_PERMISSION_MODE" ]] && args+=(--permission-mode "$ZSH_CLAUDE_DEFAULT_PERMISSION_MODE")
+  claude --effort "$effort" "${args[@]}" "$@"
 }
 
 # Channel aliases
 
-alias clch-tg='claude --channels plugin:telegram@claude-plugins-official'
-alias clch-dc='claude --channels plugin:discord@claude-plugins-official'
+alias clch-tg='_claude_with_defaults --channels plugin:telegram@claude-plugins-official'
+alias clch-dc='_claude_with_defaults --channels plugin:discord@claude-plugins-official'
 
 function clch() {
   if [[ -z "$1" ]]; then
@@ -81,7 +87,7 @@ function clch() {
   fi
   local channel="$1"
   shift
-  claude --channels "$channel" "$@"
+  _claude_with_defaults --channels "$channel" "$@"
 }
 
 # Helper functions
@@ -92,7 +98,7 @@ function clds() {
   local dir="${PWD##*/}"
   [[ "$PWD" == "$HOME" ]] && dir="HOME"
   [[ "$PWD" == "/" ]] && dir="ROOT"
-  claude --resume "$dir" "$@" 2>/dev/null || claude -n "$dir" "$@"
+  _claude_with_defaults --resume "$dir" "$@" 2>/dev/null || _claude_with_defaults -n "$dir" "$@"
 }
 
 # Resume from a PR number


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Initial plugin implementation
- README
- Aliases
- Autocompletion for models and efforts
- Config for defaults


## Other comments:
Claude assisted in creating this plugin.
Tested all aliases manually.
Tested config in `.zshrc`.
Two use cases I've loved using is prompting Claude for quick queries (`clp "my query"` ) and to hook up my terminal session to my discord channel (`clch-dc`).