### PR TITLE
feat(talosctl): Add completions for talosctl

### DIFF
--- a/plugins/talosctl/README.md
+++ b/plugins/talosctl/README.md
@@ -1,0 +1,20 @@
+# talosctl plugin
+
+This plugin adds completion for the [talosctl](https://docs.siderolabs.com/talos/v1.12/learn-more/talosctl) CLI for managing [Talos](https://github.com/siderolabs/talos) Linux.
+
+To use it, add `talosctl` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... talosctl)
+```
+
+This plugin does not add any aliases.
+
+## Cache
+
+This plugin caches the completion script and is automatically updated asynchronously when the plugin is
+loaded, which is usually when you start up a new terminal emulator.
+
+The cache is stored at:
+
+- `$ZSH_CACHE/completions/_talosctl` completions script

--- a/plugins/talosctl/talosctl.plugin.zsh
+++ b/plugins/talosctl/talosctl.plugin.zsh
@@ -1,0 +1,14 @@
+# Autocompletion for talosctl
+if (( ! $+commands[talosctl] )); then
+  return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `talosctl`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_talosctl" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _talosctl
+  _comps[talosctl]=_talosctl
+fi
+
+talosctl completion zsh >| "$ZSH_CACHE_DIR/completions/_talosctl" &|


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- adds a new plugin for [talosctl](https://docs.siderolabs.com/talos/v1.12/learn-more/talosctl)

## Other comments

- I based this heavily off my previous PR where I added the ngrok plugin
- No new aliases, just completions for now
- I've been testing this for quite a [while](https://github.com/ohmyzsh/ohmyzsh/commit/bdd539632e05ec0c8c4daebfc9117a43c2e3bede) across different systems and it's been stable.
- I used AI to helm me create the README. 
...
