### PR TITLE
docs: typos

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -371,7 +371,7 @@ multi == 1 && /^[^#]*\)/ {
   next
 }
 
-# if multi flag is enabled and we didnt find a closing parenthesis,
+# if multi flag is enabled and we didn't find a closing parenthesis,
 # get the indentation level to match when adding plugins
 multi == 1 && /^[^#]*/ {
   indent=\"\"

--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -78,7 +78,7 @@ if is-at-least 4.2.0; then
   alias -s chm=xchm
   alias -s djvu=djview
 
-  #list whats inside packed file
+  #list what's inside packed file
   alias -s zip="unzip -l"
   alias -s rar="unrar l"
   alias -s tar="tar tf"

--- a/plugins/gnu-utils/README.md
+++ b/plugins/gnu-utils/README.md
@@ -27,7 +27,7 @@ The plugin also documents two other ways to do this:
 
 1. Using a function wrapper, such that, for example, there exists a function
 named `ls` which calls `gls` instead. Since functions have a higher preference
-than commands, this ends up calling the GNU coreutil. It has also a higher
+than commands, this ends up calling the GNU coreutils. It has also a higher
 preference over shell builtins (`gecho` is called instead of the builtin `echo`).
 
 2. Using an alias. This has an even higher preference than functions, but they

--- a/plugins/grunt/grunt.plugin.zsh
+++ b/plugins/grunt/grunt.plugin.zsh
@@ -23,7 +23,7 @@
 #
 # Enable caching:
 #
-#   If you want to use the cache, set the followings in your .zshrc:
+#   If you want to use the cache, set the following in your .zshrc:
 #
 #     zstyle ':completion:*' use-cache yes
 #

--- a/plugins/history-substring-search/history-substring-search.zsh
+++ b/plugins/history-substring-search/history-substring-search.zsh
@@ -295,8 +295,8 @@ _history-substring-search-begin() {
     fi
 
     #
-    # Escape and join query parts with wildcard character '*' as seperator
-    # `(j:CHAR:)` join array to string with CHAR as seperator
+    # Escape and join query parts with wildcard character '*' as separator
+    # `(j:CHAR:)` join array to string with CHAR as separator
     #
     local search_pattern="${(j:*:)_history_substring_search_query_parts[@]//(#m)[\][()|\\*?#<>~^]/\\$MATCH}*"
 

--- a/plugins/pulumi/README.md
+++ b/plugins/pulumi/README.md
@@ -1,7 +1,7 @@
 # Pulumi
 
 This is an **Oh My Zsh plugin** for the [**Pulumi CLI**](https://www.pulumi.com/docs/iac/cli/),
-an Infrastructure as Code (IaC) tool for building, deploying and managing cloud infrastucture.
+an Infrastructure as Code (IaC) tool for building, deploying and managing cloud infrastructure.
 
 This plugin provides:
 

--- a/themes/trapd00r.zsh-theme
+++ b/themes/trapd00r.zsh-theme
@@ -115,7 +115,7 @@ prompt_jnrowe_precmd () {
   # modified, to be committed
   elif [[ $(git diff --cached --name-status 2>/dev/null ) != "" ]]; then
     dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$(zsh_path)%} %{$c0%}(%{$c5%}%?%{$c0%})"
-    PROMPT='${vcs_info_msg_0_}%{$30%} %{$bg_bold[red]%}%{$fg_bold[cyan]%}C%{$fg_bold[black]%}OMIT%{$reset_color%}
+    PROMPT='${vcs_info_msg_0_}%{$30%} %{$bg_bold[red]%}%{$fg_bold[cyan]%}C%{$fg_bold[black]%}OMMIT%{$reset_color%}
 ${dir_status}%{$reset_color%}
 > '
   elif [[ $(git diff --name-status 2>/dev/null ) != "" ]]; then

--- a/themes/trapd00r.zsh-theme
+++ b/themes/trapd00r.zsh-theme
@@ -10,7 +10,7 @@
 # scp1@shiva:pts/9-> /home » scp1 (0)
 # >
 #
-# that's  user@host:pts/-> splitted path (return status)
+# that's  user@host:pts/-> split path (return status)
 #
 # If the current directory is a git repository, we span 3 lines;
 #
@@ -115,7 +115,7 @@ prompt_jnrowe_precmd () {
   # modified, to be committed
   elif [[ $(git diff --cached --name-status 2>/dev/null ) != "" ]]; then
     dir_status="%{$c1%}%n%{$c4%}@%{$c2%}%m%{$c0%}:%{$c3%}%l%{$c6%}->%{$(zsh_path)%} %{$c0%}(%{$c5%}%?%{$c0%})"
-    PROMPT='${vcs_info_msg_0_}%{$30%} %{$bg_bold[red]%}%{$fg_bold[cyan]%}C%{$fg_bold[black]%}OMMIT%{$reset_color%}
+    PROMPT='${vcs_info_msg_0_}%{$30%} %{$bg_bold[red]%}%{$fg_bold[cyan]%}C%{$fg_bold[black]%}OMIT%{$reset_color%}
 ${dir_status}%{$reset_color%}
 > '
   elif [[ $(git diff --name-status 2>/dev/null ) != "" ]]; then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Correct spelling in `lib/cli.zsh`, plugins/common-aliases/common-aliases.plugin.zsh`, `plugins/gnu-utils/README.md`, `plugins/grunt/grunt.plugin.zsh`, `plugins/history-substring-search/history-substring-search.zsh`, `plugins/pulumi/README.md`, and `themes/trapd00r.zsh-theme`