### PR TITLE
fix(charm): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/charm/charm.plugin.zsh
+++ b/plugins/charm/charm.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_charm" ]]; then
   _comps[charm]=_charm
 fi
 
-charm completion zsh >| "$ZSH_CACHE_DIR/completions/_charm" &|
+charm completion zsh >| "$ZSH_CACHE_DIR/completions/_charm.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_charm.tmp.$$" "$ZSH_CACHE_DIR/completions/_charm" &|


### PR DESCRIPTION
Same race as #13964 (kubectl): the charm plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_charm`. A `compinit` running concurrently (common with package-manager oh-my-zsh installs) could read the file mid-write and cache it without its `#compdef` line, leaving charm without completions.

Now writes to a temp file and `mv`s it into place atomically, so concurrent compinit runs either see the previous complete file or the new one — never a partial one.
