### PR TITLE
fix(installer): tolerate sudo shims without -k

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -473,7 +473,7 @@ EOF
   # be prompted for the password either way, so this shouldn't cause any issues.
   #
   if user_can_sudo; then
-    sudo -k >/dev/null 2>&1         # -k forces the password prompt
+    sudo -k >/dev/null 2>&1 || true # -k forces the password prompt when supported
     sudo chsh -s "$zsh" "$USER"
   else
     chsh -s "$zsh" "$USER"          # run chsh normally


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes #13475.
- Makes the installer treat `sudo -k` as a best-effort credential reset before changing the default shell.
- This prevents `set -e` from aborting the installer on sudo compatibility shims, such as Alpine's `doas-sudo-shim`, that allow `sudo chsh` but do not implement `sudo -k`.

## Testing:

- Reproduced the failure with a fake `sudo` where `sudo -n -v` succeeds, `sudo -k` fails, and `sudo chsh` records whether it was reached. Before the change, `setup_shell` exited with status 1 and never called `sudo chsh`.
- Re-ran the same reproduction after the change: `setup_shell` completed and reached `sudo chsh`.
- `git diff --check`

`shellcheck` is not installed in my local environment, so I could not run it here.

## Other comments:

I used OpenAI Codex to help investigate and test this change.
