### PR TITLE
fix(macports): correct inverted logic

### DIFF
--- a/plugins/macports/macports.plugin.zsh
+++ b/plugins/macports/macports.plugin.zsh
@@ -8,7 +8,7 @@ alias puo="sudo port upgrade outdated"
 alias pup="sudo port selfupdate && sudo port upgrade outdated"
 
 port-livecheck-maintainer() {
-  (( ${+commands[port]} == 0 )) || {
+  (( ${+commands[port]} )) || {
     print -- "port: not found" >&2
     return 1
   }


### PR DESCRIPTION
## Description

The `port-livecheck-maintainer` function in the `macports` plugin has an inverted command-existence guard:

```zsh
(( ${+commands[port]} == 0 )) || {
  print -- "port: not found" >&2
  return 1
}
```

`${+commands[port]}` is `1` when `port` exists and `0` when it doesn't, so the condition is backwards:

- When `port` **is** installed → `(( 1 == 0 ))` is false → the `||` block runs → it prints `port: not found` and aborts, even though `port` is present.
- When `port` is **not** installed → `(( 0 == 0 ))` is true → the block is skipped → the function proceeds and then fails trying to run the missing `port` command.

So the guard does the exact opposite of its intent in both cases — the feature never works for users who have MacPorts installed.

## Fix

Drop the `== 0` so the check reads correctly: the not-found branch runs only when `port` is actually absent.

```zsh
(( ${+commands[port]} )) || { ... }
```

## Standards checklist

- [x] The commit message follows the commit guidelines
- [x] The change is limited in scope (single-line correctness fix)
- [x] I have read the Contribution & Style Guide