### PR TITLE
fix(pm2): escape `+` in completion regex for BSD awk

### DIFF
--- a/plugins/pm2/_pm2
+++ b/plugins/pm2/_pm2
@@ -314,7 +314,7 @@ _pm2_subcommands() {
 (( $+functions[_pm2_id_names] )) ||
 _pm2_id_names() {
   local app_list=$(pm2 list -m)
-  local -a names=(${(@f)"$(echo $app_list | awk '/^\+---/{sub("+--- ", ""); print}')"})
+  local -a names=(${(@f)"$(echo $app_list | awk '/^\+---/{sub("\\+--- ", ""); print}')"})
   local -a ids=(${(@f)"$(echo $app_list | awk '/^pm2 id/{sub("pm2 id :", ""); print}')"})
 
   if (( ${#ids} > 0 )); then


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The `_pm2_id_names` completion passed `+--- ` as the regex argument to awk's sub(). An unescaped leading `+` is an illegal primary in BSD awk (macOS /usr/bin/awk), breaking `pm2 <cmd> <TAB>` completion. GNU awk tolerates it, so the bug only showed on macOS/BSD. Escape it to `\+`.

## Other comments:

- I used an LLM to identify the problem
- Contributor for pm2 plugin (due to the contribution guidelines):
  - @cuspymd Creator of plugin
  - @carlosala Last update completion
