### PR TITLE
chore(key-bindings): remove dead commented-out emacs keybindings

### DIFF
--- a/lib/key-bindings.zsh
+++ b/lib/key-bindings.zsh
@@ -125,21 +125,3 @@ bindkey '\C-x\C-e' edit-command-line
 # file rename magick
 bindkey "^[m" copy-prev-shell-word
 
-# consider emacs keybindings:
-
-#bindkey -e  ## emacs key bindings
-#
-#bindkey '^[[A' up-line-or-search
-#bindkey '^[[B' down-line-or-search
-#bindkey '^[^[[C' emacs-forward-word
-#bindkey '^[^[[D' emacs-backward-word
-#
-#bindkey -s '^X^Z' '%-^M'
-#bindkey '^[e' expand-cmd-path
-#bindkey '^[^I' reverse-menu-complete
-#bindkey '^X^N' accept-and-infer-next-history
-#bindkey '^W' kill-region
-#bindkey '^I' complete-word
-## Fix weird sequence that rxvt produces
-#bindkey -s '^[[Z' '\t'
-#


### PR DESCRIPTION
Fixes part of #13838.

Removes the ~18 lines of commented-out emacs keybindings in `lib/key-bindings.zsh` that have been dead/unreferenced for a long time. No functional change, just cleanup for clarity.

AI-assisted: drafted with help from Claude (code review identified the dead code, removal verified by me, `zsh -n` syntax-checked).