### PR TITLE
fix: allow running with nounset option

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -14,10 +14,10 @@ bindkey -M menuselect '^o' accept-and-infer-next-history
 zstyle ':completion:*:*:*:*:*' menu select
 
 # case insensitive (all), partial-word and substring completion
-if [[ "$CASE_SENSITIVE" = true ]]; then
+if [[ "${CASE_SENSITIVE:-}" = true ]]; then
   zstyle ':completion:*' matcher-list 'r:|=*' 'l:|=* r:|=*'
 else
-  if [[ "$HYPHEN_INSENSITIVE" = true ]]; then
+  if [[ "${HYPHEN_INSENSITIVE:-}" = true ]]; then
     zstyle ':completion:*' matcher-list 'm:{[:lower:][:upper:]-_}={[:upper:][:lower:]_-}' 'r:|=*' 'l:|=* r:|=*'
   else
     zstyle ':completion:*' matcher-list 'm:{[:lower:][:upper:]}={[:upper:][:lower:]}' 'r:|=*' 'l:|=* r:|=*'

--- a/lib/correction.zsh
+++ b/lib/correction.zsh
@@ -1,4 +1,4 @@
-if [[ "$ENABLE_CORRECTION" == "true" ]]; then
+if [[ "${ENABLE_CORRECTION:-}" == "true" ]]; then
   alias cp='nocorrect cp'
   alias man='nocorrect man'
   alias mkdir='nocorrect mkdir'

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -147,13 +147,13 @@ local _style
 if zstyle -t ':omz:alpha:lib:git' async-prompt \
   || { is-at-least 5.0.6 && zstyle -T ':omz:alpha:lib:git' async-prompt }; then
   function git_prompt_info() {
-    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}" ]]; then
+    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]:-}" ]]; then
       echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_info]}"
     fi
   }
 
   function git_prompt_status() {
-    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}" ]]; then
+    if [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]:-}" ]]; then
       echo -n "${_OMZ_ASYNC_OUTPUT[_omz_git_prompt_status]}"
     fi
   }
@@ -162,13 +162,13 @@ if zstyle -t ':omz:alpha:lib:git' async-prompt \
   # or any of the other prompt variables
   function _defer_async_git_register() {
     # Check if git_prompt_info is used in a prompt variable
-    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPROMPT}:${RPS1}:${RPS2}:${RPS3}:${RPS4}" in
+    case "${PS1}:${PS2:-}:${PS3:-}:${PS4:-}:${RPROMPT:-}:${RPS1:-}:${RPS2:-}:${RPS3:-}:${RPS4:-}" in
     *(\$\(git_prompt_info\)|\`git_prompt_info\`)*)
       _omz_register_handler _omz_git_prompt_info
       ;;
     esac
 
-    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPROMPT}:${RPS1}:${RPS2}:${RPS3}:${RPS4}" in
+    case "${PS1}:${PS2:-}:${PS3:-}:${PS4:-}:${RPROMPT:-}:${RPS1:-}:${RPS2:-}:${RPS3:-}:${RPS4:-}" in
     *(\$\(git_prompt_status\)|\`git_prompt_status\`)*)
       _omz_register_handler _omz_git_prompt_status
       ;;

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -1,7 +1,7 @@
 autoload -Uz is-at-least
 
 # *-magic is known buggy in some versions; disable if so
-if [[ $DISABLE_MAGIC_FUNCTIONS != true ]]; then
+if [[ ${DISABLE_MAGIC_FUNCTIONS:-} != true ]]; then
   for d in $fpath; do
     if [[ -e "$d/url-quote-magic" ]]; then
       if is-at-least 5.1; then

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -104,7 +104,7 @@ function omz_termsupport_preexec {
 
 autoload -Uz add-zsh-hook
 
-if [[ -z "$INSIDE_EMACS" || "$INSIDE_EMACS" = vterm ]]; then
+if [[ -z "${INSIDE_EMACS:-}" || "$INSIDE_EMACS" = vterm ]]; then
   add-zsh-hook precmd omz_termsupport_precmd
   add-zsh-hook preexec omz_termsupport_preexec
 fi
@@ -122,7 +122,7 @@ fi
 # As of May 2021 mlterm, PuTTY, rxvt, screen, termux & xterm simply ignore the unknown OSC.
 
 # Don't define the function if we're inside Emacs or in an SSH session (#11696)
-if [[ -n "$INSIDE_EMACS" || -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
+if [[ -n "${INSIDE_EMACS:-}" || -n "${SSH_CLIENT:-}" || -n "${SSH_TTY:-}" ]]; then
   return
 fi
 
@@ -152,7 +152,7 @@ function omz_termsupport_cwd {
   URL_PATH="$(omz_urlencode -P $PWD)" || return 1
 
   # Konsole errors if the HOST is provided
-  [[ -z "$KONSOLE_PROFILE_NAME" && -z "$KONSOLE_DBUS_SESSION"  ]] || URL_HOST=""
+  [[ -z "${KONSOLE_PROFILE_NAME:-}" && -z "${KONSOLE_DBUS_SESSION:-}"  ]] || URL_HOST=""
 
   # common control sequence (OSC 7) to set current host and path
   printf "\e]7;file://%s%s\e\\" "${URL_HOST}" "${URL_PATH}"

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -21,7 +21,7 @@ if command diff --color /dev/null{,} &>/dev/null; then
 fi
 
 # Don't set ls coloring if disabled
-[[ "$DISABLE_LS_COLORS" != true ]] || return 0
+[[ "${DISABLE_LS_COLORS:-}" != true ]] || return 0
 
 # Default coloring for BSD-based ls
 export LSCOLORS="Gxfxcxdxbxegedabagacad"

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -121,7 +121,7 @@ if ! command grep -q -Fx "$zcompdump_revision" "$ZSH_COMPDUMP" 2>/dev/null \
   zcompdump_refresh=1
 fi
 
-if [[ "$ZSH_DISABLE_COMPFIX" != true ]]; then
+if [[ "${ZSH_DISABLE_COMPFIX:-}" != true ]]; then
   source "$ZSH/lib/compfix.zsh"
   # Load only from secure directories
   compinit -i -d "$ZSH_COMPDUMP"

--- a/plugins/battery/battery.plugin.zsh
+++ b/plugins/battery/battery.plugin.zsh
@@ -66,7 +66,7 @@ if [[ "$OSTYPE" = darwin* ]]; then
       if [[ "${BATTERY_SHOW_WATTS}" = "true" ]] ; then
         watts=$(get_charger_power)
       fi
-      echo "${watts}${BATTERY_CHARGING-⚡️}"
+      echo "${watts:-}${BATTERY_CHARGING-⚡️}"
     fi
   }
 

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -15,8 +15,8 @@ zstyle -s ':omz:update' mode update_mode || {
   update_mode=prompt
 
   # If the mode zstyle setting is not set, support old-style settings
-  [[ "$DISABLE_UPDATE_PROMPT" != true ]] || update_mode=auto
-  [[ "$DISABLE_AUTO_UPDATE" != true ]] || update_mode=disabled
+  [[ "${DISABLE_UPDATE_PROMPT:-}" != true ]] || update_mode=auto
+  [[ "${DISABLE_AUTO_UPDATE:-}" != true ]] || update_mode=disabled
 }
 
 # Cancel update if:


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- prevents shell errors when running zsh with the nounset option (`set -u`)

## Other comments:

Closes #13701 
