### PR TITLE
fix(sudo): modify grep command to handle special characters in editorcmd

### DIFF
--- a/plugins/sudo/sudo.plugin.zsh
+++ b/plugins/sudo/sudo.plugin.zsh
@@ -78,7 +78,7 @@ sudo-command-line() {
     # - $realcmd is "cmd" and $EDITOR is /alternative/path/to/cmd that appears in $PATH
     if [[ "$realcmd" = (\$EDITOR|$editorcmd|${editorcmd:c}) \
       || "${realcmd:c}" = ($editorcmd|${editorcmd:c}) ]] \
-      || builtin which -a "$realcmd" | command grep -Fx -q "$editorcmd"; then
+      || builtin which -a "$realcmd" | command grep -Fx -q -- "$editorcmd"; then
       __sudo-replace-buffer "$cmd" "sudo -e"
       return
     fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [x] Allows the grep command to handle weird cases of `$editorcmd`

## Other comments:

On a brand new Fedora i3 spin, I installed zsh and omz along with some plugins including sudo. Using the keymap to prefix the current or the previous command resulted in an error even though the actual process passes:

```
grep: option requires an argument -- 'e'
```

I tried to debug this issue. My `$EDITOR` variable was set to `/usr/bin/nano` and `$VISUAL` and `$SUDO_EDITOR` were empty, before initializing omz and the plugins. But somehow, right before the grep command, the `$EDITOR` turned into `-e nvim` and the `$editorcmd` became `-e`, and then later return to the original values.

I don't have an idea where things might've gone wrong, I haven't looked very deeply into it. Simply telling grep to not parse any args seemed like a better idea and it works, so here we are.

PS: I use the same combo + some additional plugins on my Arch setup, and there seems to be no problem with it. So this might be something related to what Fedora shipped with the i3 spin.