### PR TITLE
feat(sublime-merge): Add an smerge alias

### DIFF
--- a/plugins/sublime-merge/sublime-merge.plugin.zsh
+++ b/plugins/sublime-merge/sublime-merge.plugin.zsh
@@ -19,6 +19,7 @@
 				ssm_run_sudo() {sudo $_sublime_merge_path "$@" >/dev/null 2>&1}
 				alias ssm=ssm_run_sudo
 				alias sm=sm_run
+				alias smerge="'$_sublime_merge_path'"
 				break
 			fi
 		done
@@ -33,6 +34,7 @@
 			if [[ -a $_sublime_merge_path ]]; then
 				subm () { "$_sublime_merge_path" "$@" }
 				alias sm=subm
+				alias smerge="'$_sublime_merge_path'"
 				break
 			fi
 		done
@@ -45,6 +47,7 @@
 			if [[ -a $_sublime_merge_path ]]; then
 				subm () { "$_sublime_merge_path" "$@" }
 				alias sm=subm
+				alias smerge="'$_sublime_merge_path'"
 				break
 			fi
 		done


### PR DESCRIPTION
The available command that ships with Sublime Text is `subl`, but with Sublime Merge, it's `smerge`. However, at least on macOS, neither application adds those executables to the `PATH`.

The Sublime Text plugin searches a few potential directories for the `subl` executable and [creates an alias that points to it](https://github.com/ohmyzsh/ohmyzsh/blob/97b27bb2ec0701330b18c2d3e340b22e742b3fa8/plugins/sublime/sublime.plugin.zsh#L64):
```zsh
  for _sublime_path in $_sublime_paths; do
    if [[ -a $_sublime_path ]]; then
      alias subl="'$_sublime_path'"
      (( $+commands[sudo] )) && alias sst="sudo -EH '$_sublime_path'"
      break
    fi
  done
```

And while the plugin for Sublime Merge did a good job creating a corresponding `subm` alias, it didn't create an alias for the `smerge` executable, it creates a `subm` alias isntead:

```zsh
		for _sublime_merge_path in $_sublime_darwin_paths; do
			if [[ -a $_sublime_merge_path ]]; then
				subm () { "$_sublime_merge_path" "$@" }
				alias sm=subm
				break
			fi
		done
```

This PR fixes that by also creating an `smerge` alias that points to the `smerge` executable that ships with Sublime Merge.
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [x] Add an `smerge` alias for the `smerge` executable that is distributed with Sublime Merge.

## Other comments:

I realize that one more alias isn't hugely necessary, but removes the need for Sublime Merge users to find and alias `smerge` from the Sublime Merge installation, or to add the Sublime Merge installation to their `PATH`. And making applications easier to use from the command line is, after all, the entire point of plugins.

Tested on macOS only, but the changes are pretty minimal and I each added line is the same (I literally copied and pasted).