### PR TITLE
feat(git): add `gbcopy`

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -253,8 +253,8 @@ receive further support.
 | `git_current_user_email` | Returns the `user.email` config value (Lives in `lib/git.zsh`)                                                 |
 | `git_current_user_name`  | Returns the `user.name` config value (Lives in `lib/git.zsh`)                                                  |
 | `git_develop_branch`     | Returns the name of the “development” branch: `dev`, `devel`, `development` if they exist, `develop` otherwise |
-| `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise                                                                                                                                   |
-| `gbcopy` | Copy current branch name to clipboard                                                                                          |
+| `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise                                   |
+| `gbcopy`                 | Copies current branch name to clipboard                                                                        |
 | `grename <old> <new>`    | Renames branch `<old>` to `<new>`, including on the origin remote                                              |
 | `gbda`                   | Deletes all merged branches                                                                                    |
 | `gbds`                   | Deletes all squash-merged branches (**Note: performance degrades with number of branches**)                    |

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -254,7 +254,7 @@ receive further support.
 | `git_current_user_name`  | Returns the `user.name` config value (Lives in `lib/git.zsh`)                                                  |
 | `git_develop_branch`     | Returns the name of the “development” branch: `dev`, `devel`, `development` if they exist, `develop` otherwise |
 | `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise   
-| `gbcopy` | Copy current branch name to clipboard |                                |
+| `gbcopy` | Copy current branch name to clipboard |
 | `grename <old> <new>`    | Renames branch `<old>` to `<new>`, including on the origin remote                                              |
 | `gbda`                   | Deletes all merged branches                                                                                    |
 | `gbds`                   | Deletes all squash-merged branches (**Note: performance degrades with number of branches**)                    |

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -253,8 +253,8 @@ receive further support.
 | `git_current_user_email` | Returns the `user.email` config value (Lives in `lib/git.zsh`)                                                 |
 | `git_current_user_name`  | Returns the `user.name` config value (Lives in `lib/git.zsh`)                                                  |
 | `git_develop_branch`     | Returns the name of the “development” branch: `dev`, `devel`, `development` if they exist, `develop` otherwise |
-| `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise   |
-| `gbcopy` | Copy current branch name to clipboard |
+| `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise                                                                                                                                   |
+| `gbcopy` | Copy current branch name to clipboard                                                                                          |
 | `grename <old> <new>`    | Renames branch `<old>` to `<new>`, including on the origin remote                                              |
 | `gbda`                   | Deletes all merged branches                                                                                    |
 | `gbds`                   | Deletes all squash-merged branches (**Note: performance degrades with number of branches**)                    |

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -253,7 +253,8 @@ receive further support.
 | `git_current_user_email` | Returns the `user.email` config value (Lives in `lib/git.zsh`)                                                 |
 | `git_current_user_name`  | Returns the `user.name` config value (Lives in `lib/git.zsh`)                                                  |
 | `git_develop_branch`     | Returns the name of the “development” branch: `dev`, `devel`, `development` if they exist, `develop` otherwise |
-| `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise                                   |
+| `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise   
+| `gbcopy` | Copy current branch name to clipboard |                                |
 | `grename <old> <new>`    | Renames branch `<old>` to `<new>`, including on the origin remote                                              |
 | `gbda`                   | Deletes all merged branches                                                                                    |
 | `gbds`                   | Deletes all squash-merged branches (**Note: performance degrades with number of branches**)                    |

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -253,7 +253,7 @@ receive further support.
 | `git_current_user_email` | Returns the `user.email` config value (Lives in `lib/git.zsh`)                                                 |
 | `git_current_user_name`  | Returns the `user.name` config value (Lives in `lib/git.zsh`)                                                  |
 | `git_develop_branch`     | Returns the name of the “development” branch: `dev`, `devel`, `development` if they exist, `develop` otherwise |
-| `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise   
+| `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise   |
 | `gbcopy` | Copy current branch name to clipboard |
 | `grename <old> <new>`    | Renames branch `<old>` to `<new>`, including on the origin remote                                              |
 | `gbda`                   | Deletes all merged branches                                                                                    |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -68,12 +68,15 @@ function grename() {
 # (sorted alphabetically by function name)
 # (order should follow README)
 #
-function gcb() {
-  # Controlla se siamo in un repository Git
+function gcbn() {
+  # Check if we are in a Git repository
   command git rev-parse --is-inside-work-tree &>/dev/null || return
 
-  # Prende il branch corrente, rimuove il newline e lo copia negli appunti
-  command git branch --show-current | tr -d '\n' | clipcopy
+  local branch
+  branch="$(git_current_branch)" || return
+  [[ -n "$branch" ]] || return 1
+
+  print -rn -- "$branch" | clipcopy
 }
 
 # Similar to `gunwip` but recursive "Unwips" all recent `--wip--` commits not just the last one

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -68,6 +68,13 @@ function grename() {
 # (sorted alphabetically by function name)
 # (order should follow README)
 #
+function gcb() {
+  # Controlla se siamo in un repository Git
+  command git rev-parse --is-inside-work-tree &>/dev/null || return
+
+  # Prende il branch corrente, rimuove il newline e lo copia negli appunti
+  command git branch --show-current | tr -d '\n' | clipcopy
+}
 
 # Similar to `gunwip` but recursive "Unwips" all recent `--wip--` commits not just the last one
 function gunwipall() {

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -51,7 +51,7 @@ function git_main_branch() {
 
 function gbcopy() {
   # Check if we are in a Git repository
-  command git rev-parse --is-inside-work-tree &>/dev/null || return
+  command git rev-parse --git-dir &>/dev/null || return
 
   local branch
   branch="$(command git symbolic-ref --short -q HEAD)" || return

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -49,6 +49,17 @@ function git_main_branch() {
   return 1
 }
 
+function gbcopy() {
+  # Check if we are in a Git repository
+  command git rev-parse --is-inside-work-tree &>/dev/null || return
+
+  local branch
+  branch="$(command git symbolic-ref --short -q HEAD)" || return
+  [[ -n "$branch" ]] || return 1
+
+  print -rn -- "$branch" | clipcopy
+}
+
 function grename() {
   if [[ -z "$1" || -z "$2" ]]; then
     echo "Usage: $0 old_branch new_branch"
@@ -129,17 +140,6 @@ alias gb='git branch'
 alias gba='git branch --all'
 alias gbd='git branch --delete'
 alias gbD='git branch --delete --force'
-
-function gbcopy() {
-  # Check if we are in a Git repository
-  command git rev-parse --is-inside-work-tree &>/dev/null || return
-
-  local branch
-  branch="$(command git symbolic-ref --short -q HEAD)" || return
-  [[ -n "$branch" ]] || return 1
-
-  print -rn -- "$branch" | clipcopy
-}
 
 function gbda() {
   git branch --no-color --merged | command grep -vE "^([+*]|\s*($(git_main_branch)|$(git_develop_branch))\s*$)" | command xargs git branch --delete 2>/dev/null

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -23,7 +23,6 @@ function git_develop_branch() {
   return 1
 }
 
-
 # Get the default branch name from common branch names or fallback to remote HEAD
 function git_main_branch() {
   command git rev-parse --git-dir &>/dev/null || return
@@ -48,17 +47,6 @@ function git_main_branch() {
   # If no main branch was found, fall back to master but return error
   echo master
   return 1
-}
-
-function gbcopy() {
-  # Check if we are in a Git repository
-  command git rev-parse --is-inside-work-tree &>/dev/null || return
-
-  local branch
-  branch="$(git_current_branch)" || return
-  [[ -n "$branch" ]] || return 1
-
-  print -rn -- "$branch" | clipcopy
 }
 
 function grename() {
@@ -141,6 +129,17 @@ alias gb='git branch'
 alias gba='git branch --all'
 alias gbd='git branch --delete'
 alias gbD='git branch --delete --force'
+
+function gbcopy() {
+  # Check if we are in a Git repository
+  command git rev-parse --is-inside-work-tree &>/dev/null || return
+
+  local branch
+  branch="$(git_current_branch)" || return
+  [[ -n "$branch" ]] || return 1
+
+  print -rn -- "$branch" | clipcopy
+}
 
 function gbda() {
   git branch --no-color --merged | command grep -vE "^([+*]|\s*($(git_main_branch)|$(git_develop_branch))\s*$)" | command xargs git branch --delete 2>/dev/null

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -135,7 +135,7 @@ function gbcopy() {
   command git rev-parse --is-inside-work-tree &>/dev/null || return
 
   local branch
-  branch="$(git_current_branch)" || return
+  branch="$(command git symbolic-ref --short -q HEAD)" || return
   [[ -n "$branch" ]] || return 1
 
   print -rn -- "$branch" | clipcopy

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -22,6 +22,16 @@ function git_develop_branch() {
   echo develop
   return 1
 }
+function gbcopy() {
+  # Check if we are in a Git repository
+  command git rev-parse --is-inside-work-tree &>/dev/null || return
+
+  local branch
+  branch="$(git_current_branch)" || return
+  [[ -n "$branch" ]] || return 1
+
+  print -rn -- "$branch" | clipcopy
+}
 
 # Get the default branch name from common branch names or fallback to remote HEAD
 function git_main_branch() {
@@ -47,16 +57,6 @@ function git_main_branch() {
   # If no main branch was found, fall back to master but return error
   echo master
   return 1
-}
-function gbcopy() {
-  # Check if we are in a Git repository
-  command git rev-parse --is-inside-work-tree &>/dev/null || return
-
-  local branch
-  branch="$(git_current_branch)" || return
-  [[ -n "$branch" ]] || return 1
-
-  print -rn -- "$branch" | clipcopy
 }
 
 function grename() {

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -48,6 +48,16 @@ function git_main_branch() {
   echo master
   return 1
 }
+function gbcopy() {
+  # Check if we are in a Git repository
+  command git rev-parse --is-inside-work-tree &>/dev/null || return
+
+  local branch
+  branch="$(git_current_branch)" || return
+  [[ -n "$branch" ]] || return 1
+
+  print -rn -- "$branch" | clipcopy
+}
 
 function grename() {
   if [[ -z "$1" || -z "$2" ]]; then
@@ -68,16 +78,6 @@ function grename() {
 # (sorted alphabetically by function name)
 # (order should follow README)
 #
-function gcbn() {
-  # Check if we are in a Git repository
-  command git rev-parse --is-inside-work-tree &>/dev/null || return
-
-  local branch
-  branch="$(git_current_branch)" || return
-  [[ -n "$branch" ]] || return 1
-
-  print -rn -- "$branch" | clipcopy
-}
 
 # Similar to `gunwip` but recursive "Unwips" all recent `--wip--` commits not just the last one
 function gunwipall() {

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -22,16 +22,7 @@ function git_develop_branch() {
   echo develop
   return 1
 }
-function gbcopy() {
-  # Check if we are in a Git repository
-  command git rev-parse --is-inside-work-tree &>/dev/null || return
 
-  local branch
-  branch="$(git_current_branch)" || return
-  [[ -n "$branch" ]] || return 1
-
-  print -rn -- "$branch" | clipcopy
-}
 
 # Get the default branch name from common branch names or fallback to remote HEAD
 function git_main_branch() {
@@ -57,6 +48,17 @@ function git_main_branch() {
   # If no main branch was found, fall back to master but return error
   echo master
   return 1
+}
+
+function gbcopy() {
+  # Check if we are in a Git repository
+  command git rev-parse --is-inside-work-tree &>/dev/null || return
+
+  local branch
+  branch="$(git_current_branch)" || return
+  [[ -n "$branch" ]] || return 1
+
+  print -rn -- "$branch" | clipcopy
 }
 
 function grename() {

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -50,11 +50,10 @@ function git_main_branch() {
 }
 
 function gbcopy() {
-  # Check if we are in a Git repository
   command git rev-parse --git-dir &>/dev/null || return
 
   local branch
-  branch="$(command git symbolic-ref --short -q HEAD)" || return
+  branch="$(git_current_branch)" || return
   [[ -n "$branch" ]] || return 1
 
   print -rn -- "$branch" | clipcopy


### PR DESCRIPTION
### Summary
Renames the helper function to `gbcopy` to clearly signal its functionality (copying the current Git branch name to clipboard via `clipcopy`).

### Changes
- Renamed function to `gbcopy`.
- Moved definition out of the WIP section to its proper alphabetical spot under `Functions Current`.
- Added `gbcopy` documentation row to `plugins/git/README.md`.
