### PR TITLE
feat(systemadmin): replace clrz with pszombie alias

### DIFF
--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -28,6 +28,8 @@ alias mkdir='mkdir -pv'
 # get top process eating memory
 alias psmem='ps -e -orss=,args= | sort -b -k1 -nr'
 alias psmem10='ps -e -orss=,args= | sort -b -k1 -nr | head -n 10'
+# list all zombie processes with ownership and parent process details
+alias pszombie="ps -eo user,pid,ppid,state,cmd | awk '\$4==\"Z\"'"
 # get top process eating cpu if not work try execute : export LC_ALL='C'
 alias pscpu='ps -e -o pcpu,cpu,nice,state,cputime,args | sort -k1,1n -nr'
 alias pscpu10='ps -e -o pcpu,cpu,nice,state,cputime,args | sort -k1,1n -nr | head -n 10'
@@ -177,10 +179,10 @@ function getip() {
   fi
 }
 
-# Clear zombie processes
-function clrz() {
-  ps -eal | awk '{ if ($2 == "Z") {print $4}}' | kill -9
-}
+## Clear zombie processes
+#function clrz() {
+#  ps -eal | awk '{ if ($2 == "Z") {print $4}}' | kill -9
+#}
 
 # Second concurrent
 function conssec() {


### PR DESCRIPTION
Closes #13861

Replaces the broken `clrz` function with a new `pszombie` alias in the systemadmin plugin.

## Why
- The old `clrz` function used `ps -eal` output parsed with awk, then piped PIDs into `kill -9` — but zombie processes cannot be killed (their parent must reap them), so it was misleading.
- The new `pszombie` alias lists zombie processes with user, PID, PPID, state and command for actual diagnosis.
- Old `clrz` kept but commented out for reference.

## Change
- `plugins/systemadmin/systemadmin.plugin.zsh`: +6/-4