### PR TITLE
feat(clipboard): support OSC 52 terminal clipboard

### DIFF
--- a/lib/clipboard.zsh
+++ b/lib/clipboard.zsh
@@ -16,6 +16,7 @@
 # - doitclient (for SSH) http://www.chiark.greenend.org.uk/~sgtatham/doit/
 # - win32yank (Windows)
 # - tmux (if $TMUX is set)
+# - OSC 52 terminal escape (opt-in via ZSH_CLIPBOARD_OSC52=true)
 #
 # Defines two functions, clipcopy and clippaste, based on the detected platform.
 ##
@@ -84,6 +85,16 @@ function detect-clipboard() {
   elif [ -n "${TMUX:-}" ] && (( ${+commands[tmux]} )); then
     function clipcopy() { tmux load-buffer -w "${1:--}"; }
     function clippaste() { tmux save-buffer -; }
+  elif [[ "${ZSH_CLIPBOARD_OSC52:-}" == true ]] && [[ -t 1 ]] && [[ -n "${TERM:-}" ]] && [[ "$TERM" != dumb ]] && (( ${+commands[base64]} )); then
+    # OSC 52 clipboard escape; supported by most modern terminals and
+    # tmux, and works over plain SSH without any helper binaries.
+    # This only handles copying; there's no standard OSC 52 read/paste.
+    function clipcopy() {
+      local payload
+      payload="$(base64 < "${1:-/dev/stdin}" | tr -d '\n')"
+      printf '\033]52;c;%s\a' "${payload}"
+    }
+    function clippaste() { print "clippaste: OSC 52 has no paste channel on this platform" >&2; return 1; }
   else
     function _retry_clipboard_detection_or_fail() {
       local clipcmd="${1}"; shift

--- a/plugins/claude/README.md
+++ b/plugins/claude/README.md
@@ -1,0 +1,20 @@
+# Claude Code plugin
+
+This plugin provides aliases for the [Claude Code](https://code.claude.com/docs/en/cli) CLI.
+
+To use it, add `claude` to the plugins array in your .zshrc file:
+
+```zsh
+plugins=(... claude)
+```
+
+## Aliases
+
+| Alias | Command                 | Description                               |
+|-------|-------------------------|-------------------------------------------|
+| `cc`  | `claude`                | Interactive prompt                         |
+| `ccx` | `claude --continue`     | Continue the most recent conversation      |
+| `ccr` | `claude --resume`       | Resume a specific conversation by session  |
+| `ccp` | `claude --print`        | Print response and exit (for pipes)        |
+| `ccm` | `claude --model`        | Set the model for the current session      |
+| `cch` | `claude --help`         | Show help                                 |

--- a/plugins/claude/claude.plugin.zsh
+++ b/plugins/claude/claude.plugin.zsh
@@ -1,0 +1,10 @@
+if (( ! $+commands[claude] )); then
+  return
+fi
+
+alias cc='claude'
+alias ccx='claude --continue'
+alias ccr='claude --resume'
+alias ccp='claude --print'
+alias ccm='claude --model'
+alias cch='claude --help'

--- a/plugins/dotenv/README.md
+++ b/plugins/dotenv/README.md
@@ -66,6 +66,17 @@ For example, this will make the plugin look for files named `.dotenv` and load t
 ZSH_DOTENV_FILE=.dotenv
 ```
 
+### ZSH_DOTENV_FILES
+
+You can specify additional dotenv files to load, in the order they should be loaded,
+with a space-separated `ZSH_DOTENV_FILES` variable. Each listed file is sourced after
+`ZSH_DOTENV_FILE`, so later files take precedence. Only existing files are loaded:
+
+```zsh
+# in ~/.zshrc, before Oh My Zsh is sourced:
+ZSH_DOTENV_FILES=".env.local .env.override"
+```
+
 ### ZSH_DOTENV_PROMPT
 
 Set `ZSH_DOTENV_PROMPT=false` in your zshrc file if you don't want the confirmation message.

--- a/plugins/dotenv/dotenv.plugin.zsh
+++ b/plugins/dotenv/dotenv.plugin.zsh
@@ -7,6 +7,9 @@
 : ${ZSH_DOTENV_ALLOWED_LIST:="${ZSH_CACHE_DIR:-$ZSH/cache}/dotenv-allowed.list"}
 : ${ZSH_DOTENV_DISALLOWED_LIST:="${ZSH_CACHE_DIR:-$ZSH/cache}/dotenv-disallowed.list"}
 
+# Additional dotenv files to load in the specified order (see ZSH_DOTENV_FILE)
+: ${ZSH_DOTENV_FILES:=}
+
 ## Functions
 
 _parse_dotenv_content() {
@@ -273,7 +276,18 @@ _dotenv_check_syntax() {
 }
 
 source_env() {
-  if [[ ! -f "$ZSH_DOTENV_FILE" ]] && [[ ! -p "$ZSH_DOTENV_FILE" ]]; then
+  local -a env_files=("$ZSH_DOTENV_FILE")
+  [[ -n "$ZSH_DOTENV_FILES" ]] && env_files+=("${(@s: :)ZSH_DOTENV_FILES}")
+  local env_file found=false
+
+  for env_file in "${env_files[@]}"; do
+    [[ -n "$env_file" ]] || continue
+    if [[ -f "$env_file" ]] || [[ -p "$env_file" ]]; then
+      found=true
+      break
+    fi
+  done
+  if [[ "$found" == false ]]; then
     return
   fi
 
@@ -299,7 +313,7 @@ source_env() {
       [[ $column -eq 1 ]] || echo
 
       # print same-line prompt and output newline character if necessary
-      echo -n "dotenv: found '$ZSH_DOTENV_FILE' file. Source it? ([y]es/[N]o/[a]lways/n[e]ver) "
+      echo -n "dotenv: found '$env_file' file. Source it? ([y]es/[N]o/[a]lways/n[e]ver) "
       read -k 1 confirmation
       [[ "$confirmation" = $'\n' ]] || echo
 
@@ -314,20 +328,25 @@ source_env() {
   fi
 
   local content
-  if [[ -p "$ZSH_DOTENV_FILE" ]]; then
-    _dotenv_read_limited "$ZSH_DOTENV_FILE" || return 1
-    content="$REPLY"
-    _dotenv_check_syntax "$ZSH_DOTENV_FILE" "$content" || return 1
+  for env_file in "${env_files[@]}"; do
+    [[ -n "$env_file" ]] || continue
+    [[ -f "$env_file" ]] || [[ -p "$env_file" ]] || continue
+
+    if [[ -p "$env_file" ]]; then
+      _dotenv_read_limited "$env_file" || return 1
+      content="$REPLY"
+      _dotenv_check_syntax "$env_file" "$content" || return 1
+
+      setopt localoptions allexport
+      _parse_dotenv_content "$content"
+      continue
+    fi
+
+    _dotenv_check_syntax "$env_file" || return 1
 
     setopt localoptions allexport
-    _parse_dotenv_content "$content"
-    return
-  fi
-
-  _dotenv_check_syntax "$ZSH_DOTENV_FILE" || return 1
-
-  setopt localoptions allexport
-  parse_dotenv "$ZSH_DOTENV_FILE"
+    parse_dotenv "$env_file"
+  done
 }
 
 autoload -U add-zsh-hook

--- a/plugins/dotenv/tests/basic-parsing.zunit
+++ b/plugins/dotenv/tests/basic-parsing.zunit
@@ -3,11 +3,13 @@
 
 @setup {
   typeset -g fixture="$(_create_temp_fixture)"
+  typeset -g fixture2="$(_create_temp_fixture)"
   typeset -gA expected_vars=()
 }
 
 @teardown {
   [[ -f "$fixture" ]] && command rm -f "$fixture"
+  [[ -f "$fixture2" ]] && command rm -f "$fixture2"
   unset DOTENV_TEST_VARS DOTENV_SOURCE_VARS 2>/dev/null
 }
 
@@ -395,4 +397,32 @@ EOF
   _parse_dotenv_test "$fixture"
 
   assert "DOTENV_TEST_VARS" var_same_as "expected_vars"
+}
+
+@test 'source_env loads multiple files via ZSH_DOTENV_FILES in order' {
+  > "$fixture" <<'EOF'
+FROM_FIRST=1
+FROM_BOTH=first
+EOF
+  > "$fixture2" <<'EOF'
+FROM_SECOND=2
+FROM_BOTH=second
+EOF
+
+  local saved_file="$ZSH_DOTENV_FILE"
+  local saved_files="$ZSH_DOTENV_FILES"
+
+  ZSH_DOTENV_FILE="$fixture"
+  ZSH_DOTENV_FILES="${fixture2:A}"
+  ZSH_DOTENV_PROMPT=false
+
+  source_env
+
+  assert "FROM_FIRST" var_is_set
+  assert "FROM_SECOND" var_is_set
+  assert "$FROM_BOTH" equals "second"
+
+  unset FROM_FIRST FROM_SECOND FROM_BOTH 2>/dev/null
+  ZSH_DOTENV_FILE="$saved_file"
+  ZSH_DOTENV_FILES="$saved_files"
 }

--- a/plugins/vi-mode/README.md
+++ b/plugins/vi-mode/README.md
@@ -37,6 +37,12 @@ plugins=(... vi-mode)
 - `INSERT_MODE_INDICATOR`: controls the string displayed when the shell is in insert mode.
   See [Mode indicators](#mode-indicators) for details.
 
+- `VISUAL_MODE_INDICATOR`: controls the string displayed when the shell is in visual mode.
+  See [Mode indicators](#mode-indicators) for details.
+
+- `VISUAL_LINE_MODE_INDICATOR`: controls the string displayed when the shell is in visual line mode.
+  See [Mode indicators](#mode-indicators) for details.
+
 - `VI_MODE_DISABLE_CLIPBOARD`: If set, disables clipboard integration on yank/paste
 
 ## Mode indicators
@@ -51,6 +57,14 @@ These settings support Prompt Expansion sequences. For example:
 ```zsh
 MODE_INDICATOR="%F{white}+%f"
 INSERT_MODE_INDICATOR="%F{yellow}+%f"
+```
+
+When in visual mode (or visual line mode), the `VISUAL_MODE_INDICATOR` (and
+`VISUAL_LINE_MODE_INDICATOR`) variables can be used to customize the display:
+
+```zsh
+VISUAL_MODE_INDICATOR="%F{green}VISUAL%f"
+VISUAL_LINE_MODE_INDICATOR="%F{green}VISUAL LINE%f"
 ```
 
 ### Adding mode indicators to your prompt

--- a/plugins/vi-mode/vi-mode.plugin.zsh
+++ b/plugins/vi-mode/vi-mode.plugin.zsh
@@ -163,9 +163,25 @@ fi
 
 # if mode indicator wasn't setup by theme, define default, we'll leave INSERT_MODE_INDICATOR empty by default
 typeset -g MODE_INDICATOR=${MODE_INDICATOR:='%B%F{red}<%b<<%f'}
+typeset -g VISUAL_MODE_INDICATOR=${VISUAL_MODE_INDICATOR:='%F{yellow}VISUAL%f'}
+typeset -g VISUAL_LINE_MODE_INDICATOR=${VISUAL_LINE_MODE_INDICATOR:='%F{yellow}VISUAL LINE%f'}
 
 function vi_mode_prompt_info() {
-  echo "${${VI_KEYMAP/vicmd/$MODE_INDICATOR}/(main|viins)/$INSERT_MODE_INDICATOR}"
+  local indicator=""
+  case "${VI_KEYMAP}" in
+    vicmd) indicator="$MODE_INDICATOR" ;;
+    main|viins) indicator="$INSERT_MODE_INDICATOR" ;;
+    visual)
+      # zsh uses the same "visual" keymap for both visual and visual-line
+      # modes; REGION_ACTIVE distinguishes them (1 = char, 2 = line).
+      if (( REGION_ACTIVE == 2 )); then
+        indicator="$VISUAL_LINE_MODE_INDICATOR"
+      else
+        indicator="$VISUAL_MODE_INDICATOR"
+      fi
+      ;;
+  esac
+  echo "$indicator"
 }
 
 # define right prompt, if it wasn't defined by a theme

--- a/plugins/zsh-navigation-tools/n-bindings
+++ b/plugins/zsh-navigation-tools/n-bindings
@@ -1,0 +1,13 @@
+# Copy this file into /usr/share/zsh/site-functions/
+# and add 'autoload n-bindings' to .zshrc
+#
+# This function lists all current zsh key bindings grouped by keymap
+
+local keymap
+
+for keymap in $(bindkey -l); do
+    echo "== $keymap =="
+    bindkey -M "$keymap" -L
+done
+
+# vim: set filetype=zsh:

--- a/plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh
+++ b/plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh
@@ -65,9 +65,9 @@ unset __ZNT_CONFIG_FILES
 # Load functions
 #
 
-autoload n-aliases n-cd n-env n-functions n-history n-kill n-list n-list-draw n-list-input n-options n-panelize n-help
+autoload n-aliases n-bindings n-cd n-env n-functions n-history n-kill n-list n-list-draw n-list-input n-options n-panelize n-help
 autoload znt-usetty-wrapper znt-history-widget znt-cd-widget znt-kill-widget
-alias naliases=n-aliases ncd=n-cd nenv=n-env nfunctions=n-functions nhistory=n-history
+alias naliases=n-aliases nbindings=n-bindings ncd=n-cd nenv=n-env nfunctions=n-functions nhistory=n-history
 alias nkill=n-kill noptions=n-options npanelize=n-panelize nhelp=n-help
 
 zle -N znt-history-widget


### PR DESCRIPTION
Adds an opt-in OSC 52 (terminal clipboard escape) clipboard backend for `clipcopy`. Enabled with:

```zsh
ZSH_CLIPBOARD_OSC52=true
```

Works over plain SSH and in most modern terminals/tmux without a clipboard helper binary. OSC 52 has no standard paste channel, so `clippaste` prints an explanatory error when this backend is active.

Closes #13459