### PR TITLE
fix(updater): silence git version check output

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -28,7 +28,7 @@ zstyle -s ':omz:update' mode update_mode || {
 if [[ "$update_mode" = disabled ]] \
    || [[ ! -w "$ZSH" || ! -O "$ZSH" ]] \
    || [[ ! -t 1 && ${POWERLEVEL9K_INSTANT_PROMPT:-off} == off ]] \
-   || ! command git --version 2>&1 >/dev/null \
+   || ! command git --version >/dev/null 2>&1 \
    || (builtin cd -q "$ZSH"; ! command git rev-parse --is-inside-work-tree &>/dev/null); then
   unset update_mode
   return


### PR DESCRIPTION
The guard clause in `check_for_upgrade.sh` that checks whether git is installed has its redirections in the wrong order:

```zsh
   || ! command git --version 2>&1 >/dev/null \
```

Redirections are applied left to right, so `2>&1` points stderr at wherever stdout currently is (the terminal), and only then does `>/dev/null` move stdout. The net result is the opposite of the intent: stdout is discarded and stderr goes to the screen.

On a system without git, that means every interactive startup prints

```
zsh: command not found: git
```

before the prompt — which is precisely what this guard exists to avoid, since it's checking for git's absence so it can quietly disable the updater. It also breaks Powerlevel10k's instant prompt, which aborts if anything writes to the terminal during init.

Worth noting the exit status is identical either way (127 in both forms), so the guard already detects a missing git correctly today. This only changes whether it does so silently.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Swap `2>&1 >/dev/null` to `>/dev/null 2>&1` so the git availability check is actually silent.

## Other comments:

AI-assisted: I've been using Oh My Zsh for years and wanted to contribute something back, so I used Claude to help audit the tree for bugs. This was one of the things it turned up. I've read the surrounding code, confirmed the behaviour myself on zsh 5.9.2, and can explain the change.

I checked #13828 — it also touches `check_for_upgrade.sh` but only from line 108 down, so there's no overlap.
