### PR TITLE
Add AWS CDK plugin

### DIFF
--- a/plugins/cdk/README.md
+++ b/plugins/cdk/README.md
@@ -1,0 +1,15 @@
+# AWS CDK plugin
+
+This plugin adds completion for the [AWS Cloud Development Kit (CDK)](https://aws.amazon.com/cdk/) CLI.
+
+To use it, add `cdk` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... cdk)
+```
+
+If the `cdk` command is installed globally, the plugin uses it directly. If `cdk` is not found but `npx` is
+available, the plugin defines a `cdk` wrapper that runs `npx -- cdk`, which supports project-local CDK
+installations.
+
+This plugin does not add any aliases.

--- a/plugins/cdk/cdk.plugin.zsh
+++ b/plugins/cdk/cdk.plugin.zsh
@@ -1,0 +1,22 @@
+# AWS CDK plugin
+#
+# Adds completion for the AWS CDK CLI. If `cdk` is not installed globally but
+# `npx` is available, define a wrapper so project-local CDK installations work.
+
+if (( ! $+commands[cdk] )); then
+  if (( ! $+commands[npx] )); then
+    return
+  fi
+
+  function cdk() {
+    npx -- cdk "$@"
+  }
+fi
+
+function _cdk_yargs_completions() {
+  local -a reply
+  reply=(${(f)"$(COMP_CWORD="$((CURRENT - 1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" cdk --get-yargs-completions "${words[@]}")"})
+  _describe 'values' reply
+}
+
+compdef _cdk_yargs_completions cdk


### PR DESCRIPTION
## Standards checklist
- [x] The PR title is descriptive.
- [x] The PR does only one thing.
- [x] The PR does not include unnecessary commits.
- [x] The code follows the project style.

## Description
Adds a new `cdk` plugin for AWS CDK. The plugin registers zsh completion using CDK's yargs completion hook and defines a fallback `cdk` wrapper through `npx -- cdk` when no global `cdk` command is available.

Fixes #11816

## Validation
- `zsh -n plugins/cdk/cdk.plugin.zsh`
- Sourced-plugin smoke test with a fake `cdk --get-yargs-completions` executable
- README presence and basic usage checks