### PR TITLE
feat(claude): add plugin with aliases for Claude Code CLI

### DIFF
--- a/plugins/claude/README.md
+++ b/plugins/claude/README.md
@@ -1,0 +1,20 @@
+# Claude Code plugin
+
+This plugin provides aliases for the [Claude Code](https://code.claude.com/docs/en/cli) CLI.
+
+To use it, add `claude` to the plugins array in your .zshrc file:
+
+```zsh
+plugins=(... claude)
+```
+
+## Aliases
+
+| Alias | Command                 | Description                               |
+|-------|-------------------------|-------------------------------------------|
+| `cc`  | `claude`                | Interactive prompt                         |
+| `ccx` | `claude --continue`     | Continue the most recent conversation      |
+| `ccr` | `claude --resume`       | Resume a specific conversation by session  |
+| `ccp` | `claude --print`        | Print response and exit (for pipes)        |
+| `ccm` | `claude --model`        | Set the model for the current session      |
+| `cch` | `claude --help`         | Show help                                 |

--- a/plugins/claude/claude.plugin.zsh
+++ b/plugins/claude/claude.plugin.zsh
@@ -1,0 +1,10 @@
+if (( ! $+commands[claude] )); then
+  return
+fi
+
+alias cc='claude'
+alias ccx='claude --continue'
+alias ccr='claude --resume'
+alias ccp='claude --print'
+alias ccm='claude --model'
+alias cch='claude --help'

--- a/plugins/zsh-navigation-tools/n-bindings
+++ b/plugins/zsh-navigation-tools/n-bindings
@@ -1,0 +1,13 @@
+# Copy this file into /usr/share/zsh/site-functions/
+# and add 'autoload n-bindings' to .zshrc
+#
+# This function lists all current zsh key bindings grouped by keymap
+
+local keymap
+
+for keymap in $(bindkey -l); do
+    echo "== $keymap =="
+    bindkey -M "$keymap" -L
+done
+
+# vim: set filetype=zsh:

--- a/plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh
+++ b/plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh
@@ -65,9 +65,9 @@ unset __ZNT_CONFIG_FILES
 # Load functions
 #
 
-autoload n-aliases n-cd n-env n-functions n-history n-kill n-list n-list-draw n-list-input n-options n-panelize n-help
+autoload n-aliases n-bindings n-cd n-env n-functions n-history n-kill n-list n-list-draw n-list-input n-options n-panelize n-help
 autoload znt-usetty-wrapper znt-history-widget znt-cd-widget znt-kill-widget
-alias naliases=n-aliases ncd=n-cd nenv=n-env nfunctions=n-functions nhistory=n-history
+alias naliases=n-aliases nbindings=n-bindings ncd=n-cd nenv=n-env nfunctions=n-functions nhistory=n-history
 alias nkill=n-kill noptions=n-options npanelize=n-panelize nhelp=n-help
 
 zle -N znt-history-widget


### PR DESCRIPTION
Adds a `claude` plugin with aliases for the [Claude Code](https://code.claude.com/docs/en/cli) CLI.

| Alias | Command             | Description                          |
|-------|---------------------|--------------------------------------|
| `cc`  | `claude`            | Interactive prompt                    |
| `ccx` | `claude --continue` | Continue the most recent conversation |
| `ccr` | `claude --resume`   | Resume a conversation by session      |
| `ccp` | `claude --print`    | Print response and exit               |
| `ccm` | `claude --model`    | Set model for the current session     |
| `cch` | `claude --help`     | Show help                             |

Closes #13728