### PR TITLE
feat(git): add `glom` alias for `git pull origin $(git_main_branch)`

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -132,6 +132,7 @@ plugins=(... git)
 | `gprumi`               | `git pull --rebase=interactive upstream $(git_main_branch)`                                                                     |
 | `ggpull`               | `git pull origin "$(git_current_branch)"`                                                                                       |
 | `ggl`                  | `git pull origin $(current_branch)`                                                                                             |
+| `glom`                 | `git pull origin $(git_main_branch)`                                                                                            |
 | `gluc`                 | `git pull upstream $(git_current_branch)`                                                                                       |
 | `glum`                 | `git pull upstream $(git_main_branch)`                                                                                          |
 | `gp`                   | `git push`                                                                                                                      |

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -295,6 +295,7 @@ function ggl() {
 }
 compdef _git ggl=git-pull
 
+alias glom='git pull origin $(git_main_branch)'
 alias gluc='git pull upstream $(git_current_branch)'
 alias glum='git pull upstream $(git_main_branch)'
 alias gp='git push'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `glom` alias for `git pull origin $(git_main_branch)` to the git plugin
- Document the new alias in the git plugin README

## Other comments:

Use case: pulling the main branch from origin while staying on a feature branch's
context (e.g. pulling new in changes into current feature branch that happened in the meantime on master) is one of my
most common daily git workflows. The plugin already covers every neighboring
variant of this command:

- `glum` = `git pull upstream $(git_main_branch)` (same pull, upstream remote)
- `gprom` = `git pull --rebase origin $(git_main_branch)` (same pull, with rebase)
- `gmom` = `git merge origin/$(git_main_branch)`

The plain `git pull origin main` is arguably the most frequent of these for the
majority of users who work directly on origin rather than a fork, but it's the
only one missing. `glom` completes the set and follows the existing naming
scheme (`gl` + `o`rigin + `m`ain, mirroring `glum`).

`glom` does not collide with any existing alias or common system command.
Uses `$(git_main_branch)` like all sibling aliases, so it works with `main`,
`master`, and the other detected main branch names.