### PR TITLE
fix(git): avoid illegal byte sequence

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -40,6 +40,15 @@ function _omz_git_prompt_info() {
 }
 
 function _omz_git_prompt_status() {
+  # OHMYZSH-13330: avoid "regex matching error: illegal byte sequence".
+  # zsh's "=~" operator delegates to the C library regex, which aborts with
+  # REG_ILLSEQ when the subject contains an invalid byte sequence under a
+  # multibyte locale (e.g. a filename with non-UTF-8 bytes in `git status`
+  # output). Forcing the C locale makes every byte a valid character, so the
+  # regex matching below never fails that way. `git status --porcelain` is
+  # locale-independent, so this does not change the parsed output.
+  local -x LC_ALL=C
+
   [[ "$(__git_prompt_git config --get oh-my-zsh.hide-status 2>/dev/null)" = 1 ]] && return
 
   # Maps a git status prefix to an internal constant


### PR DESCRIPTION
## Summary

- `_omz_git_prompt_status` crashed with `regex matching error: illegal byte sequence` whenever `git status --porcelain` output contained an invalid byte sequence (e.g. a filename that is not valid UTF-8 under the current locale). Fixes #13330.
- The error fired once per status prefix, flooding the prompt with repeated messages and dropping every per-file status.
- Forcing `local -x LC_ALL=C` inside the function makes every byte a valid single-byte character, so the `=~` matches never fail. `git status --porcelain` is locale-independent, so the parsed output is unchanged.

## Changes

- `lib/git.zsh`: add `local -x LC_ALL=C` at the top of `_omz_git_prompt_status`, with an explanatory comment.

## Reproduction & Fix

A repository whose `git status` output includes an invalid UTF-8 byte (common for files committed on systems with a different encoding) triggers the crash on every prompt refresh.

### Before
![before](https://github.com/zhoufengen/ohmyzsh/releases/download/pr-media-fix-git-prompt-locale/before.png)

### After
![after](https://github.com/zhoufengen/ohmyzsh/releases/download/pr-media-fix-git-prompt-locale/after.png)

## Testing

ohmyzsh has no unit-test suite; CI runs `zsh -n` syntax checks. All 576 scripts pass, including the changed file. The reproduction above shows the error is gone and all statuses are correctly parsed.

Test suite passing on the fix branch:

![tests pass](https://github.com/zhoufengen/ohmyzsh/releases/download/pr-media-fix-git-prompt-locale/test-output.png)

## Related Issues

Fixes #13330
