### PR TITLE
feat(cdk): add plugin for aws cdk

### DIFF
--- a/plugins/cdk/README.md
+++ b/plugins/cdk/README.md
@@ -1,0 +1,21 @@
+# AWS CDK
+
+This plugin adds completion for the [AWS Cloud Development Kit (CDK)](https://aws.amazon.com/cdk/), as well as some aliases for common commands.
+
+To use it, add `cdk` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... cdk)
+```
+
+## Aliases
+
+| Alias     | Command        | Description                                               |
+| --------- | -------------- | --------------------------------------------------------- |
+| `cdkc`    | `cdk context`  | Manage cached context values                              |
+| `cdkd`    | `cdk deploy`   | Deploys the stack(s) named STACKS into your AWS account   |
+| `cdkdiff` | `cdk diff`     | Compares the specified stack with the deployed stack      |
+| `cdki`    | `cdk init`     | Create a new, empty CDK project                           |
+| `cdkl`    | `cdk list`     | Lists all stacks in the app                               |
+| `cdks`    | `cdk synth`    | Synthesizes and prints the CloudFormation template        |
+| `cdkx`    | `cdk destroy`  | Destroy the stack(s) named STACKS                         |

--- a/plugins/cdk/cdk.plugin.zsh
+++ b/plugins/cdk/cdk.plugin.zsh
@@ -1,0 +1,22 @@
+if (( ! $+commands[cdk] )); then
+  return
+fi
+
+_cdk_yargs_completions() {
+  local reply
+  local si=$IFS
+  IFS=$' '
+  reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" cdk --get-yargs-completions "${words[@]}"))
+  IFS=$si
+  _describe 'values' reply
+}
+compdef _cdk_yargs_completions cdk
+
+# Aliases
+alias cdkc="cdk context"
+alias cdkd="cdk deploy"
+alias cdkdiff="cdk diff"
+alias cdki="cdk init"
+alias cdkl="cdk list"
+alias cdks="cdk synth"
+alias cdkx="cdk destroy"


### PR DESCRIPTION
### If the feature request is for a plugin or theme, specify it here.

CDK Plugin

### If the feature solves a problem you have, specify it here.

Resolves #11816. The issue requests a new ohmyzsh plugin for AWS CDK to provide autocompletion for its commands.

### Describe the proposed feature.

A new plugin for AWS CDK (`cdk`). It leverages `yargs` based completions (`cdk --get-yargs-completions`) and also provides standard aliases:

- `cdkc`: `cdk context`
- `cdkd`: `cdk deploy`
- `cdkdiff`: `cdk diff`
- `cdki`: `cdk init`
- `cdkl`: `cdk list`
- `cdks`: `cdk synth`
- `cdkx`: `cdk destroy`

### Describe alternatives you've considered

Using `yargs` built-in completion allows it to seamlessly support updates to the CDK CLI options without requiring manual mapping.

### Additional context

N/A

### Related Issues

Resolves #11816
