### PR TITLE
fix(brew): register Homebrew completion after compinit

### DIFF
--- a/plugins/brew/brew.plugin.zsh
+++ b/plugins/brew/brew.plugin.zsh
@@ -44,6 +44,18 @@ if [[ -d "$HOMEBREW_PREFIX/share/zsh/site-functions" ]]; then
   fpath+=("$HOMEBREW_PREFIX/share/zsh/site-functions")
 fi
 
+# If the completion file doesn't exist yet, we need to autoload it and
+# bind it to `brew`. Otherwise, compinit will have already done that.
+if [[ -f "$HOMEBREW_PREFIX/share/zsh/site-functions/_brew" ]]; then
+  if [[ ! -f "$ZSH_CACHE_DIR/completions/_brew" ]]; then
+    typeset -g -A _comps
+    autoload -Uz _brew
+    _comps[brew]=_brew
+  fi
+  command ln -sfn "$HOMEBREW_PREFIX/share/zsh/site-functions/_brew" \
+    "$ZSH_CACHE_DIR/completions/_brew"
+fi
+
 alias ba='brew autoremove'
 alias bcfg='brew config'
 alias bci='brew info --cask'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

The brew plugin adds Homebrew's site-functions dir to `fpath`, but plugins are sourced after `compinit`. So `_brew` never gets registered on a fresh shell, and `brew <TAB>` falls back to file completion.

Same pattern as docker/kubectl/volta: bind `_brew` for the current session if the cache file is missing, and symlink Homebrew's completion into `$ZSH_CACHE_DIR/completions` so the next shell picks it up during `compinit`.

Fixes #12183

## Other comments:

cc @mcornella

Tested locally:

- `zsh -n plugins/brew/brew.plugin.zsh`
- First-load session: `_comps[brew]` is unset before the plugin, set to `_brew` after
- Second-load session: `compinit` already sets `_comps[brew]=_brew` from the cache symlink