### PR TITLE
docker plugin: create completions directory if it doesn't exist

### DIFF
--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -51,6 +51,9 @@ fi
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `docker`. Otherwise, compinit will have already done that.
 if [[ ! -f "$ZSH_CACHE_DIR/completions/_docker" ]]; then
+  if [[ ! -f "$ZSH_CACHE_DIR/completions" ]]; then
+    mkdir -p "$ZSH_CACHE_DIR/completions"
+  fi
   typeset -g -A _comps
   autoload -Uz _docker
   _comps[docker]=_docker


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fix #13679: Ensure the completions directory exists so the below cp / tee statements don't fail.

## Other comments:
Instead of the check could also call mkdir -p every time. I've seen both behaviors in other plugins.
...
