### PR TITLE
feat(updater): add cooldown option to delay applying updates (#13813)

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,15 @@ zstyle ':omz:update' frequency 7
 zstyle ':omz:update' frequency 0
 ```
 
+By default, updates always pull the latest changes. If you'd rather let others kick the tires first
+before an update reaches your machine, you can set a cooldown (in days). You'll still get everything —
+just a little later:
+
+```sh
+# Only apply updates that are at least 10 days old
+zstyle ':omz:update' cooldown 10
+```
+
 ### Updates Verbosity
 
 You can also limit the update verbosity with the following settings:

--- a/README.md
+++ b/README.md
@@ -475,6 +475,13 @@ just a little later:
 zstyle ':omz:update' cooldown 10
 ```
 
+`omz update` honors this setting. If you call `upgrade.sh` directly, pass the same
+value with `-c`, because that script does not read your `.zshrc`:
+
+```sh
+$ZSH/tools/upgrade.sh -c 10
+```
+
 ### Updates Verbosity
 
 You can also limit the update verbosity with the following settings:

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -903,8 +903,11 @@ function _omz::update {
   }
 
   # Run update script
+  local verbose_mode cooldown_days
   zstyle -s ':omz:update' verbose verbose_mode || verbose_mode=default
-  ZSH="$ZSH" command zsh -f "$ZSH/tools/upgrade.sh" -i -v $verbose_mode || return $?
+  zstyle -s ':omz:update' cooldown cooldown_days || cooldown_days=0
+  [[ $cooldown_days == <-> ]] || cooldown_days=0
+  ZSH="$ZSH" command zsh -f "$ZSH/tools/upgrade.sh" -i -v $verbose_mode -c $cooldown_days || return $?
 
   # Update last updated file
   zmodload zsh/datetime

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -28,8 +28,11 @@ ZSH_THEME="robbyrussell"
 # zstyle ':omz:update' mode auto      # update automatically without asking
 # zstyle ':omz:update' mode reminder  # just remind me to update when it's time
 
-# Uncomment the following line to change how often to auto-update (in days).
+# Uncomment the following line to change the frequency the auto-updater is run (in days).
 # zstyle ':omz:update' frequency 13
+
+# Uncomment the following line to set how old an update must be before it's applied, manually or via the auto-updater (in days).
+# zstyle ':omz:update' cooldown 10
 
 # Uncomment the following line if pasting URLs and other text is messed up.
 # DISABLE_MAGIC_FUNCTIONS="true"

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -47,6 +47,26 @@ function is_update_available() {
   remote=${"$(builtin cd -q "$ZSH"; git config --local oh-my-zsh.remote)":-origin}
   remote_url=$(builtin cd -q "$ZSH"; git config remote.$remote.url)
 
+  local cooldown_days
+  zstyle -s ':omz:update' cooldown cooldown_days || cooldown_days=0
+  [[ $cooldown_days == <-> ]] || cooldown_days=0
+
+  if (( cooldown_days > 0 )); then
+    local local_head cutoff_epoch cooldown_ref
+    local_head=$(builtin cd -q "$ZSH"; git rev-parse $branch 2>/dev/null) || return 0
+    (builtin cd -q "$ZSH"; LANG= git fetch --quiet $remote $branch) || return 1
+    zmodload zsh/datetime
+    cutoff_epoch=$(( EPOCHSECONDS - cooldown_days * 86400 ))
+    cooldown_ref=$(builtin cd -q "$ZSH"; git log --format="%H %ct" FETCH_HEAD \
+      | awk -v c="$cutoff_epoch" '$2 <= c { print $1; exit }')
+    [[ -n "$cooldown_ref" ]] || return 1
+    [[ "$cooldown_ref" != "$local_head" ]] || return 1
+    if (builtin cd -q "$ZSH"; git merge-base --is-ancestor "$cooldown_ref" "$local_head" 2>/dev/null); then
+      return 1
+    fi
+    return 0
+  fi
+
   local repo
   case "$remote_url" in
   https://github.com/*) repo=${${remote_url#https://github.com/}%.git} ;;
@@ -109,8 +129,10 @@ EOD
 }
 
 function update_ohmyzsh() {
-  local verbose_mode
+  local verbose_mode cooldown_days
   zstyle -s ':omz:update' verbose verbose_mode || verbose_mode=default
+  zstyle -s ':omz:update' cooldown cooldown_days || cooldown_days=0
+  [[ $cooldown_days == <-> ]] || cooldown_days=0
 
   # Force verbose mode to silent if p10k instant prompt is enabled
   if [[ ${POWERLEVEL9K_INSTANT_PROMPT:-off} != "off" ]]; then
@@ -118,13 +140,13 @@ function update_ohmyzsh() {
   fi
 
   if [[ "$update_mode" != background-alpha ]] \
-    && LANG= ZSH="$ZSH" zsh -f "$ZSH/tools/upgrade.sh" -i -v $verbose_mode; then
+    && LANG= ZSH="$ZSH" zsh -f "$ZSH/tools/upgrade.sh" -i -v $verbose_mode -c $cooldown_days; then
     update_last_updated_file
     return $?
   fi
 
   local exit_status error
-  if error=$(LANG= ZSH="$ZSH" zsh -f "$ZSH/tools/upgrade.sh" -i -v silent 2>&1); then
+  if error=$(LANG= ZSH="$ZSH" zsh -f "$ZSH/tools/upgrade.sh" -i -v silent -c $cooldown_days 2>&1); then
     update_last_updated_file 0 "Update successful"
   else
     exit_status=$?

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -57,7 +57,7 @@ function is_update_available() {
     (builtin cd -q "$ZSH"; LANG= git fetch --quiet $remote $branch) || return 1
     zmodload zsh/datetime
     cutoff_epoch=$(( EPOCHSECONDS - cooldown_days * 86400 ))
-    cooldown_ref=$(builtin cd -q "$ZSH"; git log --format="%H %ct" FETCH_HEAD \
+    cooldown_ref=$(builtin cd -q "$ZSH"; git log --first-parent --format="%H %ct" FETCH_HEAD \
       | awk -v c="$cutoff_epoch" '$2 <= c { print $1; exit }')
     [[ -n "$cooldown_ref" ]] || return 1
     [[ "$cooldown_ref" != "$local_head" ]] || return 1

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -231,6 +231,10 @@ local ret=0
 remote=${"$(git config --local oh-my-zsh.remote)":-origin}
 branch=${"$(git config --local oh-my-zsh.branch)":-master}
 
+# cooldown: minimum age (in days) of commits to apply
+local cooldown_days
+zstyle -s ':omz:update' cooldown cooldown_days || cooldown_days=0
+
 # repository state
 last_head=$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)
 # checkout update branch
@@ -242,7 +246,20 @@ last_commit=$(git rev-parse "$branch")
 if [[ $verbose_mode != silent ]]; then
   printf "${BLUE}%s${RESET}\n" "Updating Oh My Zsh"
 fi
-if LANG= git pull --quiet --rebase $remote $branch; then
+if {
+  if (( cooldown_days > 0 )); then
+    zmodload zsh/datetime
+    local cutoff_epoch cooldown_ref
+    cutoff_epoch=$(( EPOCHSECONDS - cooldown_days * 86400 ))
+    LANG= git fetch --quiet $remote $branch && {
+      cooldown_ref=$(git log --format="%H %ct" "$remote/$branch" \
+        | awk -v c="$cutoff_epoch" '$2 <= c { print $1; exit }')
+      [[ -z "$cooldown_ref" ]] || LANG= git merge --ff-only --quiet "$cooldown_ref"
+    }
+  else
+    LANG= git pull --quiet --rebase $remote $branch
+  fi
+}; then
   # Check if it was really updated or not
   if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]; then
     message="Oh My Zsh is already at the latest version."

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -248,7 +248,7 @@ update_with_cooldown() {
   cutoff_epoch=$(( EPOCHSECONDS - cooldown_days * 86400 ))
   LANG= git fetch --quiet $remote $branch || return $?
 
-  cooldown_ref=$(git log --format="%H %ct" FETCH_HEAD \
+  cooldown_ref=$(git log --first-parent --format="%H %ct" FETCH_HEAD \
     | awk -v c="$cutoff_epoch" '$2 <= c { print $1; exit }')
 
   [[ -n "$cooldown_ref" ]] || return 0

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -13,6 +13,8 @@ case "$ZSH_EVAL_CONTEXT" in
   *:file) echo "error: this file should not be sourced" && return 1 ;;
 esac
 
+zmodload zsh/datetime
+
 # Define "$ZSH" if not defined -- in theory this should be `export`ed by the calling script
 if [[ -z "$ZSH" ]]; then
   ZSH="${0:a:h:h}"
@@ -22,8 +24,9 @@ cd "$ZSH"
 
 verbose_mode="default"
 interactive=false
+cooldown_days=0
 
-while getopts "v:i" opt; do
+while getopts "v:ic:" opt; do
   case $opt in
     v)
       if [[ $OPTARG == default || $OPTARG == minimal || $OPTARG == silent ]]; then
@@ -34,6 +37,14 @@ while getopts "v:i" opt; do
       fi
       ;;
     i) interactive=true ;;
+    c)
+      if [[ $OPTARG == <-> ]]; then
+        cooldown_days=$OPTARG
+      else
+        echo "[oh-my-zsh] update cooldown '$OPTARG' is not valid"
+        echo "[oh-my-zsh] valid options are a non-negative integer (days)"
+      fi
+      ;;
   esac
 done
 
@@ -231,9 +242,27 @@ local ret=0
 remote=${"$(git config --local oh-my-zsh.remote)":-origin}
 branch=${"$(git config --local oh-my-zsh.branch)":-master}
 
-# cooldown: minimum age (in days) of commits to apply
-local cooldown_days
-zstyle -s ':omz:update' cooldown cooldown_days || cooldown_days=0
+update_with_cooldown() {
+  local cutoff_epoch cooldown_ref
+
+  cutoff_epoch=$(( EPOCHSECONDS - cooldown_days * 86400 ))
+  LANG= git fetch --quiet $remote $branch || return $?
+
+  cooldown_ref=$(git log --format="%H %ct" FETCH_HEAD \
+    | awk -v c="$cutoff_epoch" '$2 <= c { print $1; exit }')
+
+  [[ -n "$cooldown_ref" ]] || return 0
+
+  LANG= git merge --ff-only --quiet "$cooldown_ref"
+}
+
+perform_update() {
+  if (( cooldown_days > 0 )); then
+    update_with_cooldown
+  else
+    LANG= git pull --quiet --rebase $remote $branch
+  fi
+}
 
 # repository state
 last_head=$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)
