### PR TITLE
fix(hcloud): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/hcloud/hcloud.plugin.zsh
+++ b/plugins/hcloud/hcloud.plugin.zsh
@@ -13,7 +13,7 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_hcloud" ]]; then
   _comps[hcloud]=_hcloud
 fi
 
-hcloud completion zsh 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_hcloud" &|
+hcloud completion zsh 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_hcloud.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_hcloud.tmp.$$" "$ZSH_CACHE_DIR/completions/_hcloud" &|
 
 # Main alias
 alias hc='hcloud'


### PR DESCRIPTION
fix(hcloud): avoid racing compinit with async completion generation

The hcloud plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_hcloud. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave hcloud without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
