### PR TITLE
feat(antigravity): add plugin for Google Antigravity CLI

### DIFF
--- a/plugins/antigravity/README.md
+++ b/plugins/antigravity/README.md
@@ -1,0 +1,18 @@
+# Antigravity
+
+This plugin adds completion for the [Google Antigravity CLI](https://antigravity.google/docs/cli-features), as well as a few aliases for common commands.
+
+To use it, add `antigravity` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... antigravity)
+```
+
+## Aliases
+
+| Alias | Command |
+| --- | --- |
+| `agv` | `antigravity` |
+| `agvi` | `antigravity init` |
+| `agvb` | `antigravity build` |
+| `agvd` | `antigravity deploy` |

--- a/plugins/antigravity/antigravity.plugin.zsh
+++ b/plugins/antigravity/antigravity.plugin.zsh
@@ -1,0 +1,20 @@
+# Autocompletion for the Google Antigravity CLI (antigravity).
+if (( ! $+commands[antigravity] )); then
+  return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `antigravity`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_antigravity" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _antigravity
+  _comps[antigravity]=_antigravity
+fi
+
+antigravity completion zsh >| "$ZSH_CACHE_DIR/completions/_antigravity" &|
+
+# Aliases
+alias agv='antigravity'
+alias agvi='antigravity init'
+alias agvb='antigravity build'
+alias agvd='antigravity deploy'


### PR DESCRIPTION
### If the feature request is for a plugin or theme, specify it here.

Antigravity CLI Plugin

### If the feature solves a problem you have, specify it here.

This plugin adds autocompletion and useful aliases for the new Google Antigravity CLI.

### Describe the proposed feature.

A new plugin for the Google Antigravity CLI (`antigravity`). It adds standard autocomplete configuration and simple aliases:
- `agv`
- `agvi`
- `agvb`
- `agvd`

### Describe alternatives you've considered

N/A

### Additional context

N/A

### Related Issues

N/A
