### PR TITLE
fix(deno): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/deno/deno.plugin.zsh
+++ b/plugins/deno/deno.plugin.zsh
@@ -25,4 +25,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_deno" ]]; then
   _comps[deno]=_deno
 fi
 
-deno completions zsh >| "$ZSH_CACHE_DIR/completions/_deno" &|
+deno completions zsh >| "$ZSH_CACHE_DIR/completions/_deno.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_deno.tmp.$$" "$ZSH_CACHE_DIR/completions/_deno" &|


### PR DESCRIPTION
fix(deno): avoid racing compinit with async completion generation

The deno plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_deno. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave deno without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
