### PR TITLE
docs(git): document missing aliases

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -181,6 +181,8 @@ plugins=(... git)
 | `grst`                 | `git restore --staged`                                                                                                          |
 | `gunwip`               | `git rev-list --max-count=1 --format="%s" HEAD \| grep -q "--wip--" && git reset HEAD~1`                                        |
 | `grev`                 | `git revert`                                                                                                                    |
+| `greva`                | `git revert --abort`                                                                                                            |
+| `grevc`                | `git revert --continue`                                                                                                         |
 | `grm`                  | `git rm`                                                                                                                        |
 | `grmc`                 | `git rm --cached`                                                                                                               |
 | `gcount`               | `git shortlog --summary -n`                                                                                                     |
@@ -215,6 +217,7 @@ plugins=(... git)
 | `gunignore`            | `git update-index --no-assume-unchanged`                                                                                        |
 | `gwch`                 | `git log --patch --abbrev-commit --pretty=medium --raw`                                                                         |
 | `gwt`                  | `git worktree`                                                                                                                  |
+| `gwta`                 | `git worktree add`                                                                                                              |
 | `gwtls`                | `git worktree list`                                                                                                             |
 | `gwtmv`                | `git worktree move`                                                                                                             |
 | `gwtrm`                | `git worktree remove`                                                                                                           |


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add entries for `greva` (`git revert --abort`), `grevc` (`git revert --continue`) and `gwta` (`git worktree add`) to `plugins/git/README.md` to keep it in sync with `plugins/git/git.plugin.zsh`.

## Other comments:
Assisted by codex.