### PR TITLE
Refactor keychain plugin for version handling

### DIFF
--- a/plugins/keychain/keychain.plugin.zsh
+++ b/plugins/keychain/keychain.plugin.zsh
@@ -29,12 +29,17 @@ function {
     # Keychain 3.x: subcommand-based CLI, no --agents.
     keychain add ${^options:-} --host $SHORT_HOST ${^identities}
   else
+    local agents
+
+    # load agents to start (only used by keychain < 2.9).
+    zstyle -s :omz:plugins:keychain agents agents
+
     autoload -Uz is-at-least
     if [[ "${version_string:l}" =~ 'keychain ([0-9]+\.[0-9]+)' ]] && \
        is-at-least 2.9 "$match[1]"; then
       keychain ${^options:-} ${^identities} --host $SHORT_HOST
     else
-      keychain ${^options:-} --agents ${agents:-ssh} ${^identities} --host $SHORT_HOST
+      keychain ${^options:-} --agents ${agents:-gpg} ${^identities} --host $SHORT_HOST
     fi
   fi
 

--- a/plugins/keychain/keychain.plugin.zsh
+++ b/plugins/keychain/keychain.plugin.zsh
@@ -4,37 +4,45 @@
 SHORT_HOST=${SHORT_HOST:-${(%):-%m}}
 
 function {
-	local agents
-	local -a identities
-	local -a options
-	local _keychain_env_sh
-	local _keychain_env_sh_gpg
+  local -a identities
+  local -a options
+  local _keychain_env_sh
+  local _keychain_env_sh_gpg
+  local version_string major
 
-	# load agents to start.
-	zstyle -s :omz:plugins:keychain agents agents
+  # load identities to manage.
+  zstyle -a :omz:plugins:keychain identities identities
 
-	# load identities to manage.
-	zstyle -a :omz:plugins:keychain identities identities
+  # load additional options
+  zstyle -a :omz:plugins:keychain options options
 
-	# load additional options
-	zstyle -a :omz:plugins:keychain options options
+  # Detect major version robustly: case-insensitive, tolerant of
+  # "keychain 3.0.0_beta3" / "Keychain 3.0.0" / etc.
+  version_string=$(keychain --version 2>&1)
+  if [[ "${version_string:l}" =~ '([0-9]+)\.[0-9]+' ]]; then
+    major=${match[1]}
+  else
+    major=2
+  fi
 
-	# Check keychain version to decide whether to use --agents
-	local version_string=$(keychain --version 2>&1)
-  # start keychain, only use --agents for versions below 2.9.0
-	autoload -Uz is-at-least
-	if [[ "$version_string" =~ 'keychain ([0-9]+\.[0-9]+)' ]] && \
-      is-at-least 2.9 "$match[1]"; then
-		keychain ${^options:-} ${^identities} --host $SHORT_HOST
-	else
-		keychain ${^options:-} --agents ${agents:-gpg} ${^identities} --host $SHORT_HOST
-	fi
+  if (( major >= 3 )); then
+    # Keychain 3.x: subcommand-based CLI, no --agents.
+    keychain add ${^options:-} --host $SHORT_HOST ${^identities}
+  else
+    autoload -Uz is-at-least
+    if [[ "${version_string:l}" =~ 'keychain ([0-9]+\.[0-9]+)' ]] && \
+       is-at-least 2.9 "$match[1]"; then
+      keychain ${^options:-} ${^identities} --host $SHORT_HOST
+    else
+      keychain ${^options:-} --agents ${agents:-ssh} ${^identities} --host $SHORT_HOST
+    fi
+  fi
 
-	# Get the filenames to store/lookup the environment from
-	_keychain_env_sh="$HOME/.keychain/$SHORT_HOST-sh"
-	_keychain_env_sh_gpg="$HOME/.keychain/$SHORT_HOST-sh-gpg"
+  # Get the filenames to store/lookup the environment from
+  _keychain_env_sh="$HOME/.keychain/$SHORT_HOST-sh"
+  _keychain_env_sh_gpg="$HOME/.keychain/$SHORT_HOST-sh-gpg"
 
-	# Source environment settings.
-	[ -f "$_keychain_env_sh" ]     && . "$_keychain_env_sh"
-	[ -f "$_keychain_env_sh_gpg" ] && . "$_keychain_env_sh_gpg"
+  # Source environment settings.
+  [ -f "$_keychain_env_sh" ]     && . "$_keychain_env_sh"
+  [ -f "$_keychain_env_sh_gpg" ] && . "$_keychain_env_sh_gpg"
 }


### PR DESCRIPTION
The new keychain 3.x break the plugin version-detection logic.

This PR makes the plugin works again with the new version.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Make keychain version detection case-insensitive, since keychain 3.x
  may print its version banner as `Keychain X.Y` (capitalized) instead
  of the lowercase `keychain X.Y` the existing regex expected.
- Extract the major version number and branch on it:
  - `major >= 3` → use the new `add` subcommand syntax
    (`keychain add [options] --host <host> [identities]`), with no
    `--agents` flag, since keychain 3.x removed that option entirely.
  - `major < 3` → keep the existing 2.x/legacy behavior unchanged
    (including the `--agents` fallback for versions below 2.9).
- No changes to the `zstyle` configuration interface — existing
  `:omz:plugins:keychain identities` and `:omz:plugins:keychain options`
  settings keep working as before. The `:omz:plugins:keychain agents`
  setting is still read but only used on keychain < 2.9.

## Why

keychain 3.x is a ground-up Python rewrite
(https://github.com/danielrobbins/keychain) with a new subcommand-based
CLI. Without this fix, the plugin falls through to the legacy branch and
passes the now-removed `--agents` flag, causing: 
 Error: Option '--agents' requires an argument. Run 'keychain help add' for more information.
on every new shell.

## Testing

Verified manually on keychain 3.0.1

## Other comments:

Used Claude.ai for the PR and assisting for the changes list.