### PR TITLE
fix(cli): keep completion flag when loading multiple plugins

### DIFF
--- a/lib/cli.zsh
+++ b/lib/cli.zsh
@@ -519,7 +519,7 @@ function _omz::plugin::load {
     # Check if it has completion to reload compinit
     local -a comp_files
     comp_files=($base/_*(N))
-    has_completion=$(( $#comp_files > 0 ))
+    (( has_completion )) || has_completion=$(( $#comp_files > 0 ))
 
     # Load the plugin
     if [[ -f "$base/$plugin.plugin.zsh" ]]; then


### PR DESCRIPTION
Inside the plugin loop, `has_completion` is assigned rather than accumulated:

```zsh
has_completion=$(( $#comp_files > 0 ))
```

Each iteration overwrites what the previous one concluded, so when the loop ends the flag reflects only the last plugin named on the command line.

`omz plugin load z docker` is enough to show it. `plugins/z/_z` sets the flag to 1 on the first iteration, then `plugins/docker/` — which has no top-level `_*` file, since its completions live in a `completions/` subdirectory — resets it to 0. `compinit` never runs, `_z` ends up in `$fpath` unregistered, and pressing Tab after `z ` does nothing with no error to explain why. Reversing the argument order makes it work, which is the tell that ordering matters when it shouldn't.

`(( has_completion )) || ...` short-circuits once the flag is set, so a later plugin without completions can no longer clear it. I kept it strictly 0/1 rather than summing, since it's consumed as a boolean by the `(( has_completion ))` test further down. Loading a single plugin is unaffected — with one iteration there's nothing to overwrite.

Simulating a load of one plugin with completions followed by one without:

```
before:  has_completion=0    (compinit skipped, _z never registered)
after:   has_completion=1
```

This might be related to #10412, but that one is about the startup `$fpath` path rather than `omz plugin load`, so I don't think this closes it.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Accumulate `has_completion` across the loop instead of overwriting it, so `compinit` re-runs whenever any loaded plugin ships completions.

## Other comments:

AI-assisted: I've been using Oh My Zsh for years and wanted to contribute something back, so I used Claude to help audit the tree for bugs. This was one of the things it turned up. I've read the surrounding code, confirmed the behaviour myself on zsh 5.9.2, and can explain the change.
