### PR TITLE
fix(z): prevent stack overflow from recursive Tab binding on re-source

### DIFF
--- a/plugins/z/z.plugin.zsh
+++ b/plugins/z/z.plugin.zsh
@@ -960,8 +960,15 @@ add-zsh-hook chpwd _zshz_chpwd
 
 (( ${fpath[(ie)${0:A:h}]} <= ${#fpath} )) || fpath=( "${0:A:h}" "${fpath[@]}" )
 
-# Save the existing Tab binding
-ZSHZ[TAB_BINDING]="${$(bindkey -M main '^I')##* }"
+# Save the existing Tab binding (only on first load to avoid self-reference
+# if the plugin is sourced more than once)
+if [[ -z ${ZSHZ[TAB_BINDING]} ]] || \
+   [[ ${ZSHZ[TAB_BINDING]} == _zshz_zle_completion_widget ]]; then
+  ZSHZ[TAB_BINDING]="${$(bindkey -M main '^I')##* }"
+  # If we somehow captured our own widget (race condition), fall back to default
+  [[ ${ZSHZ[TAB_BINDING]} == _zshz_zle_completion_widget ]] && \
+    ZSHZ[TAB_BINDING]=expand-or-complete
+fi
 
 ############################################################
 # ZLE widget to fix spaces-as-wildcards completion


### PR DESCRIPTION
## Summary
- Fixes a stack overflow (`maximum nested function level reached`) introduced in #13710
- The new `_zshz_zle_completion_widget` saves the current `^I` binding and delegates to it, but if the plugin is sourced more than once, the saved binding points to the widget itself, causing infinite recursion on any Tab press
- Guards against self-reference by only capturing the binding on first load and falling back to `expand-or-complete` if the saved value is our own widget

Fixes #13714

## Test plan
- [ ] Enable `z` plugin and open a new shell
- [ ] Type `cd ` and press Tab — verify directory completion works without errors
- [ ] Source `.zshrc` again (to re-source the plugin), then repeat Tab completion — verify no stack overflow
- [ ] Type `z foo bar` and press Tab — verify multi-word completion still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)