### PR TITLE
fix(vagrant): complete VM names for suspend and rdp

### DIFF
--- a/plugins/vagrant/_vagrant
+++ b/plugins/vagrant/_vagrant
@@ -127,7 +127,7 @@ case $state in
       (box)
           __vagrant-box
       ;;
-      (up|provision|port|package|destroy|reload|ssh|ssh-config|halt|resume|status)
+      (up|provision|port|package|destroy|reload|ssh|ssh-config|halt|resume|status|suspend|rdp)
       _arguments ':feature:__vm_list'
     esac
   ;;


### PR DESCRIPTION
`vagrant suspend <TAB>` and `vagrant rdp <TAB>` complete nothing today. Both subcommands take a machine name, and both are already listed in `_1st_arguments`, but they were left out of the case that expands to the VM list.

Reapplied from #5062, opened by @schod in May 2016. His branch no longer merges — the surrounding line gained `port` in #7455 — so this lands the same one-word change against current `master`, with credit.

Closes #5062

## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- `plugins/vagrant/_vagrant`: add `suspend` and `rdp` to the case that completes VM names.

## Other comments:

Found during a pass over the oldest open PRs. Verified `zsh -n` passes, which is what CI runs; the completion itself was not exercised, as Vagrant is not installed here.

AI-assisted: Claude Code helped triage the stale PR and reapply the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUUZuQprbM9eJKToiZWVtm