### PR TITLE
 fix(git): replace deprecated syntax for percent substitution in prompt  (#13705)

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -255,7 +255,7 @@ function git_remote_status() {
         fi
 
         if [[ -n $ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED ]]; then
-            git_remote_status="$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX${remote:gs/%/%%}$git_remote_status_detailed$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX"
+            git_remote_status="$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX${remote//\%/%%}$git_remote_status_detailed$ZSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX"
         fi
 
         echo $git_remote_status

--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -36,7 +36,7 @@ function _omz_git_prompt_info() {
     && upstream=" -> ${upstream}"
   fi
 
-  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref:gs/%/%%}${upstream:gs/%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
+  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref//\%/%%}${upstream//\%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
 }
 
 function _omz_git_prompt_status() {


### PR DESCRIPTION
fix: git prompt shows extra %% after branch name when histsubstpattern is enabled (#13705)

## Standards checklist

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes

Following the issue report, and instructions in [#13705](https://github.com/ohmyzsh/ohmyzsh/issues/13705), I replaced the `:gs/%/%%` substitutions with standard parameter expansion using `//\%/%%`.

This fixes the bug where `histsubstpattern` causes `%` in `:gs` to be interpreted as a pattern, which results in `%%` being appended even when the branch name does not contain `%`.

## Validation

- Tested locally with `setopt histsubstpattern`
- Verified that `main` now renders as `main`, not `main%%`
- Ran `zsh -n lib/git.zsh`

## AI disclosure

I used AI assistance to help draft the PR description and review the wording; the code change and validation were done by me.