### PR TITLE
fix(aws): use return instead of exit to avoid killing the shell

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -9,14 +9,14 @@ function agr() {
 # Update state file if enabled
 function _aws_update_state() {
   if [[ "$AWS_PROFILE_STATE_ENABLED" == true ]]; then
-    test -d $(dirname ${AWS_STATE_FILE}) || exit 1
+    test -d $(dirname ${AWS_STATE_FILE}) || return 1
     echo "${AWS_PROFILE} ${AWS_REGION}" > "${AWS_STATE_FILE}"
   fi
 }
 
 function _aws_clear_state() {
   if [[ "$AWS_PROFILE_STATE_ENABLED" == true ]]; then
-    test -d $(dirname ${AWS_STATE_FILE}) || exit 1
+    test -d $(dirname ${AWS_STATE_FILE}) || return 1
     echo -n > "${AWS_STATE_FILE}"
   fi
 }


### PR DESCRIPTION
## Description

`_aws_update_state` and `_aws_clear_state` in the `aws` plugin run:

```zsh
test -d $(dirname ${AWS_STATE_FILE}) || exit 1
```

These are **sourced shell functions**, called from `asp` (switch profile), `asr` (switch region), and when clearing the profile. Because they run in the user's interactive shell, `exit 1` doesn't abort the helper — it **terminates the interactive shell and closes the terminal**.

This triggers whenever a user has `AWS_PROFILE_STATE_ENABLED=true` and the directory that should contain `$AWS_STATE_FILE` doesn't exist yet. Running `asp <profile>` then unexpectedly kills the session.

### Reproduction

```zsh
export AWS_PROFILE_STATE_ENABLED=true
export AWS_STATE_FILE=/tmp/does-not-exist/aws-state   # parent dir missing
asp some-profile      # -> shell exits, terminal closes
```

## Fix

Use `return 1` instead of `exit 1`, so a missing state directory aborts only the helper function and leaves the interactive shell intact. Both occurrences are updated. This only affects users who opt into `AWS_PROFILE_STATE_ENABLED=true`; behaviour is otherwise unchanged.

## Standards checklist

- [x] The commit message follows the [commit guidelines](https://github.com/ohmyzsh/ohmyzsh/blob/master/CONTRIBUTING.md)
- [x] The change is limited in scope (single bug fix, two lines)
- [x] I have read the [Contribution & Style Guide](https://github.com/ohmyzsh/ohmyzsh/blob/master/CONTRIBUTING.md)