### PR TITLE
fix(docker): resolve completion path correctly in anonymous function

### DIFF
--- a/plugins/docker/docker.plugin.zsh
+++ b/plugins/docker/docker.plugin.zsh
@@ -58,14 +58,17 @@ fi
 
 zmodload -F zsh/files b:zf_mv
 () {
+
+  local plugin_dir="$1"
+
   # `docker completion` is only available from 23.0.0 on
   # docker version returns `Docker version 24.0.2, build cb74dfcd85`
   # with `s:,:` remove the comma after the version, and select third word of it
   if zstyle -t ':omz:plugins:docker' legacy-completion || \
     ! is-at-least 23.0.0 ${${(s:,:z)"$(command docker --version)"}[3]}; then
-        command cp "${0:h}/completions/_docker" "$ZSH_CACHE_DIR/completions/_docker"
+        command cp "${plugin_dir}/completions/_docker" "$ZSH_CACHE_DIR/completions/_docker"
       else
         local TMPPREFIX="$ZSH_CACHE_DIR/completions/_docker"
         zf_mv -f -- =( command docker completion zsh ) "$TMPPREFIX"
   fi
-} &|
+} "${0:A:h}" &|


### PR DESCRIPTION
## Description

Fix the legacy Docker completion path resolution inside the background
anonymous function.

Inside the anonymous function, `$0` refers to the function itself rather
than `plugins/docker/docker.plugin.zsh`. As a result, using `$0` from
inside the function can resolve the bundled completion file from an
incorrect directory.

This change evaluates `${0:A:h}` before entering the anonymous function,
passes the absolute plugin directory as an argument, and stores it in the
local `plugin_dir` variable.

The legacy completion file is then resolved using:

```zsh
"${plugin_dir}/completions/_docker"
```

Fixes #14003

## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- [fix/docker-completion-cache](https://github.com/sony-level/ohmyzsh/compare/fix/docker-completion-cache)

## Other comments:

Tested with:

- Debian GNU/Linux 13 (trixie)
- Zsh 5.9
- Docker 26.1.5+dfsg1
- Docker legacy completion enabled

Checks performed:

- Run `zsh -n plugins/docker/docker.plugin.zsh.`
- Started a new Zsh session with legacy Docker completion enabled.
- Verified that the completion cache was generated without the incorrect path error.
- Verified completion for Docker commands.

...
