### PR TITLE
fix(updater): accept Korean IME 'ㅛ' as yes in update prompt

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -232,11 +232,14 @@ function handle_update() {
 
     # Ask for confirmation and only update on 'y', 'Y' or Enter
     # Otherwise just show a reminder for how to update
+    # ㅛ (U+315B) is the character produced at the Y key position on the Korean
+    # Dubeolsik layout, so it is accepted too to avoid cancelling the update
+    # when a Korean IME is active.
     printf "[oh-my-zsh] Would you like to update? [Y/n] "
     read -r -k 1 option
     [[ "$option" = $'\n' ]] || echo
     case "$option" in
-      [yY$'\n']) update_ohmyzsh ;;
+      [yY$'\n']|$'ㅛ') update_ohmyzsh ;;
       [nN]) update_last_updated_file ;&
       *) echo "[oh-my-zsh] You can update manually by running \`omz update\`" ;;
     esac


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Accept `ㅛ` (U+315B) as an affirmative answer in the update confirmation prompt in `tools/check_for_upgrade.sh`.

## Other comments:

**Problem**

On the Korean Dubeolsik keyboard layout, the **Y** key position produces `ㅛ` (U+315B) when a Korean IME is active. The update prompt only matched `[yY$'\n']`, so a Korean user who pressed the Y key with the IME turned on fell through to the `*` branch and had their update **silently cancelled** — the exact opposite of what they intended.

```sh
case "$option" in
  [yY$'\n']|$'ㅛ') update_ohmyzsh ;;
  ...
```

**Why this is a fix, not a feature creep**

I'm aware the prompt is meant to stay minimal and non-intrusive (see #13610). This change is in that same spirit, not against it:

- It does **not** add a new key, behavior, or option. It corrects a case where pressing the *correct* key gives the *wrong* result purely because an IME remapped the produced character. The user already pressed "Y" — the byte just arrived as `ㅛ`.
- Telling Korean users to "turn off the IME first" doesn't work, because the prompt appears unprompted at shell startup; by the time they read it and react, the keystroke is already consumed.
- There's precedent for broadening accepted affirmative input on this very prompt (#4207, merged).
- The diff is a single literal added to the existing pattern — no added complexity, no extra branch, no behavior change for any current input.

**Why only the Y position (and not the N position)**

Pressing the N-position key (`ㅜ`) already falls through to the `*` branch, which results in *not updating* — the intended outcome for "no". The only behavioral nuance is that the explicit `[nN]` branch also calls `update_last_updated_file` to reset the reminder timer. To keep this fix minimal, only the affirmative `ㅛ` is added.

**Testing**

Verified end-to-end through a pseudo-terminal that `read -r -k 1` reads the multibyte `ㅛ` (bytes `e3 85 9b`) as a single character and matches the new pattern:

| Input | Bytes | Result |
|-------|-------|--------|
| `ㅛ` (Korean IME) | `e3859b` | update (yes) |
| `y` | `79` | update (yes) |
| `n` | `6e` | skip + reset timer |
| `x` | `78` | reminder only |

**AI disclosure**

Claude Code (Anthropic) was used to assist with locating the prompt logic, verifying multibyte `read` behavior via a pseudo-terminal, and drafting this PR. The change and its rationale are fully understood and were tested manually on a Korean keyboard.
