### PR TITLE
fix(1password): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/1password/1password.plugin.zsh
+++ b/plugins/1password/1password.plugin.zsh
@@ -9,7 +9,7 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_op" ]]; then
   _comps[op]=_op
 fi
 
-op completion zsh >| "$ZSH_CACHE_DIR/completions/_op" &|
+op completion zsh >| "$ZSH_CACHE_DIR/completions/_op.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_op.tmp.$$" "$ZSH_CACHE_DIR/completions/_op" &|
 
 # Load opswd function
 autoload -Uz opswd


### PR DESCRIPTION
Same race as #13964 (kubectl): the 1password plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_op`. A `compinit` running concurrently (common with package-manager oh-my-zsh installs) could read the file mid-write and cache it without its `#compdef` line, leaving 1password without completions.

Now writes to a temp file and `mv`s it into place atomically, so concurrent compinit runs either see the previous complete file or the new one — never a partial one.
