### PR TITLE
fix(tailscale): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/tailscale/tailscale.plugin.zsh
+++ b/plugins/tailscale/tailscale.plugin.zsh
@@ -22,4 +22,4 @@ if (( $+aliases[tailscale] )); then
   _comps[${aliases[tailscale]:t}]=_tailscale
 fi
 
-tailscale completion zsh >| "$ZSH_CACHE_DIR/completions/_tailscale" &|
+tailscale completion zsh >| "$ZSH_CACHE_DIR/completions/_tailscale.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_tailscale.tmp.$$" "$ZSH_CACHE_DIR/completions/_tailscale" &|


### PR DESCRIPTION
fix(tailscale): avoid racing compinit with async completion generation

The tailscale plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_tailscale. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave tailscale without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