@@ -246,23 +275,17 @@ last_commit=$(git rev-parse "$branch")
 if [[ $verbose_mode != silent ]]; then
   printf "${BLUE}%s${RESET}\n" "Updating Oh My Zsh"
 fi
-if {
-  if (( cooldown_days > 0 )); then
-    zmodload zsh/datetime
-    local cutoff_epoch cooldown_ref
-    cutoff_epoch=$(( EPOCHSECONDS - cooldown_days * 86400 ))
-    LANG= git fetch --quiet $remote $branch && {
-      cooldown_ref=$(git log --format="%H %ct" "$remote/$branch" \
-        | awk -v c="$cutoff_epoch" '$2 <= c { print $1; exit }')
-      [[ -z "$cooldown_ref" ]] || LANG= git merge --ff-only --quiet "$cooldown_ref"
-    }
-  else
-    LANG= git pull --quiet --rebase $remote $branch
-  fi
-}; then
+if perform_update; then
   # Check if it was really updated or not
   if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]; then
-    message="Oh My Zsh is already at the latest version."
+    if (( cooldown_days > 0 )); then
+      head_ct=$(git log -1 --format=%ct HEAD)
+      age_days=$(( (EPOCHSECONDS - head_ct) / 86400 ))
+      (( age_days < 0 )) && age_days=0
+      message="Oh My Zsh is already at a version ${age_days} days old."
+    else
+      message="Oh My Zsh is already at the latest version."
+    fi
   else
     message="Hooray! Oh My Zsh has been updated!"
 


