### PR TITLE
fix(task): avoid racing compinit with async completion generation

### DIFF
--- a/plugins/task/task.plugin.zsh
+++ b/plugins/task/task.plugin.zsh
@@ -11,4 +11,4 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_task" ]]; then
 fi
 
 # Generate and load task completion
-task --completion zsh >! "$ZSH_CACHE_DIR/completions/_task" &|
+task --completion zsh >! "$ZSH_CACHE_DIR/completions/_task.tmp.$$" && mv -f "$ZSH_CACHE_DIR/completions/_task.tmp.$$" "$ZSH_CACHE_DIR/completions/_task" &|


### PR DESCRIPTION
fix(task): avoid racing compinit with async completion generation

The task plugin generated completions in the background directly
into $ZSH_CACHE_DIR/completions/_task. A compinit running after
the plugin loads (common with package-manager installs like antidote,
zinit, etc.) could read the file mid-write, cache it without its
#compdef line, and leave task without completions.

The generation now writes to a temp file and mv's it into place
atomically, so concurrent compinit runs either see the previous
complete file or the new one — never a partial one.
