### PR TITLE
Add gcbc helper to copy current git branch name

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -255,6 +255,7 @@ receive further support.
 | `git_develop_branch`     | Returns the name of the “development” branch: `dev`, `devel`, `development` if they exist, `develop` otherwise |
 | `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise                                   |
 | `grename <old> <new>`    | Renames branch `<old>` to `<new>`, including on the origin remote                                              |
+| `gcbc`                   | Copies the current branch name to the system clipboard (uses `clipcopy`)                                       |
 | `gbda`                   | Deletes all merged branches                                                                                    |
 | `gbds`                   | Deletes all squash-merged branches (**Note: performance degrades with number of branches**)                    |
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -159,6 +159,14 @@ alias gbg='LANG=C git branch -vv | grep ": gone\]"'
 alias gco='git checkout'
 alias gcor='git checkout --recurse-submodules'
 alias gcb='git checkout -b'
+function gcbc() {
+  local branch=$(git branch --show-current 2>/dev/null) || return
+  if [[ -z "$branch" ]]; then
+    print -u2 "gcbc: not on a branch"
+    return 1
+  fi
+  print -rn -- "$branch" | clipcopy
+}
 alias gcB='git checkout -B'
 alias gcd='git checkout $(git_develop_branch)'
 alias gcm='git checkout $(git_main_branch)'


### PR DESCRIPTION
## Summary

Fixes #13843.

Add `gcbc` to copy the current Git branch name with Oh My Zsh's existing cross-platform `clipcopy` helper. The requested `gcb` name is already the alias for `git checkout -b`, so this uses the next unambiguous name.

Detached HEAD is handled explicitly: the function prints an error and returns 1 instead of copying an empty value.

## Test plan

- [x] `zsh -n plugins/git/git.plugin.zsh`
- [x] Diff is limited to the function and its Git plugin documentation
