### PR TITLE
chore(ansible): zsh-ify some code

### DIFF
--- a/plugins/ansible/ansible.plugin.zsh
+++ b/plugins/ansible/ansible.plugin.zsh
@@ -1,13 +1,13 @@
 # Functions
-function ansible-version(){
+function ansible-version() {
     ansible --version
 }
 
-function ansible-role-init(){
-    if ! [ -z $1 ] ; then
+function ansible-role-init() {
+    if [[ -n "$1" ]]; then
         echo "Ansible Role : $1 Creating...."
-        ansible-galaxy init $1
-        tree $1
+        ansible-galaxy init "$1"
+        tree "$1"
     else
         echo "Usage : ansible-role-init <role name>"
         echo "Example : ansible-role-init role1"


### PR DESCRIPTION
## Summary

This PR fixes a few issues in the Ansible plugin:

### Changes
- **Replace bash-style test**: The `ansible-role-init` function used `! [ -z $1 ]` which is a bash-style test. Changed to zsh-native `[[ -n "$1" ]]` for consistency with the rest of the oh-my-zsh codebase.
- **Quote variables**: The `$1` variable was unquoted in `ansible-galaxy init $1` and `tree $1` calls, which would break if the role name contains spaces. Both are now properly quoted.
- **Consistent style**: Added missing space before function parentheses for consistency.

## Testing
- Verified that the function still works correctly with simple role names
- The quoting fix ensures role names with spaces (e.g., `ansible-role-init "my role"`) are handled properly