### PR TITLE
fix(core): add Ghostty OSC 8 support

### DIFF
--- a/tools/changelog.sh
+++ b/tools/changelog.sh
@@ -221,12 +221,12 @@ supports_hyperlinks() {
 
   # If $TERM_PROGRAM is set, these terminals support hyperlinks
   case "$TERM_PROGRAM" in
-  Hyper|iTerm.app|terminology|WezTerm|vscode) return 0 ;;
+  ghostty|Hyper|iTerm.app|terminology|vscode|WezTerm) return 0 ;;
   esac
 
   # These termcap entries support hyperlinks
   case "$TERM" in
-  xterm-kitty|alacritty|alacritty-direct) return 0 ;;
+  alacritty|alacritty-direct|xterm-ghostty|xterm-kitty) return 0 ;;
   esac
 
   # xfce4-terminal supports hyperlinks

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -168,12 +168,12 @@ supports_hyperlinks() {
 
   # If $TERM_PROGRAM is set, these terminals support hyperlinks
   case "$TERM_PROGRAM" in
-  Hyper|iTerm.app|terminology|WezTerm|vscode) return 0 ;;
+  ghostty|Hyper|iTerm.app|terminology|vscode|WezTerm) return 0 ;;
   esac
 
   # These termcap entries support hyperlinks
   case "$TERM" in
-  xterm-kitty|alacritty|alacritty-direct) return 0 ;;
+  alacritty|alacritty-direct|xterm-ghostty|xterm-kitty) return 0 ;;
   esac
 
   # xfce4-terminal supports hyperlinks

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -95,12 +95,12 @@ supports_hyperlinks() {
 
   # If $TERM_PROGRAM is set, these terminals support hyperlinks
   case "$TERM_PROGRAM" in
-  Hyper|iTerm.app|terminology|WezTerm|vscode) return 0 ;;
+  ghostty|Hyper|iTerm.app|terminology|vscode|WezTerm) return 0 ;;
   esac
 
   # These termcap entries support hyperlinks
   case "$TERM" in
-  xterm-kitty|alacritty|alacritty-direct) return 0 ;;
+  alacritty|alacritty-direct|xterm-ghostty|xterm-kitty) return 0 ;;
   esac
 
   # xfce4-terminal supports hyperlinks


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Recognize Ghostty's `TERM_PROGRAM=ghostty` and `TERM=xterm-ghostty` identifiers.
- Enable OSC 8 hyperlinks in the changelog, updater, and installer when running in Ghostty.
- Keep the terminal identifier lists alphabetized.

## Other comments:

This extends the existing changelog hyperlink support from [#11578](https://github.com/ohmyzsh/ohmyzsh/pull/11578).

Tested manually in Ghostty by running `tools/changelog.sh` directly and command-clicking commit and PR links successfully. All modified scripts pass `zsh -n`.

The scope is intentionally limited to Ghostty.

AI-assisted: Codex helped investigate, implement, and test this change; I reviewed the resulting diff.
