### PR TITLE
feat(ufw): complete route rule actions

### DIFF
--- a/plugins/ufw/README.md
+++ b/plugins/ufw/README.md
@@ -16,3 +16,4 @@ Some of the commands include:
 * `deny <port>/<optional: protocol>` add deny rule
 * `disable` disables the firewall
 * `enable` enables the firewall
+* `route` add route rule

--- a/plugins/ufw/_ufw
+++ b/plugins/ufw/_ufw
@@ -31,6 +31,7 @@ _1st_arguments=(
   'reject:add reject rule'
   'reload:reloads firewall'
   'reset:reset firewall'
+  'route:add route rule'
   'show:show firewall report'
   'status:show firewall status'
   'version:display version information'
@@ -43,6 +44,7 @@ _arguments -C \
   '1:: :->cmds' \
   '2:: :->subcmds' \
   '3:: :->subsubcmds' \
+  '4:: :->subsubsubcmds' \
 && return 0
 
 local rules
@@ -83,6 +85,17 @@ case "$state" in
           'raw' 'builtins' 'before-rules' 'user-rules' 'after-rules' 'logging-rules' 'listening' 'added' \
         && ret=0
         ;;
+      (route)
+        _values 'route' \
+          'delete[delete route rule]' \
+          'insert[insert route rule at NUM]' \
+          'prepend[prepend route rule]' \
+          'allow[add allow route rule]' \
+          'deny[add deny route rule]' \
+          'reject[add reject route rule]' \
+          'limit[add limit route rule]' \
+        && ret=0
+        ;;
       (delete)
         rules="$(_ufw_delete_rules)"
         if [[ -n "$rules" ]] ; then
@@ -108,6 +121,37 @@ case "$state" in
         _values 'default-direction' \
           'incoming' 'outgoing' \
         && ret=0
+        ;;
+      (route)
+        case "$line[2]" in
+          (delete|prepend)
+            _values 'route-action' \
+              'allow[route allow rule]' \
+              'deny[route deny rule]' \
+              'reject[route reject rule]' \
+              'limit[route limit rule]' \
+            && ret=0
+            ;;
+          (insert)
+            _message 'route rule number'
+            ;;
+        esac
+        ;;
+    esac
+    ;;
+  (subsubsubcmds)
+    case "$line[1]" in
+      (route)
+        case "$line[2]" in
+          (insert)
+            _values 'route-action' \
+              'allow[route allow rule]' \
+              'deny[route deny rule]' \
+              'reject[route reject rule]' \
+              'limit[route limit rule]' \
+            && ret=0
+            ;;
+        esac
         ;;
     esac
 esac


### PR DESCRIPTION
## Description

Adds `ufw route` to the ufw plugin completion list and completes the route rule actions from the ufw man page:

- `delete`
- `insert`
- `prepend`
- `allow`
- `deny`
- `reject`
- `limit`

For nested route forms, completion now also suggests route actions after `ufw route delete`, `ufw route prepend`, and `ufw route insert NUM`.

Fixes #11025.

## Validation

- `zsh -n plugins/ufw/_ufw`
- `git diff --check HEAD~1 HEAD`
- confirmed the new `route` completion entries are present in `plugins/ufw/_ufw`

## AI disclosure

AI-assisted. I reviewed the existing completion style, kept the change scoped to the ufw plugin, and ran the validation commands listed above.
