### PR TITLE
fix(brew): add sbin to PATH

### DIFF
--- a/plugins/brew/README.md
+++ b/plugins/brew/README.md
@@ -17,6 +17,12 @@ If `brew` is not found in the PATH, this plugin will attempt to find it in commo
 In case you installed `brew` in a non-common location, you can still set `BREW_LOCATION` variable pointing to
 the `brew` binary before sourcing `oh-my-zsh.sh` and it'll set up the environment.
 
+### sbin directory
+
+This plugin also adds `$HOMEBREW_PREFIX/sbin` to the PATH if the directory exists and isn't already present.
+Some Homebrew formulae (e.g. `mtr`) install executables to `sbin`, which `brew doctor` checks for. This
+ensures the `bdr` alias runs without warnings.
+
 ## Aliases
 
 | Alias    | Command                                 | Description                                                           |

--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -30,6 +30,16 @@ if [[ -z "$HOMEBREW_PREFIX" ]]; then
   export HOMEBREW_PREFIX="$(brew --prefix)"
 fi
 
+# Add Homebrew sbin to PATH if it exists and is not already in PATH.
+# Homebrew's shellenv only adds bin directories, not sbin. Some formulae
+# (e.g. mtr) install executables to sbin, and brew doctor warns if it's
+# missing from PATH.
+if [[ -d "$HOMEBREW_PREFIX/sbin" ]]; then
+  if [[ ! "$PATH" == *"$HOMEBREW_PREFIX/sbin"* ]]; then
+    export PATH="$HOMEBREW_PREFIX/sbin:$PATH"
+  fi
+fi
+
 if [[ -d "$HOMEBREW_PREFIX/share/zsh/site-functions" ]]; then
   fpath+=("$HOMEBREW_PREFIX/share/zsh/site-functions")
 fi


### PR DESCRIPTION
## Description

Some Homebrew formulae (e.g. \mtr\) install executables to \/opt/homebrew/sbin\ (Apple Silicon) or \/usr/local/sbin\ (Intel). Homebrew's \shellenv\ only adds \in\ directories to PATH, so \rew doctor\ warns that \sbin\ is missing when these formulae are installed.

This fix adds \\/sbin\ to PATH when:
- The \sbin\ directory exists under the Homebrew prefix
- It's not already present in PATH (avoids duplicates)

## Related Issue
Fixes #13704

## Verification Steps
1. Enable the \rew\ plugin in \.zshrc\ and reload the shell
2. Install a formula that puts executables in sbin: \rew install mtr\
3. Run \dr\ (brew doctor) — the sbin warning should no longer appear