### PR TITLE
fix(docker): handle empty container list in dsta stop-all command

### DIFF
--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -29,8 +29,17 @@ alias 'drm!'='docker container rm -f'
 alias dsprune='docker system prune'
 alias dst='docker container start'
 alias drs='docker container restart'
-alias dsta='docker stop $(docker ps -q)'
 alias dstp='docker container stop'
+# Function to stop all running containers (handles empty list gracefully)
+function dsta() {
+  local containers
+  containers=(${(f)"$(docker ps -q)"})
+  if (( ${#containers} > 0 )); then
+    docker stop "${containers[@]}"
+  else
+    echo "docker: no running containers to stop"
+  fi
+}
 alias dsts='docker stats'
 alias dtop='docker top'
 alias dvi='docker volume inspect'


### PR DESCRIPTION
## Summary

The `dsta` alias (stop all running containers) previously used:
```zsh
alias dsta='docker stop $(docker ps -q)'
```

This would fail with a usage error when no containers were running, since `docker stop` requires at least one argument:
```
$ dsta
"docker stop" requires at least 1 argument.
See 'docker stop --help'.
```

### Fix
Convert the alias to a function that:
1. Captures the list of running container IDs
2. Checks if any containers exist before calling `docker stop`
3. Prints a helpful message when no containers are running

```zsh
function dsta() {
  local containers
  containers=(${(f)"$(docker ps -q)"})
  if (( ${#containers} > 0 )); then
    docker stop "${containers[@]}"
  else
    echo "docker: no running containers to stop"
  fi
}
```

The behavior when containers ARE running is unchanged.