### PR TITLE
fix(chezmoi): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/chezmoi/chezmoi.plugin.zsh
+++ b/plugins/chezmoi/chezmoi.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_chezmoi" ]]; then
   _comps[chezmoi]=_chezmoi
 fi
 
-chezmoi completion zsh >| "$ZSH_CACHE_DIR/completions/_chezmoi" &|
+chezmoi completion zsh >| "$ZSH_CACHE_DIR/completions/_chezmoi.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_chezmoi.tmp.$$" "$ZSH_CACHE_DIR/completions/_chezmoi" &|


### PR DESCRIPTION
Same race as #13964 (kubectl): the chezmoi plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_chezmoi`. A `compinit` running concurrently (common with package-manager oh-my-zsh installs) could read the file mid-write and cache it without its `#compdef` line, leaving chezmoi without completions.

Now writes to a temp file and `mv`s it into place atomically, so concurrent compinit runs either see the previous complete file or the new one — never a partial one.
