### PR TITLE
fix(aws): send asr() error message to stderr and reset terminal color

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -69,7 +69,7 @@ function asr() {
   local -a available_regions
   available_regions=($(aws_regions))
   if [[ -z "${available_regions[(r)$1]}" ]]; then
-    echo "${fg[red]}Available regions: \n$(aws_regions)"
+    echo "${fg[red]}Available regions: \n$(aws_regions)${reset_color}" >&2
     return 1
   fi
 


### PR DESCRIPTION
## Description

`asr()` currently prints its "Available regions" error to stdout without resetting the color, so after a failed `asr <invalid-region>` the terminal stays red and the diagnostics end up in piped output. The sibling helper `asp()` already does both things correctly (`>&2` and `${reset_color}`), so this just mirrors it.

Refs #13949 (the earlier PR on that ticket, #14022, was withdrawn by its author)

## How was this tested?

- Diff is a single line matching the existing `asp()` idiom in the same file
- oh-my-zsh CI runs the plugin checks on this repo
