### PR TITLE
feat(vi-mode): add visual mode indicators

### DIFF
--- a/plugins/claude/README.md
+++ b/plugins/claude/README.md
@@ -1,0 +1,20 @@
+# Claude Code plugin
+
+This plugin provides aliases for the [Claude Code](https://code.claude.com/docs/en/cli) CLI.
+
+To use it, add `claude` to the plugins array in your .zshrc file:
+
+```zsh
+plugins=(... claude)
+```
+
+## Aliases
+
+| Alias | Command                 | Description                               |
+|-------|-------------------------|-------------------------------------------|
+| `cc`  | `claude`                | Interactive prompt                         |
+| `ccx` | `claude --continue`     | Continue the most recent conversation      |
+| `ccr` | `claude --resume`       | Resume a specific conversation by session  |
+| `ccp` | `claude --print`        | Print response and exit (for pipes)        |
+| `ccm` | `claude --model`        | Set the model for the current session      |
+| `cch` | `claude --help`         | Show help                                 |

--- a/plugins/claude/claude.plugin.zsh
+++ b/plugins/claude/claude.plugin.zsh
@@ -1,0 +1,10 @@
+if (( ! $+commands[claude] )); then
+  return
+fi
+
+alias cc='claude'
+alias ccx='claude --continue'
+alias ccr='claude --resume'
+alias ccp='claude --print'
+alias ccm='claude --model'
+alias cch='claude --help'

--- a/plugins/vi-mode/README.md
+++ b/plugins/vi-mode/README.md
@@ -37,6 +37,12 @@ plugins=(... vi-mode)
 - `INSERT_MODE_INDICATOR`: controls the string displayed when the shell is in insert mode.
   See [Mode indicators](#mode-indicators) for details.
 
+- `VISUAL_MODE_INDICATOR`: controls the string displayed when the shell is in visual mode.
+  See [Mode indicators](#mode-indicators) for details.
+
+- `VISUAL_LINE_MODE_INDICATOR`: controls the string displayed when the shell is in visual line mode.
+  See [Mode indicators](#mode-indicators) for details.
+
 - `VI_MODE_DISABLE_CLIPBOARD`: If set, disables clipboard integration on yank/paste
 
 ## Mode indicators
@@ -51,6 +57,14 @@ These settings support Prompt Expansion sequences. For example:
 ```zsh
 MODE_INDICATOR="%F{white}+%f"
 INSERT_MODE_INDICATOR="%F{yellow}+%f"
+```
+
+When in visual mode (or visual line mode), the `VISUAL_MODE_INDICATOR` (and
+`VISUAL_LINE_MODE_INDICATOR`) variables can be used to customize the display:
+
+```zsh
+VISUAL_MODE_INDICATOR="%F{green}VISUAL%f"
+VISUAL_LINE_MODE_INDICATOR="%F{green}VISUAL LINE%f"
 ```
 
 ### Adding mode indicators to your prompt

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -163,9 +163,25 @@ fi
 
 # if mode indicator wasn't setup by theme, define default, we'll leave INSERT_MODE_INDICATOR empty by default
 typeset -g MODE_INDICATOR=${MODE_INDICATOR:='%B%F{red}<%b<<%f'}
+typeset -g VISUAL_MODE_INDICATOR=${VISUAL_MODE_INDICATOR:='%F{yellow}VISUAL%f'}
+typeset -g VISUAL_LINE_MODE_INDICATOR=${VISUAL_LINE_MODE_INDICATOR:='%F{yellow}VISUAL LINE%f'}
 
 function vi_mode_prompt_info() {
-  echo "${${VI_KEYMAP/vicmd/$MODE_INDICATOR}/(main|viins)/$INSERT_MODE_INDICATOR}"
+  local indicator=""
+  case "${VI_KEYMAP}" in
+    vicmd) indicator="$MODE_INDICATOR" ;;
+    main|viins) indicator="$INSERT_MODE_INDICATOR" ;;
+    visual)
+      # zsh uses the same "visual" keymap for both visual and visual-line
+      # modes; REGION_ACTIVE distinguishes them (1 = char, 2 = line).
+      if (( REGION_ACTIVE == 2 )); then
+        indicator="$VISUAL_LINE_MODE_INDICATOR"
+      else
+        indicator="$VISUAL_MODE_INDICATOR"
+      fi
+      ;;
+  esac
+  echo "$indicator"
 }
 
 # define right prompt, if it wasn't defined by a theme

--- a/plugins/zsh-navigation-tools/n-bindings
+++ b/plugins/zsh-navigation-tools/n-bindings
@@ -1,0 +1,13 @@
+# Copy this file into /usr/share/zsh/site-functions/
+# and add 'autoload n-bindings' to .zshrc
+#
+# This function lists all current zsh key bindings grouped by keymap
+
+local keymap
+
+for keymap in $(bindkey -l); do
+    echo "== $keymap =="
+    bindkey -M "$keymap" -L
+done
+
+# vim: set filetype=zsh:

--- a/plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh
+++ b/plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh
@@ -65,9 +65,9 @@ unset __ZNT_CONFIG_FILES
 # Load functions
 #
 
-autoload n-aliases n-cd n-env n-functions n-history n-kill n-list n-list-draw n-list-input n-options n-panelize n-help
+autoload n-aliases n-bindings n-cd n-env n-functions n-history n-kill n-list n-list-draw n-list-input n-options n-panelize n-help
 autoload znt-usetty-wrapper znt-history-widget znt-cd-widget znt-kill-widget
-alias naliases=n-aliases ncd=n-cd nenv=n-env nfunctions=n-functions nhistory=n-history
+alias naliases=n-aliases nbindings=n-bindings ncd=n-cd nenv=n-env nfunctions=n-functions nhistory=n-history
 alias nkill=n-kill noptions=n-options npanelize=n-panelize nhelp=n-help
 
 zle -N znt-history-widget


### PR DESCRIPTION
Adds configurable `VISUAL_MODE_INDICATOR` and `VISUAL_LINE_MODE_INDICATOR` variables to show when the shell is in visual / visual line mode, mirroring the existing `MODE_INDICATOR` / `INSERT_MODE_INDICATOR`.

`REGION_ACTIVE` distinguishes the two visual modes (1 = charwise, 2 = linewise) since zsh maps both to the same `visual` keymap.

Closes #13625