### PR TITLE
feat(zsh-interactive-cd): add opt-in zic_accept_last to auto-accept single match

### DIFF
--- a/plugins/zsh-interactive-cd/README.md
+++ b/plugins/zsh-interactive-cd/README.md
@@ -19,3 +19,11 @@ This plugin provides an interactive way to change directories in zsh using fzf.
 ## Usage
 
 Press tab for completion as usual, it'll launch fzf automatically. Check fzf’s [readme](https://github.com/junegunn/fzf#search-syntax) for more search syntax usage.
+
+## Configuration
+
+Set `zic_accept_last=true` in your `~/.zshrc` to have fzf automatically accept the last remaining match once the list is filtered down to a single directory:
+
+```zsh
+zic_accept_last=true
+```

--- a/plugins/zsh-interactive-cd/zsh-interactive-cd.plugin.zsh
+++ b/plugins/zsh-interactive-cd/zsh-interactive-cd.plugin.zsh
@@ -81,11 +81,16 @@ __zic_fzf_bindings() {
   autoload is-at-least
   fzf=$(__zic_fzf_prog)
 
+  bindings="shift-tab:up,tab:down"
   if $(is-at-least '0.21.0' $(${=fzf} --version)); then
-    echo 'shift-tab:up,tab:down,bspace:backward-delete-char/eof'
-  else
-    echo 'shift-tab:up,tab:down'
+    bindings="$bindings,bspace:backward-delete-char/eof"
   fi
+
+  if [ "$zic_accept_last" = "true" ]; then
+    bindings="$bindings,one:accept"
+  fi
+
+  echo "$bindings"
 }
 
 _zic_list_generator() {


### PR DESCRIPTION
Adds an opt-in `zic_accept_last` configuration variable. When set to `true`, the plugin appends `one:accept` to the fzf bindings so the last remaining match is accepted automatically instead of requiring Enter.

```zsh
zic_accept_last=true
```

Closes #13131