### PR TITLE
fix(golang): complete go module tools

### DIFF
--- a/plugins/golang/_golang
+++ b/plugins/golang/_golang
@@ -15,6 +15,52 @@ __go_identifiers() {
   compadd $(godoc -templates "$tmpl_path" ${words[-2]} 2> /dev/null)
 }
 
+__go_tool_commands() {
+  local -a tools tool_commands
+  local -A command_seen short_count
+  local tool command
+
+  tools=("${(@f)$(go tool 2>/dev/null)}")
+
+  # Go 1.24+ lists module tools by package path, but also accepts unique
+  # default binary names for those tools.
+  for tool in "${tools[@]}"; do
+    [[ -n $tool ]] || continue
+
+    (( command_seen[$tool]++ ))
+
+    if [[ $tool == */* ]]; then
+      command=${tool:t}
+
+      if [[ $command == v[0-9]* && ${command#v} != *[^0-9]* ]] && (( ${command#v} > 1 )); then
+        command=${${tool%/$command}:t}
+      fi
+
+      (( short_count[$command]++ ))
+    fi
+  done
+
+  for tool in "${tools[@]}"; do
+    [[ -n $tool ]] || continue
+
+    tool_commands+=("$tool")
+
+    if [[ $tool == */* ]]; then
+      command=${tool:t}
+
+      if [[ $command == v[0-9]* && ${command#v} != *[^0-9]* ]] && (( ${command#v} > 1 )); then
+        command=${${tool%/$command}:t}
+      fi
+
+      if (( short_count[$command] == 1 && ! command_seen[$command] )); then
+        tool_commands+=("$command")
+      fi
+    fi
+  done
+
+  _values "go tool" "${tool_commands[@]}"
+}
+
 _go() {
   typeset -a commands build_flags
   commands+=(
@@ -208,7 +254,7 @@ _go() {
     ;;
   tool)
     if (( CURRENT == 3 )); then
-        _values "go tool" $(go tool)
+        __go_tool_commands
         return
     fi
     case ${words[3]} in


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (N/A; no aliases added)

## Changes:

- Add Go 1.24+ module tool default binary names to `go tool` completions when they are unique and do not shadow existing tool names.
- Keep completing the full package paths printed by `go tool`.

Fixes #13057.

## Other comments:

AI-assisted.

Tested with:

- `zsh -n plugins/golang/_golang`
- `git diff --check`
- Go 1.24 repro using `go get -tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1`, verifying completion candidates include both `oapi-codegen` and the full package path.
