### PR TITLE
fix(kubectl): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -10,7 +10,11 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_kubectl" ]]; then
   _comps[kubectl]=_kubectl
 fi
 
-kubectl completion zsh 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_kubectl" &|
+# Generate the completion into a temporary file and move it into place
+# atomically, so a compinit running concurrently (package-manager setups
+# may run it after this plugin) never reads an empty or partial file.
+local _kubectl_tmp="$ZSH_CACHE_DIR/completions/_kubectl.tmp.$$"
+kubectl completion zsh 2> /dev/null >| "$_kubectl_tmp" && mv -f "$_kubectl_tmp" "$ZSH_CACHE_DIR/completions/_kubectl" &|
 
 # This command is used a LOT both below and in daily life
 alias k=kubectl


### PR DESCRIPTION
Fixes #13964

The kubectl plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_kubectl`. A `compinit` running after the plugin loads (common with package-manager installs like antidote, zinit, etc.) could read the file mid-write, cache it without its `#compdef` line, and leave kubectl without completions.

The generation now writes to a temp file and `mv`s it into place atomically, so concurrent compinit runs either see the previous complete file or the new one — never a partial one.
