### PR TITLE
fix(eza): enhance hyperlink option handling in eza plugin

### DIFF
--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -53,7 +53,12 @@ function _configure_eza() {
     _EZA_TAIL+=("--time-style='$_val'")
   fi
   if zstyle -t ":omz:plugins:eza" "hyperlink"; then
-    _EZA_TAIL+=("--hyperlink")
+    case "${_val:l}" in
+      yes|true|on|1) _val=auto ;;
+    esac
+    if [[ ${_val:l} == (always|auto|automatic|never) ]]; then
+      _EZA_TAIL+=("--hyperlink=${_val:l}")
+    fi
   fi
 }
 


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [X] The PR title is descriptive.
- [X] The PR doesn't replicate another PR which is already open.
- [X] I have read the contribution guide and followed all the instructions.
- [X] The code follows the code style guide detailed in the wiki.
- [X] The code is mine or it's from somewhere with an MIT-compatible license.
- [X] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [X] The code is efficient, to the best of my ability, and does not waste computer resources.
- [X] The code is stable and I have tested it myself, to the best of my abilities.
- [X] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Updated the hyperlink configuration logic to handle the new eza parameter syntax, with a fallback to "auto" for existing setups

## Other comments:

`eza` commit implementing the new `--hyperlink` usage: https://github.com/eza-community/eza/commit/72e323171ca7466b62c5d2a5d0da8d1b5edc9593