### PR TITLE
fix(ngrok): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/ngrok/ngrok.plugin.zsh
+++ b/plugins/ngrok/ngrok.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_ngrok" ]]; then
   _comps[ngrok]=_ngrok
 fi
 
-ngrok completion zsh >| "$ZSH_CACHE_DIR/completions/_ngrok" &|
+ngrok completion zsh >| "$ZSH_CACHE_DIR/completions/_ngrok.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_ngrok.tmp.$$" "$ZSH_CACHE_DIR/completions/_ngrok" &|


### PR DESCRIPTION
fix(ngrok): avoid racing compinit with async completion generation

The ngrok plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_ngrok. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave ngrok without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
