### PR TITLE
fix(git): rename gwipe to greset-clean to avoid typos with gwip

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -174,7 +174,7 @@ plugins=(... git)
 | `grhk`                 | `git reset --keep`                                                                                                              |
 | `grhs`                 | `git reset --soft`                                                                                                              |
 | `gpristine`            | `git reset --hard && git clean --force -dfx`                                                                                    |
-| `gwipe`                | `git reset --hard && git clean --force -df`                                                                                     |
+| `greset-clean`         | `git reset --hard && git clean --force -df`                                                                                     |
 | `groh`                 | `git reset origin/$(git_current_branch) --hard`                                                                                 |
 | `grs`                  | `git restore`                                                                                                                   |
 | `grss`                 | `git restore --source`                                                                                                          |
@@ -242,6 +242,7 @@ receive further support.
 | `gap`    | `git add --patch`                                         | New alias: `gapa`                                     |
 | `gcl`    | `git config --list`                                       | New alias: `gcf`                                      |
 | `gdt`    | `git difftool`                                            | No replacement                                        |
+| `gwipe`  | `git reset --hard && git clean --force -df`               | New alias: `greset-clean`                             |
 
 ## Functions
 

--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -364,7 +364,7 @@ alias grhh='git reset --hard'
 alias grhk='git reset --keep'
 alias grhs='git reset --soft'
 alias gpristine='git reset --hard && git clean --force -dfx'
-alias gwipe='git reset --hard && git clean --force -df'
+alias greset-clean='git reset --hard && git clean --force -df'
 alias groh='git reset origin/$(git_current_branch) --hard'
 alias grs='git restore'
 alias grss='git restore --source'
@@ -422,7 +422,8 @@ unset git_version
 # Logic for adding warnings on deprecated aliases or functions
 local old_name new_name
 for old_name new_name (
-  current_branch  git_current_branch
+  current_branch      git_current_branch
+  gwipe               greset-clean
 ); do
   aliases[$old_name]="
     print -Pu2 \"%F{yellow}[oh-my-zsh] '%F{red}${old_name}%F{yellow}' is deprecated, using '%F{green}${new_name}%F{yellow}' instead.%f\"


### PR DESCRIPTION
Fixes #13608