### PR TITLE
fix(updater): sync dependency deletions

### DIFF
--- a/.github/workflows/dependencies/test_updater.py
+++ b/.github/workflows/dependencies/test_updater.py
@@ -1,0 +1,54 @@
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import updater
+
+
+class DependencyApplyUpstreamChangesTest(unittest.TestCase):
+    def test_apply_upstream_changes_removes_stale_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            worktree = tmp_path / "worktree"
+            source = tmp_path / "source"
+            target = worktree / "plugins" / "example"
+
+            source.mkdir()
+            (source / "kept.zsh").write_text("new content")
+            (source / ".git").mkdir()
+            (source / ".github").mkdir()
+
+            target.mkdir(parents=True)
+            (target / "kept.zsh").write_text("old content")
+            (target / "stale.zsh").write_text("stale content")
+
+            def fake_clone(_remote_url, _ref, repo_dir, reclone=False):
+                shutil.copytree(source, repo_dir, dirs_exist_ok=True)
+
+            dependency = updater.Dependency(
+                "plugins/example",
+                {"repo": "owner/repo", "branch": "main", "version": "old"},
+            )
+
+            previous_cwd = os.getcwd()
+            try:
+                os.chdir(worktree)
+                with (
+                    patch.object(updater, "TMP_DIR", str(tmp_path / "tmp")),
+                    patch.object(updater.Git, "clone", fake_clone),
+                ):
+                    dependency._Dependency__apply_upstream_changes("new")
+            finally:
+                os.chdir(previous_cwd)
+
+            self.assertEqual((target / "kept.zsh").read_text(), "new content")
+            self.assertFalse((target / "stale.zsh").exists())
+            self.assertFalse((target / ".git").exists())
+            self.assertFalse((target / ".github").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/dependencies/updater.py
+++ b/.github/workflows/dependencies/updater.py
@@ -325,10 +325,16 @@ Check out the [list of changes]({status["compare_url"]}).
 
         # Copy files from upstream repo
         print(f"Copying files from {repo_dir} to {path}", file=sys.stderr)
+        if os.path.exists(path):
+            if os.path.islink(path) or os.path.isfile(path):
+                os.remove(path)
+            else:
+                shutil.rmtree(path)
+
+        os.makedirs(os.path.dirname(path), exist_ok=True)
         shutil.copytree(
             repo_dir,
             path,
-            dirs_exist_ok=True,
             ignore=shutil.ignore_patterns(*GLOBAL_IGNORE),
         )
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Clears an existing vendored dependency path before copying the selected upstream ref into it.
- Keeps the existing `.git` / `.github` / `.gitignore` copy ignore behavior.
- Adds a regression test that proves stale vendored files are removed during the sync.

This addresses the delete-aware sync part of #13763. The current `master` branch already appears to use the resolved source ref for tags and includes untracked files in the dirty check, so this PR keeps the scope to stale files left behind by overlay copying.

## Other comments:

AI-assisted.

Verified locally with:

```bash
PYTHONPATH=.github/workflows/dependencies /tmp/ohmyzsh-updater-venv/bin/python -m unittest discover -s .github/workflows/dependencies -p 'test_*.py'
/tmp/ohmyzsh-updater-venv/bin/python -m py_compile .github/workflows/dependencies/updater.py .github/workflows/dependencies/test_updater.py
git diff --check
```
