### PR TITLE
refactor(plugins): use cached background completion generation

### DIFF
--- a/plugins/invoke/invoke.plugin.zsh
+++ b/plugins/invoke/invoke.plugin.zsh
@@ -1,5 +1,14 @@
-# Autocompletion for invoke.
-#
-if [ $commands[invoke] ]; then
-  source <(invoke --print-completion-script=zsh)
+# Autocompletion for the Invoke CLI (invoke).
+if (( ! $+commands[invoke] )); then
+  return
 fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `invoke`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_invoke" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _invoke
+  _comps[invoke]=_invoke
+fi
+
+invoke --print-completion-script=zsh >| "$ZSH_CACHE_DIR/completions/_invoke" &|

--- a/plugins/istioctl/istioctl.plugin.zsh
+++ b/plugins/istioctl/istioctl.plugin.zsh
@@ -1,4 +1,14 @@
-if [ $commands[istioctl] ]; then
-  source <(istioctl completion zsh)
-  compdef _istioctl istioctl
+# Autocompletion for the Istio CLI (istioctl).
+if (( ! $+commands[istioctl] )); then
+  return
 fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `istioctl`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_istioctl" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _istioctl
+  _comps[istioctl]=_istioctl
+fi
+
+istioctl completion zsh >| "$ZSH_CACHE_DIR/completions/_istioctl" &|

--- a/plugins/kn/kn.plugin.zsh
+++ b/plugins/kn/kn.plugin.zsh
@@ -1,8 +1,17 @@
-# Autocompletion for kn, the command line interface for knative
+# Autocompletion for kn, the command line interface for Knative.
 #
 # Author: https://github.com/btannous
 
-if [ $commands[kn] ]; then
-  source <(kn completion zsh)
-  compdef _kn kn
+if (( ! $+commands[kn] )); then
+  return
 fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `kn`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_kn" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _kn
+  _comps[kn]=_kn
+fi
+
+kn completion zsh >| "$ZSH_CACHE_DIR/completions/_kn" &|

--- a/plugins/kompose/kompose.plugin.zsh
+++ b/plugins/kompose/kompose.plugin.zsh
@@ -1,3 +1,14 @@
-if [ $commands[kompose] ]; then
-  source <(kompose completion zsh)
+# Autocompletion for the Kompose CLI (kompose).
+if (( ! $+commands[kompose] )); then
+  return
 fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `kompose`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_kompose" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _kompose
+  _comps[kompose]=_kompose
+fi
+
+kompose completion zsh >| "$ZSH_CACHE_DIR/completions/_kompose" &|

--- a/plugins/kops/kops.plugin.zsh
+++ b/plugins/kops/kops.plugin.zsh
@@ -1,3 +1,14 @@
-if [ $commands[kops] ]; then
-  source <(kops completion zsh)
+# Autocompletion for the Kubernetes Operations CLI (kops).
+if (( ! $+commands[kops] )); then
+  return
 fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `kops`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_kops" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _kops
+  _comps[kops]=_kops
+fi
+
+kops completion zsh >| "$ZSH_CACHE_DIR/completions/_kops" &|

--- a/plugins/oc/oc.plugin.zsh
+++ b/plugins/oc/oc.plugin.zsh
@@ -2,7 +2,16 @@
 #
 # Author: https://github.com/kevinkirkup
 
-if [ $commands[oc] ]; then
-  source <(oc completion zsh)
-  compdef _oc oc
+if (( ! $+commands[oc] )); then
+  return
 fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `oc`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_oc" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _oc
+  _comps[oc]=_oc
+fi
+
+oc completion zsh >| "$ZSH_CACHE_DIR/completions/_oc" &|

--- a/plugins/operator-sdk/operator-sdk.plugin.zsh
+++ b/plugins/operator-sdk/operator-sdk.plugin.zsh
@@ -1,4 +1,14 @@
-if [ $commands[operator-sdk] ]; then
-  source <(operator-sdk completion zsh)
-  compdef _operator-sdk operator-sdk
+# Autocompletion for the Operator SDK CLI (operator-sdk).
+if (( ! $+commands[operator-sdk] )); then
+  return
 fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `operator-sdk`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_operator-sdk" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _operator-sdk
+  _comps[operator-sdk]=_operator-sdk
+fi
+
+operator-sdk completion zsh >| "$ZSH_CACHE_DIR/completions/_operator-sdk" &|

--- a/plugins/please/please.plugin.zsh
+++ b/plugins/please/please.plugin.zsh
@@ -1,6 +1,17 @@
-if (( $+commands[plz] )); then
-    source <(plz --completion_script)
+# Autocompletion for the Please build system CLI (plz).
+if (( ! $+commands[plz] )); then
+  return
 fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `plz`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_plz" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _plz
+  _comps[plz]=_plz
+fi
+
+plz --completion_script >| "$ZSH_CACHE_DIR/completions/_plz" &|
 
 alias pb='plz build'
 alias pt='plz test'

--- a/plugins/svcat/svcat.plugin.zsh
+++ b/plugins/svcat/svcat.plugin.zsh
@@ -1,6 +1,14 @@
-# Autocompletion for svcat.
-#
-
-if [ $commands[svcat] ]; then
-  source <(svcat completion zsh)
+# Autocompletion for the Service Catalog CLI (svcat).
+if (( ! $+commands[svcat] )); then
+  return
 fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `svcat`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_svcat" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _svcat
+  _comps[svcat]=_svcat
+fi
+
+svcat completion zsh >| "$ZSH_CACHE_DIR/completions/_svcat" &|


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- use cached background completion generation for plugins that used `source`.

## Other comments:

- used AI to find an update the completion plugins. reviewed them manually.
- please let me know if you'd like me to split this into individual commits.