### PR TITLE
fix(pulumi): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/pulumi/pulumi.plugin.zsh
+++ b/plugins/pulumi/pulumi.plugin.zsh
@@ -10,7 +10,7 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_pulumi" ]]; then
   _comps[pulumi]=_pulumi
 fi
 
-pulumi gen-completion zsh >| "$ZSH_CACHE_DIR/completions/_pulumi" &|
+pulumi gen-completion zsh >| "$ZSH_CACHE_DIR/completions/_pulumi.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_pulumi.tmp.$$" "$ZSH_CACHE_DIR/completions/_pulumi" &|
 
 # Aliases
 alias pul='pulumi'


### PR DESCRIPTION
fix(pulumi): avoid racing compinit with async completion generation

The pulumi plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_pulumi. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave pulumi without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
