### PR TITLE
fix(brew): add /opt/homebrew/sbin to PATH

### DIFF
--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -23,6 +23,13 @@ if (( ! $+commands[brew] )); then
   unset BREW_LOCATION
 fi
 
+if [[ "$BREW_LOCATION" == "/opt/homebrew/bin/brew" && -d "/opt/homebrew/sbin" ]]; then
+    path=("/opt/homebrew/sbin" $path)
+  fi
+
+  unset BREW_LOCATION
+fi
+
 if [[ -z "$HOMEBREW_PREFIX" ]]; then
   # Maintain compatibility with potential custom user profiles, where we had
   # previously relied on always sourcing shellenv. OMZ plugins should not rely


### PR DESCRIPTION
This PR fixes the issue where /opt/homebrew/sbin was missing from the PATH on macOS Apple Silicon, causing warnings when running brew doctor or using formulae that install executables to sbin.

The fix checks if Homebrew is installed in /opt/homebrew and ensures the sbin directory exists before adding it to the path array.

Closes #13704