### PR TITLE
fix(completion): keep case folding for partial matches

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -18,9 +18,15 @@ if [[ "$CASE_SENSITIVE" = true ]]; then
   zstyle ':completion:*' matcher-list 'r:|=*' 'l:|=* r:|=*'
 else
   if [[ "$HYPHEN_INSENSITIVE" = true ]]; then
-    zstyle ':completion:*' matcher-list 'm:{[:lower:][:upper:]-_}={[:upper:][:lower:]_-}' 'r:|=*' 'l:|=* r:|=*'
+    zstyle ':completion:*' matcher-list \
+      'm:{[:lower:][:upper:]-_}={[:upper:][:lower:]_-}' \
+      'm:{[:lower:][:upper:]-_}={[:upper:][:lower:]_-} r:|=*' \
+      'm:{[:lower:][:upper:]-_}={[:upper:][:lower:]_-} l:|=* r:|=*'
   else
-    zstyle ':completion:*' matcher-list 'm:{[:lower:][:upper:]}={[:upper:][:lower:]}' 'r:|=*' 'l:|=* r:|=*'
+    zstyle ':completion:*' matcher-list \
+      'm:{[:lower:][:upper:]}={[:upper:][:lower:]}' \
+      'm:{[:lower:][:upper:]}={[:upper:][:lower:]} r:|=*' \
+      'm:{[:lower:][:upper:]}={[:upper:][:lower:]} l:|=* r:|=*'
   fi
 fi
 unset CASE_SENSITIVE HYPHEN_INSENSITIVE


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes #13412.
- Keeps case folding enabled for partial-word completion fallback matchers.
- Keeps the existing `CASE_SENSITIVE=true` behavior unchanged.
- Applies the same composition to the `HYPHEN_INSENSITIVE=true` matcher path so `_`/`-` folding is also retained during partial-word fallback.

Previously, the default matcher list was:

```zsh
m:{[:lower:][:upper:]}={[:upper:][:lower:]}
r:|=*
l:|=* r:|=*
```

The partial-word matchers (`r:|=*` and `l:|=* r:|=*`) did not include the case-insensitive matcher, so a query such as `search` could fail to match a later word segment like `Search` in `Anki-Search-Stats-Extended`.

## Testing:

- Verified the default matcher list now composes case folding with partial-word fallback:
  - `zsh -fc 'ZSH_CACHE_DIR=${TMPDIR:-/tmp}; source lib/completion.zsh; zstyle -a ":completion:*" matcher-list matchers; print -rl -- $matchers'`
- Verified `HYPHEN_INSENSITIVE=true` composes both case and hyphen folding into the partial-word fallback matchers.
- Verified `CASE_SENSITIVE=true` still outputs the original case-sensitive partial matcher list.
- `git diff --check`

`shellcheck` is not installed in my local environment, so I could not run it here.

## Other comments:

I used OpenAI Codex to help investigate and test this change.
