### PR TITLE
fix(jonathan): avoid unicode box-drawing in ghostty

### DIFF
--- a/themes/jonathan.zsh-theme
+++ b/themes/jonathan.zsh-theme
@@ -60,7 +60,14 @@ ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[yellow]%} %{%G═%}"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[cyan]%} %{%G✭%}"
 
 # Use extended characters to look nicer if supported.
-if [[ "${langinfo[CODESET]}" = UTF-8 ]]; then
+if [[ "${TERM_PROGRAM:-}" = ghostty ]]; then
+  PR_SET_CHARSET=""
+  PR_HBAR="-"
+  PR_ULCORNER="-"
+  PR_LLCORNER="-"
+  PR_LRCORNER="-"
+  PR_URCORNER="-"
+elif [[ "${langinfo[CODESET]}" = UTF-8 ]]; then
   PR_SET_CHARSET=""
   PR_HBAR="─"
   PR_ULCORNER="┌"


### PR DESCRIPTION
Fixes the jonathan theme rendering broken box-drawing glyphs in ghostty terminals by falling back to ASCII characters.

The theme used unicode box-drawing characters which ghostty does not render in the prompt context, producing garbled output. This replaces them with ASCII equivalents.

## Changes
- `themes/jonathan.zsh-theme`: replace unicode box-drawing with ASCII fallback (8 additions, 1 deletion)