### PR TITLE
fix(aliases): preserve trailing double quotes in als output

### DIFF
--- a/plugins/aliases/cheatsheet.py
+++ b/plugins/aliases/cheatsheet.py
@@ -6,7 +6,9 @@ import argparse
 
 def parse(line):
     left = line[0:line.find('=')].strip()
-    right = line[line.find('=')+1:].strip('\'"\n ')
+    right = line[line.find('=')+1:].strip('\n ')
+    if len(right) >= 2 and right[0] == right[-1] and right[0] in '\'"':
+        right = right[1:-1]
     try:
         cmd = next(part for part in right.split() if len([char for char in '=<>' if char in part])==0)
     except StopIteration:


### PR DESCRIPTION
﻿## Description

The `als` function from the aliases plugin drops trailing double quotes from alias values when they contain quoted strings.

### Root Cause

The `parse()` function in `cheatsheet.py` uses `.strip('\'"\n ')` which strips all matching characters from both ends of the string, including internal quote characters.

For example, with alias `now='date +"%T"'`:
- `alias` outputs: `now='date +"%T"'`
- After stripping: `date +"%T` (trailing `"` is lost because `"` is in the strip set)

### Fix

Only strip matching surrounding quote pairs when both the first and last characters are the same quote character, instead of blindly stripping all quote characters from both ends.

Fixes #13637
