### PR TITLE
test(git): add regression tests for non-UTF-8 bytes in git status output

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -103,6 +103,11 @@ function _omz_git_prompt_status() {
   local status_lines
   status_lines=("${(@f)${status_text}}")
 
+  # Use C locale for regex matching to avoid "illegal byte sequence" errors
+  # when branch names or file paths contain non-ASCII characters (e.g. Chinese)
+  local _omz_lc_all=$LC_ALL
+  LC_ALL=C
+
   # If the tracking line exists, get and parse it
   if [[ "$status_lines[1]" =~ "^## [^ ]+ \[(.*)\]" ]]; then
     local branch_statuses
@@ -125,6 +130,8 @@ function _omz_git_prompt_status() {
       statuses_seen[$status_constant]=1
     fi
   done
+
+  LC_ALL=$_omz_lc_all
 
   # Display the seen statuses in the order specified
   local status_prompt

--- a/lib/tests/git.test.zsh
+++ b/lib/tests/git.test.zsh
@@ -1,0 +1,74 @@
+#!/usr/bin/zsh -df
+
+# Regression tests for lib/git.zsh
+
+local -i _failures=0
+
+run_test() {
+  local description="$1"
+  local got="$2"
+  local expected="$3"
+
+  print -u2 "Test: $description"
+  if [[ "$got" == "$expected" ]]; then
+    print -u2 "\e[32mSuccess\e[0m"
+  else
+    print -u2 "\e[31mError\e[0m"
+    print -u2 "  expected: ${(q)expected}"
+    print -u2 "  got:      ${(q)got}"
+    (( _failures++ ))
+  fi
+  print -u2 ""
+}
+
+# ---------------------------------------------------------------------------
+# Set up: source git.zsh and override __git_prompt_git with a controllable mock
+# ---------------------------------------------------------------------------
+
+source "${0:h:h}/git.zsh" 2>/dev/null
+
+# The mock returns canned `git status --porcelain -b` output and denies stash.
+# Callers set _mock_status_output before calling _omz_git_prompt_status.
+_mock_status_output=""
+function __git_prompt_git() {
+  case "$*" in
+    "config --get oh-my-zsh.hide-status") return 1 ;;
+    "rev-parse --verify refs/stash")       return 1 ;;
+    "status --porcelain -b")               printf "%s\n" "$_mock_status_output" ;;
+    *)                                     return 1 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Bug #13330: _omz_git_prompt_status emits "regex matching error: illegal byte
+# sequence" when the git branch name contains non-ASCII characters (e.g. Chinese).
+# Root cause: zsh's =~ operator with [^ ]+ is locale-aware and rejects multibyte
+# sequences unless LC_ALL=C is set for the match.
+# ---------------------------------------------------------------------------
+
+# Chinese branch with upstream tracking info
+_mock_status_output="## 中文-1.0.0-中文...origin/中文-1.0.0-中文 [ahead 1]"
+stderr_output=$( { _omz_git_prompt_status } 2>&1 1>/dev/null )
+run_test \
+  "no 'illegal byte sequence' error with Chinese branch name (bug #13330)" \
+  "${stderr_output}" \
+  ""
+
+# Chinese branch with no tracking info (the regex should simply not match)
+_mock_status_output="## 中文-branch"
+stderr_output=$( { _omz_git_prompt_status } 2>&1 1>/dev/null )
+run_test \
+  "no error when Chinese branch has no tracking info" \
+  "${stderr_output}" \
+  ""
+
+# Regression: ASCII branch names must still be parsed correctly
+_mock_status_output="## main...origin/main [behind 3]"
+ZSH_THEME_GIT_PROMPT_BEHIND="<"
+output=$( _omz_git_prompt_status 2>/dev/null )
+run_test \
+  "ASCII branch with 'behind' tracking info still detected" \
+  "${output}" \
+  "<"
+
+exit $_failures

