### PR TITLE
fix(oh-my-zsh.sh): make startup compatible with set -eu (fixes #13854)

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -48,15 +48,15 @@ omz_f() {
 unset -f omz_f
 
 # If ZSH is not defined, use the current script's directory.
-[[ -n "$ZSH" ]] || export ZSH="${${(%):-%x}:a:h}"
+[[ -v ZSH ]] || export ZSH="${${(%):-%x}:a:h}"
 
 # Set ZSH_CUSTOM to the path where your custom config files
 # and plugins exists, or else we will use the default custom/
-[[ -n "$ZSH_CUSTOM" ]] || ZSH_CUSTOM="$ZSH/custom"
+[[ -v ZSH_CUSTOM ]] || ZSH_CUSTOM="$ZSH/custom"
 
 # Set ZSH_CACHE_DIR to the path where cache files should be created
 # or else we will use the default cache/
-[[ -n "$ZSH_CACHE_DIR" ]] || ZSH_CACHE_DIR="$ZSH/cache"
+[[ -v ZSH_CACHE_DIR ]] || ZSH_CACHE_DIR="$ZSH/cache"
 
 # Make sure $ZSH_CACHE_DIR is writable, otherwise use a directory in $HOME
 if [[ ! -w "$ZSH_CACHE_DIR" ]]; then
@@ -87,7 +87,7 @@ is_plugin() {
 
 # Add all defined plugins to fpath. This must be done
 # before running compinit.
-for plugin ($plugins); do
+for plugin (${plugins[@]}); do
   if is_plugin "$ZSH_CUSTOM" "$plugin"; then
     fpath=("$ZSH_CUSTOM/plugins/$plugin" $fpath)
   elif is_plugin "$ZSH" "$plugin"; then
@@ -106,7 +106,7 @@ else
 fi
 
 # Save the location of the current completion dump file.
-if [[ -z "$ZSH_COMPDUMP" ]]; then
+if [[ -z "${ZSH_COMPDUMP-}" ]]; then
   ZSH_COMPDUMP="${ZDOTDIR:-$HOME}/.zcompdump-${SHORT_HOST}-${ZSH_VERSION}"
 fi
 
@@ -121,7 +121,7 @@ if ! command grep -q -Fx "$zcompdump_revision" "$ZSH_COMPDUMP" 2>/dev/null \
   zcompdump_refresh=1
 fi
 
-if [[ "$ZSH_DISABLE_COMPFIX" != true ]]; then
+if [[ "${ZSH_DISABLE_COMPFIX-}" != true ]]; then
   source "$ZSH/lib/compfix.zsh"
   # Load only from secure directories
   # Reset the flag compinit sets when -i excludes insecure entries
@@ -202,7 +202,7 @@ done
 unset lib_file
 
 # Load all of the plugins that were defined in ~/.zshrc
-for plugin ($plugins); do
+for plugin (${plugins[@]}); do
   _omz_source "plugins/$plugin/$plugin.plugin.zsh"
 done
 unset plugin
@@ -220,7 +220,7 @@ is_theme() {
   builtin test -f $base_dir/$name.zsh-theme
 }
 
-if [[ -n "$ZSH_THEME" ]]; then
+if [[ -n "${ZSH_THEME-}" ]]; then
   if is_theme "$ZSH_CUSTOM" "$ZSH_THEME"; then
     source "$ZSH_CUSTOM/$ZSH_THEME.zsh-theme"
   elif is_theme "$ZSH_CUSTOM/themes" "$ZSH_THEME"; then
@@ -233,4 +233,4 @@ if [[ -n "$ZSH_THEME" ]]; then
 fi
 
 # set completion colors to be the same as `ls`, after theme has been loaded
-[[ -z "$LS_COLORS" ]] || zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
+[[ -z "${LS_COLORS-}" ]] || zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"


### PR DESCRIPTION
Fixes #13854

oh-my-zsh.sh startup now handles set -eu (errexit + nounset) without aborting on unset variables. Adds guards for unbound variables.