### PR TITLE
fix(gh): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/gh/gh.plugin.zsh
+++ b/plugins/gh/gh.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_gh" ]]; then
   _comps[gh]=_gh
 fi
 
-gh completion --shell zsh >| "$ZSH_CACHE_DIR/completions/_gh" &|
+gh completion --shell zsh >| "$ZSH_CACHE_DIR/completions/_gh.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_gh.tmp.$$" "$ZSH_CACHE_DIR/completions/_gh" &|


### PR DESCRIPTION
fix(gh): avoid racing compinit with async completion generation

The gh plugin generated completions in the background directly into
$ZSH_CACHE_DIR/completions/_gh. A compinit running after the
plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave gh without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
