### PR TITLE
fix(poetry-env): preserve venv in project subdirectories

### DIFF
--- a/plugins/poetry-env/README.md
+++ b/plugins/poetry-env/README.md
@@ -1,7 +1,9 @@
 # Poetry Environment Plugin
 
-This plugin automatically changes poetry environment when you cd into or out of the project directory.
-Note: Script looks for pyproject.toml file to determine poetry if its a poetry environment
+This plugin automatically activates a Poetry environment when you enter a
+directory containing both `pyproject.toml` and `poetry.lock`. It keeps the
+environment active in project subdirectories, switches to nested Poetry
+projects, and deactivates it when you leave the project tree.
 
 To use it, add `poetry-env` to the plugins array in your zshrc file:
 

--- a/plugins/poetry-env/poetry-env.plugin.zsh
+++ b/plugins/poetry-env/poetry-env.plugin.zsh
@@ -1,15 +1,23 @@
 _togglePoetryShell() {
   # Determine if currently in a Poetry-managed directory
   local in_poetry_dir=0
+  local in_active_poetry_dir=0
   if [[ -f "$PWD/pyproject.toml" && -f "$PWD/poetry.lock" ]]; then
     in_poetry_dir=1
   fi
 
-  # Deactivate the current environment if moving out of a Poetry directory or into a different Poetry directory
-  if [[ $poetry_active -eq 1 ]] && { [[ $in_poetry_dir -eq 0 ]] || [[ "$PWD" != "$poetry_dir"* ]]; }; then
-    export poetry_active=0
-    unset poetry_dir
-    (( $+functions[deactivate] )) && deactivate
+  # Deactivate when leaving the active project or entering a nested project
+  if [[ $poetry_active -eq 1 ]]; then
+    if [[ "$PWD" == "$poetry_dir" || "$PWD" == "$poetry_dir"/* ]]; then
+      in_active_poetry_dir=1
+    fi
+
+    if [[ $in_active_poetry_dir -eq 0 ]] ||
+      { [[ $in_poetry_dir -eq 1 ]] && [[ "$PWD" != "$poetry_dir" ]]; }; then
+      export poetry_active=0
+      unset poetry_dir
+      (( $+functions[deactivate] )) && deactivate
+    fi
   fi
 
   # Activate the environment if in a Poetry directory and no environment is currently active

--- a/plugins/poetry-env/poetry-env.plugin.zsh
+++ b/plugins/poetry-env/poetry-env.plugin.zsh
@@ -8,7 +8,8 @@ _togglePoetryShell() {
 
   # Deactivate when leaving the active project or entering a nested project
   if [[ $poetry_active -eq 1 ]]; then
-    if [[ "$PWD" == "$poetry_dir" || "$PWD" == "$poetry_dir"/* ]]; then
+    local project_dir="${poetry_dir%/}"
+    if [[ "$PWD" == "$project_dir" || "$PWD" == "$project_dir"/* ]]; then
       in_active_poetry_dir=1
     fi
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Keep the active Poetry environment while navigating ordinary project subdirectories.
- Deactivate and switch when entering a valid nested Poetry project.
- Match project paths on a directory boundary, so a sibling such as `project2` is not treated as a child of `project`.
- Document the two marker files and the navigation behavior.

Fixes #12377.

## Testing:

- Ran the repository's CI syntax command locally: all 579 matched Zsh files passed `zsh -n`.
- Ran an isolated `zsh -f` navigation smoke test covering project activation, ordinary and incomplete nested directories, a valid nested Poetry project, its child, returning to the parent project, a same-prefix sibling project, paths with spaces, and leaving the project tree.
- Reproduced the original child-directory deactivation against `origin/master`; all eight navigation scenarios pass with this branch.

## Other comments:

No aliases are introduced, so the alias-use-case checklist item is not applicable.

AI-assisted: Codex analyzed the existing state transitions, drafted the condition, and assembled the test matrix. The final condition was cross-checked against the reported regression and edge cases, and the tests above were run locally.

cc @carlosala

