### PR TITLE
fix(updater): retry invalid update prompt input

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -108,6 +108,28 @@ ERROR='${error//\'/’}'
 EOD
 }
 
+function read_update_confirmation() {
+  local option prompt
+  prompt="[oh-my-zsh] Would you like to update? [Y/n] "
+
+  while true; do
+    printf "%s" "$prompt"
+
+    if ! read -r -k 1 option; then
+      echo
+      return 1
+    fi
+
+    [[ "$option" = $'\n' ]] || echo
+
+    case "$option" in
+      [yY$'\n']) return 0 ;;
+      [nN]) return 1 ;;
+      *) prompt="[oh-my-zsh] Please enter 'y' or 'n': " ;;
+    esac
+  done
+}
+
 function update_ohmyzsh() {
   local verbose_mode
   zstyle -s ':omz:update' verbose verbose_mode || verbose_mode=default
@@ -162,7 +184,7 @@ function handle_update() {
   () {
     emulate -L zsh
 
-    local epoch_target mtime option LAST_EPOCH
+    local epoch_target mtime LAST_EPOCH
 
     # Remove lock directory if older than a day
     zmodload zsh/datetime
@@ -187,7 +209,7 @@ function handle_update() {
     trap "
       ret=\$?
       unset update_mode
-      unset -f current_epoch is_update_available update_last_updated_file update_ohmyzsh handle_update 2>/dev/null
+      unset -f current_epoch is_update_available update_last_updated_file read_update_confirmation update_ohmyzsh handle_update 2>/dev/null
       command rm -rf '$ZSH/log/update.lock'
       return \$ret
     " EXIT INT QUIT
@@ -231,19 +253,16 @@ function handle_update() {
     fi
 
     # Ask for confirmation and only update on 'y', 'Y' or Enter
-    # Otherwise just show a reminder for how to update
-    printf "[oh-my-zsh] Would you like to update? [Y/n] "
-    read -r -k 1 option
-    [[ "$option" = $'\n' ]] || echo
-    case "$option" in
-      [yY$'\n']) update_ohmyzsh ;;
-      [nN]) update_last_updated_file ;&
-      *) echo "[oh-my-zsh] You can update manually by running \`omz update\`" ;;
-    esac
+    if read_update_confirmation; then
+      update_ohmyzsh
+    else
+      update_last_updated_file
+      echo "[oh-my-zsh] You can update manually by running \`omz update\`"
+    fi
   }
 
   unset update_mode
-  unset -f current_epoch is_update_available update_last_updated_file update_ohmyzsh handle_update
+  unset -f current_epoch is_update_available update_last_updated_file read_update_confirmation update_ohmyzsh handle_update
 }
 
 case "$update_mode" in


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Retry the update confirmation prompt when the user enters a key other than `y`, `Y`, Enter, `n`, or `N`.
- Keep the existing behavior for accepted answers: `y`, `Y`, and Enter update; `n` and `N` skip and reset the update reminder timer.

## Other comments:

This is related to #13791, but it takes a different approach. That PR accepts Korean IME `ㅛ` as an affirmative answer. This PR treats `ㅛ` as invalid input and asks again, which also covers other accidental keypresses without adding layout-specific affirmative keys.

I also checked for prior related work before opening this:

- #13791 is open and related, but not the same behavior.
- #9330 was closed because `[Y/n]` intentionally uses uppercase `Y` to show the default answer; this PR keeps that convention unchanged.
- Searches for "update prompt invalid input", "Please enter y or n", "Korean IME update prompt", "check_for_upgrade read -k", and "update confirmation" did not show another rejected or merged PR for retrying invalid confirmation input.

Testing:

- `zsh -n tools/check_for_upgrade.sh`
- `git diff --check HEAD^ HEAD`
- Drove `tools/check_for_upgrade.sh` through a `zsh/zpty` pseudo-terminal with a fake `$ZSH/tools/upgrade.sh` and verified:
  - Enter updates.
  - `n` skips and shows the manual update reminder.
  - `ㅛn` prompts again, then skips.
  - `ㅛy` prompts again, then updates.

AI disclosure:

Codex was used to help locate the prompt logic, search related issues and pull requests, and run pseudo-terminal verification. I reviewed the change, understand the behavior, and tested it locally.
