### PR TITLE
fix(flutter): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/flutter/flutter.plugin.zsh
+++ b/plugins/flutter/flutter.plugin.zsh
@@ -30,4 +30,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_flutter" ]]; then
   _comps[flutter]=_flutter
 fi
 
-flutter zsh-completion < /dev/null >| "$ZSH_CACHE_DIR/completions/_flutter" &|
+flutter zsh-completion < /dev/null >| "$ZSH_CACHE_DIR/completions/_flutter.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_flutter.tmp.$$" "$ZSH_CACHE_DIR/completions/_flutter" &|


### PR DESCRIPTION
fix(flutter): avoid racing compinit with async completion generation

The flutter plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_flutter. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave flutter without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
