### PR TITLE
fix(fnm): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/fnm/fnm.plugin.zsh
+++ b/plugins/fnm/fnm.plugin.zsh
@@ -10,7 +10,7 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_fnm" ]]; then
   _comps[fnm]=_fnm
 fi
 
-fnm completions --shell=zsh >| "$ZSH_CACHE_DIR/completions/_fnm" &|
+fnm completions --shell=zsh >| "$ZSH_CACHE_DIR/completions/_fnm.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_fnm.tmp.$$" "$ZSH_CACHE_DIR/completions/_fnm" &|
 
 if zstyle -t ':omz:plugins:fnm' autostart; then
   local -a fnm_env_cmd


### PR DESCRIPTION
fix(fnm): avoid racing compinit with async completion generation

The fnm plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_fnm. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave fnm without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
