### PR TITLE
fix(minikube): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/minikube/minikube.plugin.zsh
+++ b/plugins/minikube/minikube.plugin.zsh
@@ -10,4 +10,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_minikube" ]]; then
   _comps[minikube]=_minikube
 fi
 
-minikube completion zsh >| "$ZSH_CACHE_DIR/completions/_minikube" &|
+minikube completion zsh >| "$ZSH_CACHE_DIR/completions/_minikube.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_minikube.tmp.$$" "$ZSH_CACHE_DIR/completions/_minikube" &|


### PR DESCRIPTION
fix(minikube): avoid racing compinit with async completion generation

The minikube plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_minikube. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave minikube without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
