### PR TITLE
fix(deno): remove deprecated aliases and add modern ones

### DIFF
--- a/plugins/deno/README.md
+++ b/plugins/deno/README.md
@@ -4,17 +4,17 @@ This plugin sets up completion and aliases for [Deno](https://deno.land).
 
 ## Aliases
 
-| Alias | Full command        |
-| ----- | ------------------- |
-| db    | deno bundle         |
-| dc    | deno compile        |
-| dca   | deno cache          |
-| dfmt  | deno fmt            |
-| dh    | deno help           |
-| dli   | deno lint           |
-| drn   | deno run            |
-| drA   | deno run -A         |
-| drw   | deno run --watch    |
-| dru   | deno run --unstable |
-| dts   | deno test           |
-| dup   | deno upgrade        |
+| Alias | Full command     |
+| ----- | ---------------- |
+| dc    | deno compile     |
+| dca   | deno cache       |
+| dck   | deno check       |
+| dfmt  | deno fmt         |
+| dh    | deno help        |
+| dli   | deno lint        |
+| drn   | deno run         |
+| drA   | deno run -A      |
+| drw   | deno run --watch |
+| dsv   | deno serve       |
+| dts   | deno test        |
+| dup   | deno upgrade     |

--- a/plugins/deno/deno.plugin.zsh
+++ b/plugins/deno/deno.plugin.zsh
@@ -1,14 +1,14 @@
 # ALIASES
-alias db='deno bundle'
 alias dc='deno compile'
 alias dca='deno cache'
+alias dck='deno check'
 alias dfmt='deno fmt'
 alias dh='deno help'
 alias dli='deno lint'
 alias drn='deno run'
 alias drA='deno run -A'
 alias drw='deno run --watch'
-alias dru='deno run --unstable'
+alias dsv='deno serve'
 alias dts='deno test'
 alias dup='deno upgrade'
 


### PR DESCRIPTION
## Summary

This PR updates the Deno plugin to remove deprecated commands and add aliases for newer Deno features.

### Removed aliases
- `db` (`deno bundle`): The `bundle` subcommand was deprecated in Deno 1.x and removed in Deno 2.0. Users should use `deno compile` or external bundlers instead.
- `dru` (`deno run --unstable`): The `--unstable` flag has been deprecated in favor of granular `--unstable-*` flags (e.g., `--unstable-worker-options`).

### Added aliases
- `dck` (`deno check`): Type-check modules without executing them.
- `dsv` (`deno serve`): Run an HTTP server (introduced in Deno 1.37, stabilized in Deno 2.0).

### Updated
- README table to reflect the alias changes.

## Checklist
- [x] The plugin aliases have been tested (manually verified alias expansions)
- [x] README has been updated accordingly