### PR TITLE
perf: deduplicate fpath before comparing cached zcompdump metadata

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -110,9 +110,14 @@ if [[ -z "$ZSH_COMPDUMP" ]]; then
   ZSH_COMPDUMP="${ZDOTDIR:-$HOME}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
-# Construct zcompdump OMZ metadata
+# Construct zcompdump OMZ metadata. fpath is deduplicated (preserving
+# first-occurrence order) before comparison so that sessions which
+# differ only in duplicate counts produce identical metadata. Order is
+# preserved because `compinit` resolves colliding completion files by
+# first-occurrence in fpath, so two fpaths with the same entries in a
+# different order can legitimately produce different completions.
 zcompdump_revision="#omz revision: $(builtin cd -q "$ZSH"; git rev-parse HEAD 2>/dev/null)"
-zcompdump_fpath="#omz fpath: $fpath"
+zcompdump_fpath="#omz fpath: ${${(@u)fpath}}"
 
 # Delete the zcompdump file if OMZ zcompdump metadata changed
 if ! command grep -q -Fx "$zcompdump_revision" "$ZSH_COMPDUMP" 2>/dev/null \


### PR DESCRIPTION
## Summary

Fixes silent compinit cache invalidation where `.zcompdump` is deleted
and rebuilt on every shell startup in any setup where another init
file injects duplicate entries into `$fpath` (macOS Homebrew, pyenv,
conda, nvm, mise, direnv, etc.). The underlying dump is functionally
valid in these cases; the existing `grep -Fx` metadata check just
fails to recognize it.

Closes #13720.

## What changed

`zcompdump_fpath` now uses `${${(@u)fpath}}` (dedup via array
expansion, preserving first-occurrence order) instead of raw `$fpath`.
Sessions that differ only in fpath duplicate counts now compare equal,
so the cache is preserved across sessions where `brew shellenv` or a
similar hook re-prepends an already-present directory.

**Preserving first-occurrence order is deliberate.** zsh's `compinit`
resolves colliding completion files (two directories both shipping
`_foo`) by taking whichever appears first in `$fpath`. Two fpaths
containing the same set of entries in different orders can therefore
register different `compdef` bindings and are *not* semantically
equivalent. An earlier revision of this patch used `${${(@onu)fpath}}`
(sort + dedup) and was withdrawn after review feedback from @mologie
on the issue thread, who correctly noted that sort-normalizing would
mask legitimate invalidation in that case. Dedup-only cannot cause
that regression: removing later duplicates never changes which entry
is first, so the collision winner is identical before and after dedup.

No new settings. No behavior change for users whose fpath was already
duplicate-free. No change to insecure-directory warnings, compfix
behavior, zrecompile, or any public variable.

Users will see exactly one cache rebuild on first upgrade (because the
stored metadata was in the old non-deduped form). After that, cache
hits work as originally intended.

## Scope of the fix (what this PR does and does not cover)

This PR fixes the dominant real-world cause of spurious invalidation:
**duplicate entries injected by shell init hooks.** It does not claim
to fix the narrower case where two sessions produce fpaths with the
same *set* of entries in a legitimately different order (e.g. plugin
manager A prepends while plugin manager B appends, with no duplicates
on either side). In that case the current `grep -Fx` invalidation is
preserved and the rebuild is unnecessary but correct.

For a design that handles the reorder-of-non-colliding-entries case
automatically, see the "Future work" note below on per-fpath-hashed
dump paths. That is intentionally left for a follow-up PR to keep this
diff minimal and low-risk.

## Measurements

Benchmarked with `hyperfine --warmup 3 --min-runs 15 --max-runs 30 'zsh -i -c exit'`
on macOS (arm64, Apple Silicon, zsh 5.9), driven by a `.zprofile` that
alternates between injecting 1 and 2 copies of the same fpath entry to
mimic real-world drift (e.g. `brew shellenv` run once vs. twice across
login/interactive shells). The "1-plugin" row uses `plugins=(git)`; the
"13-plugin" row uses a representative realistic set (git, brew, fzf,
kubectl, npm, node, aws, docker, history, colored-man-pages,
command-not-found, sudo, virtualenv).

