### PR TITLE
feat(apple): randomize logo color

### DIFF
--- a/themes/apple.zsh-theme
+++ b/themes/apple.zsh-theme
@@ -1,7 +1,3 @@
-function toon {
-  echo -n ""
-}
-
 autoload -Uz vcs_info
 zstyle ':vcs_info:*' check-for-changes true
 zstyle ':vcs_info:*' unstagedstr '%F{red}*'   # display this when there are unstaged changes
@@ -15,10 +11,15 @@ zstyle ':vcs_info:*' enable git cvs svn
 
 theme_precmd () {
   vcs_info
+
+  local apple_colors=(red green yellow blue magenta cyan white)
+  local random_color=$apple_colors[$(( RANDOM % ${#apple_colors[@]} + 1 ))]
+
+  APPLE_PROMPT="%F{$random_color}%f"
 }
 
 setopt prompt_subst
-PROMPT='%{$fg[magenta]%}$(toon)%{$reset_color%} %~/ %{$reset_color%}${vcs_info_msg_0_}%{$reset_color%}'
+PROMPT='${APPLE_PROMPT} %~/ %{$reset_color%}${vcs_info_msg_0_}%{$reset_color%}'
 
 autoload -U add-zsh-hook
 add-zsh-hook precmd theme_precmd


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

use and pre-defined color list and an environment variable RANDOM to change the color every time user hit enter

## Other comments:
I just had this sudden idea to see if it could be implemented; it's okay if it doesn't get merged.

<img width="697" height="579" alt="Screenshot 2026-04-02 at 17 00 34" src="https://github.com/user-attachments/assets/30af1b9a-19de-46d2-b338-5209a0a122a4" />

