### PR TITLE
fix(tmux): respect ZSH_TMUX_UNICODE in tds

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -183,7 +183,10 @@ function _tmux_directory_session() {
   # human friendly unique session name for this directory
   local session_name="${dir}-${md5:0:6}"
   # create or attach to the session
-  tmux new -As "$session_name"
+  local -a tmux_cmd
+  tmux_cmd=(command tmux)
+  [[ "$ZSH_TMUX_UNICODE" == "true" ]] && tmux_cmd+=(-u)
+  $tmux_cmd new -As "$session_name"
 }
 
 alias tds=_tmux_directory_session


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine ~or it's from somewhere with an MIT-compatible license~.
- [x] ~If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.~
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] ~If the code introduces new aliases, I provide a valid use case for all plugin users down below.~

## Changes:

Append `-u` option to `tmux` launched by `tds` when `$ZSH_TMUX_UNICODE` is `true`.

## Other comments:

Given there is a similar request for `$ZSH_TMUX_CONFIG` (#10367), we may refactor the plugin code to have a shared function for launching `tmux` with options applicable to all tmux plugin aliases. I didn't take the approach because I'm not confident about which environment variable should be taken into account when. Let me know if I should revisit the approach.