### PR TITLE
fix(per-directory-history): prevent fc -p from clearing preexec $1

### DIFF
--- a/plugins/per-directory-history/per-directory-history.zsh
+++ b/plugins/per-directory-history/per-directory-history.zsh
@@ -128,7 +128,6 @@ function _per-directory-history-addhistory() {
           fc -AI $HISTFILE
           fc -AI $_per_directory_history_directory
       fi
-      fc -p $_per_directory_history_directory
   fi
 }
 
@@ -153,6 +152,7 @@ function _per-directory-history-set-directory-history() {
   HISTSIZE=$original_histsize
   if [[ -e "$_per_directory_history_directory" ]]; then
     fc -R "$_per_directory_history_directory"
+    fc -p "$_per_directory_history_directory"
   fi
 }
 
@@ -163,6 +163,7 @@ function _per-directory-history-set-global-history() {
   HISTSIZE=$original_histsize
   if [[ -e "$HISTFILE" ]]; then
     fc -R "$HISTFILE"
+    fc -p "$HISTFILE"
   fi
 }
 

--- a/plugins/per-directory-history/per-directory-history.zsh
+++ b/plugins/per-directory-history/per-directory-history.zsh
@@ -91,13 +91,14 @@ bindkey -M vicmd $PER_DIRECTORY_HISTORY_TOGGLE per-directory-history-toggle-hist
 #-------------------------------------------------------------------------------
 
 _per_directory_history_directory="$HISTORY_BASE${PWD:A}/history"
+_per_directory_history_global="$HISTFILE"
 
 function _per-directory-history-change-directory() {
   _per_directory_history_directory="$HISTORY_BASE${PWD:A}/history"
   mkdir -p ${_per_directory_history_directory:h}
   if [[ $_per_directory_history_is_global == false ]]; then
     #save to the global history
-    fc -AI $HISTFILE
+    fc -AI "$_per_directory_history_global"
     #save history to previous file
     local prev="$HISTORY_BASE${OLDPWD:A}/history"
     mkdir -p ${prev:h}
@@ -125,7 +126,7 @@ function _per-directory-history-addhistory() {
       if [[ -o share_history ]] || \
          [[ -o inc_append_history ]] || \
          [[ -o inc_append_history_time ]]; then
-          fc -AI $HISTFILE
+          fc -AI "$_per_directory_history_global"
           fc -AI $_per_directory_history_directory
       fi
   fi
@@ -146,7 +147,7 @@ function _per-directory-history-precmd() {
 }
 
 function _per-directory-history-set-directory-history() {
-  fc -AI $HISTFILE
+  fc -AI "$_per_directory_history_global"
   local original_histsize=$HISTSIZE
   HISTSIZE=0
   HISTSIZE=$original_histsize
@@ -161,9 +162,9 @@ function _per-directory-history-set-global-history() {
   local original_histsize=$HISTSIZE
   HISTSIZE=0
   HISTSIZE=$original_histsize
-  if [[ -e "$HISTFILE" ]]; then
-    fc -R "$HISTFILE"
-    fc -p "$HISTFILE"
+  if [[ -e "$_per_directory_history_global" ]]; then
+    fc -R "$_per_directory_history_global"
+    fc -p "$_per_directory_history_global"
   fi
 }
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide.

**AI-assisted**: OpenClaw assisted with root cause analysis and fix implementation.

## Problem

When per-directory-history plugin is enabled, `fc -p` is called inside the `zshaddhistory` hook on every command. This corrupts preexec hook argument passing, causing `preexec_functions` to receive an empty `$1`.

See #12926 for detailed repro steps.

## Root Cause

`_per-directory-history-addhistory` calls `fc -p $directory` on every command. Repeated history context pushes pollute zsh preexec state.

## Fix

Move `fc -p` from `_per-directory-history-addhistory` to init functions:
- `_per-directory-history-set-directory-history`: add `fc -p "$_per_directory_history_directory"`
- `_per-directory-history-set-global-history`: add `fc -p "$HISTFILE"`

`fc -AI` calls in addhistory already persist to both files. `fc -p` is a one-time context switch, not a per-command operation.

Fixes #12926
