### PR TITLE
fix(jj): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/jj/jj.plugin.zsh
+++ b/plugins/jj/jj.plugin.zsh
@@ -11,7 +11,7 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_jj" ]]; then
   _comps[jj]=_jj
 fi
 
-COMPLETE=zsh jj >| "$ZSH_CACHE_DIR/completions/_jj" &|
+COMPLETE=zsh jj >| "$ZSH_CACHE_DIR/completions/_jj.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_jj.tmp.$$" "$ZSH_CACHE_DIR/completions/_jj" &|
 
 function __jj_prompt_jj() {
   local -a flags


### PR DESCRIPTION
fix(jj): avoid racing compinit with async completion generation

The jj plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_jj. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave jj without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
