### PR TITLE
feat(systemd): Add support for different privilege elevation tools

### DIFF
--- a/plugins/systemd/README.md
+++ b/plugins/systemd/README.md
@@ -10,44 +10,64 @@ plugins=(... systemd)
 
 ## Aliases
 
-| Alias                  | Command                            | Description                                                      |
-|:-----------------------|:-----------------------------------|:-----------------------------------------------------------------|
-| `sc-failed`            | `systemctl --failed`               | List failed systemd units                                        |
-| `sc-list-units`        | `systemctl list-units`             | List all units systemd has in memory                             |
-| `sc-is-active`         | `systemctl is-active`              | Show whether a unit is active                                    |
-| `sc-status`            | `systemctl status`                 | Show terse runtime status information about one or more units    |
-| `sc-show`              | `systemctl show`                   | Show properties of units, jobs, or the manager itself            |
-| `sc-help`              | `systemctl help`                   | Show man page of units                                           |
-| `sc-list-unit-files`   | `systemctl list-unit-files`        | List unit files installed on the system                          |
-| `sc-is-enabled`        | `systemctl is-enabled`             | Checks whether any of the specified unit files are enabled       |
-| `sc-list-jobs`         | `systemctl list-jobs`              | List jobs that are in progress                                   |
-| `sc-show-environment`  | `systemctl show-environment`       | Dump the systemd manager environment block                       |
-| `sc-cat`               | `systemctl cat`                    | Show backing files of one or more units                          |
-| `sc-list-timers`       | `systemctl list-timers`            | List timer units currently in memory                             |
-| **Aliases with sudo**                                                                                                        |||
-| `sc-start`             | `sudo systemctl start`             | Start Unit(s)                                                    |
-| `sc-stop`              | `sudo systemctl stop`              | Stop Unit(s)                                                     |
-| `sc-reload`            | `sudo systemctl reload`            | Reload Unit(s)                                                   |
-| `sc-restart`           | `sudo systemctl restart`           | Restart Unit(s)                                                  |
-| `sc-try-restart`       | `sudo systemctl try-restart`       | Restart Unit(s)                                                  |
-| `sc-isolate`           | `sudo systemctl isolate`           | Start a unit and its dependencies and stop all others            |
-| `sc-kill`              | `sudo systemctl kill`              | Kill unit(s)                                                     |
-| `sc-reset-failed`      | `sudo systemctl reset-failed`      | Reset the "failed" state of the specified units,                 |
-| `sc-enable`            | `sudo systemctl enable`            | Enable unit(s)                                                   |
-| `sc-disable`           | `sudo systemctl disable`           | Disable unit(s)                                                  |
-| `sc-reenable`          | `sudo systemctl reenable`          | Reenable unit(s)                                                 |
-| `sc-preset`            | `sudo systemctl preset`            | Reset the enable/disable status one or more unit files           |
-| `sc-mask`              | `sudo systemctl mask`              | Mask unit(s)                                                     |
-| `sc-unmask`            | `sudo systemctl unmask`            | Unmask unit(s)                                                   |
-| `sc-link`              | `sudo systemctl link`              | Link a unit file into the unit file search path                  |
-| `sc-load`              | `sudo systemctl load`              | Load unit(s)                                                     |
-| `sc-cancel`            | `sudo systemctl cancel`            | Cancel job(s)                                                    |
-| `sc-set-environment`   | `sudo systemctl set-environment`   | Set one or more systemd manager environment variables            |
-| `sc-unset-environment` | `sudo systemctl unset-environment` | Unset one or more systemd manager environment variables          |
-| `sc-edit`              | `sudo systemctl edit`              | Edit a drop-in snippet or a whole replacement file with `--full` |
-| `sc-enable-now`        | `sudo systemctl enable --now`      | Enable and start unit(s)                                         |
-| `sc-disable-now`       | `sudo systemctl disable --now`     | Disable and stop unit(s)                                         |
-| `sc-mask-now`          | `sudo systemctl mask --now`        | Mask and stop unit(s)                                            |
+| Alias                  | Command                             | Description                                                      |
+|:-----------------------|:------------------------------------|:-----------------------------------------------------------------|
+| `sc-failed`            | `systemctl --failed`                | List failed systemd units                                        |
+| `sc-list-units`        | `systemctl list-units`              | List all units systemd has in memory                             |
+| `sc-is-active`         | `systemctl is-active`               | Show whether a unit is active                                    |
+| `sc-status`            | `systemctl status`                  | Show terse runtime status information about one or more units    |
+| `sc-show`              | `systemctl show`                    | Show properties of units, jobs, or the manager itself            |
+| `sc-help`              | `systemctl help`                    | Show man page of units                                           |
+| `sc-list-unit-files`   | `systemctl list-unit-files`         | List unit files installed on the system                          |
+| `sc-is-enabled`        | `systemctl is-enabled`              | Checks whether any of the specified unit files are enabled       |
+| `sc-list-jobs`         | `systemctl list-jobs`               | List jobs that are in progress                                   |
+| `sc-show-environment`  | `systemctl show-environment`        | Dump the systemd manager environment block                       |
+| `sc-cat`               | `systemctl cat`                     | Show backing files of one or more units                          |
+| `sc-list-timers`       | `systemctl list-timers`             | List timer units currently in memory                             |
+| **Privileged aliases**                                                                                                        |||
+| `sc-start`             | `$SUDO systemctl start`             | Start Unit(s)                                                    |
+| `sc-stop`              | `$SUDO systemctl stop`              | Stop Unit(s)                                                     |
+| `sc-reload`            | `$SUDO systemctl reload`            | Reload Unit(s)                                                   |
+| `sc-restart`           | `$SUDO systemctl restart`           | Restart Unit(s)                                                  |
+| `sc-try-restart`       | `$SUDO systemctl try-restart`       | Restart Unit(s)                                                  |
+| `sc-isolate`           | `$SUDO systemctl isolate`           | Start a unit and its dependencies and stop all others            |
+| `sc-kill`              | `$SUDO systemctl kill`              | Kill unit(s)                                                     |
+| `sc-reset-failed`      | `$SUDO systemctl reset-failed`      | Reset the "failed" state of the specified units,                 |
+| `sc-enable`            | `$SUDO systemctl enable`            | Enable unit(s)                                                   |
+| `sc-disable`           | `$SUDO systemctl disable`           | Disable unit(s)                                                  |
+| `sc-reenable`          | `$SUDO systemctl reenable`          | Reenable unit(s)                                                 |
+| `sc-preset`            | `$SUDO systemctl preset`            | Reset the enable/disable status one or more unit files           |
+| `sc-mask`              | `$SUDO systemctl mask`              | Mask unit(s)                                                     |
+| `sc-unmask`            | `$SUDO systemctl unmask`            | Unmask unit(s)                                                   |
+| `sc-link`              | `$SUDO systemctl link`              | Link a unit file into the unit file search path                  |
+| `sc-load`              | `$SUDO systemctl load`              | Load unit(s)                                                     |
+| `sc-cancel`            | `$SUDO systemctl cancel`            | Cancel job(s)                                                    |
+| `sc-set-environment`   | `$SUDO systemctl set-environment`   | Set one or more systemd manager environment variables            |
+| `sc-unset-environment` | `$SUDO systemctl unset-environment` | Unset one or more systemd manager environment variables          |
+| `sc-edit`              | `$SUDO systemctl edit`              | Edit a drop-in snippet or a whole replacement file with `--full` |
+| `sc-enable-now`        | `$SUDO systemctl enable --now`      | Enable and start unit(s)                                         |
+| `sc-disable-now`       | `$SUDO systemctl disable --now`     | Disable and stop unit(s)                                         |
+| `sc-mask-now`          | `$SUDO systemctl mask --now`        | Mask and stop unit(s)                                            |
+
+### Privileged aliases
+
+systemd plugin supports multiple privilege elevation tools. When evaluating aliases `$SUDO`
+(`$privilege_tool` in code) gets expanded to the relevant command.
+
+You can choose which tool to use by setting `$ZSH_THEME_SYSTEMD_PRIVILEGE_TOOL`. The
+default, which is used when the variable is not set (or set incorrectrly) is `sudo`.
+
+Available options are:
+
+| Tool             | Command   | Comment                                                                                 | 
+|:-----------------|:----------|:----------------------------------------------------------------------------------------|
+| `builtin-polkit` | --        | Does no prepend any command, leaving authorization to systemd                           | 
+| `custom`         | varies    | Sets `$privilege_tool` to the value of `$ZSH_THEME_SYSTEMD_PRIVILEGE_TOOL_CUSTOM`       |
+| `sudo`           | `sudo`    | Default value                                                                           |
+| `sudo-rs`        | `sudo-rs` | Memory safe implementation of sudo                                                      | 
+| `doas`           | `doas`    | Fork of OpenBSD `doas` command                                                          |
+| `pkexec`         | `pkexec`  | Uses polkit for authorization                                                           |
+| `run0`           | `run0`    | Part of systemd, does not rely on suid. Uses the same polkit action as `builtin-polkit` | 
 
 ### User aliases
 

