### PR TITLE
docs(brew): correct `brews` description

### DIFF
--- a/plugins/brew/README.md
+++ b/plugins/brew/README.md
@@ -40,7 +40,7 @@ the `brew` binary before sourcing `oh-my-zsh.sh` and it'll set up the environmen
 | `bo`     | `brew outdated`                         | List installed formulae that have an updated version available.       |
 | `br`     | `brew reinstall`                        | Reinstall a formula.                                                  |
 | `brewp`  | `brew pin`                              | Pin a specified formula so that it's not upgraded.                    |
-| `brews`  | `brew list -1`                          | List installed formulae or the installed files for a given formula.   |
+| `brews`  | _function_                              | List installed leaf formulae with their dependencies, then casks.     |
 | `brewsp` | `brew list --pinned`                    | List pinned formulae, or show the version of a given formula.         |
 | `brh`    | `brew reinstall --HEAD`                 | Reinstall a formula with --HEAD                                       |
 | `bs`     | `brew search`                           | Perform a substring search of cask tokens and formula names for text. |


### PR DESCRIPTION
### Standards

- [x] My code follows the [style guidelines of this project](https://github.com/ohmyzsh/ohmyzsh/wiki/Coding-style-guide).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.

### What

Fix the description for the `brews` row in the `brew` plugin README aliases table.

### Why

`brews` was an alias for `brew list -1` until PR #10135 (merged Dec 2021), which replaced the alias with a shell function that prints leaf formulae with their dependencies, then casks:

https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/brew/brew.plugin.zsh#L74-L85

The README row was never updated and still claims `brews` runs `brew list -1` and lists "installed formulae or the installed files for a given formula", which is wrong on both counts (the function takes no argument and never calls `brew list -1`).

### Diff

```
-| `brews`  | `brew list -1`                          | List installed formulae or the installed files for a given formula.   |
+| `brews`  | _function_                              | List installed leaf formulae with their dependencies, then casks.     |
```

`_function_` matches how other docs in the repo annotate plugin functions in alias tables (it is not an alias to a single command, so showing one would itself be misleading).

### How tested

- Re-read `plugins/brew/brew.plugin.zsh` and confirmed the `brews` function body matches the new description.
- `git log --follow` on `plugins/brew/brew.plugin.zsh` confirms the alias-to-function change in #10135 and no later revert.