### PR TITLE
feat(updater): add cooldown option to delay applying updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,15 @@ zstyle ':omz:update' frequency 7
 zstyle ':omz:update' frequency 0
 ```
 
+By default, updates always pull the latest changes. If you'd rather let others kick the tires first
+before an update reaches your machine, you can set a cooldown (in days). You'll still get everything —
+just a little later:
+
+```sh
+# Only apply updates that are at least 10 days old
+zstyle ':omz:update' cooldown 10
+```
+
 ### Updates Verbosity
 
 You can also limit the update verbosity with the following settings:

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -28,8 +28,11 @@ ZSH_THEME="robbyrussell"
 # zstyle ':omz:update' mode auto      # update automatically without asking
 # zstyle ':omz:update' mode reminder  # just remind me to update when it's time
 
-# Uncomment the following line to change how often to auto-update (in days).
+# Uncomment the following line to change the frequency the auto-updater is run (in days).
 # zstyle ':omz:update' frequency 13
+
+# Uncomment the following line to set how old an update must be before it's applied, manually or via the auto-updater (in days).
+# zstyle ':omz:update' cooldown 10
 
 # Uncomment the following line if pasting URLs and other text is messed up.
 # DISABLE_MAGIC_FUNCTIONS="true"

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -231,6 +231,10 @@ local ret=0
 remote=${"$(git config --local oh-my-zsh.remote)":-origin}
 branch=${"$(git config --local oh-my-zsh.branch)":-master}
 
+# cooldown: minimum age (in days) of commits to apply
+local cooldown_days
+zstyle -s ':omz:update' cooldown cooldown_days || cooldown_days=0
+
 # repository state
 last_head=$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)
 # checkout update branch
@@ -242,7 +246,20 @@ last_commit=$(git rev-parse "$branch")
 if [[ $verbose_mode != silent ]]; then
   printf "${BLUE}%s${RESET}\n" "Updating Oh My Zsh"
 fi
-if LANG= git pull --quiet --rebase $remote $branch; then
+if {
+  if (( cooldown_days > 0 )); then
+    zmodload zsh/datetime
+    local cutoff_epoch cooldown_ref
+    cutoff_epoch=$(( EPOCHSECONDS - cooldown_days * 86400 ))
+    LANG= git fetch --quiet $remote $branch && {
+      cooldown_ref=$(git log --format="%H %ct" "$remote/$branch" \
+        | awk -v c="$cutoff_epoch" '$2 <= c { print $1; exit }')
+      [[ -z "$cooldown_ref" ]] || LANG= git merge --ff-only --quiet "$cooldown_ref"
+    }
+  else
+    LANG= git pull --quiet --rebase $remote $branch
+  fi
+}; then
   # Check if it was really updated or not
   if [[ "$(git rev-parse HEAD)" = "$last_commit" ]]; then
     message="Oh My Zsh is already at the latest version."


### PR DESCRIPTION
Closes #13813

Introduces a new `zstyle ':omz:update' cooldown <days>` setting that limits the updater to only apply commits that are at least N days old. Defaults to 0 (current behavior - always pull latest).

When cooldown is set, the updater fetches the remote branch and finds the most recent commit whose committer timestamp is at least N days old, then applies it via `git merge --ff-only`.

## Motivation
Automated update runs (e.g. cron) can pull in a newly-broken commit before it is caught. A cooldown lets users delay adoption of fresh commits while still staying up to date.

## Changes
- `tools/upgrade.sh`: cooldown check + safe apply
- `templates/zshrc.zsh-template`: documented zstyle
- `README.md`: docs