### PR TITLE
feat(podman-compose): add podman-compose plugin with aliases and docs

### DIFF
--- a/plugins/podman-compose/README.md
+++ b/plugins/podman-compose/README.md
@@ -1,0 +1,36 @@
+# Podman-compose plugin
+
+This plugin provides aliases for [podman-compose](https://github.com/containers/podman-compose), a tool for running podman containers using compose files.
+It is inspired by the `docker-compose` plugin and includes similar aliases for a familiar workflow.
+
+To use it, add `podman-compose` to the plugins array of your zshrc file:
+
+```zsh
+plugins=(... podman-compose)
+```
+
+## Aliases
+
+| Alias      | Command                          | Description                                                                      |
+|------------|----------------------------------|----------------------------------------------------------------------------------|
+| pco        | `podman-compose`                 | Podman-compose main command                                                      |
+| pcb        | `podman-compose build`           | Build containers                                                                 |
+| pce        | `podman-compose exec`            | Execute command inside a container                                               |
+| pcps       | `podman-compose ps`              | List containers                                                                  |
+| pcrestart  | `podman-compose restart`         | Restart container                                                                |
+| pcrm       | `podman-compose rm`              | Remove container                                                                 |
+| pcr        | `podman-compose run`             | Run a command in container                                                       |
+| pcstop     | `podman-compose stop`            | Stop a container                                                                 |
+| pcup       | `podman-compose up`              | Build, (re)create, start, and attach to containers for a service                 |
+| pcupb      | `podman-compose up --build`      | Same as `pcup`, but build images before starting containers                      |
+| pcupd      | `podman-compose up -d`           | Same as `pcup`, but starts as daemon                                             |
+| pcupdb     | `podman-compose up -d --build`   | Same as `pcup`, but build images before starting containers and starts as daemon |
+| pcdn       | `podman-compose down`            | Stop and remove containers                                                       |
+| pcl        | `podman-compose logs`            | Show logs of container                                                           |
+| pclf       | `podman-compose logs -f`         | Show logs and follow output                                                      |
+| pclF       | `podman-compose logs -f --tail 0`| Just follow recent logs                                                          |
+| pcpull     | `podman-compose pull`            | Pull image of a service                                                          |
+| pcstart    | `podman-compose start`           | Start a container                                                                |
+| pck        | `podman-compose kill`            | Kills containers                                                                 |
+| pcpause    | `podman-compose pause`           | Pause containers                                                                 |
+| pcunpause  | `podman-compose unpause`         | Unpause containers                                                               |

--- a/plugins/podman-compose/podman-compose.plugin.zsh
+++ b/plugins/podman-compose/podman-compose.plugin.zsh
@@ -1,0 +1,38 @@
+# Aliases for podman-compose
+# Inspired by the docker-compose plugin
+
+# Check if podman-compose is installed
+if (( ! $+commands[podman-compose] )); then
+  # Fallback to 'podman compose' if available
+  if podman compose version >/dev/null 2>&1; then
+    pccmd='podman compose'
+  else
+    return
+  fi
+else
+  pccmd='podman-compose'
+fi
+
+alias pco="$pccmd"
+alias pcb="$pccmd build"
+alias pce="$pccmd exec"
+alias pcps="$pccmd ps"
+alias pcrestart="$pccmd restart"
+alias pcrm="$pccmd rm"
+alias pcr="$pccmd run"
+alias pcstop="$pccmd stop"
+alias pcup="$pccmd up"
+alias pcupb="$pccmd up --build"
+alias pcupd="$pccmd up -d"
+alias pcupdb="$pccmd up -d --build"
+alias pcdn="$pccmd down"
+alias pcl="$pccmd logs"
+alias pclf="$pccmd logs -f"
+alias pclF="$pccmd logs -f --tail 0"
+alias pcpull="$pccmd pull"
+alias pcstart="$pccmd start"
+alias pck="$pccmd kill"
+alias pcpause="$pccmd pause"
+alias pcunpause="$pccmd unpause"
+
+unset pccmd


### PR DESCRIPTION
## Standards checklist:
- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open. (References closed PR #11684)
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:
- Added a new `podman-compose` plugin with common aliases inspired by the `docker-compose` plugin.
- Added `pcpause` and `pcunpause` commands (previously suggested in #11684).
- Added comprehensive documentation in `README.md`.

## AI Disclosure:
AI-assisted. This plugin structure and documentation were generated with the assistance of an AI coding assistant (Gemini/Antigravity) and subsequently reviewed and refined manually.

## Alias Justifications:
The aliases follow the established naming convention used in the `docker-compose` plugin (using `pc` prefix instead of `dc`). This ensures a familiar and efficient workflow for users migrating from Docker to Podman or using both tools.

| Alias | Workflow Use Case |
|-------|-------------------|
| `pcupd` | Common workflow for starting services in detached mode. |
| `pcl` / `pclf` | Essential for debugging and monitoring container logs. |
| `pcdn` | Fast cleanup of environments. |
| `pcpause` | Useful for temporarily suspending heavy workloads without stopping them. |

## Other comments:
This PR revives the effort from #11684, which was closed due to the author deleting their fork. It ensures that Podman users have the same high-quality alias support as Docker users.
