### PR TITLE
feat(git): add gcbc helper to copy current branch name

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -255,6 +255,7 @@ receive further support.
 | `git_develop_branch`     | Returns the name of the “development” branch: `dev`, `devel`, `development` if they exist, `develop` otherwise |
 | `git_main_branch`        | Returns the name of the main branch: `main` if it exists, `master` otherwise                                   |
 | `grename <old> <new>`    | Renames branch `<old>` to `<new>`, including on the origin remote                                              |
+| `gcbc`                   | Copies the current branch name to the system clipboard (uses `clipcopy`)                                       |
 | `gbda`                   | Deletes all merged branches                                                                                    |
 | `gbds`                   | Deletes all squash-merged branches (**Note: performance degrades with number of branches**)                    |
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -159,6 +159,14 @@ alias gbg='LANG=C git branch -vv | grep ": gone\]"'
 alias gco='git checkout'
 alias gcor='git checkout --recurse-submodules'
 alias gcb='git checkout -b'
+function gcbc() {
+  local branch=$(git branch --show-current 2>/dev/null) || return
+  if [[ -z "$branch" ]]; then
+    print -u2 "gcbc: not on a branch"
+    return 1
+  fi
+  print -rn -- "$branch" | clipcopy
+}
 alias gcB='git checkout -B'
 alias gcd='git checkout $(git_develop_branch)'
 alias gcm='git checkout $(git_main_branch)'


### PR DESCRIPTION
Closes #13867

Adds a `gcbc` function to the git plugin that copies the current branch name to the system clipboard using the existing `clipcopy` helper.

## Details
- `git branch --show-current` gets the branch; falls back to error message on stderr when not on a branch (detached HEAD, etc.)
- Mirrors existing conventions in the git plugin (`grename`, `git_main_branch` etc.)
- README table updated

## Tested
- `gcbc` on a branch: copies branch name
- `gcbc` in detached HEAD: prints `gcbc: not on a branch`, returns 1