### PR TITLE
fix(git): support nounset option

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -162,13 +162,13 @@ if zstyle -t ':omz:alpha:lib:git' async-prompt \
   # or any of the other prompt variables
   function _defer_async_git_register() {
     # Check if git_prompt_info is used in a prompt variable
-    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPROMPT}:${RPS1}:${RPS2}:${RPS3}:${RPS4}" in
+    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPROMPT-}:${RPS1-}:${RPS2-}:${RPS3-}:${RPS4-}" in
     *(\$\(git_prompt_info\)|\`git_prompt_info\`)*)
       _omz_register_handler _omz_git_prompt_info
       ;;
     esac
 
-    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPROMPT}:${RPS1}:${RPS2}:${RPS3}:${RPS4}" in
+    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPROMPT-}:${RPS1-}:${RPS2-}:${RPS3-}:${RPS4-}" in
     *(\$\(git_prompt_status\)|\`git_prompt_status\`)*)
       _omz_register_handler _omz_git_prompt_status
       ;;


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide.

**AI-assisted**: OpenClaw assisted with root cause analysis and fix implementation.

## Problem

When `set -u` (nounset option) is enabled, opening a terminal with
ohmyzsh produces shell errors because `${RPROMPT}` and the right-side
prompt variables `${RPS1}`-`${RPS4}` may not be set.

```
_defer_async_git_register:2: RPROMPT: parameter not set
```

See #13701.

## Fix

Add `-` to the parameter expansion to provide an empty default
when these variables are unset:
- `${RPROMPT}` → `${RPROMPT-}`
- `${RPS1}` → `${RPS1-}` (same for RPS2-RPS4)

This matches the existing approach for `${PS1}`-`${PS4}` which
are always set by zsh and don't need this treatment.

Fixes #13701