### PR TITLE
feat(incus): add incus plugin with tab completion

### DIFF
--- a/plugins/incus/README.md
+++ b/plugins/incus/README.md
@@ -1,0 +1,9 @@
+# incus
+
+This plugin provides completion for [incus](https://linuxcontainers.org/incus/), a modern fork of LXD.
+
+To use it add `incus` to the plugins array in your zshrc file.
+
+```zsh
+plugins=(... incus)
+```

--- a/plugins/incus/incus.plugin.zsh
+++ b/plugins/incus/incus.plugin.zsh
@@ -1,0 +1,27 @@
+_incus_get_command_list () {
+    $_comp_command1 | sed "1,/Available Commands/d" | awk '/^[ \t]*[a-z]+/ { print $1 }'
+}
+
+_incus_get_subcommand_list () {
+    $_comp_command1 ${words[2]} | sed "1,/Available Commands/d" | awk '/^[ \t]*[a-z]+/ { print $1 }'
+}
+
+_incus () {
+  local curcontext="$curcontext" state line
+  typeset -A opt_args
+  _arguments \
+    '1: :->command'\
+    '*: :->args'
+
+  case $state in
+    command)
+      compadd $(_incus_get_command_list)
+      ;;
+    *)
+        compadd $(_incus_get_subcommand_list)
+      ;;
+  esac
+}
+
+compdef _incus incus
+


### PR DESCRIPTION
Adds a new `incus` plugin providing tab completion for the `incus` CLI (LXD fork), covering both top-level commands and subcommands, mirroring the existing `lxd` plugin.

Closes #13788