### PR TITLE
fix(git): restore `git_develop_branch` fallback in `gbds`

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -137,8 +137,9 @@ function gbda() {
 # Copied and modified from James Roeder (jmaroeder) under MIT License
 # https://github.com/jmaroeder/plugin-git/blob/216723ef4f9e8dde399661c39c80bdf73f4076c4/functions/gbda.fish
 function gbds() {
-  local default_branch=$(git_main_branch)
-  (( ! $? )) || default_branch=$(git_develop_branch)
+  local default_branch
+  default_branch=$(git_main_branch) \
+    || default_branch=$(git_develop_branch)
 
   git for-each-ref refs/heads/ "--format=%(refname:short)" | \
     while read branch; do


### PR DESCRIPTION
```zsh
local default_branch=$(git_main_branch)
(( ! $? )) || default_branch=$(git_develop_branch)
```

In zsh the exit status of `local var=$(cmd)` is the status of the `local` builtin, not of the command substitution — `local` succeeded, so `$?` is 0. The test therefore always passes, the `||` always short-circuits, and the `git_develop_branch` fallback is dead code.

That matters because `git_main_branch` doesn't simply fail when it finds nothing. Lines 47-49 have it guess and report that it guessed:

```zsh
# If no main branch was found, fall back to master but return error
echo master
return 1
```

So in a repository whose default branch is `develop` or `dev`, with no `master` or `main` anywhere, `default_branch` is left as the string `master` — a branch that doesn't exist. Every `git merge-base master $branch` then fails, nothing is ever identified as squash-merged, and `gbds` deletes nothing and reports nothing. For a command whose job is deleting branches, silently doing nothing is a fairly unhelpful failure mode.

Splitting the declaration from the assignment makes the status meaningful again. I used `||` directly rather than keeping the `$?` test, since that removes the need to reason about what `$?` refers to at that point — which is the trap the original fell into.

Verified with a stub that mimics `git_main_branch`'s echo-`master`-and-return-1 behaviour:

```
before:  master     (fallback never ran)
after:   develop
```

and with a stub that succeeds, confirming the success path still short-circuits and doesn't call `git_develop_branch`:

```
after:   main
```

Repos that do have `main` or `master` are unaffected, so this only repairs the failing case rather than changing which branch is preferred.

One thing I noticed while here but deliberately left alone to keep this reviewable: the same `local x=$(...)` followed by a `$?` test appears elsewhere in the tree and is probably worth a grep.

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Split the declaration from the assignment in `gbds` so a failing `git_main_branch` actually triggers the `git_develop_branch` fallback.

## Other comments:

AI-assisted: I've been using Oh My Zsh for years and wanted to contribute something back, so I used Claude to help audit the tree for bugs. This was one of the things it turned up. I've read the surrounding code, confirmed the behaviour myself on zsh 5.9.2, and can explain the change.
