### PR TITLE
feat(gitignore): add caching to `gi` completion

### DIFF
--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -13,9 +13,28 @@ _gitignoreio_get_command_list() {
   _gi_curl "list" | tr "," "\n"
 }
 
-_gitignoreio () {
+__gitignoreio_caching_policy() {
+  local -a oldp
+  oldp=("$1"(Nm+7))
+  (($#oldp))
+}
+
+_gitignoreio() {
   compset -P '*,'
-  compadd -S '' $(_gitignoreio_get_command_list)
+
+  local cache_policy
+  zstyle -s ":completion:${curcontext}:" cache-policy cache_policy
+  if [[ -z "$cache_policy" ]]; then
+    zstyle ":completion:${curcontext}:" cache-policy __gitignoreio_caching_policy
+  fi
+
+  local -a _gi_list
+  if _cache_invalid gi-list || ! _retrieve_cache gi-list; then
+    _gi_list=(${(f)"$(_gitignoreio_get_command_list)"})
+    _store_cache gi-list _gi_list
+  fi
+
+  compadd -S '' -a _gi_list
 }
 
 compdef _gitignoreio gi

--- a/plugins/gitignore/gitignore.plugin.zsh
+++ b/plugins/gitignore/gitignore.plugin.zsh
@@ -10,6 +10,7 @@ function gi() {
 }
 
 _gitignoreio_get_command_list() {
+  setopt local_options pipe_fail
   _gi_curl "list" | tr "," "\n"
 }
 
@@ -17,6 +18,17 @@ __gitignoreio_caching_policy() {
   local -a oldp
   oldp=("$1"(Nm+7))
   (($#oldp))
+}
+
+_gitignoreio_retrieve_stale_cache() {
+  zstyle -t ":completion:${curcontext}:" use-cache || return 1
+
+  local cache_dir
+  zstyle -s ":completion:${curcontext}:" cache-path cache_dir
+  : ${cache_dir:=${ZDOTDIR:-$HOME}/.zcompcache}
+
+  [[ -e "$cache_dir/gi-list" ]] || return 1
+  . "$cache_dir/gi-list"
 }
 
 _gitignoreio() {
@@ -30,8 +42,13 @@ _gitignoreio() {
 
   local -a _gi_list
   if _cache_invalid gi-list || ! _retrieve_cache gi-list; then
-    _gi_list=(${(f)"$(_gitignoreio_get_command_list)"})
-    _store_cache gi-list _gi_list
+    local command_list
+    if command_list="$(_gitignoreio_get_command_list)" && [[ -n "$command_list" ]]; then
+      _gi_list=(${(f)command_list})
+      _store_cache gi-list _gi_list
+    else
+      _gitignoreio_retrieve_stale_cache
+    fi
   fi
 
   compadd -S '' -a _gi_list


### PR DESCRIPTION
Adds a cache policy for the `gi` command completion function, i.e. `_gitignoreio`. Previously, every completion call would request the list endpoint of gitignore.io over the network, resulting in a delay between pressing <Tab> and the autocomplete options showing up.

Since we don't expect the gitignore.io templates to change that frequently, configured the cache policy to expire after 7 days.

CC: @carlosala 

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- **Added caching to `_gitignoreio` completion:** Implemented Zsh's `_store_cache` and `_retrieve_cache` mechanisms to store the list of available gitignore templates locally.
- **Implemented a 7-day cache policy:** Added `__gitignoreio_caching_policy` to ensure the template list is refreshed weekly, as gitignore.io templates do not change frequently.
- **Improved completion latency:** By avoiding a mandatory network request to gitignore.io/api/list on every <Tab> press, the user interface remains responsive even when offline or on slow connections.

## Other comments:

### Testing performed:

1. **Latency Verification:** Confirmed that after the initial fetch, pressing <Tab> after typing `gi vim,` provides all available options instantly without network delay.
1. **Cache Expiry Logic:** Verified the 7-day expiry policy by manually manipulating the cache file date:
   - Ran `touch -d '10 days ago' ~/.oh-my-zsh/cache/gi-list`. Pressing <Tab> correctly triggered a new network request (reintroducing the delay), confirming the cache expired.
   - Ran `touch -d '5 days ago' ~/.oh-my-zsh/cache/gi-list`. Pressing <Tab> remained instant, confirming the cache stayed valid within the 7-day window.


Fixes #13736 