### PR TITLE
fix(globalias): prevent alias expansion when prefixed with backslash

### DIFF
--- a/plugins/globalias/globalias.plugin.zsh
+++ b/plugins/globalias/globalias.plugin.zsh
@@ -3,6 +3,10 @@ globalias() {
    # (z) splits into words using shell parsing
    # (A) makes it an array even if there's only one element
    local word=${${(Az)LBUFFER}[-1]}
+   if [[ $word[1] == '\' ]]; then
+     zle self-insert
+     return
+   fi
    if [[ $GLOBALIAS_FILTER_VALUES[(Ie)$word] -eq 0 ]]; then
       zle _expand_alias
       zle expand-word


### PR DESCRIPTION
## Summary
- Add early return in `globalias` function when the last word starts with backslash
- Allows escaping alias expansion by prefixing with `\`, inserting the alias literally even when globalias is enabled

## Test plan
- [ ] Type `\alias` — alias name is inserted literally without expansion
- [ ] Type just `alias` — normal alias expansion still works as expected