### PR TITLE
fix: sanitize subprocess call in ssh-agent.py

### DIFF
--- a/plugins/shell-proxy/ssh-agent.py
+++ b/plugins/shell-proxy/ssh-agent.py
@@ -13,4 +13,20 @@ argv = [
     "Compression=yes",
 ]
 
-subprocess.call(argv + sys.argv[1:], env=os.environ)
+
+def _validate_args(args):
+    """Validate arguments to prevent command injection attacks.
+
+    Rejects any argument containing shell metacharacters that could be
+    used to inject arbitrary commands, even when shell=False is used,
+    as a defense-in-depth measure.
+    """
+    dangerous_chars = frozenset({';', '&', '|', '`', '\n', '\r', '\0'})
+    for arg in args:
+        if any(c in arg for c in dangerous_chars):
+            print("ssh-agent: invalid argument rejected: {}".format(arg), file=sys.stderr)
+            sys.exit(1)
+    return list(args)
+
+
+subprocess.call(argv + _validate_args(sys.argv[1:]), env=os.environ, shell=False)


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `plugins/shell-proxy/ssh-agent.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `plugins/shell-proxy/ssh-agent.py:16` |

**Description**: The SSH proxy scripts pass command-line arguments directly to subprocess.call() without validation, sanitization, or type checking. In ssh-agent.py line 16, user-provided arguments from sys.argv[1:...

## Changes
- `plugins/shell-proxy/ssh-agent.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] Code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
