### PR TITLE
fix(kind): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/kind/kind.plugin.zsh
+++ b/plugins/kind/kind.plugin.zsh
@@ -11,7 +11,7 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_kind" ]]; then
 fi
 
 # Generate and load kind completion
-kind completion zsh >! "$ZSH_CACHE_DIR/completions/_kind" &|
+kind completion zsh >! "$ZSH_CACHE_DIR/completions/_kind.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_kind.tmp.$$" "$ZSH_CACHE_DIR/completions/_kind" &|
 
 # Register aliases
 alias kicc="kind create cluster"


### PR DESCRIPTION
Same race as #13964 (kubectl): the kind plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_kind`. A `compinit` running concurrently (common with package-manager oh-my-zsh installs) could read the file mid-write and cache it without its `#compdef` line, leaving kind without completions.

Now writes to a temp file and `mv`s it into place atomically, so concurrent compinit runs either see the previous complete file or the new one — never a partial one.
