### PR TITLE
fix(asdf): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -12,4 +12,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_asdf" ]]; then
   autoload -Uz _asdf
   _comps[asdf]=_asdf
 fi
-asdf completion zsh >| "$ZSH_CACHE_DIR/completions/_asdf" &|
+asdf completion zsh >| "$ZSH_CACHE_DIR/completions/_asdf.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_asdf.tmp.$$" "$ZSH_CACHE_DIR/completions/_asdf" &|


### PR DESCRIPTION
Same race as #13964 (kubectl): the asdf plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_asdf`. A `compinit` running concurrently (common with package-manager oh-my-zsh installs) could read the file mid-write and cache it without its `#compdef` line, leaving asdf without completions.

Now writes to a temp file and `mv`s it into place atomically, so concurrent compinit runs either see the previous complete file or the new one — never a partial one.
