### PR TITLE
fix(jonathan): make compatible with Ghostty shell-integration

### DIFF
--- a/themes/jonathan.zsh-theme
+++ b/themes/jonathan.zsh-theme
@@ -102,25 +102,11 @@ else
 fi
 
 # Finally, the prompt.
-PROMPT='${PR_SET_CHARSET}${PR_STITLE}${(e)PR_TITLEBAR}\
-${PR_CYAN}${PR_ULCORNER}${PR_HBAR}${PR_GREY}(\
-${PR_GREEN}%${PR_PWDLEN}<...<%~%<<\
-${PR_GREY})$(virtualenv_prompt_info)$(ruby_prompt_info)$(conda_prompt_info)${PR_CYAN}${PR_HBAR}${PR_HBAR}${(e)PR_FILLBAR}${PR_HBAR}${PR_GREY}(\
-${PR_CYAN}%(!.%SROOT%s.%n)${PR_GREY}@${PR_GREEN}%m:%l\
-${PR_GREY})${PR_CYAN}${PR_HBAR}${PR_URCORNER}\
-
-${PR_CYAN}${PR_LLCORNER}${PR_BLUE}${PR_HBAR}(\
-${PR_YELLOW}%D{%H:%M:%S}\
-${PR_LIGHT_BLUE}%{$reset_color%}$(git_prompt_info)$(git_prompt_status)${PR_BLUE})${PR_CYAN}${PR_HBAR}\
-${PR_HBAR}\
->${PR_NO_COLOUR} '
+PROMPT='${PR_SET_CHARSET}${PR_STITLE}${(e)PR_TITLEBAR}${PR_CYAN}${PR_ULCORNER}${PR_HBAR}${PR_GREY}(${PR_GREEN}%${PR_PWDLEN}<...<%~%<<${PR_GREY})$(virtualenv_prompt_info)$(ruby_prompt_info)$(conda_prompt_info)${PR_CYAN}${PR_HBAR}${PR_HBAR}${(e)PR_FILLBAR}${PR_HBAR}${PR_GREY}(${PR_CYAN}%(!.%SROOT%s.%n)${PR_GREY}@${PR_GREEN}%m:%l${PR_GREY})${PR_CYAN}${PR_HBAR}${PR_URCORNER}
+${PR_CYAN}${PR_LLCORNER}${PR_BLUE}${PR_HBAR}(${PR_YELLOW}%D{%H:%M:%S}${PR_LIGHT_BLUE}%{$reset_color%}$(git_prompt_info)$(git_prompt_status)${PR_BLUE})${PR_CYAN}${PR_HBAR}${PR_HBAR}>${PR_NO_COLOUR} '
 
 # display exitcode on the right when > 0
 return_code="%(?..%{$fg[red]%}%? ↵ %{$reset_color%})"
-RPROMPT=' $return_code${PR_CYAN}${PR_HBAR}${PR_BLUE}${PR_HBAR}\
-(${PR_YELLOW}%D{%a,%b%d}${PR_BLUE})${PR_HBAR}${PR_CYAN}${PR_LRCORNER}${PR_NO_COLOUR}'
+RPROMPT=' $return_code${PR_CYAN}${PR_HBAR}${PR_BLUE}${PR_HBAR}(${PR_YELLOW}%D{%a,%b%d}${PR_BLUE})${PR_HBAR}${PR_CYAN}${PR_LRCORNER}${PR_NO_COLOUR}'
 
-PS2='${PR_CYAN}${PR_HBAR}\
-${PR_BLUE}${PR_HBAR}(\
-${PR_LIGHT_GREEN}%_${PR_BLUE})${PR_HBAR}\
-${PR_CYAN}${PR_HBAR}${PR_NO_COLOUR} '
+PS2='${PR_CYAN}${PR_HBAR}${PR_BLUE}${PR_HBAR}(${PR_LIGHT_GREEN}%_${PR_BLUE})${PR_HBAR}${PR_CYAN}${PR_HBAR}${PR_NO_COLOUR} '


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The issue is that Ghostty shell-integration tries to parse PS1. How we're defining it now, the precmd function from Ghostty does not properly read the newlines, resulting in broken prompts. This doesn't happen if:

- Zsh is reloaded (`omz reload` or `exec zsh`)
- Ghostty shell integration is disabled (`shell-integration = none` in config)

This fix just removes the newlines, and it's enough to fix the integration.

Fixes #13640 