### PR TITLE
fix(cli): fallback to zsh when ZSH_ARGZERO is not abs path

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -738,6 +738,12 @@ function _omz::reload {
 
   # Old zsh versions don't have ZSH_ARGZERO
   local zsh="${ZSH_ARGZERO:-${functrace[-1]%:*}}"
+  # ZSH_ARGZERO is how zsh was invoked, not the executable path. A bare
+  # name ("zsh"), login flag ("-zsh") or relative path ("./bin/zsh") is
+  # re-resolved via $PATH or stale after a cwd change, so fall back to
+  # $SHELL when it holds a zsh path; a non-zsh $SHELL (e.g. /bin/bash for
+  # users launching zsh manually) keeps the previous PATH resolution. See #13919.
+  [[ "$zsh" != /* && "$SHELL" == *zsh* ]] && zsh="$SHELL"
   # Check whether to run a login shell
   [[ "$zsh" = -* || -o login ]] && exec -l "${zsh#-}" || exec "$zsh"
 }
@@ -916,6 +922,12 @@ function _omz::update {
   if [[ "$(builtin cd -q "$ZSH"; git rev-parse HEAD)" != "$last_commit" ]]; then
     # Old zsh versions don't have ZSH_ARGZERO
     local zsh="${ZSH_ARGZERO:-${functrace[-1]%:*}}"
+    # ZSH_ARGZERO is how zsh was invoked, not the executable path. A bare
+    # name ("zsh"), login flag ("-zsh") or relative path ("./bin/zsh") is
+    # re-resolved via $PATH or stale after a cwd change, so fall back to
+    # $SHELL when it holds a zsh path; a non-zsh $SHELL (e.g. /bin/bash for
+    # users launching zsh manually) keeps the previous PATH resolution. See #13919.
+    [[ "$zsh" != /* && "$SHELL" == *zsh* ]] && zsh="$SHELL"
     # Check whether to run a login shell
     [[ "$zsh" = -* || -o login ]] && exec -l "${zsh#-}" || exec "$zsh"
   fi

--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -738,6 +738,9 @@ function _omz::reload {
 
   # Old zsh versions don't have ZSH_ARGZERO
   local zsh="${ZSH_ARGZERO:-${functrace[-1]%:*}}"
+  # ZSH_ARGZERO is how zsh was invoked, not the path to it, so re-resolve
+  # anything that is not absolute (see #13919)
+  [[ "${zsh#-}" != /* ]] && (( $+commands[zsh] )) && zsh="$commands[zsh]"
   # Check whether to run a login shell
   [[ "$zsh" = -* || -o login ]] && exec -l "${zsh#-}" || exec "$zsh"
 }
@@ -916,6 +919,9 @@ function _omz::update {
   if [[ "$(builtin cd -q "$ZSH"; git rev-parse HEAD)" != "$last_commit" ]]; then
     # Old zsh versions don't have ZSH_ARGZERO
     local zsh="${ZSH_ARGZERO:-${functrace[-1]%:*}}"
+    # ZSH_ARGZERO is how zsh was invoked, not the path to it, so re-resolve
+    # anything that is not absolute (see #13919)
+    [[ "${zsh#-}" != /* ]] && (( $+commands[zsh] )) && zsh="$commands[zsh]"
     # Check whether to run a login shell
     [[ "$zsh" = -* || -o login ]] && exec -l "${zsh#-}" || exec "$zsh"
   fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

### Summary

`_omz::reload` and `_omz::update` (the post-update restart) restart the shell using `ZSH_ARGZERO`:

```sh
local zsh="${ZSH_ARGZERO:-${functrace[-1]%:*}}"
[[ "$zsh" = -* || -o login ]] && exec -l "${zsh#-}" || exec "$zsh"
```

But `ZSH_ARGZERO` reflects how zsh was *invoked*, not the running executable path (#13919):

- a login shell has `ZSH_ARGZERO=-zsh`;
- a bare invocation has `ZSH_ARGZERO=zsh`;
- a relative path like `./bin/zsh` goes stale after a cwd change.

In all three cases `exec` re-resolves the name via `$PATH` (or the stale cwd), so `omz reload` can silently restart a *different* zsh (or fail outright).

### Fix

When `ZSH_ARGZERO` is not an absolute path, fall back to \$commands[zsh], zsh's own \$PATH lookup. A login shell's leading `-` is ignored, so `-zsh` still falls back while `-/usr/bin/zsh` keeps the exact binary:

```diff
  local zsh="\${ZSH_ARGZERO:-${functrace[-1]%:*}}"
+ [[ "${zsh#-}" != /* ]] && (( $+commands[zsh] )) && zsh="$commands[zsh]"
  [[ "$zsh" = -* || -o login ]] && exec -l "${zsh#-}" || exec "$zsh"
```

\$SHELL is deliberately not used: it is the configured login shell and may point to a different zsh build than the one running (e.g. Homebrew zsh on macOS without `chsh`, where `SHELL=/bin/zsh`). \$commands[zsh] is zsh's own \$PATH lookup, so the fallback execs the zsh that is resolvable right now, the same zsh the bare-name form would resolve to at `exec` time. The earlier \$SHELL fallback and its `*zsh*` pattern are gone entirely (nothing can match `zshbogus`-style paths). If the lookup finds no `zsh` on \$PATH, the value is left as-is and `exec` re-resolves it at exec time, as before. Switched from \$SHELL to \$commands[zsh] per review.

Applied to both call sites (`_omz::reload` and the restart-after-update in `_omz::update`).

## Other comments:

### Verification

Verified the exact conditionals on zsh 5.9 (Alpine container), with a Homebrew-style zsh first on \$PATH:

| `ZSH_ARGZERO` | `\$SHELL` | previous revision | current |
|---|---|---|---|
| `zsh` | `/bin/zsh` (different build) | `/bin/zsh` | `\$commands[zsh]` (the Homebrew one) |
| `zsh` | `/usr/local/bin/zshbogus` | bogus path | `\$commands[zsh]` |
| `zsh` | `/bin/bash` | `zsh` (via \$PATH) | `\$commands[zsh]` |
| `-zsh` | `/bin/zsh` | `exec -l /bin/zsh` | `exec -l \$commands[zsh]` |
| `-/usr/bin/zsh` (login, absolute) | `/bin/zsh` | `exec -l /bin/zsh` (\$SHELL won) | `exec -l /usr/bin/zsh` (exact) |
| `./bin/zsh` (stale cwd) | `/bin/zsh` | `/bin/zsh` | `\$commands[zsh]` |
| `/usr/bin/zsh` (absolute) | any | unchanged | unchanged |
| `zsh` (no zsh on \$PATH) | any | `zsh` | `zsh` (unchanged, exec re-resolves) |

(`-zsh` rows reflect a real login shell: `-o login` is on, so `-l` is kept. The `-/usr/bin/zsh` row was verified with a real `exec` on zsh 5.9: the target reports `ZSH_ARGZERO=-/usr/bin/zsh`, not the PATH-first zsh.)

Closes #13919

AI disclosure: this change was prepared with AI coding agents (Claude, via Claude Code), reviewed and revised line by line by me.

