### PR TITLE
fix(terraform): add command guard and document missing aliases

### DIFF
--- a/plugins/terraform/README.md
+++ b/plugins/terraform/README.md
@@ -21,6 +21,7 @@ plugins=(... terraform)
 | `tfa`   | `terraform apply`                      |
 | `tfa!`  | `terraform apply -auto-approve`        |
 | `tfap`  | `terraform apply -parallelism=1`       |
+| `tfapp` | `terraform apply tfplan`               |
 | `tfc`   | `terraform console`                    |
 | `tfd`   | `terraform destroy`                    |
 | `tfd!`  | `terraform destroy -auto-approve`      |
@@ -33,6 +34,7 @@ plugins=(... terraform)
 | `tfiur` | `terraform init -upgrade -reconfigure` |
 | `tfo`   | `terraform output`                     |
 | `tfp`   | `terraform plan`                       |
+| `tfpo`  | `terraform plan -out tfplan`           |
 | `tfv`   | `terraform validate`                   |
 | `tfs`   | `terraform state`                      |
 | `tft`   | `terraform test`                       |

--- a/plugins/terraform/terraform.plugin.zsh
+++ b/plugins/terraform/terraform.plugin.zsh
@@ -1,3 +1,8 @@
+# Return immediately if terraform is not found
+if (( ! ${+commands[terraform]} )); then
+  return
+fi
+
 function tf_prompt_info() {
   # dont show 'default' workspace in home dir
   [[ "$PWD" != ~ ]] || return


### PR DESCRIPTION
## Summary

This PR adds a command existence guard check to the terraform plugin and documents two missing aliases in the README.

### Changes

1. **Added command guard check**: The terraform plugin was missing a command existence check at the top. This means all aliases (`tf`, `tfa`, `tfp`, etc.) and functions (`tf_prompt_info`, `tf_version_prompt_info`) were created even when terraform was not installed. This is inconsistent with other plugins like `bun`, `volta`, `gh`, `helm`, etc. that all guard with `if (( ! ${+commands[terraform]} )); then return; fi`.

2. **Documented missing aliases in README**: The `tfapp` (`terraform apply tfplan`) and `tfpo` (`terraform plan -out tfplan`) aliases exist in the plugin but were missing from the README documentation table.

## Testing

- Verified the plugin loads correctly when terraform is installed
- Verified no aliases/functions are created when terraform is not installed
- Confirmed `tfapp` and `tfpo` aliases match their documented commands