| Configuration | 1 plugin | 13 plugins |
|---|---|---|
| `master` — cache invalidated every session | 2104 ms ± 144 ms | 3442 ms ± 190 ms |
| This PR (`${${(@u)fpath}}`) — cache preserved | **279 ms ± 25 ms** | **348 ms ± 23 ms** |
| Speedup | **7.5×** | **9.9×** |

For reference, I also benchmarked the rejected sort+dedup form
(`${${(@onu)fpath}}`) at 1 plugin: **308 ms ± 25 ms**. Dedup-only is
marginally faster than sort+dedup because `(u)` does less work than
`(onu)`, and it is strictly more correct (see Alternatives below).

## Correctness validation

Two reproduction scripts run against master and both patch variants
confirm dedup-only is the only form that passes both cases:

| Variant | duplicate-injection case | collision-reorder case |
|---|---|---|
| `master` (unpatched) | ✗ cache rewritten every run | ✓ correctly invalidates |
| `${${(@u)fpath}}` (**this PR**) | ✓ cache reused | ✓ correctly invalidates |
| `${${(@onu)fpath}}` (rejected) | ✓ cache reused | ✗ **stale dump retained** |

The "duplicate-injection case" deterministically alternates between 1
and 2 copies of the same fpath entry and checks that the stored
`.zcompdump` mtime is stable across runs. The "collision-reorder"
case creates two directories each shipping a `_git` completion file,
flips their order in `$fpath` between runs, and checks that the dump
is rewritten when the first-occurrence (and therefore the `compdef`
winner) changes. The sort+dedup form fails this case because its
stored metadata is identical across both orderings, so OMZ serves the
stale dump matched against the wrong `_git` winner.

