### PR TITLE
fix(dnf): use `--installed` to support dnf 4 and 5

### DIFF
--- a/plugins/dnf/README.md
+++ b/plugins/dnf/README.md
@@ -18,7 +18,7 @@ of `dnf5` and uses it as drop-in alternative to the slower `dnf`.
 | Alias | Command                 | Description              |
 |-------|-------------------------|--------------------------|
 | dnfl  | `dnf list`              | List packages            |
-| dnfli | `dnf list installed`    | List installed packages  |
+| dnfli | `dnf list --installed`  | List installed packages  |
 | dnfgl | `dnf grouplist`         | List package groups      |
 | dnfmc | `dnf makecache`         | Generate metadata cache  |
 | dnfp  | `dnf info`              | Show package information |

--- a/plugins/dnf/dnf.plugin.zsh
+++ b/plugins/dnf/dnf.plugin.zsh
@@ -5,7 +5,7 @@ local dnfprog="dnf"
 command -v dnf5 > /dev/null && dnfprog=dnf5
 
 alias dnfl="${dnfprog} list"                       # List packages
-alias dnfli="${dnfprog} list installed"            # List installed packages
+alias dnfli="${dnfprog} list --installed"          # List installed packages
 alias dnfmc="${dnfprog} makecache"                 # Generate metadata cache
 alias dnfp="${dnfprog} info"                       # Show package information
 alias dnfs="${dnfprog} search"                     # Search package


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Synced `dnfli` behaviour across DNF4 and DNF5



## Other comments:

Today, the `dnfli` alias behaves differently under DNF4 and DNF5. The intention of the alias, is to list all installed packages. On DNF5, this no longer works due to changes in the CLI. DNF5 currently expects a package name and treats `installed` as such. 

This PR enforces dnf4 plugin behaviour, by using version-agnostic syntax, always listing _all_ installed packages, as per the intention of the alias.
