### PR TITLE
fix(josh): escape % in branch before computing branch_size

### DIFF
--- a/themes/josh.zsh-theme
+++ b/themes/josh.zsh-theme
@@ -10,6 +10,7 @@ function josh_prompt {
   prompt=" "
 
   branch=$(git_current_branch)
+  branch="${branch//\%/%%}"
   ruby_version=$(ruby_prompt_info)
   path_size=${#PWD}
   branch_size=${#branch}
@@ -31,7 +32,7 @@ function josh_prompt {
     prompt=" $prompt"
   done
 
-  prompt="%{%F{green}%}$PWD$prompt%{%F{red}%}$(ruby_prompt_info)%{$reset_color%} ${branch//\%/%%}"
+  prompt="%{%F{green}%}$PWD$prompt%{%F{red}%}$(ruby_prompt_info)%{$reset_color%} ${branch}"
 
   echo $prompt
 }


### PR DESCRIPTION
## What

`c90141e` introduced `%`-escaping in the josh theme by changing the
final prompt line to use `${branch//\%/%%}`. But `branch_size` was
still computed from the raw branch name before escaping:

```zsh
branch=$(git_current_branch)
branch_size=${#branch}      # raw length
...
prompt="... ${branch//\%/%%}"  # displayed length may be longer
```

For a branch like `feat/100%done` (13 chars raw), the displayed string
`feat/100%%done` is 14 chars. The padding calculation sees 13, so the
prompt ends up one space too wide—one extra space per `%` in the branch
name.

## Fix

Move the escaping step immediately after `git_current_branch`, before
`branch_size` is computed, so both the size and the prompt string use
the same (escaped) value:

```zsh
branch=$(git_current_branch)
branch="${branch//\%/%%}"   # escape first
branch_size=${#branch}      # then measure
...
prompt="... ${branch}"      # already escaped
```

## Reproducer

```zsh
# In a git repo, create a branch with % in the name:
git checkout -b "feat/100%done"

# With ZSH_THEME=josh, the right-hand padding will be off by 1
# (one extra leading space before the branch name in the prompt line)
```

## Notes

`%` characters in branch names are uncommon but valid per git's ref
naming rules. The misalignment only appears after `c90141e` introduced
the escaping substitution without updating the size calculation.

---

Found this while reviewing recent commits with a static analysis tool
I built that checks for prompt width calculation regressions in zsh
theme files. Manually verified by reading the before/after diff of
`c90141e` against the current theme code.

AI-assisted: the bug was flagged by my tool; I reviewed and confirmed it manually.