### PR TITLE
fix(doctl): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/doctl/doctl.plugin.zsh
+++ b/plugins/doctl/doctl.plugin.zsh
@@ -14,4 +14,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_doctl" ]]; then
   _comps[doctl]=_doctl
 fi
 
-doctl completion zsh >| "$ZSH_CACHE_DIR/completions/_doctl" &|
+doctl completion zsh >| "$ZSH_CACHE_DIR/completions/_doctl.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_doctl.tmp.$$" "$ZSH_CACHE_DIR/completions/_doctl" &|


### PR DESCRIPTION
Same race as #13964 (kubectl): the doctl plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_doctl`. A `compinit` running concurrently (common with package-manager oh-my-zsh installs) could read the file mid-write and cache it without its `#compdef` line, leaving doctl without completions.

Now writes to a temp file and `mv`s it into place atomically, so concurrent compinit runs either see the previous complete file or the new one — never a partial one.
