### PR TITLE
fix(pipenv): use argcomplete for pipenv >= 2026.5.0

### DIFF
--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -10,7 +10,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_pipenv" ]]; then
   _comps[pipenv]=_pipenv
 fi
 
-_PIPENV_COMPLETE=zsh_source pipenv >| "$ZSH_CACHE_DIR/completions/_pipenv" &|
+# pipenv >= 2026.5.0 dropped _PIPENV_COMPLETE in favor of argcomplete
+if (( $+commands[register-python-argcomplete] )); then
+  register-python-argcomplete pipenv >| "$ZSH_CACHE_DIR/completions/_pipenv" &|
+else
+  _PIPENV_COMPLETE=zsh_source pipenv >| "$ZSH_CACHE_DIR/completions/_pipenv" &|
+fi
 
 if zstyle -T ':omz:plugins:pipenv' auto-shell; then
   # Automatic pipenv shell activation/deactivation


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide.

**AI-assisted**: OpenClaw assisted with root cause analysis and fix implementation.

## Problem

pipenv >= 2026.5.0 dropped the `_PIPENV_COMPLETE` environment variable
in favor of `argcomplete`. Users see an error message every time they
open a shell with the pipenv plugin enabled.

See #13719.

## Fix

Check for the `register-python-argcomplete` command (available when
`pipenv[completion]` extra is installed) and use it if present.
Fall back to the old `_PIPENV_COMPLETE` method for older pipenv
versions.

Fixes #13719