--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -67,13 +67,68 @@ power_commands=(
   suspend
 )
 
+if [[ -z "$ZSH_THEME_SYSTEMD_PRIVILEGE_TOOL" ]]; then
+  ZSH_THEME_SYSTEMD_PRIVILEGE_TOOL="sudo"
+fi
+
+# Error messages are defined in variables for better formatting
+privilege_tool_error_msg="\
+zsh systemd plugin:
+  \$ZSH_THEME_SYSTEMD_PRIVILEGE_TOOL is set to unknown value
+  Use 'custom' if the one you use in unsupported, or
+  'builtin-polkit' if you want to use builtin authentication methods.
+  Defaulting to 'sudo'"
+
+privilege_tool_custom_error_msg="\
+zsh systemd plugin:
+  \$ZSH_THEME_SYSTEMD_PRIVILEGE_TOOL is set to 'custom', but
+  \$ZSH_THEME_SYSTEMD_PRIVILEGE_TOOL_CUSTOM is not set.
+  Defaulting to 'sudo'"
+
+case "$ZSH_THEME_SYSTEMD_PRIVILEGE_TOOL" in
+  builtin-polkit)
+    # Since all the privilege escalation is done by systemctl itself, it's 
+    # easier to alias them as unprivileged
+    user_commands+=( "${sudo_commands[@]}" )
+    unset sudo_commands
+    privilege_tool=""
+    ;;
+  custom)
+    if [[ -n "$ZSH_THEME_SYSTEMD_PRIVILEGE_TOOL_CUSTOM" ]]; then
+      privilege_tool="$ZSH_THEME_SYSTEMD_PRIVILEGE_TOOL_CUSTOM"  
+    else
+      print "$privilege_tool_custom_error_msg" >&2
+      privilege_tool="sudo"
+    fi
+    ;;
+  sudo)
+    privilege_tool="sudo"
+    ;;
+  sudo-rs)
+    privilege_tool="sudo-rs"
+    ;;
+  doas)
+    privilege_tool="doas"
+    ;;
+  pkexec)
+    privilege_tool="pkexec"
+    ;;
+  run0)
+    privilege_tool="run0"
+    ;;
+  *)
+    print "$privilege_tool_error_msg" >&2
+    privilege_tool="sudo"
+    ;;
+esac
+
 for c in $user_commands; do
   alias "sc-$c"="systemctl $c"
   alias "scu-$c"="systemctl --user $c"
 done
 
 for c in $sudo_commands; do
-  alias "sc-$c"="sudo systemctl $c"
+  alias "sc-$c"="$privilege_tool systemctl $c"
   alias "scu-$c"="systemctl --user $c"
 done
 
@@ -81,7 +136,8 @@ for c in $power_commands; do
   alias "sc-$c"="systemctl $c"
 done
 
-unset c user_commands sudo_commands power_commands
+unset c user_commands sudo_commands power_commands privilege_tool
+unset privilege_tool_error_msg privilege_tool_custom_error_msg
 
 
 # --now commands


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds support for privilege elevation tools other than `sudo` in systemd plugin

## Other comments:

systemd plugin hardcodes `sudo` as only privilege elevation tool. I tried my best to address this.

Supported tools are `sudo`, `sudo-rs`, `doas`, `pkexec`, `run0` and polkit authorization that is present in systemd. There's also `custom` tool, which allows user to set arbitrary command as prefix.

Known problems:
- Some commands, like `systemctl edit` do not ask for authorization via polkit, fixing this behavior in plugin would require more serious changes
- `custom` tool may introduce code execution vulnerabilities