### PR TITLE
feat(sprite): Add completions for sprite

### DIFF
--- a/plugins/sprite/README.md
+++ b/plugins/sprite/README.md
@@ -1,0 +1,20 @@
+# sprite plugin
+
+This plugin adds completion for the [Sprites CLI](https://docs.sprites.dev/cli/installation) (`sprite`).
+
+To use it, add `sprite` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... sprite)
+```
+
+This plugin does not add any aliases.
+
+## Cache
+
+This plugin caches the completion script and is automatically updated asynchronously when the plugin is
+loaded, which is usually when you start up a new terminal emulator.
+
+The cache is stored at:
+
+- `$ZSH_CACHE_DIR/completions/_sprite` completions script

--- a/plugins/sprite/sprite.plugin.zsh
+++ b/plugins/sprite/sprite.plugin.zsh
@@ -1,0 +1,14 @@
+# Autocompletion for sprite
+if (( ! $+commands[sprite] )); then
+  return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `sprite`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_sprite" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _sprite
+  _comps[sprite]=_sprite
+fi
+
+sprite completion zsh >| "$ZSH_CACHE_DIR/completions/_sprite" &|

--- a/plugins/sprite/sprite.plugin.zsh
+++ b/plugins/sprite/sprite.plugin.zsh
@@ -11,4 +11,7 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_sprite" ]]; then
   _comps[sprite]=_sprite
 fi
 
-sprite completion zsh >| "$ZSH_CACHE_DIR/completions/_sprite" &|
+() {
+  local tmpfile="$ZSH_CACHE_DIR/completions/_sprite.$$.tmp"
+  sprite completion zsh >| "$tmpfile" 2>/dev/null && command mv -f "$tmpfile" "$ZSH_CACHE_DIR/completions/_sprite" || command rm -f "$tmpfile"
+} &|


### PR DESCRIPTION
sprite is the CLI tool for [sprites](https://docs.sprites.dev) - stateful sandbox environments with checkpoint and restore.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- adds a new plugin for [sprite](https://docs.sprites.dev/cli/commands/) CLI

## Other comments:

- I created an AI skill for creating an Oh My Zsh plugin, based off the ngrok plugin(merged) I've contributed.
- Used the AI skill to generate the plugin.
- No aliases included.
- Works on my machine

<img width="686" height="452" alt="Screenshot 2026-04-20 at 9 12 15 PM" src="https://github.com/user-attachments/assets/24a0d73d-c47f-4882-9e41-dce020b1d028" />

...
