### PR TITLE
feat(command-not-found): add alpine support

### DIFF
--- a/plugins/command-not-found/README.md
+++ b/plugins/command-not-found/README.md
@@ -32,5 +32,6 @@ It works out of the box with the command-not-found packages for:
 - [SUSE](https://www.unix.com/man-page/suse/1/command-not-found/)
 - [Gentoo](https://github.com/AndrewAmmerlaan/command-not-found-gentoo/tree/main)
 - [Void Linux](https://codeberg.org/classabbyamp/xbps-command-not-found)
+- [Alpine Linux](https://pkgs.alpinelinux.org/package/edge/main/x86_64/command-not-found)
 
 You can add support for other platforms by submitting a Pull Request.

--- a/plugins/command-not-found/command-not-found.plugin.zsh
+++ b/plugins/command-not-found/command-not-found.plugin.zsh
@@ -74,3 +74,10 @@ if [[ -x /usr/bin/command-not-found ]]; then
     /usr/bin/command-not-found "$1"
   }
 fi
+
+# Alpine: https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/main/command-not-found/APKBUILD
+if [[ -x /usr/libexec/command-not-found ]]; then
+  command_not_found_handler() {
+    /usr/libexec/command-not-found "$1"
+  }
+fi


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add Alpine Linux support for plugin `command-not-found` 

## Other comments:

N/A
