### PR TITLE
Feature Request (Installer): Add specific flag to skip Zsh execution after installation

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -32,6 +32,7 @@
 #
 # You can also pass some arguments to the install script to set some these options:
 #   --skip-chsh: has the same behavior as setting CHSH to 'no'
+#   --skip-runzsh: has the same behavior as setting RUNZSH to 'no'
 #   --unattended: sets both CHSH and RUNZSH to 'no'
 #   --keep-zshrc: sets KEEP_ZSHRC to 'yes'
 # For example:
@@ -343,7 +344,7 @@ setup_zshrc() {
       echo "${FMT_YELLOW}Found ${zdot}/.zshrc.${FMT_RESET} ${FMT_GREEN}Keeping...${FMT_RESET}"
       return
     fi
-    
+
     if [ $OVERWRITE_CONFIRMATION != "no" ]; then
       # Ask user for confirmation before backing up and overwriting
       echo "${FMT_YELLOW}Found ${zdot}/.zshrc."
@@ -522,6 +523,7 @@ main() {
   while [ $# -gt 0 ]; do
     case $1 in
       --unattended) RUNZSH=no; CHSH=no; OVERWRITE_CONFIRMATION=no ;;
+      --skip-runzsh) RUNZSH=no ;;
       --skip-chsh) CHSH=no ;;
       --keep-zshrc) KEEP_ZSHRC=yes ;;
     esac


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- This flag would skip executing a Zsh subshell without forcingly use --unattended,
allowing the user to still choose to change the default shell and overwrite the
current .zshrc file at users's $HOME.
This flag is compatible with other established ways to skip running a Zsh subshell,
like `RUNZSH=yes sh -c "$(<fetch_OMZ_installer_command>)`, or `--unattended`, as
noted in PR (https://github.com/ohmyzsh/ohmyzsh/pull/5853#issuecomment-496625733)

## Other comments:

I know there are established options to do this, I just thought adding a simple flag would be harmless and consistent with other ways the installer can be configured.
