### PR TITLE
fix(deno): move guard check before aliases and remove deprecated commands

### DIFF
--- a/plugins/deno/README.md
+++ b/plugins/deno/README.md
@@ -2,19 +2,23 @@
 
 This plugin sets up completion and aliases for [Deno](https://deno.land).
 
+To use it, add `deno` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... deno)
+```
+
 ## Aliases
 
-| Alias | Full command        |
-| ----- | ------------------- |
-| db    | deno bundle         |
-| dc    | deno compile        |
-| dca   | deno cache          |
-| dfmt  | deno fmt            |
-| dh    | deno help           |
-| dli   | deno lint           |
-| drn   | deno run            |
-| drA   | deno run -A         |
-| drw   | deno run --watch    |
-| dru   | deno run --unstable |
-| dts   | deno test           |
-| dup   | deno upgrade        |
+| Alias | Full command     |
+| ----- | ---------------- |
+| dc    | deno compile     |
+| dca   | deno cache       |
+| dfmt  | deno fmt         |
+| dh    | deno help        |
+| dli   | deno lint        |
+| drn   | deno run         |
+| drA   | deno run -A      |
+| drw   | deno run --watch |
+| dts   | deno test        |
+| dup   | deno upgrade     |

--- a/plugins/deno/deno.plugin.zsh
+++ b/plugins/deno/deno.plugin.zsh
@@ -1,5 +1,9 @@
+# Return immediately if deno is not found
+if (( ! ${+commands[deno]} )); then
+  return
+fi
+
 # ALIASES
-alias db='deno bundle'
 alias dc='deno compile'
 alias dca='deno cache'
 alias dfmt='deno fmt'
@@ -8,15 +12,10 @@ alias dli='deno lint'
 alias drn='deno run'
 alias drA='deno run -A'
 alias drw='deno run --watch'
-alias dru='deno run --unstable'
 alias dts='deno test'
 alias dup='deno upgrade'
 
 # COMPLETION FUNCTION
-if (( ! $+commands[deno] )); then
-  return
-fi
-
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `deno`. Otherwise, compinit will have already done that.
 if [[ ! -f "$ZSH_CACHE_DIR/completions/_deno" ]]; then


### PR DESCRIPTION
## Summary

This PR fixes two issues in the deno plugin:

1. **Guard check placement**: The command existence check (`if (( ! $+commands[deno] ))`) was placed after the aliases, meaning aliases like `db`, `dc`, `drn`, etc. were created even when deno was not installed. This is inconsistent with other plugins (bun, volta, gh, etc.) that check for the command first.

2. **Removed deprecated aliases**:
   - `db` → `deno bundle`: The `bundle` command was deprecated in Deno 1.x and removed in Deno 2.0 (see https://docs.deno.com/runtime/manual/tools/bundler)
   - `dru` → `deno run --unstable`: The blanket `--unstable` flag was replaced by granular `--unstable-*` feature flags in Deno 2.0

## Changes

- Moved the `if (( ! ${+commands[deno]} ))` guard to the top of the plugin file
- Removed the `db` alias (`deno bundle` - removed in Deno 2.0)
- Removed the `dru` alias (`deno run --unstable` - replaced by granular flags)
- Updated README to reflect the removed aliases and added standard usage instructions

## Testing

- Verified the plugin loads correctly when deno is installed
- Verified no aliases are created when deno is not installed