### PR TITLE
fix(argocd): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/argocd/argocd.plugin.zsh
+++ b/plugins/argocd/argocd.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_argocd" ]]; then
   _comps[argocd]=_argocd
 fi
 
-argocd completion zsh >| "$ZSH_CACHE_DIR/completions/_argocd" &|
+argocd completion zsh >| "$ZSH_CACHE_DIR/completions/_argocd.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_argocd.tmp.$$" "$ZSH_CACHE_DIR/completions/_argocd" &|


### PR DESCRIPTION
Same race as #13964 (kubectl): the argocd plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_argocd`. A `compinit` running concurrently could read a partial file and cache it as empty.

Now writes to a temp file and moves it into place atomically.
