### PR TITLE
fix(mise): activate using `~/.local/bin/mise`

### DIFF
--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -1,9 +1,9 @@
-if (( ! $+commands[mise] )); then
+if [[ ! -x ~/.local/bin/mise ]]; then
   return
 fi
 
 # Load mise hooks
-eval "$(mise activate zsh)"
+eval "$(~/.local/bin/mise activate zsh)"
 
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `mise`. Otherwise, compinit will have already done that.

--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -1,4 +1,3 @@
-local _mise_bin
 if (( $+commands[mise] )); then
   _mise_bin=mise
 elif [[ -x ~/.local/bin/mise ]]; then
@@ -9,6 +8,7 @@ fi
 
 # Load mise hooks
 eval "$($_mise_bin activate zsh)"
+unset _mise_bin
 
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `mise`. Otherwise, compinit will have already done that.

--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -1,9 +1,14 @@
-if [[ ! -x ~/.local/bin/mise ]]; then
+local _mise_bin
+if (( $+commands[mise] )); then
+  _mise_bin=mise
+elif [[ -x ~/.local/bin/mise ]]; then
+  _mise_bin=~/.local/bin/mise
+else
   return
 fi
 
 # Load mise hooks
-eval "$(~/.local/bin/mise activate zsh)"
+eval "$($_mise activate zsh)"
 
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `mise`. Otherwise, compinit will have already done that.

--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -8,7 +8,7 @@ else
 fi
 
 # Load mise hooks
-eval "$($_mise activate zsh)"
+eval "$($_mise_bin activate zsh)"
 
 # If the completion file doesn't exist yet, we need to autoload it and
 # bind it to `mise`. Otherwise, compinit will have already done that.


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Instead of expecting `mise` command to exist, follows the official guide to activate it: https://mise.jdx.dev/getting-started.html#activate-mise:

> `echo 'eval "$(~/.local/bin/mise activate zsh)"' >> ~/.zshrc`