### PR TITLE
feat(uv-env): create plugin

### DIFF
--- a/plugins/uv-env/README.md
+++ b/plugins/uv-env/README.md
@@ -1,0 +1,10 @@
+# uv Environment Plugin
+
+This plugin automatically activates the uv virtual environment when you cd into a project directory, and deactivates it when you cd out.
+Note: Script looks for pyproject.toml and uv.lock files to determine if it's a uv project
+
+To use it, add `uv-env` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... uv-env)
+```

--- a/plugins/uv-env/uv-env.plugin.zsh
+++ b/plugins/uv-env/uv-env.plugin.zsh
@@ -1,0 +1,26 @@
+_toggleUvShell() {
+  local in_uv_dir=0
+  if [[ -f "$PWD/pyproject.toml" && -f "$PWD/uv.lock" ]]; then
+    in_uv_dir=1
+  fi
+
+  if [[ $uv_active -eq 1 ]] && { [[ $in_uv_dir -eq 0 ]] || [[ "$PWD" != "$uv_dir" && "$PWD" != "$uv_dir"/* ]]; }; then
+    export uv_active=0
+    unset uv_dir
+    (( $+functions[deactivate] )) && deactivate
+  fi
+
+  if [[ $in_uv_dir -eq 1 ]] && [[ $uv_active -ne 1 ]]; then
+    venv_dir="${UV_PROJECT_ENVIRONMENT:-$PWD/.venv}"
+    [[ "$venv_dir" != /* ]] && venv_dir="$PWD/$venv_dir"
+
+    if [[ -f "${venv_dir}/bin/activate" ]]; then
+      export uv_active=1
+      export uv_dir="$PWD"
+      source "${venv_dir}/bin/activate"
+    fi
+  fi
+}
+autoload -U add-zsh-hook
+add-zsh-hook chpwd _toggleUvShell
+_toggleUvShell

--- a/plugins/uv-env/uv-env.plugin.zsh
+++ b/plugins/uv-env/uv-env.plugin.zsh
@@ -5,22 +5,22 @@ _toggleUvShell() {
   fi
 
   if [[ $uv_active -eq 1 ]] && { [[ $in_uv_dir -eq 0 ]] || [[ "$PWD" != "$uv_dir" && "$PWD" != "$uv_dir"/* ]]; }; then
-    export uv_active=0
+    typeset -g uv_active=0
     unset uv_dir
     (( $+functions[deactivate] )) && deactivate
   fi
 
   if [[ $in_uv_dir -eq 1 ]] && [[ $uv_active -ne 1 ]]; then
-    venv_dir="${UV_PROJECT_ENVIRONMENT:-$PWD/.venv}"
+    local venv_dir="${UV_PROJECT_ENVIRONMENT:-$PWD/.venv}"
     [[ "$venv_dir" != /* ]] && venv_dir="$PWD/$venv_dir"
 
     if [[ -f "${venv_dir}/bin/activate" ]]; then
-      export uv_active=1
-      export uv_dir="$PWD"
+      typeset -g uv_active=1
+      typeset -g uv_dir="$PWD"
       source "${venv_dir}/bin/activate"
     fi
   fi
 }
-autoload -U add-zsh-hook
+autoload -Uz add-zsh-hook
 add-zsh-hook chpwd _toggleUvShell
 _toggleUvShell


### PR DESCRIPTION
This plugin automatically activates/deactivates a uv-managed virtual environment when you cd into or out of a project directory. It looks for pyproject.toml and uv.lock to detect a uv project, and reads UV_PROJECT_ENVIRONMENT to support custom venv locations.

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Added `plugins/uv-env/uv-env.plugin.zsh`: hooks into `chpwd` to activate the project's `.venv` when entering a directory containing `pyproject.toml` and `uv.lock`, and deactivates it when leaving.
- Added `plugins/uv-env/README.md`: usage instructions for the plugin.
- Modeled directly on the existing `poetry-env` plugin, adapted for uv:
  - Detects uv projects via `uv.lock` instead of `poetry.lock`.
  - Resolves the venv path directly (`UV_PROJECT_ENVIRONMENT` or `.venv`) instead of shelling out to a CLI command, avoiding a subprocess call on every directory change.
  - Uses a stricter directory-boundary check when comparing `$PWD` against the active project dir, to avoid false-matching sibling directories with a shared prefix (e.g. `myproject` vs `myproject2`).

## Other comments:

None
