### PR TITLE
fix(install): prevent command injection via \ in install.sh

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -49,9 +49,18 @@ USER=${USER:-$(id -u -n)}
 # $HOME is defined at the time of login, but it could be unset. If it is unset,
 # a tilde by itself (~) will not be expanded to the current user's home directory.
 # POSIX: https://pubs.opengroup.org/onlinepubs/009696899/basedefs/xbd_chap08.html#tag_08_03
-HOME="${HOME:-$(getent passwd $USER 2>/dev/null | cut -d: -f6)}"
-# macOS does not have getent, but this works even if $HOME is unset
-HOME="${HOME:-$(eval echo ~"$USER")}"
+HOME="${HOME:-$(getent passwd "$USER" 2>/dev/null | cut -d: -f6)}"
+# macOS does not have getent; fall back to tilde expansion, but only if $USER
+# is a safe username. The eval below would otherwise expand any shell
+# metacharacters in $USER and allow command injection (CWE-78).
+case "$USER" in
+  *[![:alnum:]_.-]*|'')
+    HOME="${HOME:-$PWD}"
+    ;;
+  *)
+    HOME="${HOME:-$(eval echo ~"$USER")}"
+    ;;
+esac
 
 
 # Track if $ZSH was provided

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -49,18 +49,31 @@ USER=${USER:-$(id -u -n)}
 # $HOME is defined at the time of login, but it could be unset. If it is unset,
 # a tilde by itself (~) will not be expanded to the current user's home directory.
 # POSIX: https://pubs.opengroup.org/onlinepubs/009696899/basedefs/xbd_chap08.html#tag_08_03
-HOME="${HOME:-$(getent passwd "$USER" 2>/dev/null | cut -d: -f6)}"
-# macOS does not have getent; fall back to tilde expansion, but only if $USER
-# is a safe username. The eval below would otherwise expand any shell
-# metacharacters in $USER and allow command injection (CWE-78).
-case "$USER" in
-  *[![:alnum:]_.-]*|'')
-    HOME="${HOME:-$PWD}"
-    ;;
-  *)
-    HOME="${HOME:-$(eval echo ~"$USER")}"
-    ;;
-esac
+if [ -z "$HOME" ]; then
+  HOME=$(getent passwd "$USER" 2>/dev/null | cut -d: -f6)
+
+  # macOS does not have getent; fall back to tilde expansion, but only if
+  # $USER is a safe username. The eval below would otherwise expand any shell
+  # metacharacters in $USER and allow command injection (CWE-78).
+  case "$USER" in
+    *[![:alnum:]_.-]*|'')
+      ;;
+    *)
+      resolved_home=$(eval echo ~"$USER")
+      # Unknown users are not expanded and produce a literal "~username".
+      [ "$resolved_home" = "~$USER" ] || HOME=$resolved_home
+      ;;
+  esac
+
+  case "$HOME" in
+    /*) ;;
+    *)
+      echo "Error: unable to determine the current user's home directory." >&2
+      echo "Set HOME explicitly and rerun the installer." >&2
+      exit 1
+      ;;
+  esac
+fi
 
 
 # Track if $ZSH was provided


### PR DESCRIPTION
## Problem

`tools/install.sh` runs an `eval` on a value derived from the environment:

```sh
HOME="${HOME:-$(getent passwd $USER 2>/dev/null | cut -d: -f6)}"
# macOS does not have getent, but this works even if $HOME is unset
HOME="${HOME:-$(eval echo ~"$USER")}"
```

When `HOME` is unset (e.g. containers, minimal environments), `eval echo ~"$USER"` expands any shell metacharacters in `$USER` (CWE-78). A crafted `USER` like `x"; touch /tmp/pwned; "` executes the embedded command. The script is normally run via `curl | sh`, so the environment is attacker-influencable in some setups.

Additionally, `getent passwd $USER` is unquoted (word splitting).

## Fix

Validate the username against a safe character set before the `eval`, falling back to `$PWD` for unsafe/empty values, and quote `$USER` in the `getent` call:

```sh
HOME="${HOME:-$(getent passwd "$USER" 2>/dev/null | cut -d: -f6)}"
case "$USER" in
  *[![:alnum:]_.-]*|'')
    HOME="${HOME:-$PWD}"
    ;;
  *)
    HOME="${HOME:-$(eval echo ~"$USER")}"
    ;;
esac
```

Behavior for normal usernames is unchanged (tilde expansion still applies); only unsafe `$USER` values are short-circuited.

## Tests

- `bash -n tools/install.sh` passes.
- Functional tests in bash: malicious `USER='x"; touch /tmp/pwned; "'` → no file created, `HOME` falls back to `$PWD`; `USER=root` → `HOME=/root`; `USER=john.doe-test` (valid chars) → unchanged behavior; empty `USER` → `$PWD`.