Reproduction scripts: `reproduce-duplicates.sh` and
`reproduce-collision-reorder.sh` (attached to the issue; both run in a
`mktemp -d` sandbox and do not touch the user's real `$HOME`).

## Tested on

- macOS 15 (arm64), zsh 5.9, OMZ commit on master at time of testing
- Plugins tested: minimal (`git` only) and representative
  13-plugin set (git, brew, fzf, kubectl, npm, node, aws, docker,
  history, colored-man-pages, command-not-found, sudo, virtualenv)

Automated verification against both reproduction scripts (see
"Correctness validation" above). Manual verification:
- First shell builds dump once; subsequent shells reuse it
- `compdef` works (no "command not found: compdef" errors)
- Tab completion for brew, git, kubectl, aws, npm all functional
- `omz update` correctly invalidates via the revision check
  (verified by flipping `zcompdump_revision` on disk)
- Adding a new plugin to `plugins=(...)` correctly invalidates via
  the fpath check (verified by adding/removing a test plugin and
  confirming new completions are picked up without manual
  `rm .zcompdump*`)
- Reordering colliding completion files is still detected: the
  `reproduce-collision-reorder.sh` script exercises exactly the
  scenario @mologie flagged — two directories each shipping `_git`,
  with fpath order flipping between runs. With this patch the dump
  is correctly rewritten on every flip, so the completion winner
  changes accordingly. (This is the failure mode a sort+dedup form
  would introduce; dedup-only is strictly safe.)

## Prior art

- [ctechols gist](https://gist.github.com/ctechols/ca1035271ad134841284)
  (2015, 213 stars) — the original "`compinit -C` if dump is fresh"
  community workaround. This PR solves the same problem but through
  the safer path of making OMZ's existing invalidation logic work
  correctly.
- [forivall:use-cached-compdump](https://github.com/ohmyzsh/ohmyzsh/compare/master...forivall:oh-my-zsh:use-cached-compdump)
  (Nov 2024) — unfiled branch proposing a `ZSH_COMPINIT_CACHE=true`
  opt-in. That approach has trade-offs (see "Alternatives considered"
  below).

## Alternatives considered

I looked at what other popular zsh plugin managers do and at
@romkatv's [zsh-bench](https://github.com/romkatv/zsh-bench) analysis
before choosing this approach.

**Sort + dedup (`${${(@onu)fpath}}`, rejected after review):** an
earlier revision of this patch used this form. Withdrawn after
@mologie pointed out on #13720 that zsh's `compinit` resolves
colliding completion files by first-occurrence in `$fpath`, so two
fpaths with the same entries in a different order can legitimately
register different `compdef` functions. Sort-normalizing would mask
that invalidation and could serve a stale dump matched against the
wrong winner. The current dedup-only form preserves first-occurrence
order and is strictly safe under zsh's actual semantics.

**Opt-in time-based cache (`ZSH_COMPINIT_CACHE=true`, rejected for
this PR):** short-circuit to `compinit -C -d "$ZSH_COMPDUMP" -D` when
the dump is less than 24 h old. This is the pattern @forivall proposed
and is what Prezto does by default. Per
[zsh-bench's "Cutting Corners" section](https://github.com/romkatv/zsh-bench/tree/master/README.md#cutting-corners)
and the Prezto issue
[#2010](https://github.com/sorin-ionescu/prezto/issues/2010), this
pattern has a real UX cost: newly installed tool completions won't
appear for up to 24 h until the user manually runs `rm ~/.zcompdump*`.
zcomet and zim both moved away from this pattern after @romkatv's
review.

**Per-directory mtime check (zsh4humans/zim style, follow-up
candidate):** replace string comparison with iteration over each
directory in `$fpath` comparing mtime to the dump. Strictly more
accurate than string comparison — catches completions added to
existing directories, which the current logic misses. Worth exploring
as a follow-up once this PR lands.

**Per-fpath-hashed dump paths (follow-up candidate, per @mologie's
suggestion on #13720):** hash the live `$fpath` into the dump filename
so each distinct fpath gets its own cache and reorders of colliding
non-duplicate entries produce distinct caches automatically. Strictly
more correct than any normalization approach and auto-recovers when a
user toggles between fpath configurations. Trade-offs: cache files
accumulate (needs LRU or age-based cleanup), larger diff, and invites
bikeshedding about cache directory layout and XDG compliance. Better
as a separate follow-up PR once the duplicate-injection bleeding is
stopped.

Options B, C, and D are intentionally out of scope for this PR; see
the issue for full discussion.

## AI-assisted disclosure

Per the
[AI-assisted contributions section of CONTRIBUTING.md](https://github.com/ohmyzsh/ohmyzsh/blob/master/CONTRIBUTING.md#a-note-on-ai-assisted-contributions):

This patch was developed with AI assistance during root-cause
investigation of a real OMZ slow-startup problem on a Homebrew-enabled
macOS install. The AI helped diagnose the `grep -Fx` failure and
draft the patch and PR description.

Two QA iterations were performed during patch development:

1. An initial attempt used the single-form `${(onu)fpath}` which
   silently does not apply sort/unique flags to the fpath array in a
   double-quoted string context. The reproduction script (attached to
   the issue) caught this on first run — the stored fpath was not
   actually normalized — and the patch was corrected to the nested
   form.

2. The nested form was initially written as `${${(@onu)fpath}}` (sort
   + numeric-sort + unique). After review feedback from @mologie on
   the issue thread pointed out that fpath order is semantically
   meaningful to `compinit`'s collision resolution, the patch was
   narrowed to `${${(@u)fpath}}` (dedup only, preserving
   first-occurrence order). This change is explicitly called out so
   reviewers know the final form was arrived at through review, not
   by initial design.

All code references, measurements, and verification steps were
performed locally. The author understands every line of the change,
reviewed the Zsh parameter expansion flags documentation, and can
defend or revise any part on request.

cc @forivall — thank you for the prior branch exploring the
`ZSH_COMPINIT_CACHE` direction. Your analysis was part of the
reasoning process even though this PR takes a different approach.

cc @mologie — thank you for the order-sensitivity review on the
issue. The patch is narrower and more defensible as a result.