### PR DESCRIPTION
Hey folks... wanted to share some context on the approach here before you dig in.

My first instinct was to use `git rebase `to land on a specific historical commit, since the existing updater already uses `--rebase`. But I got a bit nervous about introducing a bare `git rebase <SHA>` into the workflow. It's less predictable than rebasing to a branch tip, and if a user's local copy somehow ended up ahead of the cooldown ref (e.g. they'd manually updated previously), we'd be attempting to rebase onto an ancestor which could leave things in a weird state.

Instead I went with `git fetch` + `git merge --ff-only` to the target commit. Fast-forward only means if you're already at or past the cooldown ref, it's a clean no-op... nothing moves. It also feels closer in spirit to what `git pull` does, just with a specific commit as the target rather than the branch tip.

One other thing worth calling out: I'm filtering by committer timestamp (`%ct`) rather than author date. Since our workflow is PR based, the committer date is when GitHub actually merged the code which is what we care about for "how old is this change really." Author dates are self-reported and could be backdated.

Would love to see some folks help us kick the tires on this before we mark it ready. Open to feedback!

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Introduces a `zstyle ':omz:update' cooldown <days>` setting that limits the
  updater to only apply commits that are at least N days old. Defaults to 0
  (current behavior — always pull latest).
- When cooldown is active, the updater fetches the remote branch, finds the most
  recent commit whose committer timestamp is at least N days old, and applies it
  via `git merge --ff-only`. If the local copy is already at or past the cooldown
  ref, nothing changes.
- `tools/upgrade.sh`: reads cooldown zstyle; replaces `git pull --rebase` with
  `git fetch` + `git merge --ff-only` when cooldown > 0
- `README.md`: documents the new setting under "Getting Updates"
- `templates/zshrc.zsh-template`: adds a commented-out cooldown example alongside
  frequency, with rephrased comments so the two read as a pair

## Other comments:

Claude Code was used to assist with the implementation of this feature.

Closes #13813