### PR TITLE
feat(jj): add aliases for workspace operations

### DIFF
--- a/plugins/jj/jj.plugin.zsh
+++ b/plugins/jj/jj.plugin.zsh
@@ -70,3 +70,6 @@ alias jjrt='cd "$(jj root || echo .)"'
 alias jjsp='jj split'
 alias jjsq='jj squash'
 alias jjst='jj status'
+alias jjwa='jj workspace add'
+alias jjwf='jj workspace forget'
+


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- added `jjwa` alias for `jj workspace add`
- added `jjwf` alias for `jj workspace forget`

## Other comments:

Simply put, the usecase is identical to the `gwta` and `gwtrm` alias for `git worktree` operations. I opted only for those two - jj also has `list`, `rename`,` root` and `update-stale` operations for workspaces, but I don't think they are used very often to warrant an alias.