### PR TITLE
fix(mise): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -14,4 +14,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_mise" ]]; then
 fi
 
 # Generate and load mise completion
-mise completion zsh >| "$ZSH_CACHE_DIR/completions/_mise" &|
+mise completion zsh >| "$ZSH_CACHE_DIR/completions/_mise.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_mise.tmp.$$" "$ZSH_CACHE_DIR/completions/_mise" &|


### PR DESCRIPTION
fix(mise): avoid racing compinit with async completion generation

The mise plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_mise. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave mise without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
