### PR TITLE
fix(buf): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/buf/buf.plugin.zsh
+++ b/plugins/buf/buf.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_buf" ]]; then
 fi
 
 # Generate and load buf completion
-buf completion zsh >! "$ZSH_CACHE_DIR/completions/_buf" &|
+buf completion zsh >! "$ZSH_CACHE_DIR/completions/_buf.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_buf.tmp.$$" "$ZSH_CACHE_DIR/completions/_buf" &|


### PR DESCRIPTION
Same race as #13964 (kubectl): the buf plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_buf`. A `compinit` running concurrently (common with package-manager oh-my-zsh installs) could read the file mid-write and cache it without its `#compdef` line, leaving buf without completions.

Now writes to a temp file and `mv`s it into place atomically, so concurrent compinit runs either see the previous complete file or the new one — never a partial one.
