### PR TITLE
fix(tmux): treat xterm-direct as 256-color

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -87,8 +87,8 @@ _build_tmux_alias "tkss" "kill-session" "-t"
 
 unfunction _build_tmux_alias
 
-# Determine if the terminal supports 256 colors
-if [[ $terminfo[colors] == 256 ]]; then
+# Determine if the terminal supports at least 256 colors
+if [[ $terminfo[colors] -ge 256 ]]; then
   export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITH_256COLOR
 else
   export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITHOUT_256COLOR

--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -88,7 +88,7 @@ _build_tmux_alias "tkss" "kill-session" "-t"
 unfunction _build_tmux_alias
 
 # Determine if the terminal supports at least 256 colors
-if [[ $terminfo[colors] -ge 256 ]]; then
+if (( ${+terminfo[colors]} )) && [[ $terminfo[colors] -ge 256 ]]; then
   export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITH_256COLOR
 else
   export ZSH_TMUX_TERM=$ZSH_TMUX_FIXTERM_WITHOUT_256COLOR


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes #13628.
- Treat terminals with `terminfo[colors] >= 256` as 256-color capable in the tmux plugin, so `TERM=xterm-direct` uses the 256-color fallback instead of the non-256-color fallback.

## Other comments:

- Before: a temporary `xterm-direct` terminfo entry with `colors=32767` resolved to `tmux`.
- After: the same repro resolves to `tmux-256color`.
- Baseline: `TERM=xterm-256color` still resolves to `tmux-256color`.
- Validation:
  - `zsh -n plugins/tmux/tmux.plugin.zsh`
  - `TERM=xterm-256color ZSH_TMUX_FIXTERM_WITHOUT_256COLOR=tmux ZSH_TMUX_FIXTERM_WITH_256COLOR=tmux-256color zsh -fc 'autoload -Uz compinit; compinit >/dev/null 2>&1; source plugins/tmux/tmux.plugin.zsh >/dev/null 2>&1; echo baseline:$ZSH_TMUX_TERM:$terminfo[colors]'`
  - Temporary `xterm-direct` terminfo repro: `before:tmux:32767` -> `after:tmux-256color:32767`
- AI-assisted: I used Codex to help prepare the patch and validate the reproduction steps.
