### PR TITLE
feat(cdk): add plugin

### DIFF
--- a/plugins/cdk/README.md
+++ b/plugins/cdk/README.md
@@ -1,11 +1,6 @@
 # AWS CDK Plugin
 
-This plugin provides aliases and autocompletion for the
-[AWS Cloud Development Kit (CDK)](https://aws.amazon.com/cdk/) CLI.
-
-## Requirements
-
-- [AWS CDK CLI](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html) installed (`npm install -g aws-cdk`)
+This plugin provides aliases and autocompletion for the [AWS Cloud Development Kit (CDK)](https://aws.amazon.com/cdk/) CLI.
 
 ## Usage
 
@@ -14,6 +9,10 @@ Add `cdk` to the plugins array in your `.zshrc`:
 ```zsh
 plugins=(... cdk)
 ```
+
+## Requirements
+
+- [AWS CDK CLI](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html) installed (`npm install -g aws-cdk`)
 
 ## Aliases
 

--- a/plugins/cdk/README.md
+++ b/plugins/cdk/README.md
@@ -1,0 +1,33 @@
+# AWS CDK Plugin
+
+This plugin provides aliases and autocompletion for the
+[AWS Cloud Development Kit (CDK)](https://aws.amazon.com/cdk/) CLI.
+
+## Requirements
+
+- [AWS CDK CLI](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html) installed (`npm install -g aws-cdk`)
+
+## Usage
+
+Add `cdk` to the plugins array in your `.zshrc`:
+
+```zsh
+plugins=(... cdk)
+```
+
+## Aliases
+
+| Alias        | Command           | Description                        |
+| ------------ | ----------------- | ---------------------------------- |
+| `cdkl`       | `cdk list`        | List all stacks in the app         |
+| `cdksynth`   | `cdk synth`       | Synthesize CloudFormation template |
+| `cdkdiff`    | `cdk diff`        | Compare deployed vs local stack    |
+| `cdkdeploy`  | `cdk deploy`      | Deploy stack to AWS                |
+| `cdkdestroy` | `cdk destroy`     | Destroy deployed stack             |
+| `cdkboot`    | `cdk bootstrap`   | Bootstrap CDK environment          |
+| `cdkdoc`     | `cdk docs`        | Open CDK documentation             |
+| `cdkinit`    | `cdk init`        | Initialize a new CDK project       |
+| `cdkwatch`   | `cdk watch`       | Watch for changes and auto-deploy  |
+| `cdkctx`     | `cdk context`     | Manage cached context values       |
+| `cdkack`     | `cdk acknowledge` | Acknowledge a notice               |
+| `cdkver`     | `cdk --version`   | Print CDK version                  |

--- a/plugins/cdk/_cdk
+++ b/plugins/cdk/_cdk
@@ -1,0 +1,12 @@
+#compdef cdk
+
+# Originally found and adapted from: https://github.com/aws/aws-cdk/discussions/24380#discussioncomment-5158176
+
+local -a reply
+local IFS
+IFS=$'\n' reply=($(COMP_CWORD="$((CURRENT-1))" \
+          COMP_LINE="$BUFFER" \
+          COMP_POINT="$CURSOR" \
+          cdk --get-yargs-completions "${words[@]}"))
+
+_describe 'values' reply

--- a/plugins/cdk/cdk.plugin.zsh
+++ b/plugins/cdk/cdk.plugin.zsh
@@ -1,0 +1,26 @@
+# AWS CDK plugin for Oh My Zsh
+# Provides aliases and autocompletion for the AWS Cloud Development Kit (CDK) CLI
+
+# Aliases
+alias cdkl='cdk list'
+alias cdksynth='cdk synth'
+alias cdkdiff='cdk diff'
+alias cdkdeploy='cdk deploy'
+alias cdkdestroy='cdk destroy'
+alias cdkboot='cdk bootstrap'
+alias cdkdoc='cdk docs'
+alias cdkinit='cdk init'
+alias cdkwatch='cdk watch'
+alias cdkctx='cdk context'
+alias cdkack='cdk acknowledge'
+alias cdkver='cdk --version'
+
+# Autocompletion
+if command -v cdk &>/dev/null; then
+  _cdk_completion() {
+    local -a completions
+    completions=($(cdk completion 2>/dev/null))
+    compadd -a completions
+  }
+  compdef _cdk_completion cdk
+fi

--- a/plugins/cdk/cdk.plugin.zsh
+++ b/plugins/cdk/cdk.plugin.zsh
@@ -1,6 +1,3 @@
-# AWS CDK plugin for Oh My Zsh
-# Provides aliases and autocompletion for the AWS Cloud Development Kit (CDK) CLI
-
 # Aliases
 alias cdkl='cdk list'
 alias cdksynth='cdk synth'
@@ -14,13 +11,3 @@ alias cdkwatch='cdk watch'
 alias cdkctx='cdk context'
 alias cdkack='cdk acknowledge'
 alias cdkver='cdk --version'
-
-# Autocompletion
-if command -v cdk &>/dev/null; then
-  _cdk_completion() {
-    local -a completions
-    completions=($(cdk completion 2>/dev/null))
-    compadd -a completions
-  }
-  compdef _cdk_completion cdk
-fi


### PR DESCRIPTION
## Description

This PR adds a new plugin for the [AWS Cloud Development Kit (CDK)](https://aws.amazon.com/cdk/), 
a popular tool for defining cloud infrastructure in code and provisioning it through AWS CloudFormation.

Closes #11816

## What's Added

- `plugins/cdk/cdk.plugin.zsh` — aliases and autocompletion for the CDK CLI
- `plugins/cdk/README.md` — documentation with alias table and usage instructions

## Aliases

| Alias        | Command           |
| ------------ | ----------------- |
| `cdkl`       | `cdk list`        |
| `cdksynth`   | `cdk synth`       |
| `cdkdiff`    | `cdk diff`        |
| `cdkdeploy`  | `cdk deploy`      |
| `cdkdestroy` | `cdk destroy`     |
| `cdkboot`    | `cdk bootstrap`   |
| `cdkdoc`     | `cdk docs`        |
| `cdkinit`    | `cdk init`        |
| `cdkwatch`   | `cdk watch`       |
| `cdkctx`     | `cdk context`     |
| `cdkack`     | `cdk acknowledge` |
| `cdkver`     | `cdk --version`   |

## Testing

Tested with:
- AWS CDK CLI v2 (`npm install -g aws-cdk`)
- Zsh on macOS and Linux

## Checklist

- [x] The plugin follows the existing style of other plugins
- [x] README.md is included with usage and alias documentation
- [x] No breaking changes to existing plugins