### PR TITLE
fix(aws): quote vars to support spaces

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -9,14 +9,14 @@ function agr() {
 # Update state file if enabled
 function _aws_update_state() {
   if [[ "$AWS_PROFILE_STATE_ENABLED" == true ]]; then
-    test -d $(dirname ${AWS_STATE_FILE}) || return 1
+    test -d "$(dirname "${AWS_STATE_FILE}")" || return 1
     echo "${AWS_PROFILE} ${AWS_REGION}" > "${AWS_STATE_FILE}"
   fi
 }
 
 function _aws_clear_state() {
   if [[ "$AWS_PROFILE_STATE_ENABLED" == true ]]; then
-    test -d $(dirname ${AWS_STATE_FILE}) || return 1
+    test -d "$(dirname "${AWS_STATE_FILE}")" || return 1
     echo -n > "${AWS_STATE_FILE}"
   fi
 }


### PR DESCRIPTION
## What

`_aws_update_state()` and `_aws_clear_state()` check the state file's
directory with an unquoted command substitution:

```zsh
test -d $(dirname ${AWS_STATE_FILE}) || return 1
```

In zsh, the *output* of `$(...)` command substitution is word-split
even though plain `$var` expansion isn't. If `AWS_STATE_FILE` points
to a path containing a space, `dirname` returns a path with a space in
it, that gets split into multiple words, and `test -d` receives too
many arguments — silently failing and returning 1.

## Fix

Quote both the inner variable and the outer command substitution:

```zsh
test -d "$(dirname "${AWS_STATE_FILE}")" || return 1
```

## Reproducer

Ran the actual `asp` command end-to-end (not just the internal
function) with a HOME directory containing a space, a real
`~/.aws/config` profile, and `AWS_PROFILE_STATE_ENABLED=true`:

```zsh
export HOME="/tmp/aws home test"
export AWS_CONFIG_FILE="$HOME/.aws/config"
export AWS_PROFILE_STATE_ENABLED=true
export AWS_STATE_FILE="$HOME/.aws_current_profile"
source plugins/aws/aws.plugin.zsh
asp myprofile
```

Output before the fix:
```
_aws_update_state:test:2: too many arguments
BUG: state file NOT created
```

After the fix, same steps:
```
state file exists: myprofile
```

Also re-verified the normal (no-space) path still works with the fix
applied — no regression.

Screenshot of the actual terminal repro:
<img width="580" height="433" alt="ohmyzsh-13868-aws-state-space-path-bug" src="https://github.com/user-attachments/assets/d30b95af-d92d-4ff9-8e34-179e973c93d4" />

## Notes

The default `AWS_STATE_FILE` (`/tmp/.aws_current_profile`) has no
space, so this only bites users who set a custom path — synced
folders, some corporate home-directory setups, etc. Fails silently
(no error shown to the user by default flow), so AWS profile
persistence across shell sessions just quietly stops working.

---

Found via VeriQA, a tool I've been building on the side to catch
these kinds of cross-file bugs automatically — manually verified the
root cause and fix before submitting this PR.