### PR TITLE
fix(arduino-cli): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/arduino-cli/arduino-cli.plugin.zsh
+++ b/plugins/arduino-cli/arduino-cli.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_arduino-cli" ]]; then
 fi
 
 # Generate and load arduino-cli completion
-arduino-cli completion zsh >! "$ZSH_CACHE_DIR/completions/_arduino-cli" &|
+arduino-cli completion zsh >! "$ZSH_CACHE_DIR/completions/_arduino-cli.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_arduino-cli.tmp.$$" "$ZSH_CACHE_DIR/completions/_arduino-cli" &|


### PR DESCRIPTION
Same race as #13964 (kubectl): the arduino-cli plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_arduino-cli`. A `compinit` running concurrently (common with package-manager oh-my-zsh installs) could read the file mid-write and cache it without its `#compdef` line, leaving arduino-cli without completions.

Now writes to a temp file and `mv`s it into place atomically, so concurrent compinit runs either see the previous complete file or the new one — never a partial one.
