### PR TITLE
fix(core): support nounset startup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,3 +41,5 @@ jobs:
                       ./themes/*.zsh-theme; do
             zsh -n "$file" || return 1
           done
+      - name: Check nounset startup
+        run: zsh -df lib/tests/nounset.test.zsh

--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -14,10 +14,10 @@ bindkey -M menuselect '^o' accept-and-infer-next-history
 zstyle ':completion:*:*:*:*:*' menu select
 
 # case insensitive (all), partial-word and substring completion
-if [[ "$CASE_SENSITIVE" = true ]]; then
+if [[ ${CASE_SENSITIVE-} = true ]]; then
   zstyle ':completion:*' matcher-list 'r:|=*' 'l:|=* r:|=*'
 else
-  if [[ "$HYPHEN_INSENSITIVE" = true ]]; then
+  if [[ ${HYPHEN_INSENSITIVE-} = true ]]; then
     zstyle ':completion:*' matcher-list 'm:{[:lower:][:upper:]-_}={[:upper:][:lower:]_-}' 'r:|=*' 'l:|=* r:|=*'
   else
     zstyle ':completion:*' matcher-list 'm:{[:lower:][:upper:]}={[:upper:][:lower:]}' 'r:|=*' 'l:|=* r:|=*'

--- a/lib/correction.zsh
+++ b/lib/correction.zsh
@@ -1,4 +1,4 @@
-if [[ "$ENABLE_CORRECTION" == "true" ]]; then
+if [[ ${ENABLE_CORRECTION-} == "true" ]]; then
   alias cp='nocorrect cp'
   alias man='nocorrect man'
   alias mkdir='nocorrect mkdir'

--- a/lib/functions.zsh
+++ b/lib/functions.zsh
@@ -141,7 +141,7 @@ function default() {
 #    0 if the env variable exists, 3 if it was set
 #
 function env_default() {
-    [[ ${parameters[$1]} = *-export* ]] && return 0
+    [[ ${parameters[$1]-} = *-export* ]] && return 0
     export "$1=$2" && return 3
 }
 

--- a/lib/history.zsh
+++ b/lib/history.zsh
@@ -35,7 +35,7 @@ case ${HIST_STAMPS-} in
 esac
 
 ## History file configuration
-[ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history"
+[ -z ${HISTFILE-} ] && HISTFILE="$HOME/.zsh_history"
 [ "$HISTSIZE" -lt 50000 ] && HISTSIZE=50000
 [ "$SAVEHIST" -lt 10000 ] && SAVEHIST=10000
 

--- a/lib/misc.zsh
+++ b/lib/misc.zsh
@@ -1,7 +1,7 @@
 autoload -Uz is-at-least
 
 # *-magic is known buggy in some versions; disable if so
-if [[ $DISABLE_MAGIC_FUNCTIONS != true ]]; then
+if [[ ${DISABLE_MAGIC_FUNCTIONS-} != true ]]; then
   for d in $fpath; do
     if [[ -e "$d/url-quote-magic" ]]; then
       if is-at-least 5.1; then

--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -25,7 +25,7 @@ function title {
       print -Pn "\ek${1:q}\e\\" # set screen hardstatus
       ;;
     *)
-      if [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
+      if [[ ${TERM_PROGRAM-} == "iTerm.app" ]]; then
         print -Pn "\e]2;${2:q}\a" # set window name
         print -Pn "\e]1;${1:q}\a" # set tab name
       else
@@ -41,7 +41,7 @@ function title {
 ZSH_THEME_TERM_TAB_TITLE_IDLE="%15<..<%~%<<" #15 char left truncated PWD
 ZSH_THEME_TERM_TITLE_IDLE="%n@%m:%~"
 # Avoid duplication of directory in terminals with independent dir display
-if [[ "$TERM_PROGRAM" == Apple_Terminal ]]; then
+if [[ ${TERM_PROGRAM-} == Apple_Terminal ]]; then
   ZSH_THEME_TERM_TITLE_IDLE="%n@%m"
 fi
 
@@ -104,7 +104,7 @@ function omz_termsupport_preexec {
 
 autoload -Uz add-zsh-hook
 
-if [[ -z "$INSIDE_EMACS" || "$INSIDE_EMACS" = vterm ]]; then
+if [[ -z ${INSIDE_EMACS-} || ${INSIDE_EMACS-} = vterm ]]; then
   add-zsh-hook precmd omz_termsupport_precmd
   add-zsh-hook preexec omz_termsupport_preexec
 fi
@@ -122,7 +122,7 @@ fi
 # As of May 2021 mlterm, PuTTY, rxvt, screen, termux & xterm simply ignore the unknown OSC.
 
 # Don't define the function if we're inside Emacs or in an SSH session (#11696)
-if [[ -n "$INSIDE_EMACS" || -n "$SSH_CLIENT" || -n "$SSH_TTY" ]]; then
+if [[ -n ${INSIDE_EMACS-} || -n ${SSH_CLIENT-} || -n ${SSH_TTY-} ]]; then
   return
 fi
 
@@ -133,7 +133,7 @@ case "$TERM" in
   contour*|foot*) ;;
   *)
     # Terminal.app and iTerm2 process OSC 7 correctly
-    case "$TERM_PROGRAM" in
+    case "${TERM_PROGRAM-}" in
       Apple_Terminal|iTerm.app) ;;
       *) return ;;
     esac ;;

--- a/lib/tests/nounset.test.zsh
+++ b/lib/tests/nounset.test.zsh
@@ -1,0 +1,12 @@
+#!/usr/bin/env zsh -df
+
+set -u
+
+export ZSH="${0:A:h:h:h}"
+export HOME="$(mktemp -d)"
+export ZDOTDIR="$HOME"
+plugins=()
+
+trap 'rm -rf "$HOME"' EXIT
+
+source "$ZSH/oh-my-zsh.sh"

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -21,13 +21,13 @@ if command diff --color /dev/null{,} &>/dev/null; then
 fi
 
 # Don't set ls coloring if disabled
-[[ "$DISABLE_LS_COLORS" != true ]] || return 0
+[[ ${DISABLE_LS_COLORS-} != true ]] || return 0
 
 # Default coloring for BSD-based ls
 export LSCOLORS="Gxfxcxdxbxegedabagacad"
 
 # Default coloring for GNU-based ls
-if [[ -z "$LS_COLORS" ]]; then
+if [[ -z ${LS_COLORS-} ]]; then
   # Define LS_COLORS via dircolors if available. Otherwise, set a default
   # equivalent to LSCOLORS (generated via https://geoff.greer.fm/lscolors)
   if (( $+commands[dircolors] )); then

--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -48,15 +48,15 @@ omz_f() {
 unset -f omz_f
 
 # If ZSH is not defined, use the current script's directory.
-[[ -n "$ZSH" ]] || export ZSH="${${(%):-%x}:a:h}"
+[[ -n ${ZSH-} ]] || export ZSH="${${(%):-%x}:a:h}"
 
 # Set ZSH_CUSTOM to the path where your custom config files
 # and plugins exists, or else we will use the default custom/
-[[ -n "$ZSH_CUSTOM" ]] || ZSH_CUSTOM="$ZSH/custom"
+[[ -n ${ZSH_CUSTOM-} ]] || ZSH_CUSTOM="$ZSH/custom"
 
 # Set ZSH_CACHE_DIR to the path where cache files should be created
 # or else we will use the default cache/
-[[ -n "$ZSH_CACHE_DIR" ]] || ZSH_CACHE_DIR="$ZSH/cache"
+[[ -n ${ZSH_CACHE_DIR-} ]] || ZSH_CACHE_DIR="$ZSH/cache"
 
 # Make sure $ZSH_CACHE_DIR is writable, otherwise use a directory in $HOME
 if [[ ! -w "$ZSH_CACHE_DIR" ]]; then
@@ -98,15 +98,15 @@ for plugin ($plugins); do
 done
 
 # Figure out the SHORT hostname
-if [[ "$OSTYPE" = darwin* ]]; then
+if [[ ${OSTYPE-} = darwin* ]]; then
   # macOS's $HOST changes with dhcp, etc. Use LocalHostName if possible.
-  SHORT_HOST=$(scutil --get LocalHostName 2>/dev/null) || SHORT_HOST="${HOST/.*/}"
+  SHORT_HOST=$(scutil --get LocalHostName 2>/dev/null) || SHORT_HOST="${HOST-}"
 else
