### PR TITLE
fix(installer): handle sudo shims that don't support -k flag

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -473,7 +473,8 @@ EOF
   # be prompted for the password either way, so this shouldn't cause any issues.
   #
   if user_can_sudo; then
-    sudo -k chsh -s "$zsh" "$USER"  # -k forces the password prompt
+    sudo -k >/dev/null 2>&1         # -k forces the password prompt
+    sudo chsh -s "$zsh" "$USER"
   else
     chsh -s "$zsh" "$USER"          # run chsh normally
   fi


### PR DESCRIPTION
Related to #13585

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Implement requested changes from #13585