### PR TITLE
fix(git): use canonical `--remotes`

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -45,7 +45,7 @@ plugins=(... git)
 | `gbgD`                 | `LANG=C git branch --no-color -vv \| grep ": gone\]" \| cut -c 3- \| awk '"'"'{print $1}'"'"' \| xargs git branch -D`           |
 | `gbm`                  | `git branch --move`                                                                                                             |
 | `gbnm`                 | `git branch --no-merged`                                                                                                        |
-| `gbr`                  | `git branch --remote`                                                                                                           |
+| `gbr`                  | `git branch --remotes`                                                                                                          |
 | `ggsup`                | `git branch --set-upstream-to=origin/$(git_current_branch)`                                                                     |
 | `gbg`                  | `LANG=C git branch -vv \| grep ": gone\]"`                                                                                      |
 | `gco`                  | `git checkout`                                                                                                                  |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -153,7 +153,7 @@ alias gbgd='LANG=C git branch --no-color -vv | grep ": gone\]" | cut -c 3- | awk
 alias gbgD='LANG=C git branch --no-color -vv | grep ": gone\]" | cut -c 3- | awk '"'"'{print $1}'"'"' | xargs git branch -D'
 alias gbm='git branch --move'
 alias gbnm='git branch --no-merged'
-alias gbr='git branch --remote'
+alias gbr='git branch --remotes'
 alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'
 alias gbg='LANG=C git branch -vv | grep ": gone\]"'
 alias gco='git checkout'


### PR DESCRIPTION
Git's long-option abbreviation allows `--remote` to work, but the [git-branch](https://git-scm.com/docs/git-branch) documentation specifies the plural form `--remotes`.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Updated the `gbr` alias in the Git plugin to use the canonical documented long option `--remotes` instead of the abbreviation `--remote`.
- Updated the Git plugin README.md to reflect this change.

## Other comments:

The original alias was added in commit 9a0196dbf72521319a0fa0db4ae84603c2c79868 on Aug 10, 2014 and it hasn't changed since. It works because Git's command-line parser accepts any long option as long as it uniquely identifies a single option.

For example, provided none of the prefixes are ambiguous, all of these are typically equivalent:

```
git branch --remotes
git branch --remote
git branch --remo
git branch --rem
```

If Git were ever to gain another `git branch` option beginning with `--remote...` (for example `--remote-only`), then `--remote` might become ambiguous and stop working, whereas `--remotes` would continue to work.

I ran this change passed ChatGPT to sense-check my understanding, and it said:

> This is a nice catch, and I think you’ve stumbled across one of Git’s more subtle command-line behaviours.

It went on to say:

> ### Was `--remote` ever official?
>
> As far as I can tell, no.
>
> The documentation consistently shows:
>
> ```
> -r
> --remotes
> ```
>
> and doesn't mention `--remote` as an alias.

https://chatgpt.com/share/6a6b6750-3b24-83ed-9c04-fbd95d0c7eb9