### PR TITLE
fix: load completion files atomically

### DIFF
--- a/plugins/1password/1password.plugin.zsh
+++ b/plugins/1password/1password.plugin.zsh
@@ -11,7 +11,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_op" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   op completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/1password/1password.plugin.zsh
+++ b/plugins/1password/1password.plugin.zsh
@@ -9,11 +9,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_op" ]]; then
   _comps[op]=_op
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_op" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  op completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_op"
+  zf_mv -f -- =( op completion zsh ) "$TMPPREFIX"
 } &|
 
 # Load opswd function

--- a/plugins/1password/1password.plugin.zsh
+++ b/plugins/1password/1password.plugin.zsh
@@ -9,7 +9,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_op" ]]; then
   _comps[op]=_op
 fi
 
-op completion zsh >| "$ZSH_CACHE_DIR/completions/_op" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_op" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  op completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
 
 # Load opswd function
 autoload -Uz opswd

--- a/plugins/arduino-cli/arduino-cli.plugin.zsh
+++ b/plugins/arduino-cli/arduino-cli.plugin.zsh
@@ -13,7 +13,7 @@ fi
 # Generate and load arduino-cli completion
 {
   local completion="$ZSH_CACHE_DIR/completions/_arduino-cli" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   arduino-cli completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/arduino-cli/arduino-cli.plugin.zsh
+++ b/plugins/arduino-cli/arduino-cli.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_arduino-cli" ]]; then
 fi
 
 # Generate and load arduino-cli completion
-arduino-cli completion zsh >! "$ZSH_CACHE_DIR/completions/_arduino-cli" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_arduino-cli" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  arduino-cli completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/arduino-cli/arduino-cli.plugin.zsh
+++ b/plugins/arduino-cli/arduino-cli.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_arduino-cli" ]]; then
 fi
 
 # Generate and load arduino-cli completion
-{
-  local completion="$ZSH_CACHE_DIR/completions/_arduino-cli" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  arduino-cli completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_arduino-cli"
+  zf_mv -f -- =( arduino-cli completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/argocd/argocd.plugin.zsh
+++ b/plugins/argocd/argocd.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_argocd" ]]; then
   _comps[argocd]=_argocd
 fi
 
-argocd completion zsh >| "$ZSH_CACHE_DIR/completions/_argocd" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_argocd" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  argocd completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/argocd/argocd.plugin.zsh
+++ b/plugins/argocd/argocd.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_argocd" ]]; then
   _comps[argocd]=_argocd
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_argocd" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  argocd completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_argocd"
+  zf_mv -f -- =( argocd completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/argocd/argocd.plugin.zsh
+++ b/plugins/argocd/argocd.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_argocd" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   argocd completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -12,9 +12,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_asdf" ]]; then
   autoload -Uz _asdf
   _comps[asdf]=_asdf
 fi
-{
-  local completion="$ZSH_CACHE_DIR/completions/_asdf" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  asdf completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_asdf"
+  zf_mv -f -- =( asdf completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -12,4 +12,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_asdf" ]]; then
   autoload -Uz _asdf
   _comps[asdf]=_asdf
 fi
-asdf completion zsh >| "$ZSH_CACHE_DIR/completions/_asdf" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_asdf" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  asdf completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/asdf/asdf.plugin.zsh
+++ b/plugins/asdf/asdf.plugin.zsh
@@ -14,7 +14,7 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_asdf" ]]; then
 fi
 {
   local completion="$ZSH_CACHE_DIR/completions/_asdf" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   asdf completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/buf/buf.plugin.zsh
+++ b/plugins/buf/buf.plugin.zsh
@@ -13,7 +13,7 @@ fi
 # Generate and load buf completion
 {
   local completion="$ZSH_CACHE_DIR/completions/_buf" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   buf completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/buf/buf.plugin.zsh
+++ b/plugins/buf/buf.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_buf" ]]; then
 fi
 
 # Generate and load buf completion
-buf completion zsh >! "$ZSH_CACHE_DIR/completions/_buf" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_buf" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  buf completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/buf/buf.plugin.zsh
+++ b/plugins/buf/buf.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_buf" ]]; then
 fi
 
 # Generate and load buf completion
-{
-  local completion="$ZSH_CACHE_DIR/completions/_buf" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  buf completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_buf"
+  zf_mv -f -- =( buf completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/bun/bun.plugin.zsh
+++ b/plugins/bun/bun.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_bun" ]]; then
   _comps[bun]=_bun
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_bun" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  SHELL=zsh bun completions >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_bun"
+  zf_mv -f -- =( SHELL=zsh bun completions ) "$TMPPREFIX"
 } &|

--- a/plugins/bun/bun.plugin.zsh
+++ b/plugins/bun/bun.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_bun" ]]; then
   _comps[bun]=_bun
 fi
 
-SHELL=zsh bun completions >| "$ZSH_CACHE_DIR/completions/_bun" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_bun" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  SHELL=zsh bun completions >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/bun/bun.plugin.zsh
+++ b/plugins/bun/bun.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_bun" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   SHELL=zsh bun completions >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/charm/charm.plugin.zsh
+++ b/plugins/charm/charm.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_charm" ]]; then
   _comps[charm]=_charm
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_charm" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  charm completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_charm"
+  zf_mv -f -- =( charm completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/charm/charm.plugin.zsh
+++ b/plugins/charm/charm.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_charm" ]]; then
   _comps[charm]=_charm
 fi
 
-charm completion zsh >| "$ZSH_CACHE_DIR/completions/_charm" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_charm" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  charm completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/charm/charm.plugin.zsh
+++ b/plugins/charm/charm.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_charm" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   charm completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/chezmoi/chezmoi.plugin.zsh
+++ b/plugins/chezmoi/chezmoi.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_chezmoi" ]]; then
   _comps[chezmoi]=_chezmoi
 fi
 
-chezmoi completion zsh >| "$ZSH_CACHE_DIR/completions/_chezmoi" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_chezmoi" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  chezmoi completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/chezmoi/chezmoi.plugin.zsh
+++ b/plugins/chezmoi/chezmoi.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_chezmoi" ]]; then
   _comps[chezmoi]=_chezmoi
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_chezmoi" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  chezmoi completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_chezmoi"
+  zf_mv -f -- =( chezmoi completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/chezmoi/chezmoi.plugin.zsh
+++ b/plugins/chezmoi/chezmoi.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_chezmoi" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   chezmoi completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/codex/codex.plugin.zsh
+++ b/plugins/codex/codex.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_codex" ]]; then
   _comps[codex]=_codex
 fi
 
-codex completion zsh < /dev/null 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_codex" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_codex" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  codex completion zsh < /dev/null 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/codex/codex.plugin.zsh
+++ b/plugins/codex/codex.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_codex" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   codex completion zsh < /dev/null 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/codex/codex.plugin.zsh
+++ b/plugins/codex/codex.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_codex" ]]; then
   _comps[codex]=_codex
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_codex" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  codex completion zsh < /dev/null 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_codex"
+  zf_mv -f -- =( codex completion zsh < /dev/null 2> /dev/null ) "$TMPPREFIX"
 } &|

--- a/plugins/deno/deno.plugin.zsh
+++ b/plugins/deno/deno.plugin.zsh
@@ -25,9 +25,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_deno" ]]; then
   _comps[deno]=_deno
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_deno" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  deno completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_deno"
+  zf_mv -f -- =( deno completions zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/deno/deno.plugin.zsh
+++ b/plugins/deno/deno.plugin.zsh
@@ -25,4 +25,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_deno" ]]; then
   _comps[deno]=_deno
 fi
 
-deno completions zsh >| "$ZSH_CACHE_DIR/completions/_deno" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_deno" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  deno completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/deno/deno.plugin.zsh
+++ b/plugins/deno/deno.plugin.zsh
@@ -27,7 +27,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_deno" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   deno completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -64,6 +64,9 @@ fi
     ! is-at-least 23.0.0 ${${(s:,:z)"$(command docker --version)"}[3]}; then
         command cp "${0:h}/completions/_docker" "$ZSH_CACHE_DIR/completions/_docker"
       else
-        command docker completion zsh | tee "$ZSH_CACHE_DIR/completions/_docker" > /dev/null
+        local completion="$ZSH_CACHE_DIR/completions/_docker" tmp
+        tmp=$(command mktemp "$completion.XXXXXX") || exit
+        command docker completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+        command rm -f "$tmp"
   fi
 } &|

--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -65,7 +65,7 @@ fi
         command cp "${0:h}/completions/_docker" "$ZSH_CACHE_DIR/completions/_docker"
       else
         local completion="$ZSH_CACHE_DIR/completions/_docker" tmp
-        tmp=$(command mktemp "$completion.XXXXXX") || exit
+        tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
         command docker completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
         command rm -f "$tmp"
   fi

--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -56,7 +56,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_docker" ]]; then
   _comps[docker]=_docker
 fi
 
-{
+zmodload -F zsh/files b:zf_mv
+() {
   # `docker completion` is only available from 23.0.0 on
   # docker version returns `Docker version 24.0.2, build cb74dfcd85`
   # with `s:,:` remove the comma after the version, and select third word of it
@@ -64,9 +65,7 @@ fi
     ! is-at-least 23.0.0 ${${(s:,:z)"$(command docker --version)"}[3]}; then
         command cp "${0:h}/completions/_docker" "$ZSH_CACHE_DIR/completions/_docker"
       else
-        local completion="$ZSH_CACHE_DIR/completions/_docker" tmp
-        tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-        command docker completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-        command rm -f "$tmp"
+        local TMPPREFIX="$ZSH_CACHE_DIR/completions/_docker"
+        zf_mv -f -- =( command docker completion zsh ) "$TMPPREFIX"
   fi
 } &|

--- a/plugins/doctl/doctl.plugin.zsh
+++ b/plugins/doctl/doctl.plugin.zsh
@@ -14,9 +14,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_doctl" ]]; then
   _comps[doctl]=_doctl
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_doctl" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  doctl completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_doctl"
+  zf_mv -f -- =( doctl completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/doctl/doctl.plugin.zsh
+++ b/plugins/doctl/doctl.plugin.zsh
@@ -14,4 +14,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_doctl" ]]; then
   _comps[doctl]=_doctl
 fi
 
-doctl completion zsh >| "$ZSH_CACHE_DIR/completions/_doctl" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_doctl" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  doctl completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/doctl/doctl.plugin.zsh
+++ b/plugins/doctl/doctl.plugin.zsh
@@ -16,7 +16,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_doctl" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   doctl completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/flutter/flutter.plugin.zsh
+++ b/plugins/flutter/flutter.plugin.zsh
@@ -30,4 +30,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_flutter" ]]; then
   _comps[flutter]=_flutter
 fi
 
-flutter zsh-completion < /dev/null >| "$ZSH_CACHE_DIR/completions/_flutter" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_flutter" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  flutter zsh-completion < /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/flutter/flutter.plugin.zsh
+++ b/plugins/flutter/flutter.plugin.zsh
@@ -30,9 +30,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_flutter" ]]; then
   _comps[flutter]=_flutter
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_flutter" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  flutter zsh-completion < /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_flutter"
+  zf_mv -f -- =( flutter zsh-completion < /dev/null ) "$TMPPREFIX"
 } &|

--- a/plugins/flutter/flutter.plugin.zsh
+++ b/plugins/flutter/flutter.plugin.zsh
@@ -32,7 +32,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_flutter" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   flutter zsh-completion < /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/fluxcd/fluxcd.plugin.zsh
+++ b/plugins/fluxcd/fluxcd.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_flux" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   flux completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/fluxcd/fluxcd.plugin.zsh
+++ b/plugins/fluxcd/fluxcd.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_flux" ]]; then
   _comps[flux]=_flux
 fi
 
-flux completion zsh >| "$ZSH_CACHE_DIR/completions/_flux" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_flux" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  flux completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/fluxcd/fluxcd.plugin.zsh
+++ b/plugins/fluxcd/fluxcd.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_flux" ]]; then
   _comps[flux]=_flux
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_flux" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  flux completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_flux"
+  zf_mv -f -- =( flux completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/fnm/fnm.plugin.zsh
+++ b/plugins/fnm/fnm.plugin.zsh
@@ -10,11 +10,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_fnm" ]]; then
   _comps[fnm]=_fnm
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_fnm" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  fnm completions --shell=zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_fnm"
+  zf_mv -f -- =( fnm completions --shell=zsh ) "$TMPPREFIX"
 } &|
 
 if zstyle -t ':omz:plugins:fnm' autostart; then

--- a/plugins/fnm/fnm.plugin.zsh
+++ b/plugins/fnm/fnm.plugin.zsh
@@ -12,7 +12,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_fnm" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   fnm completions --shell=zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/fnm/fnm.plugin.zsh
+++ b/plugins/fnm/fnm.plugin.zsh
@@ -10,7 +10,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_fnm" ]]; then
   _comps[fnm]=_fnm
 fi
 
-fnm completions --shell=zsh >| "$ZSH_CACHE_DIR/completions/_fnm" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_fnm" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  fnm completions --shell=zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
 
 if zstyle -t ':omz:plugins:fnm' autostart; then
   local -a fnm_env_cmd

--- a/plugins/gh/gh.plugin.zsh
+++ b/plugins/gh/gh.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_gh" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   gh completion --shell zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/gh/gh.plugin.zsh
+++ b/plugins/gh/gh.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_gh" ]]; then
   _comps[gh]=_gh
 fi
 
-gh completion --shell zsh >| "$ZSH_CACHE_DIR/completions/_gh" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_gh" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  gh completion --shell zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/gh/gh.plugin.zsh
+++ b/plugins/gh/gh.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_gh" ]]; then
   _comps[gh]=_gh
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_gh" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  gh completion --shell zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_gh"
+  zf_mv -f -- =( gh completion --shell zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/hasura/hasura.plugin.zsh
+++ b/plugins/hasura/hasura.plugin.zsh
@@ -9,5 +9,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_hasura" ]]; then
   source "$ZSH_CACHE_DIR/completions/_hasura"
 else
   source "$ZSH_CACHE_DIR/completions/_hasura"
-  hasura completion zsh --file "$ZSH_CACHE_DIR/completions/_hasura" >/dev/null &|
+  {
+    local completion="$ZSH_CACHE_DIR/completions/_hasura" tmp
+    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    hasura completion zsh --file "$tmp" >/dev/null && command mv -f "$tmp" "$completion"
+    command rm -f "$tmp"
+  } &|
 fi

--- a/plugins/hasura/hasura.plugin.zsh
+++ b/plugins/hasura/hasura.plugin.zsh
@@ -9,10 +9,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_hasura" ]]; then
   source "$ZSH_CACHE_DIR/completions/_hasura"
 else
   source "$ZSH_CACHE_DIR/completions/_hasura"
-  {
-    local completion="$ZSH_CACHE_DIR/completions/_hasura" tmp
-    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-    hasura completion zsh --file "$tmp" >/dev/null && command mv -f "$tmp" "$completion"
-    command rm -f "$tmp"
+  zmodload -F zsh/files b:zf_mv
+  () {
+    local TMPPREFIX="$ZSH_CACHE_DIR/completions/_hasura"
+    zf_mv -f -- =( hasura completion zsh ) "$TMPPREFIX"
   } &|
 fi

--- a/plugins/hasura/hasura.plugin.zsh
+++ b/plugins/hasura/hasura.plugin.zsh
@@ -11,7 +11,7 @@ else
   source "$ZSH_CACHE_DIR/completions/_hasura"
   {
     local completion="$ZSH_CACHE_DIR/completions/_hasura" tmp
-    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
     hasura completion zsh --file "$tmp" >/dev/null && command mv -f "$tmp" "$completion"
     command rm -f "$tmp"
   } &|

--- a/plugins/hcloud/hcloud.plugin.zsh
+++ b/plugins/hcloud/hcloud.plugin.zsh
@@ -15,7 +15,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_hcloud" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   hcloud completion zsh 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/hcloud/hcloud.plugin.zsh
+++ b/plugins/hcloud/hcloud.plugin.zsh
@@ -13,11 +13,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_hcloud" ]]; then
   _comps[hcloud]=_hcloud
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_hcloud" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  hcloud completion zsh 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_hcloud"
+  zf_mv -f -- =( hcloud completion zsh 2> /dev/null ) "$TMPPREFIX"
 } &|
 
 # Main alias

--- a/plugins/hcloud/hcloud.plugin.zsh
+++ b/plugins/hcloud/hcloud.plugin.zsh
@@ -13,7 +13,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_hcloud" ]]; then
   _comps[hcloud]=_hcloud
 fi
 
-hcloud completion zsh 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_hcloud" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_hcloud" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  hcloud completion zsh 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
 
 # Main alias
 alias hc='hcloud'

--- a/plugins/helm/helm.plugin.zsh
+++ b/plugins/helm/helm.plugin.zsh
@@ -9,7 +9,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_helm" ]]; then
   source "$ZSH_CACHE_DIR/completions/_helm"
 else
   source "$ZSH_CACHE_DIR/completions/_helm"
-  helm completion zsh | tee "$ZSH_CACHE_DIR/completions/_helm" >/dev/null &|
+  {
+    local completion="$ZSH_CACHE_DIR/completions/_helm" tmp
+    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    helm completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+    command rm -f "$tmp"
+  } &|
 fi
 
 alias h='helm'

--- a/plugins/helm/helm.plugin.zsh
+++ b/plugins/helm/helm.plugin.zsh
@@ -11,7 +11,7 @@ else
   source "$ZSH_CACHE_DIR/completions/_helm"
   {
     local completion="$ZSH_CACHE_DIR/completions/_helm" tmp
-    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
     helm completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
     command rm -f "$tmp"
   } &|

--- a/plugins/helm/helm.plugin.zsh
+++ b/plugins/helm/helm.plugin.zsh
@@ -9,11 +9,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_helm" ]]; then
   source "$ZSH_CACHE_DIR/completions/_helm"
 else
   source "$ZSH_CACHE_DIR/completions/_helm"
-  {
-    local completion="$ZSH_CACHE_DIR/completions/_helm" tmp
-    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-    helm completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-    command rm -f "$tmp"
+  zmodload -F zsh/files b:zf_mv
+  () {
+    local TMPPREFIX="$ZSH_CACHE_DIR/completions/_helm"
+    zf_mv -f -- =( helm completion zsh ) "$TMPPREFIX"
   } &|
 fi
 

--- a/plugins/jj/jj.plugin.zsh
+++ b/plugins/jj/jj.plugin.zsh
@@ -11,11 +11,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_jj" ]]; then
   _comps[jj]=_jj
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_jj" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  COMPLETE=zsh jj >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_jj"
+  zf_mv -f -- =( COMPLETE=zsh jj ) "$TMPPREFIX"
 } &|
 
 function __jj_prompt_jj() {

--- a/plugins/jj/jj.plugin.zsh
+++ b/plugins/jj/jj.plugin.zsh
@@ -11,7 +11,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_jj" ]]; then
   _comps[jj]=_jj
 fi
 
-COMPLETE=zsh jj >| "$ZSH_CACHE_DIR/completions/_jj" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_jj" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  COMPLETE=zsh jj >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
 
 function __jj_prompt_jj() {
   local -a flags
@@ -72,4 +77,3 @@ alias jjsq='jj squash'
 alias jjst='jj status'
 alias jjwa='jj workspace add'
 alias jjwf='jj workspace forget'
-

--- a/plugins/jj/jj.plugin.zsh
+++ b/plugins/jj/jj.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_jj" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   COMPLETE=zsh jj >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/k9s/k9s.plugin.zsh
+++ b/plugins/k9s/k9s.plugin.zsh
@@ -11,4 +11,9 @@ fi
 
 # and then generate it in the background. On first completion,
 # the actual completion file will be loaded.
-k9s completion zsh >| "$ZSH_CACHE_DIR/completions/_k9s" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_k9s" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  k9s completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/k9s/k9s.plugin.zsh
+++ b/plugins/k9s/k9s.plugin.zsh
@@ -11,9 +11,8 @@ fi
 
 # and then generate it in the background. On first completion,
 # the actual completion file will be loaded.
-{
-  local completion="$ZSH_CACHE_DIR/completions/_k9s" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  k9s completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_k9s"
+  zf_mv -f -- =( k9s completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/k9s/k9s.plugin.zsh
+++ b/plugins/k9s/k9s.plugin.zsh
@@ -13,7 +13,7 @@ fi
 # the actual completion file will be loaded.
 {
   local completion="$ZSH_CACHE_DIR/completions/_k9s" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   k9s completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/kind/kind.plugin.zsh
+++ b/plugins/kind/kind.plugin.zsh
@@ -11,11 +11,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_kind" ]]; then
 fi
 
 # Generate and load kind completion
-{
-  local completion="$ZSH_CACHE_DIR/completions/_kind" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  kind completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_kind"
+  zf_mv -f -- =( kind completion zsh ) "$TMPPREFIX"
 } &|
 
 # Register aliases

--- a/plugins/kind/kind.plugin.zsh
+++ b/plugins/kind/kind.plugin.zsh
@@ -11,7 +11,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_kind" ]]; then
 fi
 
 # Generate and load kind completion
-kind completion zsh >! "$ZSH_CACHE_DIR/completions/_kind" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_kind" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  kind completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
 
 # Register aliases
 alias kicc="kind create cluster"

--- a/plugins/kind/kind.plugin.zsh
+++ b/plugins/kind/kind.plugin.zsh
@@ -13,7 +13,7 @@ fi
 # Generate and load kind completion
 {
   local completion="$ZSH_CACHE_DIR/completions/_kind" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   kind completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -10,11 +10,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_kubectl" ]]; then
   _comps[kubectl]=_kubectl
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_kubectl" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  kubectl completion zsh 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_kubectl"
+  zf_mv -f -- =( kubectl completion zsh 2> /dev/null ) "$TMPPREFIX"
 } &|
 
 # This command is used a LOT both below and in daily life

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -12,7 +12,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_kubectl" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   kubectl completion zsh 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -10,7 +10,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_kubectl" ]]; then
   _comps[kubectl]=_kubectl
 fi
 
-kubectl completion zsh 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_kubectl" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_kubectl" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  kubectl completion zsh 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
 
 # This command is used a LOT both below and in daily life
 alias k=kubectl

--- a/plugins/minikube/minikube.plugin.zsh
+++ b/plugins/minikube/minikube.plugin.zsh
@@ -12,7 +12,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_minikube" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   minikube completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/minikube/minikube.plugin.zsh
+++ b/plugins/minikube/minikube.plugin.zsh
@@ -10,9 +10,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_minikube" ]]; then
   _comps[minikube]=_minikube
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_minikube" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  minikube completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_minikube"
+  zf_mv -f -- =( minikube completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/minikube/minikube.plugin.zsh
+++ b/plugins/minikube/minikube.plugin.zsh
@@ -10,4 +10,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_minikube" ]]; then
   _comps[minikube]=_minikube
 fi
 
-minikube completion zsh >| "$ZSH_CACHE_DIR/completions/_minikube" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_minikube" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  minikube completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -14,4 +14,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_mise" ]]; then
 fi
 
 # Generate and load mise completion
-mise completion zsh >| "$ZSH_CACHE_DIR/completions/_mise" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_mise" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  mise completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -16,7 +16,7 @@ fi
 # Generate and load mise completion
 {
   local completion="$ZSH_CACHE_DIR/completions/_mise" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   mise completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/mise/mise.plugin.zsh
+++ b/plugins/mise/mise.plugin.zsh
@@ -14,9 +14,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_mise" ]]; then
 fi
 
 # Generate and load mise completion
-{
-  local completion="$ZSH_CACHE_DIR/completions/_mise" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  mise completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_mise"
+  zf_mv -f -- =( mise completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/molecule/molecule.plugin.zsh
+++ b/plugins/molecule/molecule.plugin.zsh
@@ -11,7 +11,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_molecule" ]]; then
   _comps[molecule]=_molecule
 fi
 
-_MOLECULE_COMPLETE=zsh_source molecule >| "$ZSH_CACHE_DIR/completions/_molecule" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_molecule" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  _MOLECULE_COMPLETE=zsh_source molecule >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
 
 # Alias
 # molecule: https://docs.ansible.com/projects/molecule/

--- a/plugins/molecule/molecule.plugin.zsh
+++ b/plugins/molecule/molecule.plugin.zsh
@@ -11,11 +11,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_molecule" ]]; then
   _comps[molecule]=_molecule
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_molecule" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  _MOLECULE_COMPLETE=zsh_source molecule >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_molecule"
+  zf_mv -f -- =( _MOLECULE_COMPLETE=zsh_source molecule ) "$TMPPREFIX"
 } &|
 
 # Alias

--- a/plugins/molecule/molecule.plugin.zsh
+++ b/plugins/molecule/molecule.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_molecule" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   _MOLECULE_COMPLETE=zsh_source molecule >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/mongo-atlas/mongo-atlas.plugin.zsh
+++ b/plugins/mongo-atlas/mongo-atlas.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_atlas" ]]; then
   _comps[atlas]=_atlas
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_atlas" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  atlas completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_atlas"
+  zf_mv -f -- =( atlas completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/mongo-atlas/mongo-atlas.plugin.zsh
+++ b/plugins/mongo-atlas/mongo-atlas.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_atlas" ]]; then
   _comps[atlas]=_atlas
 fi
 
-atlas completion zsh >| "$ZSH_CACHE_DIR/completions/atlas" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_atlas" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  atlas completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/mongo-atlas/mongo-atlas.plugin.zsh
+++ b/plugins/mongo-atlas/mongo-atlas.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_atlas" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   atlas completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/nats/nats.plugin.zsh
+++ b/plugins/nats/nats.plugin.zsh
@@ -9,7 +9,7 @@ if (( $+commands[nsc] )); then
 
   {
     local completion="$ZSH_CACHE_DIR/completions/_nsc" tmp
-    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
     nsc completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
     command rm -f "$tmp"
   } &|
@@ -26,7 +26,7 @@ if (( $+commands[nats] )); then
 
   {
     local completion="$ZSH_CACHE_DIR/completions/_nats" tmp
-    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
     nats --completion-script-zsh >| "$tmp" && command mv -f "$tmp" "$completion"
     command rm -f "$tmp"
   } &|

--- a/plugins/nats/nats.plugin.zsh
+++ b/plugins/nats/nats.plugin.zsh
@@ -7,11 +7,10 @@ if (( $+commands[nsc] )); then
     _comps[nsc]=_nsc
   fi
 
-  {
-    local completion="$ZSH_CACHE_DIR/completions/_nsc" tmp
-    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-    nsc completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-    command rm -f "$tmp"
+  zmodload -F zsh/files b:zf_mv
+  () {
+    local TMPPREFIX="$ZSH_CACHE_DIR/completions/_nsc"
+    zf_mv -f -- =( nsc completion zsh ) "$TMPPREFIX"
   } &|
 fi
 
@@ -24,10 +23,9 @@ if (( $+commands[nats] )); then
     _comps[nats]=_nats
   fi
 
-  {
-    local completion="$ZSH_CACHE_DIR/completions/_nats" tmp
-    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-    nats --completion-script-zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-    command rm -f "$tmp"
+  zmodload -F zsh/files b:zf_mv
+  () {
+    local TMPPREFIX="$ZSH_CACHE_DIR/completions/_nats"
+    zf_mv -f -- =( nats --completion-script-zsh ) "$TMPPREFIX"
   } &|
 fi

--- a/plugins/nats/nats.plugin.zsh
+++ b/plugins/nats/nats.plugin.zsh
@@ -7,7 +7,12 @@ if (( $+commands[nsc] )); then
     _comps[nsc]=_nsc
   fi
 
-  nsc completion zsh >| "$ZSH_CACHE_DIR/completions/_nsc" &|
+  {
+    local completion="$ZSH_CACHE_DIR/completions/_nsc" tmp
+    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    nsc completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+    command rm -f "$tmp"
+  } &|
 fi
 
 if (( $+commands[nats] )); then
@@ -19,5 +24,10 @@ if (( $+commands[nats] )); then
     _comps[nats]=_nats
   fi
 
-  nats --completion-script-zsh >| "$ZSH_CACHE_DIR/completions/_nats" &|
+  {
+    local completion="$ZSH_CACHE_DIR/completions/_nats" tmp
+    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    nats --completion-script-zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+    command rm -f "$tmp"
+  } &|
 fi

--- a/plugins/ngrok/ngrok.plugin.zsh
+++ b/plugins/ngrok/ngrok.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_ngrok" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   ngrok completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/ngrok/ngrok.plugin.zsh
+++ b/plugins/ngrok/ngrok.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_ngrok" ]]; then
   _comps[ngrok]=_ngrok
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_ngrok" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  ngrok completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_ngrok"
+  zf_mv -f -- =( ngrok completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/ngrok/ngrok.plugin.zsh
+++ b/plugins/ngrok/ngrok.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_ngrok" ]]; then
   _comps[ngrok]=_ngrok
 fi
 
-ngrok completion zsh >| "$ZSH_CACHE_DIR/completions/_ngrok" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_ngrok" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  ngrok completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/pass-cli/pass-cli.plugin.zsh
+++ b/plugins/pass-cli/pass-cli.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_pass-cli" ]]; then
   _comps[pass-cli]=_pass-cli
 fi
 
-pass-cli completions zsh >| "$ZSH_CACHE_DIR/completions/_pass-cli" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_pass-cli" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  pass-cli completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/pass-cli/pass-cli.plugin.zsh
+++ b/plugins/pass-cli/pass-cli.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_pass-cli" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   pass-cli completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/pass-cli/pass-cli.plugin.zsh
+++ b/plugins/pass-cli/pass-cli.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_pass-cli" ]]; then
   _comps[pass-cli]=_pass-cli
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_pass-cli" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  pass-cli completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_pass-cli"
+  zf_mv -f -- =( pass-cli completions zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -45,7 +45,7 @@ else
 
   {
     local completion="$ZSH_CACHE_DIR/completions/_pipenv" tmp
-    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
     _PIPENV_COMPLETE=zsh_source pipenv >| "$tmp" && command mv -f "$tmp" "$completion"
     command rm -f "$tmp"
   } &|

--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -43,11 +43,10 @@ else
     _comps[pipenv]=_pipenv
   fi
 
-  {
-    local completion="$ZSH_CACHE_DIR/completions/_pipenv" tmp
-    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-    _PIPENV_COMPLETE=zsh_source pipenv >| "$tmp" && command mv -f "$tmp" "$completion"
-    command rm -f "$tmp"
+  zmodload -F zsh/files b:zf_mv
+  () {
+    local TMPPREFIX="$ZSH_CACHE_DIR/completions/_pipenv"
+    zf_mv -f -- =( _PIPENV_COMPLETE=zsh_source pipenv ) "$TMPPREFIX"
   } &|
 fi
 

--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -43,7 +43,12 @@ else
     _comps[pipenv]=_pipenv
   fi
 
-  _PIPENV_COMPLETE=zsh_source pipenv >| "$ZSH_CACHE_DIR/completions/_pipenv" &|
+  {
+    local completion="$ZSH_CACHE_DIR/completions/_pipenv" tmp
+    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    _PIPENV_COMPLETE=zsh_source pipenv >| "$tmp" && command mv -f "$tmp" "$completion"
+    command rm -f "$tmp"
+  } &|
 fi
 
 if zstyle -T ':omz:plugins:pipenv' auto-shell; then

--- a/plugins/podman/podman.plugin.zsh
+++ b/plugins/podman/podman.plugin.zsh
@@ -10,7 +10,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_podman" ]]; then
   _comps[podman]=_podman
 fi
 
-podman completion zsh 2> /dev/null >| "$ZSH_CACHE_DIR/completions/_podman" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_podman" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  podman completion zsh 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
 
 alias pbl='podman build'
 alias pcin='podman container inspect'

--- a/plugins/podman/podman.plugin.zsh
+++ b/plugins/podman/podman.plugin.zsh
@@ -12,7 +12,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_podman" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   podman completion zsh 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/podman/podman.plugin.zsh
+++ b/plugins/podman/podman.plugin.zsh
@@ -10,11 +10,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_podman" ]]; then
   _comps[podman]=_podman
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_podman" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  podman completion zsh 2> /dev/null >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_podman"
+  zf_mv -f -- =( podman completion zsh 2> /dev/null ) "$TMPPREFIX"
 } &|
 
 alias pbl='podman build'

--- a/plugins/poetry/poetry.plugin.zsh
+++ b/plugins/poetry/poetry.plugin.zsh
@@ -41,7 +41,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_poetry" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   poetry completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/poetry/poetry.plugin.zsh
+++ b/plugins/poetry/poetry.plugin.zsh
@@ -39,4 +39,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_poetry" ]]; then
   _comps[poetry]=_poetry
 fi
 
-poetry completions zsh >| "$ZSH_CACHE_DIR/completions/_poetry" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_poetry" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  poetry completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/poetry/poetry.plugin.zsh
+++ b/plugins/poetry/poetry.plugin.zsh
@@ -39,9 +39,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_poetry" ]]; then
   _comps[poetry]=_poetry
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_poetry" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  poetry completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_poetry"
+  zf_mv -f -- =( poetry completions zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/procs/procs.plugin.zsh
+++ b/plugins/procs/procs.plugin.zsh
@@ -12,7 +12,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_procs" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
 
   autoload -Uz is-at-least
   local _version=$(procs --version)

--- a/plugins/procs/procs.plugin.zsh
+++ b/plugins/procs/procs.plugin.zsh
@@ -10,17 +10,16 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_procs" ]]; then
   _comps[procs]=_procs
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_procs" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_procs"
   autoload -Uz is-at-least
   local _version=$(procs --version)
-  if is-at-least "0.14" "${_version#procs }"; then
-    procs --gen-completion-out zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-    command rm -f "$tmp"
-  else
-    procs --completion-out zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-    command rm -f "$tmp"
-  fi
+  zf_mv -f -- =(
+    if is-at-least "0.14" "${_version#procs }"; then
+      procs --gen-completion-out zsh
+    else
+      procs --completion-out zsh
+    fi
+  ) "$TMPPREFIX"
 } &|

--- a/plugins/procs/procs.plugin.zsh
+++ b/plugins/procs/procs.plugin.zsh
@@ -11,11 +11,16 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_procs" ]]; then
 fi
 
 {
+  local completion="$ZSH_CACHE_DIR/completions/_procs" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+
   autoload -Uz is-at-least
   local _version=$(procs --version)
   if is-at-least "0.14" "${_version#procs }"; then
-    procs --gen-completion-out zsh >| "$ZSH_CACHE_DIR/completions/_procs"
+    procs --gen-completion-out zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+    command rm -f "$tmp"
   else
-    procs --completion-out zsh >| "$ZSH_CACHE_DIR/completions/_procs"
+    procs --completion-out zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+    command rm -f "$tmp"
   fi
 } &|

--- a/plugins/pulumi/pulumi.plugin.zsh
+++ b/plugins/pulumi/pulumi.plugin.zsh
@@ -12,7 +12,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_pulumi" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   pulumi gen-completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/pulumi/pulumi.plugin.zsh
+++ b/plugins/pulumi/pulumi.plugin.zsh
@@ -10,11 +10,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_pulumi" ]]; then
   _comps[pulumi]=_pulumi
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_pulumi" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  pulumi gen-completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_pulumi"
+  zf_mv -f -- =( pulumi gen-completion zsh ) "$TMPPREFIX"
 } &|
 
 # Aliases

--- a/plugins/pulumi/pulumi.plugin.zsh
+++ b/plugins/pulumi/pulumi.plugin.zsh
@@ -10,7 +10,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_pulumi" ]]; then
   _comps[pulumi]=_pulumi
 fi
 
-pulumi gen-completion zsh >| "$ZSH_CACHE_DIR/completions/_pulumi" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_pulumi" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  pulumi gen-completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
 
 # Aliases
 alias pul='pulumi'

--- a/plugins/qodana/qodana.plugin.zsh
+++ b/plugins/qodana/qodana.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_qodana" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   qodana completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/qodana/qodana.plugin.zsh
+++ b/plugins/qodana/qodana.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_qodana" ]]; then
   _comps[qodana]=_qodana
 fi
 
-qodana completion zsh >| "$ZSH_CACHE_DIR/completions/_qodana" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_qodana" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  qodana completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/qodana/qodana.plugin.zsh
+++ b/plugins/qodana/qodana.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_qodana" ]]; then
   _comps[qodana]=_qodana
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_qodana" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  qodana completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_qodana"
+  zf_mv -f -- =( qodana completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/rbw/rbw.plugin.zsh
+++ b/plugins/rbw/rbw.plugin.zsh
@@ -10,11 +10,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_rbw" ]]; then
   _comps[rbw]=_rbw
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_rbw" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  rbw gen-completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_rbw"
+  zf_mv -f -- =( rbw gen-completions zsh ) "$TMPPREFIX"
 } &|
 
 # rbwpw function copies the password of a service to the clipboard

--- a/plugins/rbw/rbw.plugin.zsh
+++ b/plugins/rbw/rbw.plugin.zsh
@@ -10,7 +10,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_rbw" ]]; then
   _comps[rbw]=_rbw
 fi
 
-rbw gen-completions zsh >| "$ZSH_CACHE_DIR/completions/_rbw" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_rbw" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  rbw gen-completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
 
 # rbwpw function copies the password of a service to the clipboard
 # and clears it after 20 seconds

--- a/plugins/rbw/rbw.plugin.zsh
+++ b/plugins/rbw/rbw.plugin.zsh
@@ -12,7 +12,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_rbw" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   rbw gen-completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/rclone/rclone.plugin.zsh
+++ b/plugins/rclone/rclone.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_rclone" ]]; then
   _comps[rclone]=_rclone
 fi
 
-rclone completion zsh - >| "$ZSH_CACHE_DIR/completions/_rclone" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_rclone" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  rclone completion zsh - >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/rclone/rclone.plugin.zsh
+++ b/plugins/rclone/rclone.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_rclone" ]]; then
   _comps[rclone]=_rclone
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_rclone" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  rclone completion zsh - >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_rclone"
+  zf_mv -f -- =( rclone completion zsh - ) "$TMPPREFIX"
 } &|

--- a/plugins/rclone/rclone.plugin.zsh
+++ b/plugins/rclone/rclone.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_rclone" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   rclone completion zsh - >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/rust/rust.plugin.zsh
+++ b/plugins/rust/rust.plugin.zsh
@@ -19,7 +19,12 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_rustup" ]]; then
 fi
 
 # Generate completion files in the background
-rustup completions zsh >| "$ZSH_CACHE_DIR/completions/_rustup" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_rustup" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  rustup completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
 cat >| "$ZSH_CACHE_DIR/completions/_cargo" <<'EOF'
 #compdef cargo
 source "$(rustup run ${${(z)$(rustup default)}[1]} rustc --print sysroot)"/share/zsh/site-functions/_cargo

--- a/plugins/rust/rust.plugin.zsh
+++ b/plugins/rust/rust.plugin.zsh
@@ -21,7 +21,7 @@ fi
 # Generate completion files in the background
 {
   local completion="$ZSH_CACHE_DIR/completions/_rustup" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   rustup completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/rust/rust.plugin.zsh
+++ b/plugins/rust/rust.plugin.zsh
@@ -19,11 +19,10 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_rustup" ]]; then
 fi
 
 # Generate completion files in the background
-{
-  local completion="$ZSH_CACHE_DIR/completions/_rustup" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  rustup completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_rustup"
+  zf_mv -f -- =( rustup completions zsh ) "$TMPPREFIX"
 } &|
 cat >| "$ZSH_CACHE_DIR/completions/_cargo" <<'EOF'
 #compdef cargo

--- a/plugins/sigstore/sigstore.plugin.zsh
+++ b/plugins/sigstore/sigstore.plugin.zsh
@@ -12,12 +12,11 @@ function install_autocompletion {
     _comps[$1]=_$1
   fi
 
-  {
-    local completion="$ZSH_CACHE_DIR/completions/_$1" tmp
-    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-    $1 completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-    command rm -f "$tmp"
-  } &|
+  zmodload -F zsh/files b:zf_mv
+  () {
+    local TMPPREFIX="$ZSH_CACHE_DIR/completions/_$1"
+    zf_mv -f -- =( $1 completion zsh ) "$TMPPREFIX"
+  } "$1" &|
 }
 
 install_autocompletion cosign

--- a/plugins/sigstore/sigstore.plugin.zsh
+++ b/plugins/sigstore/sigstore.plugin.zsh
@@ -14,7 +14,7 @@ function install_autocompletion {
 
   {
     local completion="$ZSH_CACHE_DIR/completions/_$1" tmp
-    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
     $1 completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
     command rm -f "$tmp"
   } &|

--- a/plugins/sigstore/sigstore.plugin.zsh
+++ b/plugins/sigstore/sigstore.plugin.zsh
@@ -12,7 +12,12 @@ function install_autocompletion {
     _comps[$1]=_$1
   fi
 
-  $1 completion zsh >| "$ZSH_CACHE_DIR/completions/_$1" &|
+  {
+    local completion="$ZSH_CACHE_DIR/completions/_$1" tmp
+    tmp=$(command mktemp "$completion.XXXXXX") || exit
+    $1 completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+    command rm -f "$tmp"
+  } &|
 }
 
 install_autocompletion cosign

--- a/plugins/skaffold/skaffold.plugin.zsh
+++ b/plugins/skaffold/skaffold.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_skaffold" ]]; then
   _comps[skaffold]=_skaffold
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_skaffold" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  skaffold completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_skaffold"
+  zf_mv -f -- =( skaffold completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/skaffold/skaffold.plugin.zsh
+++ b/plugins/skaffold/skaffold.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_skaffold" ]]; then
   _comps[skaffold]=_skaffold
 fi
 
-skaffold completion zsh >| "$ZSH_CACHE_DIR/completions/_skaffold" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_skaffold" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  skaffold completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/skaffold/skaffold.plugin.zsh
+++ b/plugins/skaffold/skaffold.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_skaffold" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   skaffold completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/stripe/stripe.plugin.zsh
+++ b/plugins/stripe/stripe.plugin.zsh
@@ -10,9 +10,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_stripe" ]]; then
   _comps[stripe]=_stripe
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_stripe" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  stripe completion --shell zsh --write-to-stdout >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_stripe"
+  zf_mv -f -- =( stripe completion --shell zsh --write-to-stdout ) "$TMPPREFIX"
 } &|

--- a/plugins/stripe/stripe.plugin.zsh
+++ b/plugins/stripe/stripe.plugin.zsh
@@ -12,7 +12,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_stripe" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   stripe completion --shell zsh --write-to-stdout >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/stripe/stripe.plugin.zsh
+++ b/plugins/stripe/stripe.plugin.zsh
@@ -10,4 +10,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_stripe" ]]; then
   _comps[stripe]=_stripe
 fi
 
-stripe completion --shell zsh --write-to-stdout >| "$ZSH_CACHE_DIR/completions/_stripe" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_stripe" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  stripe completion --shell zsh --write-to-stdout >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/tailscale/tailscale.plugin.zsh
+++ b/plugins/tailscale/tailscale.plugin.zsh
@@ -24,7 +24,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_tailscale" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   tailscale completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/tailscale/tailscale.plugin.zsh
+++ b/plugins/tailscale/tailscale.plugin.zsh
@@ -22,9 +22,8 @@ if (( $+aliases[tailscale] )); then
   _comps[${aliases[tailscale]:t}]=_tailscale
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_tailscale" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  tailscale completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_tailscale"
+  zf_mv -f -- =( tailscale completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/tailscale/tailscale.plugin.zsh
+++ b/plugins/tailscale/tailscale.plugin.zsh
@@ -22,4 +22,9 @@ if (( $+aliases[tailscale] )); then
   _comps[${aliases[tailscale]:t}]=_tailscale
 fi
 
-tailscale completion zsh >| "$ZSH_CACHE_DIR/completions/_tailscale" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_tailscale" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tailscale completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/task/task.plugin.zsh
+++ b/plugins/task/task.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_task" ]]; then
 fi
 
 # Generate and load task completion
-task --completion zsh >! "$ZSH_CACHE_DIR/completions/_task" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_task" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  task --completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/task/task.plugin.zsh
+++ b/plugins/task/task.plugin.zsh
@@ -13,7 +13,7 @@ fi
 # Generate and load task completion
 {
   local completion="$ZSH_CACHE_DIR/completions/_task" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   task --completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/task/task.plugin.zsh
+++ b/plugins/task/task.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_task" ]]; then
 fi
 
 # Generate and load task completion
-{
-  local completion="$ZSH_CACHE_DIR/completions/_task" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  task --completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_task"
+  zf_mv -f -- =( task --completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/timoni/timoni.plugin.zsh
+++ b/plugins/timoni/timoni.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_timoni" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   timoni completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/timoni/timoni.plugin.zsh
+++ b/plugins/timoni/timoni.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_timoni" ]]; then
   _comps[timoni]=_timoni
 fi
 
-timoni completion zsh >| "$ZSH_CACHE_DIR/completions/_timoni" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_timoni" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  timoni completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/timoni/timoni.plugin.zsh
+++ b/plugins/timoni/timoni.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_timoni" ]]; then
   _comps[timoni]=_timoni
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_timoni" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  timoni completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_timoni"
+  zf_mv -f -- =( timoni completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/uv/uv.plugin.zsh
+++ b/plugins/uv/uv.plugin.zsh
@@ -45,13 +45,13 @@ fi
 # Overwrites the file each time as completions might change with uv versions.
 {
   local completion="$ZSH_CACHE_DIR/completions/_uv" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   uv generate-shell-completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|
 {
   local completion="$ZSH_CACHE_DIR/completions/_uvx" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   uvx --generate-shell-completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/uv/uv.plugin.zsh
+++ b/plugins/uv/uv.plugin.zsh
@@ -43,15 +43,12 @@ fi
 
 # uv and uvx are installed together (uvx is an alias to `uv tool run`)  
 # Overwrites the file each time as completions might change with uv versions.
-{
-  local completion="$ZSH_CACHE_DIR/completions/_uv" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  uv generate-shell-completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_uv"
+  zf_mv -f -- =( uv generate-shell-completion zsh ) "$TMPPREFIX"
 } &|
-{
-  local completion="$ZSH_CACHE_DIR/completions/_uvx" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  uvx --generate-shell-completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_uvx"
+  zf_mv -f -- =( uvx --generate-shell-completion zsh ) "$TMPPREFIX"
 } &|

--- a/plugins/uv/uv.plugin.zsh
+++ b/plugins/uv/uv.plugin.zsh
@@ -43,5 +43,15 @@ fi
 
 # uv and uvx are installed together (uvx is an alias to `uv tool run`)  
 # Overwrites the file each time as completions might change with uv versions.
-uv generate-shell-completion zsh >| "$ZSH_CACHE_DIR/completions/_uv" &|
-uvx --generate-shell-completion zsh >| "$ZSH_CACHE_DIR/completions/_uvx" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_uv" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  uv generate-shell-completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_uvx" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  uvx --generate-shell-completion zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/volta/volta.plugin.zsh
+++ b/plugins/volta/volta.plugin.zsh
@@ -11,4 +11,9 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_volta" ]]; then
   _comps[volta]=_volta
 fi
 
-volta completions zsh >| "$ZSH_CACHE_DIR/completions/_volta" &|
+{
+  local completion="$ZSH_CACHE_DIR/completions/_volta" tmp
+  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  volta completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
+  command rm -f "$tmp"
+} &|

--- a/plugins/volta/volta.plugin.zsh
+++ b/plugins/volta/volta.plugin.zsh
@@ -13,7 +13,7 @@ fi
 
 {
   local completion="$ZSH_CACHE_DIR/completions/_volta" tmp
-  tmp=$(command mktemp "$completion.XXXXXX") || exit
+  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
   volta completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
   command rm -f "$tmp"
 } &|

--- a/plugins/volta/volta.plugin.zsh
+++ b/plugins/volta/volta.plugin.zsh
@@ -11,9 +11,8 @@ if [[ ! -f "$ZSH_CACHE_DIR/completions/_volta" ]]; then
   _comps[volta]=_volta
 fi
 
-{
-  local completion="$ZSH_CACHE_DIR/completions/_volta" tmp
-  tmp=$(command mktemp -t _omz_comp.XXXXXXXX) || exit
-  volta completions zsh >| "$tmp" && command mv -f "$tmp" "$completion"
-  command rm -f "$tmp"
+zmodload -F zsh/files b:zf_mv
+() {
+  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_volta"
+  zf_mv -f -- =( volta completions zsh ) "$TMPPREFIX"
 } &|


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Generate completion into tmp files before writing it to `cache/completion`.

Closes #13964