### PR TITLE
perf: avoid duplicate completion security audit

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -124,9 +124,11 @@ fi
 if [[ "$ZSH_DISABLE_COMPFIX" != true ]]; then
   source "$ZSH/lib/compfix.zsh"
   # Load only from secure directories
+  # Reset the flag compinit sets when -i excludes insecure entries
+  unset _comp_secure
   compinit -i -d "$ZSH_COMPDUMP"
   # If completion insecurities exist, warn the user
-  handle_completion_insecurities &|
+  [[ "$_comp_secure" == yes ]] && handle_completion_insecurities &|
 else
   # If the user wants it, load from all found directories
   compinit -u -d "$ZSH_COMPDUMP"


### PR DESCRIPTION
## Summary

- skip the second `compaudit` pass on clean startup
- use the `_comp_secure` flag set by stock `compinit -i` when insecure completion entries are found
- keep the existing warning and filtering behavior for insecure setups

## Why

Oh My Zsh currently runs `compinit -i`, which performs a security audit, and then always backgrounds `handle_completion_insecurities`, which performs the same audit again to build its warning. On a clean machine the second pass is unnecessary overhead.

This keeps `compinit -i` in place, so completion directories are still audited on every normal startup. It does not restore the old `compinit -C` shortcut removed in #10672, which could trust stale dump state.

Behavior after this change:

- clean startup: one `compaudit`, with no warning handler process
- insecure startup: insecure entries are still excluded and the existing full warning is shown; the second audit remains to obtain the display list
- `ZSH_DISABLE_COMPFIX=true`: unchanged

## Checks

- `zsh -n oh-my-zsh.sh`
- controlled clean full-source fixture: completion initialized and `compaudit` called once
- controlled insecure full-source fixture: insecure path removed from `fpath`, probe completion not loaded, full warning emitted, and display audit retained
- verified `_comp_secure` behavior in stock zsh sources from 4.3.9 through 5.9

Fixes #13870

AI-assisted; the implementation was reviewed and tested manually, including clean and insecure `fpath` cases.