### PR TITLE
feat(antigravity): add completions plugin

### DIFF
--- a/plugins/antigravity/README.md
+++ b/plugins/antigravity/README.md
@@ -1,0 +1,18 @@
+# Antigravity
+
+This plugin adds completion for the [Google Antigravity CLI](https://antigravity.google/docs/cli-features), as well as a few aliases for common commands.
+
+To use it, add `antigravity` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... antigravity)
+```
+
+## Aliases
+
+| Alias | Command |
+| --- | --- |
+| `agv` | `antigravity` |
+| `agvi` | `antigravity init` |
+| `agvb` | `antigravity build` |
+| `agvd` | `antigravity deploy` |

--- a/plugins/antigravity/antigravity.plugin.zsh
+++ b/plugins/antigravity/antigravity.plugin.zsh
@@ -1,0 +1,20 @@
+# Autocompletion for the Google Antigravity CLI (antigravity).
+if (( ! $+commands[antigravity] )); then
+  return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `antigravity`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_antigravity" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _antigravity
+  _comps[antigravity]=_antigravity
+fi
+
+antigravity completion zsh >| "$ZSH_CACHE_DIR/completions/_antigravity" &|
+
+# Aliases
+alias agv='antigravity'
+alias agvi='antigravity init'
+alias agvb='antigravity build'
+alias agvd='antigravity deploy'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add plugin for `antigravity` which adds autocomplete and a few standard aliases for the CLI.

## Other comments:

- Disclosing AI tools: I used an AI assistant to help draft the initial plugin code and this PR description.
- Aliases added:
  - `agv` for `antigravity` (shorthand for the main command)
  - `agvi` for `antigravity init`
  - `agvb` for `antigravity build`
  - `agvd` for `antigravity deploy`
These are the most common workflow commands for the CLI and align with other tool aliases (like `kubectl` -> `k`, etc.).
