### PR TITLE
feat(extract): add support for extracting to a specified directory

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -36,7 +36,7 @@ function _omz_git_prompt_info() {
     && upstream=" -> ${upstream}"
   fi
 
-  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref:gs/%/%%}${upstream:gs/%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
+  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref//\%/%%}${upstream//\%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
 }
 
 function _omz_git_prompt_status() {

--- a/plugins/extract/_extract
+++ b/plugins/extract/_extract
@@ -53,5 +53,6 @@ local -a exts=(
 
 _arguments \
   '(-r --remove)'{-r,--remove}'[Remove archive.]' \
+  '(-t --to-directory)'{-t,--to-directory}'[Extract to a specific directory.]' \
   "*::archive file:_files -g '(#i)*.(${(j:|:)exts})(-.)'" \
     && return 0

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -9,14 +9,41 @@ Usage: extract [-option] [file ...]
 
 Options:
     -r, --remove    Remove archive after unpacking.
+    -t, --to-directory <dir>  Extract to a specific directory instead of the current one.
 EOF
   fi
 
   local remove_archive=1
-  if [[ "$1" == "-r" ]] || [[ "$1" == "--remove" ]]; then
-    remove_archive=0
-    shift
-  fi
+  local target_directory=""
+
+  while (( $# > 0 )); do
+    case "$1" in
+      -r|--remove)
+        remove_archive=0
+        shift
+        ;;
+      -t|--to-directory)
+        shift
+        if (( $# == 0 )); then
+          echo "extract: -t/--to-directory requires a directory argument" >&2
+          return 1
+        fi
+
+        target_directory="$1"
+        shift
+
+        if [[ ! -d "$target_directory" ]]; then
+          echo "extract: '$target_directory' is not a valid directory" >&2
+          return 1
+        fi
+
+        target_directory="${target_directory%/}"
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
 
   local pwd="$PWD"
   while (( $# > 0 )); do
@@ -33,6 +60,10 @@ EOF
     # Remove the .tar extension if the file name is .tar.*
     if [[ $extract_dir =~ '\.tar$' ]]; then
       extract_dir="${extract_dir:r}"
+    fi
+
+    if [[ -n "$target_directory" ]]; then
+      extract_dir="$target_directory/${extract_dir:t}"
     fi
 
     # If there's a file or directory with the same name as the archive

--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -157,7 +157,7 @@ EOF
       # 1. Move and rename the extracted file/folder to a temporary random name
       # 2. Delete the empty folder
       # 3. Rename the extracted file/folder to the original name
-      if [[ "${content[1]:t}" == "$extract_dir" ]]; then
+      if [[ "${content[1]:t}" == "${extract_dir:t}" ]]; then
         # =(:) gives /tmp/zsh<random>, with :t it gives zsh<random>
         local tmp_name==(:); tmp_name="${tmp_name:t}"
         command mv "${content[1]}" "$tmp_name" \
@@ -165,9 +165,9 @@ EOF
         && command mv "$tmp_name" "$extract_dir"
       # Otherwise, if the extracted folder name already exists in the current
       # directory (because of a previous file / folder), keep the extract_dir
-      elif [[ ! -e "${content[1]:t}" ]]; then
-        command mv "${content[1]}" . \
-        && command rmdir "$extract_dir"
+      elif [[ ! -e "${target_directory:-.}/${content[1]:t}" ]]; then
+        command mv -- "${content[1]}" "${target_directory:-.}/" \
+        && command rmdir -- "$extract_dir"
       fi
     elif [[ ${#content} -eq 0 ]]; then
       command rmdir "$extract_dir"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Following the issue report [#13090](https://github.com/ohmyzsh/ohmyzsh/issues/13090), I added support for extracting archives to a specific directory using a new `-t`/`--to-directory` option in the `extract` plugin. It updates both the user interface and the underlying logic to handle this new feature, including input validation and completion support.

* Added `-t`/`--to-directory <dir>` option to the `extract` command, allowing users to specify a directory to extract archives into instead of the current directory. This includes validation to ensure the target is a valid directory and updates to the usage documentation.
* Modified the extraction logic to use the specified target directory when extracting files.
* Updated the `_extract` shell completion to include the new `-t`/`--to-directory` option for better CLI usability.

## AI disclosure
I used AI assistance to help draft the PR description and review the wording; the code change and validation were done by me

Fixes #13090