### PR TITLE
fix(git): force C locale only while matching status regexes

### DIFF
--- a/lib/git.zsh
+++ b/lib/git.zsh
@@ -39,16 +39,27 @@ function _omz_git_prompt_info() {
   echo "${ZSH_THEME_GIT_PROMPT_PREFIX}${ref//\%/%%}${upstream//\%/%%}$(parse_git_dirty)${ZSH_THEME_GIT_PROMPT_SUFFIX}"
 }
 
-function _omz_git_prompt_status() {
-  # OHMYZSH-13330: avoid "regex matching error: illegal byte sequence".
-  # zsh's "=~" operator delegates to the C library regex, which aborts with
-  # REG_ILLSEQ when the subject contains an invalid byte sequence under a
-  # multibyte locale (e.g. a filename with non-UTF-8 bytes in `git status`
-  # output). Forcing the C locale makes every byte a valid character, so the
-  # regex matching below never fails that way. `git status --porcelain` is
-  # locale-independent, so this does not change the parsed output.
+# Match an extended regular expression against a subject, forcing the C locale
+# only for the duration of the call.
+#
+# OHMYZSH-13330: zsh's "=~" operator delegates to the C library regex, which
+# aborts with REG_ILLSEQ when the subject contains an invalid byte sequence
+# under a multibyte locale (e.g. a filename with non-UTF-8 bytes in `git
+# status` output). Forcing the C locale makes every byte a valid character,
+# so the regex matching never fails that way. `git status --porcelain` is
+# locale-independent, so this does not change the parsed output.
+#
+# OHMYZSH-13985: the locale must be scoped to this function and not set for
+# the whole caller. Assigning LC_ALL makes zsh re-run setlocale() right away,
+# so leaving it set while the rest of the caller runs breaks multibyte
+# handling there — most visibly, `echo` refuses to expand Unicode escapes in
+# theme prompt symbols ("character not in range").
+function _omz_git_prompt_status_match() {
   local -x LC_ALL=C
+  [[ "$1" =~ "$2" ]]
+}
 
+function _omz_git_prompt_status() {
   [[ "$(__git_prompt_git config --get oh-my-zsh.hide-status 2>/dev/null)" = 1 ]] && return
 
   # Maps a git status prefix to an internal constant
@@ -113,11 +124,11 @@ function _omz_git_prompt_status() {
   status_lines=("${(@f)${status_text}}")
 
   # If the tracking line exists, get and parse it
-  if [[ "$status_lines[1]" =~ "^## [^ ]+ \[(.*)\]" ]]; then
+  if _omz_git_prompt_status_match "$status_lines[1]" "^## [^ ]+ \[(.*)\]"; then
     local branch_statuses
     branch_statuses=("${(@s/,/)match}")
     for branch_status in $branch_statuses; do
-      if [[ ! $branch_status =~ "(behind|diverged|ahead) ([0-9]+)?" ]]; then
+      if ! _omz_git_prompt_status_match "$branch_status" "(behind|diverged|ahead) ([0-9]+)?"; then
         continue
       fi
       local last_parsed_status=$prefix_constant_map[$match[1]]
@@ -130,7 +141,7 @@ function _omz_git_prompt_status() {
     local status_constant="${prefix_constant_map[$status_prefix]}"
     local status_regex=$'(^|\n)'"$status_prefix"
 
-    if [[ "$status_text" =~ $status_regex ]]; then
+    if _omz_git_prompt_status_match "$status_text" "$status_regex"; then
       statuses_seen[$status_constant]=1
     fi
   done


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Fixes #13985, without undoing what #13878 was trying to do.

The short version: `898b579` set `LC_ALL=C` for the whole `_omz_git_prompt_status` function to stop the regex from choking on invalid byte sequences (#13330). That works, but it's broader than intended — zsh re-runs `setlocale()` as soon as `LC_ALL` is assigned, so the rest of the function also runs under the C locale. When a theme uses a Unicode escape like `\U2731` for its prompt glyphs, the final `echo` can't map it to a character anymore and dies with `character not in range`, which is exactly the error reported in #13985.

So this moves the locale forcing into a tiny helper (`_omz_git_prompt_status_match`) that wraps each individual `[[ =~ ]]` check. The three call sites that parse porcelain output still get the C locale (that part of #13878 stays intact), while everything else — most importantly printing the theme symbols — keeps the user's own locale. `$match` etc. are global special parameters, so nothing changes about how matches are consumed afterwards.

For testing I ran this on an Ubuntu 24.04 container with zsh 5.9:

- the reporter's exact scenario now renders the glyph instead of erroring
- a repo with a non-UTF-8 filename no longer triggers "illegal byte sequence" (#13330 case)
- ahead / behind / diverged tracking-line parsing gives identical output to unmodified master
- full `oh-my-zsh.sh` startup smoke test passes; `zsh -n` is clean

## Other comments:

AI disclosure: this patch was prepared with the help of an AI coding agent (root-cause analysis and draft). I reproduced the bug locally, reviewed the change line by line, and ran the tests listed above myself before submitting.
