### PR TITLE
fix(bundler): use new `--all` syntax

### DIFF
--- a/plugins/bundler/README.md
+++ b/plugins/bundler/README.md
@@ -22,7 +22,7 @@ plugins=(... bundler)
 | `bo`   | `bundle open`     | Opens the source directory for a gem in your bundle      |
 | `bout` | `bundle outdated` | List installed gems with newer versions available        |
 | `bp`   | `bundle package`  | Package your needed .gem files into your application     |
-| `bu`   | `bundle update`   | Update your gems to the latest available versions        |
+| `bu`   | `bundle update --all` | Update your gems to the latest available versions    |
 
 ## Gem wrapper
 

--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -9,7 +9,7 @@ alias bl="bundle list"
 alias bo="bundle open"
 alias bout="bundle outdated"
 alias bp="bundle package"
-alias bu="bundle update"
+alias bu="bundle update --all"
 
 ## Gem wrapper
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- The use of `bundle update` is deprecated, and the new syntax requires the flag `--all`. This PR makes this simple adjustment.
