### PR TITLE
fix(extract): properly handle xz archives

### DIFF
--- a/plugins/extract/extract.plugin.zsh
+++ b/plugins/extract/extract.plugin.zsh
@@ -102,7 +102,7 @@ EOF
       (*.tar.lrz) (( $+commands[lrzuntar] )) && lrzuntar "$full_path" ;;
       (*.gz) (( $+commands[pigz] )) && pigz -cdk "$full_path" > "${file:t:r}" || gunzip -ck "$full_path" > "${file:t:r}" ;;
       (*.bz2) (( $+commands[pbzip2] )) && pbzip2 -d "$full_path" || bunzip2 "$full_path" ;;
-      (*.xz) unxz "$full_path" ;;
+      (*.xz) xzcat "$full_path" > "${file:t:r}" ;;
       (*.lrz) (( $+commands[lrunzip] )) && lrunzip "$full_path" ;;
       (*.lz4) lz4 -d "$full_path" ;;
       (*.lzma) unlzma "$full_path" ;;


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x] The PR title is descriptive.
- [ x] The PR doesn't replicate another PR which is already open.
- [x ] I have read the contribution guide and followed all the instructions.
- [ x] The code follows the code style guide detailed in the wiki.
- [ x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [ x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x] The code is stable and I have tested it myself, to the best of my abilities.
- [ x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

replace `unxz` with `xzcat`

## Other comments:

`unxz` by itself extracts `path/file.xz` to `path/file`, removing the archive in the process. This clashes with the plugins behaviour to extract into the current directory and keeping the archive by default.

example:
- extraction in same directory doesn't work at all
- extraction from other directory doesn't extract to cwd and removes archive

edit: ping as per guideline @drjaska @mcornella