### PR TITLE
feat(theme): Add JJ prompt to Agnoster theme

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -63,6 +63,12 @@ esac
 : ${AGNOSTER_GIT_DIRTY_FG:=black}
 : ${AGNOSTER_GIT_DIRTY_BG:=yellow}
 
+# Jujutsu related
+: ${AGNOSTER_JJ_CLEAN_FG:=${CURRENT_FG}}
+: ${AGNOSTER_JJ_CLEAN_BG:=green}
+: ${AGNOSTER_JJ_DIRTY_FG:=black}
+: ${AGNOSTER_JJ_DIRTY_BG:=yellow}
+
 # Bazaar related
 : ${AGNOSTER_BZR_CLEAN_FG:=${CURRENT_FG}}
 : ${AGNOSTER_BZR_CLEAN_BG:=green}
@@ -177,6 +183,7 @@ prompt_git_relative() {
   fi;
 }
 
+
 # Git: branch/detached head, dirty status
 prompt_git() {
   (( $+commands[git] )) || return
@@ -236,6 +243,25 @@ prompt_git() {
     vcs_info
     echo -n "${${ref:gs/%/%%}/refs\/heads\//$PL_BRANCH_CHAR }${vcs_info_msg_0_%% }${mode}"
     [[ $AGNOSTER_GIT_INLINE == 'true' ]] && prompt_git_relative
+  fi
+}
+
+# Jujutsu
+prompt_jj() {
+  if command -v jj &> /dev/null && jj root &> /dev/null; then
+    # local jj_bookmark=$(jj bookmark list --no-pager 2>/dev/null | head -n 1 | awk '{print $1}')
+    # Check the bookmark for the current change (@) 
+    local jj_bookmark=$(jj log -r @ --no-pager --template 'local_bookmarks.map(|b| b.name()).join(", ")' 2>/dev/null | head -n 1 | awk '{print $2}')
+    if [[ -n "$jj_bookmark" ]]; then
+      jj_id="$jj_bookmark"
+    else
+      # Fallback to change ID if no bookmark exists
+      jj_id="$(jj log -r @ --no-pager --template 'change_id.shortest(3)' 2>/dev/null | head -n 1 | awk '{print $2}')"
+    fi
+    # 
+    prompt_segment "$AGNOSTER_JJ_CLEAN_FG" "$AGNOSTER_JJ_CLEAN_BG" "${jj_id:-jj}"
+  else
+    prompt_git
   fi
 }
 
@@ -368,7 +394,7 @@ build_prompt() {
   prompt_terraform
   prompt_context
   prompt_dir
-  prompt_git
+  prompt_jj
   prompt_bzr
   prompt_hg
   prompt_end


### PR DESCRIPTION

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- add prompt_jj() to agnoster theme and replace prompt_git in build_prompt to prompt_jj
- prompt_jj() to check if repo is jj repo then add the bookmark or change-id then falls back to prompt_git

