### PR TITLE
test(aliases): add regression tests for cheatsheet quote handling

### DIFF
--- a/plugins/aliases/tests/test_cheatsheet.py
+++ b/plugins/aliases/tests/test_cheatsheet.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Tests for cheatsheet.py - regression tests for known bugs."""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from cheatsheet import parse
+
+_failures = 0
+
+def run_test(description, got, expected):
+    global _failures
+    if got == expected:
+        print(f"\033[32mSuccess\033[0m: {description}\n")
+    else:
+        print(f"\033[31mError\033[0m: {description}")
+        print(f"  expected: {expected!r}")
+        print(f"  got:      {got!r}\n", file=sys.stderr)
+        _failures += 1
+
+
+# Bug #13637: als drops trailing double quote from alias value.
+# alias now='date +"%T"' was being rendered as `now = date +"%T` (missing closing ").
+# Root cause: strip('\'"\n ') stripped " from both ends of the value string.
+
+_, right, _ = parse("now='date +\"%T\"'")
+run_test(
+    "trailing double quote preserved in single-quoted alias (bug #13637)",
+    right,
+    'date +"%T"',
+)
+
+_, right, _ = parse("foo='echo \"hello world\"'")
+run_test(
+    "both double quotes preserved when alias value contains a quoted word",
+    right,
+    'echo "hello world"',
+)
+
+# Unrelated to the bug - verify basic parsing still works correctly.
+_, right, _ = parse('bar="simple command"')
+run_test(
+    "double-quoted alias value parsed correctly",
+    right,
+    "simple command",
+)
+
+_, right, _ = parse("baz='no quotes inside'")
+run_test(
+    "single-quoted alias with no inner quotes parsed correctly",
+    right,
+    "no quotes inside",
+)
+
+sys.exit(_failures)


### PR DESCRIPTION
## Summary

The underlying bug (#13637) has since been fixed upstream in #13744 (`cb641031`), which landed the same one-line change this PR originally proposed. I've rebased and **dropped the now-redundant `cheatsheet.py` change** — this PR now only adds regression tests for that behaviour, which upstream doesn't currently have.

## What this adds

`plugins/aliases/tests/test_cheatsheet.py` covers `parse()`'s quote handling:

- `now='date +"%T"'` → `date +"%T"` — the exact case from #13637, guarding against a return to `.strip('\'"\n ')`, which ate the closing `"`
- `foo='echo "hello world"'` — inner double quotes on both sides preserved
- `bar="simple command"` and `baz='no quotes inside'` — plain single/double-quoted values still unwrap correctly

Follows the existing per-plugin layout used by `plugins/alias-finder/tests/` and `plugins/dotenv/tests/`. Standalone script, no test dependencies; exits non-zero on failure so it can be wired into CI later if desired.

## Test plan

- [x] `python3 plugins/aliases/tests/test_cheatsheet.py` against current `master` — all 4 pass, exit 0

Happy to close this if you'd rather not carry tests for this plugin.

> AI-assisted: Claude was used to write the tests and rebase this branch. The changes were reviewed and verified manually.
