### PR TITLE
fix(rclone): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/rclone/rclone.plugin.zsh
+++ b/plugins/rclone/rclone.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_rclone" ]]; then
   _comps[rclone]=_rclone
 fi
 
-rclone completion zsh - >| "$ZSH_CACHE_DIR/completions/_rclone" &|
+rclone completion zsh - >| "$ZSH_CACHE_DIR/completions/_rclone.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_rclone.tmp.$$" "$ZSH_CACHE_DIR/completions/_rclone" &|


### PR DESCRIPTION
fix(rclone): avoid racing compinit with async completion generation

The rclone plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_rclone. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave rclone without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
