### PR TITLE
feat(dnf): add dnfur alias

### DIFF
--- a/plugins/dnf/README.md
+++ b/plugins/dnf/README.md
@@ -15,18 +15,19 @@ of `dnf5` and uses it as drop-in alternative to the slower `dnf`.
 
 ## Aliases
 
-| Alias | Command                 | Description              |
-|-------|-------------------------|--------------------------|
-| dnfl  | `dnf list`              | List packages            |
-| dnfli | `dnf list --installed`  | List installed packages  |
-| dnfgl | `dnf grouplist`         | List package groups      |
-| dnfmc | `dnf makecache`         | Generate metadata cache  |
-| dnfp  | `dnf info`              | Show package information |
-| dnfs  | `dnf search`            | Search package           |
-| **Use `sudo`**                                             |
-| dnfu  | `sudo dnf upgrade`      | Upgrade package          |
-| dnfi  | `sudo dnf install`      | Install package          |
-| dnfgi | `sudo dnf groupinstall` | Install package group    |
-| dnfr  | `sudo dnf remove`       | Remove package           |
-| dnfgr | `sudo dnf groupremove`  | Remove package group     |
-| dnfc  | `sudo dnf clean all`    | Clean cache              |
+| Alias | Command                       | Description                              |
+|-------|-------------------------------|------------------------------------------|
+| dnfl  | `dnf list`                    | List packages                            |
+| dnfli | `dnf list --installed`        | List installed packages                  |
+| dnfgl | `dnf grouplist`               | List package groups                      |
+| dnfmc | `dnf makecache`               | Generate metadata cache                  |
+| dnfp  | `dnf info`                    | Show package information                 |
+| dnfs  | `dnf search`                  | Search package                           |
+| **Use `sudo`**                                                                      |
+| dnfu  | `sudo dnf upgrade`            | Upgrade package                          |
+| dnfur | `sudo dnf upgrade --refresh`  | Upgrade package (force metadata refresh) |
+| dnfi  | `sudo dnf install`            | Install package                          |
+| dnfgi | `sudo dnf groupinstall`       | Install package group                    |
+| dnfr  | `sudo dnf remove`             | Remove package                           |
+| dnfgr | `sudo dnf groupremove`        | Remove package group                     |
+| dnfc  | `sudo dnf clean all`          | Clean cache                              |

--- a/plugins/dnf/dnf.plugin.zsh
+++ b/plugins/dnf/dnf.plugin.zsh
@@ -11,6 +11,7 @@ alias dnfp="${dnfprog} info"                       # Show package information
 alias dnfs="${dnfprog} search"                     # Search package
 
 alias dnfu="sudo ${dnfprog} upgrade"               # Upgrade package
+alias dnfur="sudo ${dnfprog} upgrade --refresh"    # Upgrade package and refresh repos
 alias dnfi="sudo ${dnfprog} install"               # Install package
 alias dnfr="sudo ${dnfprog} remove"                # Remove package
 alias dnfc="sudo ${dnfprog} clean all"             # Clean cache


### PR DESCRIPTION
## Description

Adds a `dnfur` alias for `sudo dnf upgrade --refresh`, which forces a metadata refresh before running the upgrade. This is a commonly used combination when you want to ensure your package metadata is current before upgrading.

## New alias

| Alias | Command | Description |
|-------|---------|-------------|
| `dnfur` | `sudo dnf upgrade --refresh` | Upgrade package (force metadata refresh) |

## Changes

- `plugins/dnf/dnf.plugin.zsh`: add `dnfur` alias with consistent spacing (spaces, not tabs)
- `plugins/dnf/README.md`: add `dnfur` to the alias table with reformatted column widths