### PR TITLE
feat(eza): add smart-group option

### DIFF
--- a/plugins/eza/README.md
+++ b/plugins/eza/README.md
@@ -48,10 +48,11 @@ Default: `no`
 ### `show-group`
 
 ```zsh
-zstyle ':omz:plugins:eza' 'show-group' yes|no
+zstyle ':omz:plugins:eza' 'show-group' yes|no|smart
 ```
 
 If `yes` (default), always add `-g` flag to show the group ownership.
+If `smart`, adds the `--smart-group` flag to only show the group if it has a different name from the owner.
 
 Default: `yes`
 

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -9,9 +9,15 @@ typeset -a _EZA_TAIL
 function _configure_eza() {
   local _val
   # Get the head flags
-  if zstyle -T ':omz:plugins:eza' 'show-group'; then
-    _EZA_HEAD+=("g")
-  fi
+  zstyle -s ':omz:plugins:eza' 'show-group' _val
+  case "${_val:l}" in
+    yes)
+      _EZA_HEAD+=("g")
+      ;;
+    smart)
+      _EZA_TAIL+=("--smart-group")
+      ;;
+  esac
   if zstyle -t ':omz:plugins:eza' 'header'; then
     _EZA_HEAD+=("h")
   fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `smart` as an option for the eza `show-group` configuration