### PR TITLE
fix(heroku-alias): add command guard check for heroku

### DIFF
--- a/plugins/heroku-alias/heroku-alias.plugin.zsh
+++ b/plugins/heroku-alias/heroku-alias.plugin.zsh
@@ -1,3 +1,8 @@
+# Return immediately if heroku is not found
+if (( ! ${+commands[heroku]} )); then
+  return
+fi
+
 # general
 alias h='heroku'
 alias hauto='heroku autocomplete $(echo $SHELL)'


### PR DESCRIPTION
## Summary

This PR adds a command existence guard check to the `heroku-alias` plugin.

### Problem

The `heroku-alias` plugin creates 40+ aliases and a function (`hcfile`) without checking if the `heroku` CLI is installed. This means all aliases are registered even when heroku is not available, leading to "command not found" errors when users try to use them.

### Solution

Added a standard command guard at the top of the plugin:

```zsh
if (( ! ${+commands[heroku]} )); then
  return
fi
```

This is consistent with the pattern used in most other ohmyzsh plugins including `bun`, `volta`, `gh`, `helm`, `doctl`, `fluxcd`, `skaffold`, etc.

### Note

The related `heroku` plugin (not `heroku-alias`) handles autocompletion and does not need aliases, so it is unaffected.

## Testing

- Verified the plugin loads correctly when heroku is installed
- Verified no aliases are created when heroku is not installed