### PR TITLE
fix(fluxcd): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/fluxcd/fluxcd.plugin.zsh
+++ b/plugins/fluxcd/fluxcd.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_flux" ]]; then
   _comps[flux]=_flux
 fi
 
-flux completion zsh >| "$ZSH_CACHE_DIR/completions/_flux" &|
+flux completion zsh >| "$ZSH_CACHE_DIR/completions/_flux.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_flux.tmp.$$" "$ZSH_CACHE_DIR/completions/_flux" &|


### PR DESCRIPTION
Same race as #13964 (kubectl): the flux plugin generated completions in the background directly into `$ZSH_CACHE_DIR/completions/_flux` (plugin `fluxcd`). A `compinit` running concurrently (common with package-manager oh-my-zsh installs) could read the file mid-write and cache it without its `#compdef` line, leaving flux without completions.

Now writes to a temp file and `mv`s it into place atomically, so concurrent compinit runs either see the previous complete file or the new one — never a partial one.
