### PR TITLE
fix(eza): pass an explicit WHEN value to --hyperlink

### DIFF
--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -53,7 +53,13 @@ function _configure_eza() {
     _EZA_TAIL+=("--time-style='$_val'")
   fi
   if zstyle -t ":omz:plugins:eza" "hyperlink"; then
-    _EZA_TAIL+=("--hyperlink")
+    # eza >= 0.23 turns --hyperlink into an option with an optional WHEN value,
+    # so a bare --hyperlink swallows the next argument (e.g. `ll ./tmp`).
+    if eza --hyperlink=auto --version &>/dev/null; then
+      _EZA_TAIL+=("--hyperlink=auto")
+    else
+      _EZA_TAIL+=("--hyperlink")
+    fi
   fi
 }
 

--- a/plugins/eza/eza.plugin.zsh
+++ b/plugins/eza/eza.plugin.zsh
@@ -52,10 +52,9 @@ function _configure_eza() {
   if [[ $_val ]]; then
     _EZA_TAIL+=("--time-style='$_val'")
   fi
-  if zstyle -t ":omz:plugins:eza" "hyperlink"; then
-    # eza >= 0.23 turns --hyperlink into an option with an optional WHEN value,
-    # so a bare --hyperlink swallows the next argument (e.g. `ll ./tmp`).
-    if eza --hyperlink=auto --version &>/dev/null; then
+  if zstyle -t ':omz:plugins:eza' 'hyperlink'; then
+    # eza >= 0.23 needs an explicit WHEN value
+    if command eza --hyperlink=auto --version &>/dev/null; then
       _EZA_TAIL+=("--hyperlink=auto")
     else
       _EZA_TAIL+=("--hyperlink")


### PR DESCRIPTION
Since eza 0.23 `--hyperlink` is an option with an optional WHEN value
instead of a boolean flag, so a bare `--hyperlink` at the end of the
alias consumes the following argument:

    $ ll ./tmp
    error: invalid value './tmp' for '--hyperlink [<WHEN>]'
      [possible values: always, auto, never]

Pass `--hyperlink=auto` (mirroring how the plugin already handles
`--icons=auto`) when eza accepts it, and fall back to the bare flag on
older releases.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FD5F6nyEXwHsqtH7eT3HeZ
