### PR TITLE
docs(vscode): align README with current CLI behavior

### DIFF
--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -1,6 +1,6 @@
 # VS Code
 
-This plugin provides useful aliases to simplify the interaction between the command line and VS Code, VSCodium, or Cursor editor.
+This plugin provides useful aliases to simplify interaction between the command line and VS Code, VSCodium, or Cursor.
 
 To start using it, add the `vscode` plugin to your `plugins` array in `~/.zshrc`:
 
@@ -10,46 +10,45 @@ plugins=(... vscode)
 
 ## Requirements
 
-This plugin requires to have a flavour of VS Code installed and its executable available in PATH.
+This plugin requires one of the supported editors to be installed and its executable to be available in `PATH`.
 
-You can install either:
+You can install one of the following:
 
-- VS Code (code)
-- VS Code Insiders (code-insiders)
-- VSCodium (codium)
-- Cursor (cursor)
+- VS Code (`code`)
+- VS Code Insiders (`code-insiders`)
+- VSCodium (`codium`)
+- Cursor (`cursor`)
 
-### MacOS
+### macOS
 
-While Linux installations will add the executable to PATH, MacOS users might still have to do this manually:
+While Linux installations usually add the executable to `PATH`, macOS users might still have to do this manually:
 
 [For VS Code and VS Code Insiders](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line),
-open the Command Palette via (F1 or ⇧⌘P) and type shell command to find the Shell Command:
+open the Command Palette with `F1` or `Shift+Cmd+P`, then search for the following command:
 
 > Shell Command: Install 'code' command in PATH
 
 [For VSCodium](https://github.com/VSCodium/vscodium/blob/master/DOCS.md#how-do-i-open-vscodium-from-the-terminal),
-open the Command Palette via (F1 or ⇧⌘P) and type shell command to find the Shell Command:
+open the Command Palette with `F1` or `Shift+Cmd+P`, then search for the following command:
 
 > Shell Command: Install 'codium' command in PATH
 
-For Cursor, open the Command Palette via (F1 or ⌘⇧P) and type shell command to find the Shell Command:
+For Cursor, open the Command Palette with `F1` or `Cmd+Shift+P`, then search for the following command:
 
 > Shell Command: Install 'cursor' command in PATH
 
-## Using multiple flavours
+## Choosing an editor
 
-If for any reason, you ever require to use multiple flavours of VS Code i.e. VS Code (stable) and VS Code
-Insiders, you can manually specify the flavour's executable. Add the following line to the .zshrc file
-(between the `ZSH_THEME` and the `plugins=()` lines). This will make the plugin use your manually defined
-executable.
+If you have multiple supported editors installed, e.g., VS Code (stable) and VS Code Insiders, you can manually
+specify which executable the plugin should use. Add the following line to `~/.zshrc` between the `ZSH_THEME`
+and `plugins=()` lines. This makes the plugin use your manually defined executable.
 
 ```zsh
 ZSH_THEME=...
 
-# Choose between one [code, code-insiders, codium, or cursor]
-# The following line will make the plugin to open VS Code Insiders
-# Invalid entries will be ignored, no aliases will be added
+# Choose one of `code`, `code-insiders`, `codium`, or `cursor`.
+# The following line makes the plugin open VS Code Insiders.
+# Invalid entries are ignored and no aliases are added.
 VSCODE=code-insiders
 
 plugins=(... vscode)
@@ -61,29 +60,29 @@ source $ZSH/oh-my-zsh.sh
 
 | Alias                   | Command                        | Description                                                                                                 |
 | ----------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| vsc                     | code .                         | Open the current folder in VS code                                                                          |
-| vsc `dir`               | code `dir`                     | Open passed folder in VS code                                                                               |
-| vsca `dir`              | code --add `dir`               | Add folder(s) to the last active window                                                                     |
+| vsc                     | code .                         | Open the current folder in VS Code                                                                          |
+| vsc `[args ...]`        | code `[args ...]`              | Pass arguments through to VS Code, e.g., a file, folder, or CLI flags.                                      |
+| vsca `dir`              | code --add `dir`               | Add one or more folders to the last active window.                                                          |
 | vscd `file` `file`      | code --diff `file` `file`      | Compare two files with each other.                                                                          |
 | vscg `file:line[:char]` | code --goto `file:line[:char]` | Open a file at the path on the specified line and character position.                                       |
-| vscn                    | code --new-window              | Force to open a new window.                                                                                 |
-| vscr                    | code --reuse-window            | Force to open a file or folder in the last active window.                                                   |
+| vscn                    | code --new-window              | Force opening in a new window.                                                                              |
+| vscr                    | code --reuse-window            | Force opening a file or folder in the last active window.                                                   |
 | vscw                    | code --wait                    | Wait for the files to be closed before returning.                                                           |
-| vscu `dir`              | code --user-data-dir `dir`     | Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code. |
+| vscu `dir`              | code --user-data-dir `dir`     | Specifies the directory where user data is stored. Can be used to open multiple distinct instances of Code. |
 | vscp `profile`          | code --profile `profile`       | Specifies the profile to open Code with.                                                                    |
 
-## Extensions aliases
+## Extension aliases
 
-| Alias                   | Command                                                          | Description                       |
-| ----------------------- | ---------------------------------------------------------------- | --------------------------------- |
-| vsced `dir`             | code --extensions-dir `dir`                                      | Set the root path for extensions. |
-| vscie `id or vsix-path` | code --install-extension `extension-id> or <extension-vsix-path` | Installs an extension.            |
-| vscue `id or vsix-path` | code --uninstall-extension `id or vsix-path`                     | Uninstalls an extension.          |
+| Alias                       | Command                                        | Description                            |
+| --------------------------- | ---------------------------------------------- | -------------------------------------- |
+| vsced `dir`                 | code --extensions-dir `dir`                    | Set the root directory for extensions. |
+| vscie `ext-id or vsix-path` | code --install-extension `ext-id or vsix-path` | Installs or updates an extension.      |
+| vscue `ext-id`              | code --uninstall-extension `ext-id`            | Uninstalls an extension.               |
 
-## Other options:
+## Other options
 
-| Alias        | Command                   | Description                                                                                                           |
-| ------------ | ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| vscv         | code --verbose            | Print verbose output (implies --wait).                                                                                |
-| vscl `level` | code --log `level`        | Log level to use. Default is 'info'. Allowed values are 'critical', 'error', 'warn', 'info', 'debug', 'trace', 'off'. |
-| vscde        | code --disable-extensions | Disable all installed extensions.                                                                                     |
+| Alias        | Command                   | Description                              |
+| ------------ | ------------------------- | ---------------------------------------- |
+| vscv         | code --verbose            | Print verbose output (implies `--wait`). |
+| vscl `level` | code --log `level`        | Log level to use. Default is `info`.     |
+| vscde        | code --disable-extensions | Disable all installed extensions.        |


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Updated the `vscode` README to reflect the current plugin behavior and VS Code CLI semantics.
- Clarified supported editors, setup instructions, etc. where the previous documentation was ambiguous or misleading.
- Corrected command examples and arg placeholders that were inaccurate or misleading. For example, ``vsc `dir` `` can be used to open directories, files, or pass through additional args.
- Addressed inconsistencies in the documentation.

## Other comments:

...