### PR TITLE
perf(mise): regenerate completion only when stale

### DIFF
--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -7,11 +7,15 @@ eval "$(mise activate zsh)"
 
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `mise`. Otherwise, compinit will have already done that.
-if [[ ! -f "$ZSH_CACHE_DIR/completions/_mise" ]]; then
+local comp_file="$ZSH_CACHE_DIR/completions/_mise"
+
+if [[ ! -f "$comp_file" ]]; then
   typeset -g -A _comps
   autoload -Uz _mise
   _comps[mise]=_mise
 fi
 
-# Generate and load mise completion
-mise completion zsh >| "$ZSH_CACHE_DIR/completions/_mise" &|
+# Generate completion only when missing/empty or stale.
+if [[ ! -s "$comp_file" || "$commands[mise]" -nt "$comp_file" ]]; then
+  mise completion zsh >| "$comp_file" &|
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Context:

Profiling showed the mise plugin completion generation is a meaningful startup cost in interactive shells.
The plugin currently regenerates completion on every startup, even when the cached completion file is already present and up to date.

## Changes:

- regenerate _mise completion only when missing/empty or stale relative to the mise binary.

## Confirmation:

Timing comparison of 60 runs.

<img width="1280" height="800" alt="timings-comparison" src="https://github.com/user-attachments/assets/fb5beba8-121e-4f0c-95c2-f517cdb3cbc8" />


