### PR TITLE
fix(systemadmin): quote awk program in `webtraffic`

### DIFF
--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -138,7 +138,7 @@ function consume100() {
 
 # Website traffic statistics (G)
 function webtraffic() {
-  awk "{sum+=$10} END {print sum/1024/1024/1024}" "$(retlog)"
+  awk '{sum+=$10} END {print sum/1024/1024/1024}' "$(retlog)"
 }
 
 # Statistical connections 404


### PR DESCRIPTION
`webtraffic` wraps its awk program in double quotes, so zsh expands `$10` before awk ever sees it. zsh supports multi-digit positional parameters (unlike POSIX sh), so `$10` is read as the function's tenth argument, which is always unset. What awk actually receives is:

```
{sum+=} END {print sum/1024/1024/1024}
```

so the function has never printed a number — only:

```
awk: syntax error at source line 1
 context is
        >>> {sum+=} <<<
awk: illegal statement at source line 1
```

Single-quoting the program lets `$10` reach awk as a field reference, which is what was intended. This also matches the rest of the file: the awk one-liners on lines 134, 146 and 151 already use single quotes, and lines 118-119 use the escaped `\$6` form.

Tested against a two-line fixture whose 10th field is `1073741824` on each row, so a correct program has to print `2`:

```
before:  awk: syntax error ... >>> {sum+=} <<<     (exit 2)
after:   2                                          (exit 0)
```

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Use single quotes for the `webtraffic` awk program so `$10` is interpreted by awk instead of zsh.

## Other comments:

AI-assisted: I've been using Oh My Zsh for years and wanted to contribute something back, so I used Claude to help audit the tree for bugs. This was one of the things it turned up. I've read the surrounding code, confirmed the behaviour myself on zsh 5.9.2, and can explain the change.
