### PR TITLE
fix(pipenv): keep activation and the project directory in sync

### DIFF
--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -56,7 +56,11 @@ if zstyle -T ':omz:plugins:pipenv' auto-shell; then
     # deactivate shell if Pipfile doesn't exist and not in a subdir
     if [[ ! -f "$PWD/Pipfile" ]]; then
       if [[ "$PIPENV_ACTIVE" == 1 ]]; then
-        if [[ "$PWD" != "$pipfile_dir"* ]]; then
+        # Compare whole path components: `$pipfile_dir"*` also matches unrelated
+        # siblings that merely start with the same text (…/proj -> …/proj-docs),
+        # which would keep the virtualenv active outside the project.
+        local project_dir="${pipfile_dir%/}"
+        if [[ "$PWD" != "$project_dir" && "$PWD" != "$project_dir"/* ]]; then
           unset PIPENV_ACTIVE pipfile_dir
           deactivate
         fi

--- a/plugins/pipenv/pipenv.plugin.zsh
+++ b/plugins/pipenv/pipenv.plugin.zsh
@@ -63,12 +63,15 @@ if zstyle -T ':omz:plugins:pipenv' auto-shell; then
       fi
     fi
 
-    # activate the shell if Pipfile exists
+    # activate the shell if Pipfile exists and its virtualenv is usable
     if [[ "$PIPENV_ACTIVE" != 1 ]]; then
       if [[ -f "$PWD/Pipfile" ]]; then
-        export pipfile_dir="$PWD"
-        source "$(pipenv --venv)/bin/activate"
-        export PIPENV_ACTIVE=1
+        local venv_path
+        if venv_path="$(pipenv --venv 2>/dev/null)" && [[ -n "$venv_path" && -f "$venv_path/bin/activate" ]]; then
+          export pipfile_dir="$PWD"
+          source "$venv_path/bin/activate"
+          export PIPENV_ACTIVE=1
+        fi
       fi
     fi
   }


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

Fixes #10600, and fixes a second bug in the same hook that I found while testing it.

`_togglePipenvShell` gets its two halves wrong in ways that both leave the shell claiming a state it does not have. Two commits, one per bug.

**Commit 1 — activation is unguarded (#10600).** When a `Pipfile` exists but its virtualenv does not, `source "$(pipenv --venv)/bin/activate"` runs with no error handling, so:

- `pipenv --venv`'s complaint (in some versions a full Python traceback) goes straight to the shell's startup output;
- `$(pipenv --venv)` expands to empty and zsh tries to `source /bin/activate`, printing `no such file or directory`;
- `PIPENV_ACTIVE=1` and `pipfile_dir` are exported anyway although nothing was activated, which blocks every later activation attempt in that shell;
- and because `PIPENV_ACTIVE=1` was set anyway, the *next* `cd` out of the directory takes the deactivation branch and calls a `deactivate` function that no activate script ever defined.

Activation now happens only when `pipenv --venv` succeeds **and** the activate script exists. This also removes the follow-on `command not found: deactivate`, since that state is never entered.

**Commit 2 — the directory test uses string prefixes, not path components.** The deactivation guard is `[[ "$PWD" != "$pipfile_dir"* ]]`, which is true for subdirectories of the project (intended) but also for unrelated siblings that merely start with the same characters: `…/proj` → `…/proj-archive` or `…/projX` keeps the virtualenv active in a directory that has no `Pipfile` at all, and `PIPENV_ACTIVE` stays `1`. Fixed by requiring either an exact match or a `/` component boundary. Subdirectory behaviour is unchanged, and a project at `/` still matches everything.

Same class of slip as the one fixed for the git prompt in #14006. `poetry-env` has the identical prefix test on line 9 of its plugin (`"$PWD" != "$poetry_dir"*`), so it has the same bug — I left that file alone because #13932 is already open against it, but noted it there.

## Testing:

Stubbed `pipenv` driving each toolchain state, capturing stderr per step, run against this branch and `origin/master`; every cell reproduced on three consecutive runs. zsh 5.9 (the CI job is a single `ubuntu-latest` + apt zsh with no version matrix, so I am not claiming coverage beyond that one version).

| case | master | this branch |
|---|---|---|
| `Pipfile` present, venv missing (startup) | `pipenv` stderr leaks + `source:…: no such file or directory: /bin/activate` + `PIPENV_ACTIVE=1` while `VIRTUAL_ENV` unset | silent; `PIPENV_ACTIVE`/`pipfile_dir` stay unset |
| …then `cd` out of that directory | `command not found: deactivate` | silent |
| `--venv` prints a path with no `bin/activate` | same failure class | silent, stays inactive |
| healthy venv, start in project | `PIPENV_ACTIVE=1`, `VIRTUAL_ENV` set, `deactivate` defined | identical |
| healthy: project → elsewhere → back | activates → inactive → re-activates, stderr empty | identical |
| **project → unrelated `proj-archive` sibling** | ⚠️ stays active: `VIRTUAL_ENV=<proj venv> PIPENV_ACTIVE=1` | ✅ `VIRTUAL_ENV=<none> PIPENV_ACTIVE=<unset>` |
| **project → `…/proj-archive/empty`** | ⚠️ still active | ✅ still inactive |
| **deep subdir *inside* the project** (no `Pipfile` there) | stays active | stays active (unchanged) |

The boundary logic as a truth table (`stay` = keep virtualenv):

| `pipfile_dir` | `PWD` | master | this branch |
|---|---|---|---|
| `/x/proj` | `/x/proj` | stay | stay |
| `/x/proj` | `/x/proj/src` | stay | stay |
| `/x/proj` | `/x/proj-archive` | ⚠️ stay | ✅ deactivate |
| `/x/proj` | `/x/projX` | ⚠️ stay | ✅ deactivate |
| `/` | `/tmp` | stay | stay |

`zsh -n` passes on the plugin and the CI syntax sweep (`oh-my-zsh.sh`, `lib/*.zsh`, `plugins/*/*.plugin.zsh`, `plugins/*/_*`, `themes/*.zsh-theme`) is clean on this branch.

## Other comments:

If you would rather have these as two PRs, say the word and I will split commit 2 out onto its own branch — they are independent and each reverts cleanly on its own. They share a file and a function, which is why they are together here.

The two new `[[ … ]]` operands and the `local project_dir` add no measurable startup cost: the guard is a shell builtin pattern match on variables that are already set, and the previously measured `pipenv --venv` call still happens exactly once per activation attempt as before.

AI disclosure: this patch was prepared with the help of an AI coding agent (root-cause analysis, patch draft, and test harness). I reviewed every changed line and re-ran the tables above against both branches myself before submitting.
