### PR TITLE
fix(bundler): restore `bu` and add `bua` alias

### DIFF
--- a/plugins/bundler/README.md
+++ b/plugins/bundler/README.md
@@ -22,7 +22,7 @@ plugins=(... bundler)
 | `bo`   | `bundle open`     | Opens the source directory for a gem in your bundle      |
 | `bout` | `bundle outdated` | List installed gems with newer versions available        |
 | `bp`   | `bundle package`  | Package your needed .gem files into your application     |
-| `bu`   | `bundle update --all` (no arguments) or `bundle update <args>` | Update all gems, or only the given gems/options (e.g. `bu rake`, `bu --ruby`) |
+| `bu`   | `bundle update`   | Update your gems to the latest available versions          |
 
 ## Gem wrapper
 

--- a/plugins/bundler/README.md
+++ b/plugins/bundler/README.md
@@ -23,6 +23,7 @@ plugins=(... bundler)
 | `bout` | `bundle outdated` | List installed gems with newer versions available        |
 | `bp`   | `bundle package`  | Package your needed .gem files into your application     |
 | `bu`   | `bundle update`   | Update your gems to the latest available versions          |
+| `bua`  | `bundle update --all` | Update all gems to the latest available versions      |
 
 ## Gem wrapper
 

--- a/plugins/bundler/README.md
+++ b/plugins/bundler/README.md
@@ -22,7 +22,7 @@ plugins=(... bundler)
 | `bo`   | `bundle open`     | Opens the source directory for a gem in your bundle      |
 | `bout` | `bundle outdated` | List installed gems with newer versions available        |
 | `bp`   | `bundle package`  | Package your needed .gem files into your application     |
-| `bu`   | `bundle update --all` | Update your gems to the latest available versions    |
+| `bu`   | `bundle update --all` (no arguments) or `bundle update <args>` | Update all gems, or only the given gems/options (e.g. `bu rake`, `bu --ruby`) |
 
 ## Gem wrapper
 

--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -9,7 +9,16 @@ alias bl="bundle list"
 alias bo="bundle open"
 alias bout="bundle outdated"
 alias bp="bundle package"
-alias bu="bundle update --all"
+unalias bu 2>/dev/null
+# `bundle update` needs --all to update everything, but rejects --all when
+# gems or options are given (e.g. `bu <gem>`, `bu --ruby`)
+bu() {
+  if [[ $# -eq 0 ]]; then
+    bundle update --all
+  else
+    bundle update "$@"
+  fi
+}
 
 ## Gem wrapper
 

--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -10,6 +10,7 @@ alias bo="bundle open"
 alias bout="bundle outdated"
 alias bp="bundle package"
 alias bu="bundle update"
+alias bua="bundle update --all"
 
 ## Gem wrapper
 

--- a/plugins/bundler/bundler.plugin.zsh
+++ b/plugins/bundler/bundler.plugin.zsh
@@ -9,16 +9,7 @@ alias bl="bundle list"
 alias bo="bundle open"
 alias bout="bundle outdated"
 alias bp="bundle package"
-unalias bu 2>/dev/null
-# `bundle update` needs --all to update everything, but rejects --all when
-# gems or options are given (e.g. `bu <gem>`, `bu --ruby`)
-bu() {
-  if [[ $# -eq 0 ]]; then
-    bundle update --all
-  else
-    bundle update "$@"
-  fi
-}
+alias bu="bundle update"
 
 ## Gem wrapper
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fixes #13871.
- Restore `bu` to the generic `bundle update` alias so arguments pass through naturally:
  - `bu rake` -> `bundle update rake`
  - `bu --ruby` -> `bundle update --ruby`
  - `bu` -> `bundle update`
- Add `bua` as the explicit `bundle update --all` alias for users who want the all-gems update command added recently.
- Update the Bundler plugin README to document both aliases.

Bundler rejects `--all` when combined with specific gems or options. Since aliases append their arguments, `alias bu="bundle update --all"` turns `bu rake` into `bundle update --all rake`, which fails. Keeping `bu` as the generic alias fixes parameterized updates and follows the contribution guidance to prefer one generic alias.

The dedicated `bua` alias keeps the recent `bundle update --all` behavior available without making the generic `bu` alias incompatible with gem-specific updates.

## Verification:

- `zsh -n plugins/bundler/bundler.plugin.zsh`
- `zsh -fc 'source plugins/bundler/bundler.plugin.zsh; alias bu; alias bua'` reports `bu='bundle update'` and `bua='bundle update --all'`
- Fake `bundle` smoke test:
  - `bu rake` expands to `bundle update rake`
  - `bu --ruby` expands to `bundle update --ruby`
  - `bu` expands to `bundle update`
  - `bua` expands to `bundle update --all`
- `git diff --check`

## Other comments:

This update intentionally removes the function and `unalias` approach from the first PR version. That avoids assumptions about other plugins' aliases and keeps `bu` as the generic Bundler update command. The added `bua` alias covers the all-gems update use case separately.

AI disclosure: Claude Fable 5 (Claude Code) assisted with reproducing, diagnosing, implementing, and testing the original change. OpenAI Codex assisted with addressing the review feedback. I reviewed and understand the final code and verification results.
