### PR TITLE
fix(aws): send asr error message to stderr and reset color

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -69,7 +69,7 @@ function asr() {
   local -a available_regions
   available_regions=($(aws_regions))
   if [[ -z "${available_regions[(r)$1]}" ]]; then
-    echo "${fg[red]}Available regions: \n$(aws_regions)"
+    echo "${fg[red]}Available regions: \n$(aws_regions)${reset_color}" >&2
     return 1
   fi
 


### PR DESCRIPTION
Fixes #13949.

`asr()` with an invalid region echoes the error to stdout and never resets the red color, leaving the terminal permanently red for all subsequent output. The sibling `asp()` already handles this: both its error lines go to stderr and the last one appends `${reset_color}`.

```zsh
echo "${fg[red]}Available regions: \n$(aws_regions)${reset_color}" >&2
```