--- a/lib/tests/git.test.zsh
+++ b/lib/tests/git.test.zsh
@@ -1,0 +1,103 @@
+#!/usr/bin/zsh -df
+
+# Regression tests for lib/git.zsh
+
+local -i _failures=0
+
+run_test() {
+  local description="$1"
+  local got="$2"
+  local expected="$3"
+
+  print -u2 "Test: $description"
+  if [[ "$got" == "$expected" ]]; then
+    print -u2 "\e[32mSuccess\e[0m"
+  else
+    print -u2 "\e[31mError\e[0m"
+    print -u2 "  expected: ${(q)expected}"
+    print -u2 "  got:      ${(q)got}"
+    (( _failures++ ))
+  fi
+  print -u2 ""
+}
+
+# ---------------------------------------------------------------------------
+# Set up: source git.zsh and override __git_prompt_git with a controllable mock
+# ---------------------------------------------------------------------------
+
+source "${0:h:h}/git.zsh"
+
+# The mock returns canned `git status --porcelain -b` output and denies stash,
+# so the tests need no real git repository.
+# Callers set _mock_status_output before calling _omz_git_prompt_status.
+_mock_status_output=""
+function __git_prompt_git() {
+  case "$*" in
+    "config --get oh-my-zsh.hide-status") return 1 ;;
+    "rev-parse --verify refs/stash")       return 1 ;;
+    "status --porcelain -b")               printf "%s\n" "$_mock_status_output" ;;
+    *)                                     return 1 ;;
+  esac
+}
+
+# The bug under test only reproduces in a multibyte locale, so find one. Any
+# UTF-8 locale will do; the tests that need it are skipped if none exists.
+local utf8_locale="" _candidate
+for _candidate in ${(f)"$(locale -a 2>/dev/null)"}; do
+  if [[ "${_candidate:l}" == *(utf-8|utf8) ]]; then
+    utf8_locale="$_candidate"
+    break
+  fi
+done
+
+# Run _omz_git_prompt_status in a UTF-8 locale, capturing only stderr.
+capture_stderr() {
+  ( export LC_ALL="$utf8_locale"; _omz_git_prompt_status ) 2>&1 1>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Bug #13330: _omz_git_prompt_status emits "regex matching error: illegal byte
+# sequence". zsh's =~ delegates to the C library regex, which aborts with
+# REG_ILLSEQ when the subject holds bytes that are invalid in the current
+# locale's encoding -- e.g. a GBK-encoded branch name or file path while the
+# shell runs in a UTF-8 locale. Forcing LC_ALL=C makes every byte valid.
+#
+# Note that *valid* UTF-8 (Chinese characters and the like) never triggered
+# this; only bytes that don't decode in the active locale do.
+# ---------------------------------------------------------------------------
+
+if [[ -z "$utf8_locale" ]]; then
+  print -u2 "\e[33mSkipped\e[0m: no UTF-8 locale available for byte-sequence tests\n"
+else
+  # Branch name in GBK bytes (\xd6\xd0\xce\xc4 is "中文" in GBK), invalid UTF-8
+  _mock_status_output=$'## \xd6\xd0\xce\xc4-1.0.0...origin/\xd6\xd0\xce\xc4-1.0.0 [ahead 1]'
+  run_test \
+    "no 'illegal byte sequence' error for a branch name with non-UTF-8 bytes (bug #13330)" \
+    "$(capture_stderr)" \
+    ""
+
+  # Same bytes in a file path, which is matched by a different regex
+  _mock_status_output=$'## main...origin/main\n M \xd6\xd0\xce\xc4.txt'
+  run_test \
+    "no 'illegal byte sequence' error for a file path with non-UTF-8 bytes" \
+    "$(capture_stderr)" \
+    ""
+
+  # The tracking info must still be parsed, not merely fail quietly
+  _mock_status_output=$'## \xd6\xd0\xce\xc4-1.0.0...origin/\xd6\xd0\xce\xc4-1.0.0 [ahead 1]'
+  ZSH_THEME_GIT_PROMPT_AHEAD=">"
+  run_test \
+    "'ahead' tracking info still parsed for a branch name with non-UTF-8 bytes" \
+    "$( ( export LC_ALL="$utf8_locale"; _omz_git_prompt_status ) 2>/dev/null )" \
+    ">"
+fi
+
+# Regression: ASCII branch names must still be parsed correctly
+_mock_status_output="## main...origin/main [behind 3]"
+ZSH_THEME_GIT_PROMPT_BEHIND="<"
+run_test \
+  "ASCII branch with 'behind' tracking info still detected" \
+  "$(_omz_git_prompt_status 2>/dev/null)" \
+  "<"
+
+exit $_failures


### PR DESCRIPTION
## Summary

Two things changed since this PR was opened, so I've rewritten it.

**1. The fix landed upstream.** #13878 (`898b579c`, merged 2026-08-05) closed #13330 with `local -x LC_ALL=C` at the top of `_omz_git_prompt_status`. That's a better fix than the manual save/restore this PR originally proposed — it covers the whole function including early returns, restores automatically, and is exported for child processes. I've **dropped the `lib/git.zsh` change** here; nothing about the fix needs revisiting.

**2. My original root-cause description was wrong, and so were the tests.** I claimed `[^ ]+` rejects multibyte sequences in a UTF-8 locale. It doesn't — valid UTF-8 matches fine:

```zsh
$ LC_ALL=en_US.UTF-8 zsh -c '[[ "## 中文-1.0.0 [ahead 1]" =~ "^## [^ ]+ \[(.*)\]" ]]; echo rc=$?'
rc=0
```

The actual trigger is bytes that are **invalid in the active locale's encoding** — the C library regex returns `REG_ILLSEQ`. A GBK-encoded branch name or file path under a UTF-8 locale does it:

```zsh
$ LC_ALL=en_US.UTF-8 zsh -c '[[ $'"'"'## \xd6\xd0\xce\xc4-br [ahead 1]'"'"' =~ "^## [^ ]+ \[(.*)\]" ]]'
zsh: regex matching error: illegal byte sequence
```

The comment on `898b579c` has this right. Consequence: my original tests used valid UTF-8 Chinese, so they **passed with or without the fix** — they proved nothing.

## What this PR now adds

`lib/tests/git.test.zsh`, rewritten so it genuinely reproduces the bug:

- Branch-tracking line with non-UTF-8 bytes → no stderr (the `^## [^ ]+ \[(.*)\]` match)
- File path with non-UTF-8 bytes → no stderr (the per-prefix `status_text` loop, a separate regex)
- `[ahead 1]` still parsed for such a branch — proves `LC_ALL=C` keeps parsing working, not just silences the error
- ASCII `[behind 3]` control

The byte-sequence tests need a multibyte locale to reproduce, so the file picks the first UTF-8 locale from `locale -a` and skips them with a notice if the system has none. Follows the `lib/tests/cli.test.zsh` conventions (`#!/usr/bin/zsh -df`, `print -u2` result lines, non-zero exit on failure).

## Test plan

Verified in both directions against current `master`:

- [x] `zsh lib/tests/git.test.zsh` → 4/4 pass, exit 0
- [x] With `local -x LC_ALL=C` deleted from `lib/git.zsh` → 3 failures, exit 3, ASCII control still passing

Happy to close this if you'd rather not carry tests for `lib/git.zsh`.

> AI-assisted: Claude was used to rewrite these tests and verify them. The changes were reviewed and verified manually.