-  SHORT_HOST="${HOST/.*/}"
+  SHORT_HOST="${HOST-}"
 fi
 
 # Save the location of the current completion dump file.
-if [[ -z "$ZSH_COMPDUMP" ]]; then
+if [[ -z ${ZSH_COMPDUMP-} ]]; then
   ZSH_COMPDUMP="${ZDOTDIR:-$HOME}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
@@ -121,7 +121,7 @@ if ! command grep -q -Fx "$zcompdump_revision" "$ZSH_COMPDUMP" 2>/dev/null \
   zcompdump_refresh=1
 fi
 
-if [[ "$ZSH_DISABLE_COMPFIX" != true ]]; then
+if [[ ${ZSH_DISABLE_COMPFIX-} != true ]]; then
   source "$ZSH/lib/compfix.zsh"
   # Load only from secure directories
   compinit -i -d "$ZSH_COMPDUMP"
@@ -133,7 +133,7 @@ else
 fi
 
 # Append zcompdump metadata if missing
-if (( $zcompdump_refresh )) \
+if (( ${zcompdump_refresh:-0} )) \
   || ! command grep -q -Fx "$zcompdump_revision" "$ZSH_COMPDUMP" 2>/dev/null; then
   # Use `tee` in case the $ZSH_COMPDUMP filename is invalid, to silence the error
   # See https://github.com/ohmyzsh/ohmyzsh/commit/dd1a7269#commitcomment-39003489
