### PR TITLE
feat(juju): add unit and application name completion

### DIFF
--- a/plugins/juju/README.md
+++ b/plugins/juju/README.md
@@ -1,7 +1,7 @@
 # juju plugin
 
-This plugin provides useful aliases and functions for [juju](https://juju.is/) (for TAB completion,
-refer to the [official repo](https://github.com/juju/juju/blob/develop/etc/bash_completion.d/juju)).
+This plugin provides useful aliases and functions for [juju](https://juju.is/), including
+zsh tab completion for juju commands, flags, models, controllers, applications, and units.
 
 To use this plugin, add `juju` to the plugins array in your zshrc file.
 

--- a/plugins/juju/_juju
+++ b/plugins/juju/_juju
@@ -132,6 +132,37 @@ __juju_controllers()
         | command jq -r '.controllers | keys | .[]' 2>/dev/null
 }
 
+# Output all unit names for the current model (e.g. "mysql/0", "mysql/leader").
+# Includes subordinate units that appear nested under principal units.
+__juju_units()
+{
+    command juju status --format=json 2>/dev/null \
+        | command jq -r '
+            .applications // {} | to_entries[] |
+            .value.units // {} | to_entries[] |
+            ( [.key] + ( .value.subordinates // {} | keys ) ) | .[]
+          ' 2>/dev/null
+}
+
+# Complete a unit token.  If the token already contains a colon (e.g. the user
+# has typed "mysql/0:" for an scp path) we return immediately so zsh can fall
+# through to its built-in file/path completion for the remote path portion.
+__juju_complete_unit()
+{
+    local current="$1"
+    local -a units
+    __juju_debug "[complete_unit] current='${current}'"
+
+    # Once a colon is present the unit name is already complete; let the shell
+    # handle whatever comes after (remote path, etc.).
+    [[ "$current" == *:* ]] && return 1
+
+    units=("${(@f)$(__juju_units)}")
+    __juju_debug "[complete_unit] units=${#units}"
+    (( ${#units} )) || return 1
+    compadd -S '' -- "${units[@]}"
+}
+
 _juju()
 {
     # Initialise lookup arrays here so they are set on the very first invocation.
@@ -160,6 +191,28 @@ _juju()
     local -a _juju_controller_flags=(
         -c
         --controller
+    )
+    # Commands whose first positional argument is a unit name.
+    # resolved/remove-unit also accept app names but offering units is most useful.
+    local -a _juju_unit_commands=(
+        add-storage
+        attach-storage
+        debug-code
+        debug-hook
+        debug-hooks
+        resolved
+        resolve
+        show-unit
+    )
+    # Commands that accept one or more unit names as ALL positional args
+    # (remove-unit also accepts app names; we complete units here regardless).
+    local -a _juju_unit_multi_commands=(
+        remove-unit
+    )
+    # Flags that take a unit name as their value.
+    local -a _juju_unit_flags=(
+        -u
+        --unit
     )
 
     __juju_debug "[_juju] curcontext: ${curcontext}"
@@ -198,6 +251,13 @@ _juju()
         return 1
     fi
 
+    # Unit name completion: flag value (e.g. juju exec --unit <TAB>)
+    if (( ${_juju_unit_flags[(I)$prev]} )); then
+        __juju_debug "[_juju] unit flag completion, current: '${current}'"
+        __juju_complete_unit "$current" && return 0
+        return 1
+    fi
+
     if [[ -z "$subcmd" ]]; then
         # No subcommand yet — complete subcommand names.
         completions=("${(@f)$(__juju_help_commands)}")
@@ -218,6 +278,53 @@ _juju()
     if (( ${_juju_model_commands[(I)$subcmd]} )) && [[ "$current" != -* ]]; then
         __juju_debug "[_juju] model command completion, current: '${current}'"
         __juju_complete_model "$current" && return 0
+        return 1
+    fi
+
+    # Unit name completion: single-unit positional arg commands (e.g. juju ssh <TAB>,
+    # juju show-unit <TAB>, juju add-storage <TAB>).
+    if (( ${_juju_unit_commands[(I)$subcmd]} )) && [[ "$current" != -* ]]; then
+        __juju_debug "[_juju] unit command completion, current: '${current}'"
+        __juju_complete_unit "$current" && return 0
+        return 1
+    fi
+
+    # Unit name completion: commands that accept multiple unit names as positional
+    # args (e.g. juju remove-unit <TAB>  or  juju remove-unit mysql/0 <TAB>).
+    if (( ${_juju_unit_multi_commands[(I)$subcmd]} )) && [[ "$current" != -* ]]; then
+        __juju_debug "[_juju] unit multi command completion, current: '${current}'"
+        __juju_complete_unit "$current" && return 0
+        return 1
+    fi
+
+    # Unit name completion for "juju run <unit> [<unit>...] <action>":
+    # complete units until a non-unit word has been seen after the subcommand,
+    # then fall through to flag/option completion.
+    if [[ "$subcmd" == "run" ]] && [[ "$current" != -* ]]; then
+        # Count non-flag positional args after "run" (excluding current word).
+        local pos=0
+        local last_positional=""
+        for (( i = 3; i < CURRENT; i++ )); do
+            if [[ "${words[i]}" != -* ]]; then
+                (( pos++ ))
+                last_positional="${words[i]}"
+            fi
+        done
+        __juju_debug "[_juju] run: pos=${pos} last_positional='${last_positional}'"
+        # If no positional args yet, or all previous positional args look like
+        # units (app/N), keep completing units.
+        if (( pos == 0 )) || [[ "$last_positional" == */* ]]; then
+            __juju_debug "[_juju] run: completing unit"
+            __juju_complete_unit "$current" && return 0
+            return 1
+        fi
+    fi
+
+    # Unit name completion for "juju ssh <TAB>" and "juju scp <TAB>":
+    # the target may be a bare unit name or a "unit:/remote/path" token.
+    if [[ "$subcmd" == "ssh" || "$subcmd" == "scp" ]] && [[ "$current" != -* ]]; then
+        __juju_debug "[_juju] ssh/scp unit completion, current: '${current}'"
+        __juju_complete_unit "$current" && return 0
         return 1
     fi
 

--- a/plugins/juju/_juju
+++ b/plugins/juju/_juju
@@ -1,5 +1,4 @@
 #compdef juju
-(( $+functions[compdef] )) && compdef _juju juju
 
 # zsh completion for juju                                  -*- shell-script -*-
 
@@ -127,43 +126,42 @@ __juju_complete_model()
     fi
 }
 
-# Commands whose first positional argument is a model name.
-_juju_model_commands=(
-    destroy-model
-    grant-model
-    revoke-model
-    switch
-)
-
-# Flags that take a model name as their value.
-_juju_model_flags=(
-    -m
-    --model
-)
-
 __juju_controllers()
 {
     command juju controllers --format=json 2>/dev/null \
         | command jq -r '.controllers | keys | .[]' 2>/dev/null
 }
 
-# Commands whose first positional argument is a controller name.
-_juju_controller_commands=(
-    destroy-controller
-    kill-controller
-    login
-    logout
-    unregister
-)
-
-# Flags that take a controller name as their value.
-_juju_controller_flags=(
-    -c
-    --controller
-)
-
 _juju()
 {
+    # Initialise lookup arrays here so they are set on the very first invocation.
+    # (With #compdef autoloading the whole file is the function body, so any
+    # file-scope assignments only take effect during the first call — after which
+    # the inner _juju() definition replaces the autoloaded one and those
+    # assignments are never reached again.  Keeping the arrays here is the
+    # correct pattern.)
+    local -a _juju_model_commands=(
+        destroy-model
+        grant-model
+        revoke-model
+        switch
+    )
+    local -a _juju_model_flags=(
+        -m
+        --model
+    )
+    local -a _juju_controller_commands=(
+        destroy-controller
+        kill-controller
+        login
+        logout
+        unregister
+    )
+    local -a _juju_controller_flags=(
+        -c
+        --controller
+    )
+
     __juju_debug "[_juju] curcontext: ${curcontext}"
     local -a completions
 
@@ -229,3 +227,11 @@ _juju()
     (( ${#completions} )) && _describe "option" completions && return 0
     return 1
 }
+
+# When this file is autoloaded by the completion system the entire file is
+# executed as the function body on the first invocation.  The inner _juju()
+# definition above replaces that autoloaded function, but the replacement is
+# never *called* during that first run.  Explicitly calling _juju here ensures
+# completions are produced on the very first tab press, matching the standard
+# zsh pattern used by _git and other large completion files.
+_juju "$@"

--- a/plugins/juju/_juju
+++ b/plugins/juju/_juju
@@ -144,6 +144,32 @@ __juju_units()
           ' 2>/dev/null
 }
 
+# Output all application names deployed in the current model.
+__juju_applications()
+{
+    command juju status --format=json 2>/dev/null \
+        | command jq -r '.applications // {} | keys | .[]' 2>/dev/null
+}
+
+# Complete an application token.
+# For integrate/remove-relation the token may be "app:endpoint"; if a colon is
+# already present we return 1 so the caller can fall through to endpoint or
+# generic completion — the application part is already typed.
+__juju_complete_application()
+{
+    local current="$1"
+    local -a apps
+    __juju_debug "[complete_app] current='${current}'"
+
+    # Colon means "app:" prefix is done; fall through to endpoint/other completion.
+    [[ "$current" == *:* ]] && return 1
+
+    apps=("${(@f)$(__juju_applications)}")
+    __juju_debug "[complete_app] apps=${#apps}"
+    (( ${#apps} )) || return 1
+    compadd -S '' -- "${apps[@]}"
+}
+
 # Complete a unit token.  If the token already contains a colon (e.g. the user
 # has typed "mysql/0:" for an scp path) we return immediately so zsh can fall
 # through to its built-in file/path completion for the remote path portion.
@@ -214,6 +240,39 @@ _juju()
         -u
         --unit
     )
+    # Commands whose first positional argument is an application name.
+    local -a _juju_app_commands=(
+        actions
+        list-actions
+        add-unit
+        attach-resource
+        bind
+        config
+        constraints
+        expose
+        refresh
+        resources
+        list-resources
+        scale-application
+        set-constraints
+        show-action
+        show-application
+        trust
+        unexpose
+    )
+    # Commands that accept one or more application names as ALL positional args.
+    local -a _juju_app_multi_commands=(
+        remove-application
+        remove-saas
+    )
+    # Flags that take an application name as their value.
+    local -a _juju_app_flags=(
+        -a
+        --app
+        --application
+        --apps
+        --applications
+    )
 
     __juju_debug "[_juju] curcontext: ${curcontext}"
     local -a completions
@@ -258,6 +317,13 @@ _juju()
         return 1
     fi
 
+    # Application name completion: flag value (e.g. juju exec --app <TAB>)
+    if (( ${_juju_app_flags[(I)$prev]} )); then
+        __juju_debug "[_juju] app flag completion, current: '${current}'"
+        __juju_complete_application "$current" && return 0
+        return 1
+    fi
+
     if [[ -z "$subcmd" ]]; then
         # No subcommand yet — complete subcommand names.
         completions=("${(@f)$(__juju_help_commands)}")
@@ -278,6 +344,31 @@ _juju()
     if (( ${_juju_model_commands[(I)$subcmd]} )) && [[ "$current" != -* ]]; then
         __juju_debug "[_juju] model command completion, current: '${current}'"
         __juju_complete_model "$current" && return 0
+        return 1
+    fi
+
+    # Application name completion: single-application positional arg commands.
+    if (( ${_juju_app_commands[(I)$subcmd]} )) && [[ "$current" != -* ]]; then
+        __juju_debug "[_juju] app command completion, current: '${current}'"
+        __juju_complete_application "$current" && return 0
+        return 1
+    fi
+
+    # Application name completion: commands that accept multiple application names.
+    if (( ${_juju_app_multi_commands[(I)$subcmd]} )) && [[ "$current" != -* ]]; then
+        __juju_debug "[_juju] app multi command completion, current: '${current}'"
+        __juju_complete_application "$current" && return 0
+        return 1
+    fi
+
+    # Application name completion for "juju integrate"/"juju relate" and
+    # "juju remove-relation": both positional args are "app[:endpoint]".
+    # Complete the application part; once a colon is present __juju_complete_application
+    # returns 1 so we fall through to generic/flag completion for the endpoint.
+    if [[ "$subcmd" == "integrate" || "$subcmd" == "relate" || "$subcmd" == "remove-relation" ]] \
+       && [[ "$current" != -* ]]; then
+        __juju_debug "[_juju] integrate/remove-relation app completion, current: '${current}'"
+        __juju_complete_application "$current" && return 0
         return 1
     fi
 

--- a/plugins/juju/_juju
+++ b/plugins/juju/_juju
@@ -108,14 +108,14 @@ __juju_complete_model()
     if [[ "$current" == *:* ]]; then
         local ctrl="${current%%:*}"
         local models
-        models=("${(@f)$(__juju_models "$ctrl")}")
+        models=(${(f)"$(__juju_models "$ctrl")"})
         completions=("${models[@]/#/${ctrl}:}")
         __juju_debug "[complete_model] ctrl=${ctrl} completions=${#completions}: ${completions[*]}"
         compadd -S '' -q -- "${completions[@]}"
     else
         local -a models ctrls
-        models=("${(@f)$(__juju_models)}")
-        ctrls=("${(@f)$(__juju_controllers)}")
+        models=(${(f)"$(__juju_models)"})
+        ctrls=(${(f)"$(__juju_controllers)"})
         __juju_debug "[complete_model] models=${#models}: ${models[*]}"
         __juju_debug "[complete_model] ctrls=${#ctrls}: ${ctrls[*]}"
         __juju_debug "[complete_model] calling _alternative"
@@ -151,23 +151,36 @@ __juju_applications()
         | command jq -r '.applications // {} | keys | .[]' 2>/dev/null
 }
 
+# Output all SAAS/remote application names consumed by the current model.
+__juju_saas()
+{
+    command juju status --format=json 2>/dev/null \
+        | command jq -r '."application-endpoints" // {} | keys | .[]' 2>/dev/null
+}
+
 # Complete an application token.
 # For integrate/remove-relation the token may be "app:endpoint"; if a colon is
 # already present we return 1 so the caller can fall through to endpoint or
 # generic completion — the application part is already typed.
+# Pass a second arg "nospace" to suppress trailing space (for colon-syntax commands).
 __juju_complete_application()
 {
     local current="$1"
+    local no_suffix="${2:-}"
     local -a apps
     __juju_debug "[complete_app] current='${current}'"
 
     # Colon means "app:" prefix is done; fall through to endpoint/other completion.
     [[ "$current" == *:* ]] && return 1
 
-    apps=("${(@f)$(__juju_applications)}")
+    apps=(${(f)"$(__juju_applications)"})
     __juju_debug "[complete_app] apps=${#apps}"
     (( ${#apps} )) || return 1
-    compadd -S '' -- "${apps[@]}"
+    if [[ -n "$no_suffix" ]]; then
+        compadd -S '' -- "${apps[@]}"
+    else
+        compadd -- "${apps[@]}"
+    fi
 }
 
 # Complete a unit token.  If the token already contains a colon (e.g. the user
@@ -176,6 +189,7 @@ __juju_complete_application()
 __juju_complete_unit()
 {
     local current="$1"
+    local no_suffix="${2:-}"
     local -a units
     __juju_debug "[complete_unit] current='${current}'"
 
@@ -183,10 +197,14 @@ __juju_complete_unit()
     # handle whatever comes after (remote path, etc.).
     [[ "$current" == *:* ]] && return 1
 
-    units=("${(@f)$(__juju_units)}")
+    units=(${(f)"$(__juju_units)"})
     __juju_debug "[complete_unit] units=${#units}"
     (( ${#units} )) || return 1
-    compadd -S '' -- "${units[@]}"
+    if [[ -n "$no_suffix" ]]; then
+        compadd -S '' -- "${units[@]}"
+    else
+        compadd -- "${units[@]}"
+    fi
 }
 
 _juju()
@@ -263,6 +281,9 @@ _juju()
     # Commands that accept one or more application names as ALL positional args.
     local -a _juju_app_multi_commands=(
         remove-application
+    )
+    # Commands that accept one or more SAAS names as positional args.
+    local -a _juju_saas_commands=(
         remove-saas
     )
     # Flags that take an application name as their value.
@@ -282,10 +303,12 @@ _juju()
     # Find the subcommand: first non-flag word typed after "juju", excluding the
     # word currently being completed (words[CURRENT]).
     local subcmd=""
+    local subcmd_idx=0
     local i
     for (( i = 2; i < CURRENT; i++ )); do
         if [[ "${words[i]}" != -* ]]; then
             subcmd="${words[i]}"
+            subcmd_idx=$i
             break
         fi
     done
@@ -297,7 +320,7 @@ _juju()
 
     # Controller name completion: flag value (e.g. juju status -c <TAB>)
     if (( ${_juju_controller_flags[(I)$prev]} )); then
-        completions=("${(@f)$(__juju_controllers)}")
+        completions=(${(f)"$(__juju_controllers)"})
         __juju_debug "[_juju] controller flag completions: ${#completions}"
         (( ${#completions} )) && _describe "controller" completions && return 0
         return 1
@@ -313,7 +336,7 @@ _juju()
     # Unit name completion: flag value (e.g. juju exec --unit <TAB>)
     if (( ${_juju_unit_flags[(I)$prev]} )); then
         __juju_debug "[_juju] unit flag completion, current: '${current}'"
-        __juju_complete_unit "$current" && return 0
+        __juju_complete_unit "$current" nospace && return 0
         return 1
     fi
 
@@ -326,7 +349,7 @@ _juju()
 
     if [[ -z "$subcmd" ]]; then
         # No subcommand yet — complete subcommand names.
-        completions=("${(@f)$(__juju_help_commands)}")
+        completions=(${(f)"$(__juju_help_commands)"})
         __juju_debug "[_juju] command completions count: ${#completions}"
         (( ${#completions} )) && _describe "command" completions && return 0
         return 1
@@ -334,7 +357,7 @@ _juju()
 
     # Controller name completion: positional arg (e.g. juju destroy-controller <TAB>)
     if (( ${_juju_controller_commands[(I)$subcmd]} )) && [[ "$current" != -* ]]; then
-        completions=("${(@f)$(__juju_controllers)}")
+        completions=(${(f)"$(__juju_controllers)"})
         __juju_debug "[_juju] controller command completions: ${#completions}"
         (( ${#completions} )) && _describe "controller" completions && return 0
         return 1
@@ -361,6 +384,16 @@ _juju()
         return 1
     fi
 
+    # SAAS name completion for "juju remove-saas <TAB>".
+    if (( ${_juju_saas_commands[(I)$subcmd]} )) && [[ "$current" != -* ]]; then
+        __juju_debug "[_juju] saas command completion, current: '${current}'"
+        local -a saas
+        saas=(${(f)"$(__juju_saas)"})
+        (( ${#saas} )) || return 1
+        compadd -- "${saas[@]}"
+        return 0
+    fi
+
     # Application name completion for "juju integrate"/"juju relate" and
     # "juju remove-relation": both positional args are "app[:endpoint]".
     # Complete the application part; once a colon is present __juju_complete_application
@@ -368,8 +401,7 @@ _juju()
     if [[ "$subcmd" == "integrate" || "$subcmd" == "relate" || "$subcmd" == "remove-relation" ]] \
        && [[ "$current" != -* ]]; then
         __juju_debug "[_juju] integrate/remove-relation app completion, current: '${current}'"
-        __juju_complete_application "$current" && return 0
-        return 1
+        __juju_complete_application "$current" nospace && return 0
     fi
 
     # Unit name completion: single-unit positional arg commands (e.g. juju ssh <TAB>,
@@ -395,7 +427,7 @@ _juju()
         # Count non-flag positional args after "run" (excluding current word).
         local pos=0
         local last_positional=""
-        for (( i = 3; i < CURRENT; i++ )); do
+        for (( i = subcmd_idx + 1; i < CURRENT; i++ )); do
             if [[ "${words[i]}" != -* ]]; then
                 (( pos++ ))
                 last_positional="${words[i]}"
@@ -413,14 +445,23 @@ _juju()
 
     # Unit name completion for "juju ssh <TAB>" and "juju scp <TAB>":
     # the target may be a bare unit name or a "unit:/remote/path" token.
-    if [[ "$subcmd" == "ssh" || "$subcmd" == "scp" ]] && [[ "$current" != -* ]]; then
-        __juju_debug "[_juju] ssh/scp unit completion, current: '${current}'"
-        __juju_complete_unit "$current" && return 0
+    # For scp, when a colon is present, also offer local files.
+    if [[ "$subcmd" == "ssh" ]] && [[ "$current" != -* ]]; then
+        __juju_debug "[_juju] ssh unit completion, current: '${current}'"
+        __juju_complete_unit "$current" nospace && return 0
         return 1
+    fi
+    if [[ "$subcmd" == "scp" ]] && [[ "$current" != -* ]]; then
+        __juju_debug "[_juju] scp unit completion, current: '${current}'"
+        if [[ "$current" != *:* ]]; then
+            __juju_complete_unit "$current" nospace
+        fi
+        _files
+        return 0
     fi
 
     # Flag completion for all other subcommands (also shown without leading dash)
-    completions=("${(@f)$(__juju_help_options "$subcmd")}")
+    completions=(${(f)"$(__juju_help_options "$subcmd")"})
     __juju_debug "[_juju] option completions count: ${#completions}"
     (( ${#completions} )) && _describe "option" completions && return 0
     return 1


### PR DESCRIPTION
This PR extends the juju plugin's zsh completion with unit and application name autocompletion, sourced live from `juju status`. It also fixes a bug where pressing `<TAB>` for the first time in a new shell produced no completions.

Typing `juju ssh <TAB>`, `juju config <TAB>`, `juju integrate <TAB>` and many other commands will now suggest real unit and application names from the current model. The `app:endpoint` and `unit:/path` colon-suffix patterns used by `integrate` and `scp` are handled correctly — completion stops at the colon and lets the shell take over for the remainder.

The first-tab fix resolves a subtle zsh autoloading issue: with `#compdef`, the file body is the function, so a nested `_juju() {}` definition at the end was replacing but never calling the real logic on the first invocation. The fix follows the same pattern used by `_git` in the zsh distribution.


## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- `plugins/juju/_juju`: fix first-tab completion; add unit and application name completion

## Other comments:

- I'm one of the maintainers of juju in Canonical.
- AI was used as a coding assistant during development.