### PR TITLE
feat(git): add `glom` alias to log against main branch

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -107,6 +107,7 @@ plugins=(... git)
 | `glo`                  | `git log --oneline --decorate`                                                                                                  |
 | `glog`                 | `git log --oneline --decorate --graph`                                                                                          |
 | `gloga`                | `git log --oneline --decorate --graph --all`                                                                                    |
+| `glom`                 | `git log --oneline --decorate $(git_main_branch)..`                                                                             |
 | `glp`                  | `git log --pretty=<format>`                                                                                                     |
 | `glg`                  | `git log --stat`                                                                                                                |
 | `glgp`                 | `git log --stat --patch`                                                                                                        |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -241,6 +241,7 @@ alias glol='git log --graph --pretty="%Cred%h%Creset -%C(auto)%d%Creset %s %Cgre
 alias glo='git log --oneline --decorate'
 alias glog='git log --oneline --decorate --graph'
 alias gloga='git log --oneline --decorate --graph --all'
+alias glom='git log --oneline --decorate $(git_main_branch)..'
 
 # Pretty log messages
 function _git_log_prettily(){


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds the `glom` alias in the git plugin to `log` against the main branch

## Other comments:

This is useful when working on feature branches.