### PR TITLE
fix(diagnostics): correct `reserved_words` array name

### DIFF
--- a/lib/diagnostics.zsh
+++ b/lib/diagnostics.zsh
@@ -271,7 +271,7 @@ function _omz_diag_dump_check_core_commands() {
     unfunction unhash unlimit unset unsetopt vared wait whence where which zcompile
     zle zmodload zparseopts zregexparse zstyle )
   if is-at-least 5.1; then
-    reserved_word+=( declare export integer float local readonly typeset )
+    reserved_words+=( declare export integer float local readonly typeset )
   else
     builtins+=( declare export integer float local readonly typeset )
   fi


### PR DESCRIPTION
`reserved_words` is declared on line 261, but the `is-at-least 5.1` branch appends to `reserved_word` — singular. zsh doesn't complain about assigning to an undeclared name, so this silently creates a new global array that no loop ever reads, and those seven names are never checked. The `else` branch just below spells `builtins` correctly, so only the modern-zsh path is affected.

In practice that means on any zsh >= 5.1 — so essentially every install in use — `omz_diagnostic_dump` never checks whether `declare`, `export`, `integer`, `float`, `local`, `readonly` or `typeset` have been redefined, and happily reports that all core commands are defined normally.

That set isn't incidental: a shadowed `local` or `typeset` is exactly the kind of thing that makes a shell behave inexplicably, and `builtins_fatal` on line 278 already lists `local` alongside `builtin` and `command`. So the dump is currently blind to one of the three things it treats as fatal. It also leaks a stray global array as a side effect.

Before moving these I checked that all seven really are reserved words in modern zsh, so the existing test on line 280 still passes for them on an unmodified shell and this doesn't produce false warnings:

```
declare: reserved     export: reserved      integer: reserved
float: reserved       local: reserved       readonly: reserved
typeset: reserved
```

zsh promoted them to reserved words in 5.1, which is why the `is-at-least 5.1` split exists in the first place — so this just restores what the branch was meant to do.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fix the array name so the zsh >= 5.1 branch appends to `reserved_words` rather than creating an unused `reserved_word` global.

## Other comments:

AI-assisted: I've been using Oh My Zsh for years and wanted to contribute something back, so I used Claude to help audit the tree for bugs. This was one of the things it turned up. I've read the surrounding code, confirmed the behaviour myself on zsh 5.9.2, and can explain the change.