@@ -200,7 +200,7 @@ done
 unset lib_file
 
 # Load all of the plugins that were defined in ~/.zshrc
-for plugin ($plugins); do
+for plugin (${plugins-}); do
   _omz_source "plugins/$plugin/$plugin.plugin.zsh"
 done
 unset plugin
@@ -218,7 +218,7 @@ is_theme() {
   builtin test -f $base_dir/$name.zsh-theme
 }
 
-if [[ -n "$ZSH_THEME" ]]; then
+if [[ -n ${ZSH_THEME-} ]]; then
   if is_theme "$ZSH_CUSTOM" "$ZSH_THEME"; then
     source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
   elif is_theme "$ZSH_CUSTOM/themes" "$ZSH_THEME"; then
@@ -231,4 +231,4 @@ if [[ -n "$ZSH_THEME" ]]; then
 fi
 
 # set completion colors to be the same as `ls`, after theme has been loaded
-[[ -z "$LS_COLORS" ]] || zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
+[[ -z ${LS_COLORS-} ]] || zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -15,8 +15,8 @@ zstyle -s ':omz:update' mode update_mode || {
   update_mode=prompt
 
   # If the mode zstyle setting is not set, support old-style settings
-  [[ "$DISABLE_UPDATE_PROMPT" != true ]] || update_mode=auto
-  [[ "$DISABLE_AUTO_UPDATE" != true ]] || update_mode=disabled
+  [[ ${DISABLE_UPDATE_PROMPT-} != true ]] || update_mode=auto
+  [[ ${DISABLE_AUTO_UPDATE-} != true ]] || update_mode=disabled
 }
 
 # Cancel update if:


### PR DESCRIPTION
## Summary

- make core startup defaults safe when `set -u` is enabled
- preserve the existing unset-variable defaults for update settings, completion, history, terminal support, and theme loading
- add a CI smoke test that sources Oh My Zsh with unset optional configuration

The startup path previously read optional configuration variables directly. Under `nounset`, that aborted individual libraries and left the shell only partially initialized.

Fixes #13854

## Validation

- `zsh -df lib/tests/nounset.test.zsh`
- `zsh -df lib/tests/cli.test.zsh`
- `zsh -n` for every changed shell script
- `git diff --check`

AI-assisted: Codex helped investigate and implement the fix; the startup scenario was validated locally in Zsh 5.9.
