### PR TITLE
fix(codex): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/codex/codex.plugin.zsh
+++ b/plugins/codex/codex.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_codex" ]]; then
   _comps[codex]=_codex
 fi
 
-codex completion zsh < /dev/null 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_codex" &|
+codex completion zsh < /dev/null 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_codex.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_codex.tmp.$$" "$ZSH_CACHE_DIR/completions/_codex" &|


### PR DESCRIPTION
Same race as #13964 (kubectl): the codex plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_codex`. A `compinit` running concurrently (common with package-manager oh-my-zsh installs) could read the file mid-write and cache it without its `#compdef` line, leaving codex without completions.

Now writes to a temp file and `mv`s it into place atomically, so concurrent compinit runs either see the previous complete file or the new one — never a partial one.
