### PR TITLE
perf(kubectx)!: load context asynchronously

### DIFF
--- a/plugins/kubectx/README.md
+++ b/plugins/kubectx/README.md
@@ -22,6 +22,21 @@ RPS1='$(kubectx_prompt_info)'
 PROMPT="$PROMPT"'$(kubectx_prompt_info)'
 ```
 
+The context is loaded asynchronously on supported versions of zsh so that
+`kubectl` does not block the prompt. To restore synchronous behavior, add this
+before Oh My Zsh is sourced:
+
+```zsh
+zstyle ':omz:alpha:plugins:kubectx' async-prompt no
+```
+
+If your theme calls `kubectx_prompt_info` indirectly through another function,
+force registration of the async handler instead:
+
+```zsh
+zstyle ':omz:alpha:plugins:kubectx' async-prompt force
+```
+
 ### Custom context names
 
 You can rename the default context name for better readability or additional formatting.

--- a/plugins/kubectx/kubectx.plugin.zsh
+++ b/plugins/kubectx/kubectx.plugin.zsh
@@ -1,6 +1,6 @@
 typeset -g -A kubectx_mapping
 
-function kubectx_prompt_info() {
+function _omz_kubectx_prompt_info() {
   (( $+commands[kubectl] )) || return
 
   local current_ctx=$(kubectl config current-context 2> /dev/null)
@@ -13,3 +13,34 @@ function kubectx_prompt_info() {
   # the context name, as it could contain a % character.
   echo "${kubectx_mapping[$current_ctx]:-${current_ctx:gs/%/%%}}"
 }
+
+function kubectx_prompt_info() {
+  if (( ${+_OMZ_ASYNC_OUTPUT} )) \
+    && [[ -n "${_OMZ_ASYNC_OUTPUT[_omz_kubectx_prompt_info]-}" ]]; then
+    echo -n "${_OMZ_ASYNC_OUTPUT[_omz_kubectx_prompt_info]}"
+  fi
+}
+
+local _style
+if zstyle -t ':omz:alpha:plugins:kubectx' async-prompt \
+  || { is-at-least 5.0.6 && zstyle -T ':omz:alpha:plugins:kubectx' async-prompt }; then
+  function _defer_async_kubectx_register() {
+    case "${PS1}:${PS2}:${PS3}:${PS4}:${RPROMPT-}:${RPS1-}:${RPS2-}:${RPS3-}:${RPS4-}" in
+    *(\$\(kubectx_prompt_info\)|\`kubectx_prompt_info\`)*)
+      _omz_register_handler _omz_kubectx_prompt_info
+      ;;
+    esac
+
+    add-zsh-hook -d precmd _defer_async_kubectx_register
+    unset -f _defer_async_kubectx_register
+  }
+
+  autoload -Uz add-zsh-hook
+  precmd_functions=(_defer_async_kubectx_register $precmd_functions)
+elif zstyle -s ':omz:alpha:plugins:kubectx' async-prompt _style && [[ $_style == "force" ]]; then
+  _omz_register_handler _omz_kubectx_prompt_info
+else
+  function kubectx_prompt_info() {
+    _omz_kubectx_prompt_info
+  }
+fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Run `kubectl config current-context` through the existing Oh My Zsh async
  prompt API instead of blocking every prompt render.
- Register the async handler only when `kubectx_prompt_info` is referenced
  directly by a prompt variable.
- Preserve synchronous behavior on unsupported zsh versions and through the
  `async-prompt no` setting.
- Support indirect prompt wrappers through the `async-prompt force` setting.
- Keep the existing context mapping and prompt-escaping behavior unchanged.
- Handle the period before the first async result without errors when
  `nounset` is enabled.

## Other comments:

The current implementation starts `kubectl` synchronously every time the
prompt is rendered. With a large kubeconfig, this measured approximately 129
ms per prompt on macOS. The proposed renderer takes approximately 0.71 ms in
the foreground; the existing async callback updates and redraws the prompt
when `kubectl` finishes in the background.

This follows the implementation and compatibility behavior already used by
the async Git prompt. The deferred registration hook runs before
`_omz_async_request` and removes itself after the initial prompt inspection.

This changes `kubectx_prompt_info` to asynchronous behavior by default on
supported zsh versions. Users who require the previous synchronous behavior
can configure:

```zsh
zstyle ':omz:alpha:plugins:kubectx' async-prompt no
```

Themes that call `kubectx_prompt_info` indirectly can configure:

```zsh
zstyle ':omz:alpha:plugins:kubectx' async-prompt force
```

Validated locally with:

- default deferred async registration and callback
- forced async registration
- synchronous fallback
- direct and mapped Kubernetes context rendering
- `nounset` before and after async completion
- concurrent Git and kubectx async handlers
- a single deferred hook and correct hook ordering
- `zsh -n plugins/kubectx/kubectx.plugin.zsh`

No aliases are introduced by this change.

AI-assisted: OpenAI Codex assisted with profiling, implementation, test-case
development, repository-history research, and PR preparation. I reviewed and
iterated on the resulting change and validation.