### PR TITLE
fix(bun): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/bun/bun.plugin.zsh
+++ b/plugins/bun/bun.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_bun" ]]; then
   _comps[bun]=_bun
 fi
 
-SHELL=zsh bun completions >| "$ZSH_CACHE_DIR/completions/_bun" &|
+SHELL=zsh bun completions >| "$ZSH_CACHE_DIR/completions/_bun.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_bun.tmp.$$" "$ZSH_CACHE_DIR/completions/_bun" &|


### PR DESCRIPTION
fix(bun): avoid racing compinit with async completion generation

The bun plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_bun. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave bun without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
