### PR TITLE
Add pipenv argcomplete compatibility for >= 2026.5.0

### DIFF
--- a/plugins/pipenv/README.md
+++ b/plugins/pipenv/README.md
@@ -10,7 +10,7 @@ plugins=(... pipenv ...)
 
 ## Features
 
-- Adds completion for pipenv
+- Adds completion for pipenv ([install the `argcomplete` package to get it working with pipenv >= 2026.5.0](https://pipenv.pypa.io/en/latest/shell.html#shell-completion))
 - Auto activates and deactivates pipenv shell
 - Adds short aliases for common pipenv commands
   - `pch` is aliased to `pipenv check`

--- a/plugins/pipenv/README.md
+++ b/plugins/pipenv/README.md
@@ -29,6 +29,18 @@ plugins=(... pipenv ...)
   - `pvenv` is aliased to `pipenv --venv`
   - `ppy` is aliased to `pipenv --py`
 
+## Cache
+
+This plugin caches the Pipenv version to avoid running `pipenv --version` on every shell startup. The cache is automatically refreshed asynchronously when the plugin is loaded, which is usually when you start a new terminal session.
+
+For legacy Pipenv versions, the generated completion script is also cached.
+
+The cache is stored at:
+
+- `$ZSH_CACHE_DIR/pipenv_version` version of Pipenv, used to choose between argcomplete-based completion and legacy Click-based completion.
+
+- `$ZSH_CACHE_DIR/completions/_pipenv` legacy Click-based completion script.
+
 ## Configuration
 
 ### Shell activation

--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -2,15 +2,33 @@ if (( ! $+commands[pipenv] )); then
   return
 fi
 
-# If the completion file doesn't exist yet, we need to autoload it and
-# bind it to `pipenv`. Otherwise, compinit will have already done that.
-if [[ ! -f "$ZSH_CACHE_DIR/completions/_pipenv" ]]; then
-  typeset -g -A _comps
-  autoload -Uz _pipenv
-  _comps[pipenv]=_pipenv
-fi
+# Compatibility note:
+# pipenv < 2026.5.0 used Click-based shell completion driven by the
+# _PIPENV_COMPLETE environment variable.
+#
+# pipenv >= 2026.5.0 removed this mechanism and switched to argcomplete-based
+# completion using register-python-argcomplete instead.
 
-_PIPENV_COMPLETE=zsh_source pipenv >| "$ZSH_CACHE_DIR/completions/_pipenv" &|
+if (( $+commands[register-python-argcomplete] )); then
+  # pipenv >= 2026.5.0 (argcomplete-based completion)
+  autoload -U bashcompinit
+  bashcompinit
+
+  eval "$(register-python-argcomplete pipenv)"
+
+else
+  # pipenv < 2026.5.0 (legacy Click-based completion via _PIPENV_COMPLETE)
+
+  # If the completion file doesn't exist yet, we need to autoload it and
+  # bind it to `pipenv`. Otherwise, compinit will have already done that.
+  if [[ ! -f "$ZSH_CACHE_DIR/completions/_pipenv" ]]; then
+    typeset -g -A _comps
+    autoload -Uz _pipenv
+    _comps[pipenv]=_pipenv
+  fi
+
+  _PIPENV_COMPLETE=zsh_source pipenv >| "$ZSH_CACHE_DIR/completions/_pipenv" &|
+fi
 
 if zstyle -T ':omz:plugins:pipenv' auto-shell; then
   # Automatic pipenv shell activation/deactivation
@@ -34,6 +52,7 @@ if zstyle -T ':omz:plugins:pipenv' auto-shell; then
       fi
     fi
   }
+
   autoload -U add-zsh-hook
   add-zsh-hook chpwd _togglePipenvShell
   _togglePipenvShell

--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -9,15 +9,19 @@ fi
 # pipenv >= 2026.5.0 removed this mechanism and switched to argcomplete-based
 # completion using register-python-argcomplete instead.
 
-if (( $+commands[register-python-argcomplete] )); then
-  # pipenv >= 2026.5.0 (argcomplete-based completion)
-  autoload -U bashcompinit
+autoload -Uz is-at-least
+
+_pipenv_version="${$(pipenv --version 2>/dev/null)#pipenv, version }"
+
+if is-at-least 2026.5.0 "$_pipenv_version" && (( $+commands[register-python-argcomplete] )); then
+  # argcomplete-based completion
+  autoload -Uz bashcompinit
   bashcompinit
 
   eval "$(register-python-argcomplete pipenv)"
 
 else
-  # pipenv < 2026.5.0 (legacy Click-based completion via _PIPENV_COMPLETE)
+  # legacy Click-based completion via _PIPENV_COMPLETE
 
   # If the completion file doesn't exist yet, we need to autoload it and
   # bind it to `pipenv`. Otherwise, compinit will have already done that.

--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -11,7 +11,18 @@ fi
 
 autoload -Uz is-at-least
 
-_pipenv_version="${$(pipenv --version 2>/dev/null)#pipenv, version }"
+_pipenv_version_cache="$ZSH_CACHE_DIR/pipenv_version"
+
+if [[ -f "$_pipenv_version_cache" ]]; then
+  _pipenv_version="$(< "$_pipenv_version_cache" 2>/dev/null)"
+else
+  _pipenv_version="${$(pipenv --version 2>/dev/null)#pipenv, version }"
+fi
+
+{
+  _pipenv_fresh_version="${$(pipenv --version 2>/dev/null)#pipenv, version }"
+  [[ -n "$_pipenv_fresh_version" ]] && print -r -- "$_pipenv_fresh_version" >| "$_pipenv_version_cache"
+} &|
 
 if is-at-least 2026.5.0 "$_pipenv_version" && (( $+commands[register-python-argcomplete] )); then
   # argcomplete-based completion

--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -24,13 +24,14 @@ fi
   [[ -n "$_pipenv_fresh_version" ]] && print -r -- "$_pipenv_fresh_version" >| "$_pipenv_version_cache"
 } &|
 
-if is-at-least 2026.5.0 "$_pipenv_version" && (( $+commands[register-python-argcomplete] )); then
-  # argcomplete-based completion
-  autoload -Uz bashcompinit
-  bashcompinit
+if is-at-least 2026.5.0 "$_pipenv_version"; then
+  # pipenv >= 2026.5.0: argcomplete-based completion (no legacy fallback)
+  if (( $+commands[register-python-argcomplete] )); then
+    autoload -Uz bashcompinit
+    bashcompinit
 
-  eval "$(register-python-argcomplete pipenv)"
-
+    eval "$(register-python-argcomplete pipenv)"
+  fi
 else
   # legacy Click-based completion via _PIPENV_COMPLETE
 


### PR DESCRIPTION
Hey. The pipenv completion system has changed and now uses the argcomplete package for versions >= 2026.5.0.

ref 1: https://github.com/pypa/pipenv?tab=readme-ov-file#shell-completion
ref 2: https://pipenv.pypa.io/en/latest/shell.html#shell-completion

I think this fix is enough to keep both old and new versions compatible.

### OMZ log:

```zsh
[WARNING]: Console output during zsh initialization detected.

...

-- console output produced during zsh initialization follows --

Shell completion has changed in pipenv >= 2026.5.0.
The _PIPENV_COMPLETE environment variable is no longer supported.

To enable shell completion, install the completion extra and use:
  pip install pipenv[completion]
  eval "$(register-python-argcomplete pipenv)"

For more details, see: https://pipenv.pypa.io/en/latest/shell.html#shell-completion
```

---

resolve #13719