### PR TITLE
feat(ssh-agent): add option to override `$SSH_AUTH_SOCK`

### DIFF
--- a/plugins/ssh-agent/README.md
+++ b/plugins/ssh-agent/README.md
@@ -99,6 +99,33 @@ ssh-add -K -c -a /run/user/1000/ssh-auth <identities>
 
 For valid `ssh-add` arguments run `ssh-add --help` or `man ssh-add`.
 
+### `override-agent-socket-path`
+
+If you want to say goodbye to (for example) gnome-keyring, you will need a fixed, 
+constant path to SSH-agent socket. 
+By default its name is randomly generated in form of `$TMPDIR/ssh-XXXXXXXXXX/agent.<ppid>`.
+
+To override the `$SSH_AUTH_SOCK` path, use `override-agent-socket-path` style.
+
+```zsh
+zstyle :omz:plugins:ssh-agent override-agent-socket-path "/your/custom/path/socket_name"
+```
+
+Of course you should double-quote the path itself.
+Also there are few builtin default for Linux and MacOS, so you could simply add:
+
+```zsh
+zstyle :omz:plugins:ssh-agent override-agent-socket-path
+```
+
+These are the defaults:
+* Linux:
+  The default `$SSH_AUTH_SOCK` will be `"/var/run/user/<YOUR_UID>/ssh-agent"`
+* MacOS:
+  The default `$SSH_AUTH_SOCK` will be `$TMPDIR/ssh-agent.socket"` or `/tmp/ssh-agent.socket"` if `$TMPDIR` is not set for some reason.
+* On other systems the socket file will be placed in `"$HOME/.ssh/ssh-agent.socket"`
+
+
 ### Powerline 10k specific settings
 
 Powerline10k has an instant prompt setting that doesn't like when this plugin

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -18,13 +18,47 @@ function _start_agent() {
     return 1
   fi
 
+  # ssh-agent extra launch flags
+  local -a agent_extra_flags
+
+  # override $SSH_AUTH_SOCK path option
+  if zstyle -t :omz:plugins:ssh-agent override-agent-socket-path; then
+    local ssh_auth_sock_path
+    local sock_path_reply
+    zstyle -g sock_path_reply :omz:plugins:ssh-agent override-agent-socket-path
+    ssh_auth_sock_path="$sock_path_reply"
+    
+    # set fallback path by $OSTYPE
+    if [[ -z "$ssh_auth_sock_path" ]]; then
+      if [[ "$OSTYPE" == "linux"* ]]; then
+        ssh_auth_sock_path="/var/run/user/$UID/ssh-agent"
+      elif [[ "$OSTYPE" == "darwin"* ]]; then
+        ssh_auth_sock_path="${TMPDIR:-/tmp}/ssh-agent.socket"
+      else
+        ssh_auth_sock_path="$HOME/.ssh/ssh-agent.socket"
+      fi
+    fi
+
+    # check the socket dir and create if needed
+    local socket_dir="${ssh_auth_sock_path:h}"
+    if [[ ! -d "$socket_dir" ]]; then
+      mkdir -p "$socket_dir" || \
+      { echo "Error: can't create ssh socket parent directory." && return 1 }
+      chmod 700 "$socket_dir" || \
+      { echo "Error: can't change permissions of the ssh socket parent directory." && return 1 }
+    fi
+
+    # set extra flags array
+    agent_extra_flags=(-a "$ssh_auth_sock_path")
+  fi
+
   # Set a maximum lifetime for identities added to ssh-agent
   local lifetime
   zstyle -s :omz:plugins:ssh-agent lifetime lifetime
 
   # start ssh-agent and setup environment
   zstyle -t :omz:plugins:ssh-agent quiet || echo >&2 "Starting ssh-agent ..."
-  ssh-agent -s ${lifetime:+-t} ${lifetime} | sed '/^echo/d' >! "$ssh_env_cache"
+  ssh-agent "${agent_extra_flags[@]}"  -s ${lifetime:+-t} ${lifetime} | sed '/^echo/d' >! "$ssh_env_cache"
   chmod 600 "$ssh_env_cache"
   . "$ssh_env_cache" > /dev/null
 }


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

All code changes are in `_start_agent()` function of `plugins/ssh-agent/ssh-agent.plugin.zsh`:
- Added ability to override `$SSH_AUTH_SOCK` path.
Primary goal: integration with private key managers/keyrings (for example - KeepassXC)
- 3 default paths:
- - for Linux
- - MacOS
- - Other OS (fallback)

Also added info about my changes to `plugins/ssh-agent/README.md`


## Other comments:

I'll appreciate for help with MacOS testing due to lack of Mac devices.
