### PR TITLE
fix(k9s): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/k9s/k9s.plugin.zsh
+++ b/plugins/k9s/k9s.plugin.zsh
@@ -11,4 +11,4 @@ fi
 
 # and then generate it in the background. On first completion,
 # the actual completion file will be loaded.
-k9s completion zsh >| "$ZSH_CACHE_DIR/completions/_k9s" &|
+k9s completion zsh >| "$ZSH_CACHE_DIR/completions/_k9s.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_k9s.tmp.$$" "$ZSH_CACHE_DIR/completions/_k9s" &|


### PR DESCRIPTION
fix(k9s): avoid racing compinit with async completion generation

The k9s plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_k9s. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave k9s without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
