### PR TITLE
fix(aws): send asr error to stderr and reset color (fixes #13949)

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -69,7 +69,8 @@ function asr() {
   local -a available_regions
   available_regions=($(aws_regions))
   if [[ -z "${available_regions[(r)$1]}" ]]; then
-    echo "${fg[red]}Available regions: \n$(aws_regions)"
+    echo "${fg[red]}Region '$1' not found" >&2
+    echo "Available regions: ${(j:, :)available_regions:-no regions found}${reset_color}" >&2
     return 1
   fi
 


### PR DESCRIPTION
Fixes #13949


Previously asr() printed error to stdout and left terminal red (missing ${reset_color}). Now sends to stderr and resets color, matching asp() behavior. Branch rebased on latest master.