### PR TITLE
fix(vi-mode): keep cursor hook status successful

### DIFF
--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -26,7 +26,7 @@ typeset -g VI_MODE_CURSOR_OPPEND=${VI_MODE_CURSOR_OPPEND:=0}
 typeset -g VI_KEYMAP=${VI_KEYMAP:=main}
 
 function _vi-mode-set-cursor-shape-for-keymap() {
-  [[ "$VI_MODE_SET_CURSOR" = true ]] || return
+  [[ "$VI_MODE_SET_CURSOR" = true ]] || return 0
 
   # https://vt100.net/docs/vt510-rm/DECSCUSR
   local _shape=0


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes #10002.
- Makes `_vi-mode-set-cursor-shape-for-keymap` return success when cursor-shape updates are disabled.
- This prevents vi-mode hook/widget callers from returning non-zero merely because `VI_MODE_SET_CURSOR` is unset or not `true`, which can stop later hook widgets from running.

## Testing:

- Reproduced the failure before the change:
  - `zsh -fc 'source plugins/vi-mode/vi-mode.plugin.zsh; VI_MODE_SET_CURSOR=; _vi-mode-set-cursor-shape-for-keymap default'`
  - exited with status 1.
- Verified after the change that the same command exits with status 0.
- Verified cursor output is preserved when enabled:
  - `zsh -fc 'source plugins/vi-mode/vi-mode.plugin.zsh; VI_MODE_SET_CURSOR=true; _vi-mode-set-cursor-shape-for-keymap vicmd | od -An -tx1'`
  - outputs `1b 5b 32 20 71` (`ESC [ 2 q`).
- `git diff --check`

`shellcheck` is not installed in my local environment, so I could not run it here.

## Other comments:

I used OpenAI Codex to help investigate and test this change.
