### PR TITLE
feat(systemadmin)!: replace clrz with pszombie

### DIFF
--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -177,10 +177,10 @@ function getip() {
   fi
 }
 
-# Clear zombie processes
-function clrz() {
-  ps -eal | awk '{ if ($2 == "Z") {print $4}}' | kill -9
-}
+## Clear zombie processes
+#function clrz() {
+#  ps -eal | awk '{ if ($2 == "Z") {print $4}}' | kill -9
+#}
 
 # Second concurrent
 function conssec() {

--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -28,6 +28,8 @@ alias mkdir='mkdir -pv'
 # get top process eating memory
 alias psmem='ps -e -orss=,args= | sort -b -k1 -nr'
 alias psmem10='ps -e -orss=,args= | sort -b -k1 -nr | head -n 10'
+# list all zombie processes with ownership and parent process details
+alias pszombie="ps -eo user,pid,ppid,state,cmd | awk '\$4==\"Z\"'"
 # get top process eating cpu if not work try execute : export LC_ALL='C'
 alias pscpu='ps -e -o pcpu,cpu,nice,state,cputime,args | sort -k1,1n -nr'
 alias pscpu10='ps -e -o pcpu,cpu,nice,state,cputime,args | sort -k1,1n -nr | head -n 10'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added `pszombie` alias to list zombie processes with ownership, PID, and parent PID (PPID) details.
- Removed (commented out) the `clrz` function, as attempting to directly `kill -9` (a xargs is missing, I guess) zombie processes is fundamentally ineffective in Linux (zombies are already dead and must be cleared via their parent process).

## Other comments:

### Use case for `pszombie`

Zombie processes cannot be killed directly using standard signals like `kill -9`. To clear them from the process table, a system administrator needs to identify and kill or restart their parent process (PPID), or identify the owner (USER) responsible for them.

The new `pszombie` alias provides a quick, lightweight way for plugin users to monitor these defunct processes and immediately grab the exact fields (USER and PPID) required to take action and keep the process table clean.