### PR TITLE
fix(hasura): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/hasura/hasura.plugin.zsh
+++ b/plugins/hasura/hasura.plugin.zsh
@@ -9,5 +9,5 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_hasura" ]]; then
   source "$ZSH_CACHE_DIR/completions/_hasura"
 else
   source "$ZSH_CACHE_DIR/completions/_hasura"
-  hasura completion zsh --file "$ZSH_CACHE_DIR/completions/_hasura" >/dev/null &|
+  hasura completion zsh --file "$ZSH_CACHE_DIR/completions/_hasura.tmp.$$" >/dev/null && mv -f "$ZSH_CACHE_DIR/completions/_hasura.tmp.$$" "$ZSH_CACHE_DIR/completions/_hasura" &|
 fi


### PR DESCRIPTION
fix(hasura): avoid racing compinit with async completion generation

The hasura plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_hasura. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave hasura without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
