### PR TITLE
feat(git): show default branch in prompt

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -29,14 +29,35 @@ function _omz_git_prompt_info() {
   || ref=$(__git_prompt_git rev-parse --short HEAD 2> /dev/null) \
   || return 0
 
-  # Use global ZSH_THEME_GIT_SHOW_UPSTREAM=1 for including upstream remote info
-  local upstream
-  if (( ${+ZSH_THEME_GIT_SHOW_UPSTREAM} )); then
-    upstream=$(__git_prompt_git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null) \
-    && upstream=" -> ${upstream}"
+  local upstream upstream_ref
+  if (( ${+ZSH_THEME_GIT_SHOW_UPSTREAM} || ${+ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH} )); then
+    upstream_ref=$(__git_prompt_git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null) || upstream_ref=
   fi
 
-  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref//\%/%%}${upstream//\%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
+  # Use global ZSH_THEME_GIT_SHOW_UPSTREAM=1 for including upstream remote info
+  if (( ${+ZSH_THEME_GIT_SHOW_UPSTREAM} )) && [[ -n "$upstream_ref" ]]; then
+    upstream=" -> ${upstream_ref}"
+  fi
+
+  # Use global ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH=1 for including the repository's
+  # default branch, as reported by the upstream remote's HEAD, falling back to
+  # origin/HEAD. By default this only displays when it differs from the current
+  # branch. Set it to "always" to display it even when both branches are the same.
+  local default_branch default_branch_remote
+  if (( ${+ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH} )); then
+    default_branch_remote="${upstream_ref%%/*}"
+    default_branch_remote="${default_branch_remote:-origin}"
+    default_branch=$(__git_prompt_git symbolic-ref --quiet --short "refs/remotes/${default_branch_remote}/HEAD" 2>/dev/null) || default_branch=
+    default_branch=${default_branch#${default_branch_remote}/}
+    if [[ -n "$default_branch" \
+      && ( "$ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH" = always || "$default_branch" != "$ref" ) ]]; then
+      default_branch="${ZSH_THEME_GIT_PROMPT_DEFAULT_BRANCH_PREFIX:-" | default: "}${default_branch}${ZSH_THEME_GIT_PROMPT_DEFAULT_BRANCH_SUFFIX}"
+    else
+      default_branch=
+    fi
+  fi
+
+  echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref//\%/%%}${upstream//\%/%%}${default_branch//\%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
 }
 
 function _omz_git_prompt_status() {

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -9,6 +9,10 @@ ZSH_THEME_GIT_PROMPT_PREFIX="git:("   # Beginning of the git prompt, before the 
 ZSH_THEME_GIT_PROMPT_SUFFIX=")"       # End of the git prompt
 ZSH_THEME_GIT_PROMPT_DIRTY="*"        # Text to display if the branch is dirty
 ZSH_THEME_GIT_PROMPT_CLEAN=""         # Text to display if the branch is clean
+# ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH=1 # Set to 1 to show the default branch when different from current
+# ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH=always # Set to "always" to show it even when equal to current
+# ZSH_THEME_GIT_PROMPT_DEFAULT_BRANCH_PREFIX=" | default: " # Text before the default branch
+# ZSH_THEME_GIT_PROMPT_DEFAULT_BRANCH_SUFFIX=""     # Text after the default branch
 ZSH_THEME_RUBY_PROMPT_PREFIX="("
 ZSH_THEME_RUBY_PROMPT_SUFFIX=")"
 


### PR DESCRIPTION
## Standards checklist

- [x] The PR title is descriptive.
- [x] The PR does not include unrelated changes.
- [x] I have read the contribution guidelines.

## Description

Adds an opt-in way for `git_prompt_info` to show a repository's default branch alongside the current branch. This is useful when working across repositories where the default branch is not obvious from the current checkout.

The feature is disabled by default. When enabled with `ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH=1`, it reads the default branch from local `origin/HEAD` metadata and only displays it when different from the current branch. Users can set `ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH=always` to show it even when the current branch is the default branch.

Also adds theme variables for formatting the default branch segment:

- `ZSH_THEME_GIT_PROMPT_DEFAULT_BRANCH_PREFIX`
- `ZSH_THEME_GIT_PROMPT_DEFAULT_BRANCH_SUFFIX`

Examples:

```zsh
ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH=1
# git:(feature/test -> main)

ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH=always
# git:(main -> main)
```

## Motivation and Context

The existing prompt shows the current branch but not the repository default branch. For users who frequently move between repositories and PR branches, showing the default branch can help make the intended base branch visible without running another command.

The implementation avoids network calls and depends only on local Git metadata (`refs/remotes/origin/HEAD`), so prompt performance remains predictable.

## How Has This Been Tested?

- `zsh -n lib/git.zsh`
- `zsh -n lib/theme-and-appearance.zsh`
- Manual throwaway repository test:
  - default branch with `ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH=1`: `git:(main)`
  - feature branch with `ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH=1`: `git:(feature/test -> main)`
  - default branch with `ZSH_THEME_GIT_SHOW_DEFAULT_BRANCH=always`: `git:(main -> main)`
