### PR TITLE
fix(molecule): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/molecule/molecule.plugin.zsh
+++ b/plugins/molecule/molecule.plugin.zsh
@@ -11,7 +11,7 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_molecule" ]]; then
   _comps[molecule]=_molecule
 fi
 
-_MOLECULE_COMPLETE=zsh_source molecule >| "$ZSH_CACHE_DIR/completions/_molecule" &|
+_MOLECULE_COMPLETE=zsh_source molecule >| "$ZSH_CACHE_DIR/completions/_molecule.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_molecule.tmp.$$" "$ZSH_CACHE_DIR/completions/_molecule" &|
 
 # Alias
 # molecule: https://docs.ansible.com/projects/molecule/


### PR DESCRIPTION
fix(molecule): avoid racing compinit with async completion generation

The molecule plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_molecule. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave molecule without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
