### PR TITLE
feat(gcx): add completion plugin

### DIFF
--- a/plugins/gcx/README.md
+++ b/plugins/gcx/README.md
@@ -1,0 +1,18 @@
+# Grafana CLI plugin
+
+This plugin adds completion for the [Grafana CLI (gcx)](https://github.com/grafana/gcx).
+
+To use it, add `gcx` to the plugins array in your zshrc file:
+
+```zsh
+plugins=(... gcx)
+```
+
+This plugin does not add any aliases.
+
+## Cache
+
+This plugin caches the completion script and automatically updates it when the
+plugin is loaded, which is usually when you start a new terminal emulator.
+
+The cache is stored at `$ZSH_CACHE_DIR/completions/_gcx`.

--- a/plugins/gcx/gcx.plugin.zsh
+++ b/plugins/gcx/gcx.plugin.zsh
@@ -1,0 +1,14 @@
+# Autocompletion for the Grafana CLI (gcx).
+if (( ! $+commands[gcx] )); then
+  return
+fi
+
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `gcx`. Otherwise, compinit will have already done that.
+if [[ ! -f "$ZSH_CACHE_DIR/completions/_gcx" ]]; then
+  typeset -g -A _comps
+  autoload -Uz _gcx
+  _comps[gcx]=_gcx
+fi
+
+gcx completion zsh >| "$ZSH_CACHE_DIR/completions/_gcx" &|

--- a/plugins/gcx/gcx.plugin.zsh
+++ b/plugins/gcx/gcx.plugin.zsh
@@ -11,4 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_gcx" ]]; then
   _comps[gcx]=_gcx
 fi
 
-gcx completion zsh >| "$ZSH_CACHE_DIR/completions/_gcx" &|
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_gcx"
+  zf_mv -f -- =( gcx completion zsh ) "$TMPPREFIX"
+} &|


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] The code does not introduce new aliases.

## Changes:

- Add Zsh completions for [gcx](https://github.com/grafana/gcx), Grafana's CLI for managing Grafana resources and Cloud product APIs.
- Generate completions with `gcx completion zsh` and cache them in `$ZSH_CACHE_DIR`.
- Add activation and cache documentation.

## Testing:

- Enabled the plugin locally with `plugins=(... gcx)`.
- Verified `gcx` command, subcommand, and flag completion interactively.
- Ran `zsh -n plugins/gcx/gcx.plugin.zsh`.
- Confirmed the plugin creates a non-empty `$ZSH_CACHE_DIR/completions/_gcx` cache file.

## Other comments:

AI-assisted: initial implementation generated with an AI coding assistant, then reviewed and tested manually.

This is a new plugin. Additional `gcx` users are invited to test it and leave a `+1`.