### PR TITLE
fix(tmux): preserve newlines when refreshing environment

### DIFF
--- a/plugins/tmux/tmux.plugin.zsh
+++ b/plugins/tmux/tmux.plugin.zsh
@@ -167,7 +167,7 @@ function _zsh_tmux_plugin_preexec()
   local -a tmux_cmd
   tmux_cmd=(command tmux)
 
-  eval $($tmux_cmd show-environment -s)
+  eval "$($tmux_cmd show-environment -s)"
 }
 
 # Use the completions for tmux for our function


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Handles quoting correctly in `_zsh_tmux_plugin_preexec`

## Other comments:

Use claude to debug and push.