### PR TITLE
fix(helm): avoid racing compinit with async completion regeneration

### DIFF
--- a/plugins/helm/helm.plugin.zsh
+++ b/plugins/helm/helm.plugin.zsh
@@ -9,7 +9,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_helm" ]]; then
   source "$ZSH_CACHE_DIR/completions/_helm"
 else
   source "$ZSH_CACHE_DIR/completions/_helm"
-  helm completion zsh | tee "$ZSH_CACHE_DIR/completions/_helm" >/dev/null &|
+  # Regenerate atomically so a concurrent compinit never reads a partial file.
+  local _helm_tmp="$ZSH_CACHE_DIR/completions/_helm.tmp.$$"
+  helm completion zsh >| "$_helm_tmp" && mv -f "$_helm_tmp" "$ZSH_CACHE_DIR/completions/_helm" &|
 fi
 
 alias h='helm'


### PR DESCRIPTION
Same race as #13964 (kubectl): the helm plugin regenerated its completion file in the background via `tee`, writing directly to `$ZSH_CACHE_DIR/completions/_helm`. A `compinit` running concurrently (common with package-manager oh-my-zsh installs) could read the file mid-write and cache it as empty.

Now writes to a temp file and `mv`s it into place atomically.
