### PR TITLE
fix(aws): asr() prints error to stderr and resets terminal color

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -69,7 +69,8 @@ function asr() {
   local -a available_regions
   available_regions=($(aws_regions))
   if [[ -z "${available_regions[(r)$1]}" ]]; then
-    echo "${fg[red]}Available regions: \n$(aws_regions)"
+    echo "${fg[red]}Region '$1' not found" >&2
+    echo "Available regions: ${(j:, :)available_regions:-no regions found}${reset_color}" >&2
     return 1
   fi
 


### PR DESCRIPTION
Fixes #13949