### PR TITLE
feat(pitchfork): add pitchfork plugin

### DIFF
--- a/plugins/pitchfork/README.md
+++ b/plugins/pitchfork/README.md
@@ -1,0 +1,40 @@
+# pitchfork
+
+Adds integration with [pitchfork](https://github.com/jdx/pitchfork), a devilishly good process manager for
+developers. Pitchfork manages background daemons and services for local development environments, automatically
+starting and stopping them as you navigate between project directories.
+
+## Installation
+
+1. [Download & install pitchfork](https://github.com/jdx/pitchfork#installation) by running the following:
+
+```bash
+mise use -g pitchfork
+```
+
+Or install via Cargo:
+
+```bash
+cargo install pitchfork-cli
+```
+
+2. [Enable pitchfork](https://pitchfork.jdx.dev) by adding it to your `plugins` definition in `~/.zshrc`.
+
+```bash
+plugins=(pitchfork)
+```
+
+## Usage
+
+See the [pitchfork docs](https://pitchfork.jdx.dev) for full information. Here are a few examples:
+
+```bash
+pitchfork start --all     Start all configured daemons
+pitchfork stop            Stop running daemons
+pitchfork status          Show status of all daemons
+pitchfork logs [name]     View logs for a daemon
+pitchfork tui             Open the terminal dashboard
+```
+
+The plugin loads pitchfork's shell hook (`pitchfork activate zsh`), which automatically starts and stops
+daemons when you enter or leave a project directory, and sets up zsh tab-completions.

--- a/plugins/pitchfork/pitchfork.plugin.zsh
+++ b/plugins/pitchfork/pitchfork.plugin.zsh
@@ -1,0 +1,17 @@
+if (( ! $+commands[pitchfork] )); then
+  return
+fi
+
+# Load pitchfork hooks
+eval "$(pitchfork activate zsh)"
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `pitchfork`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_pitchfork" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _pitchfork
+  _comps[pitchfork]=_pitchfork
+fi
+
+# Generate and load pitchfork completion
+pitchfork completion zsh >| "$ZSH_CACHE_DIR/completions/_pitchfork" &|


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds a new plugin for [pitchfork](https://pitchfork.jdx.dev/), a developer process manager that automatically starts and stops background daemons when navigating between project directories. Based on the mise plugin structure. It also up zsh tab-completions.

## Other comments:

n/a
