### PR TITLE
fix(agnoster): respect conda changeps1 and escape env name

### DIFF
--- a/themes/agnoster.zsh-theme
+++ b/themes/agnoster.zsh-theme
@@ -314,8 +314,11 @@ prompt_dir() {
 
 # Virtualenv: current working virtualenv
 prompt_virtualenv() {
-  if [ -n "$CONDA_DEFAULT_ENV" ]; then
-    prompt_segment magenta $CURRENT_FG "🐍 $CONDA_DEFAULT_ENV"
+  # Skip the conda segment when conda is already showing the environment itself,
+  # i.e. when changeps1 is left on. This mirrors how VIRTUAL_ENV_DISABLE_PROMPT
+  # is handled below, and stops the name appearing twice in the prompt.
+  if [[ -n "$CONDA_DEFAULT_ENV" && -z "$CONDA_PROMPT_MODIFIER" ]]; then
+    prompt_segment magenta $CURRENT_FG "🐍 ${CONDA_DEFAULT_ENV:t:gs/%/%%}"
   fi
   if [[ -n "$VIRTUAL_ENV" && -n "$VIRTUAL_ENV_DISABLE_PROMPT" ]]; then
     prompt_segment "$AGNOSTER_VENV_BG" "$AGNOSTER_VENV_FG" "(${VIRTUAL_ENV:t:gs/%/%%})"


### PR DESCRIPTION
Picks up the good parts of #7067 (@John-P, 2018), which sat long enough that a different conda implementation shipped first in #13160. Closes #7067.

`prompt_virtualenv` currently shows the conda segment whenever `CONDA_DEFAULT_ENV` is set. Three problems come out of that:

**1. The env name shows up twice.** conda's `changeps1` is on by default, so conda already prepends `(myenv) ` to the prompt. Agnoster then adds its own `🐍 myenv` next to it. #7067 guarded against this with `CONDA_PROMPT_MODIFIER` and we didn't carry that over.

**2. Envs activated by path print the whole path.** `conda activate /opt/conda/envs/myenv` sets `CONDA_DEFAULT_ENV` to that full path, so the segment becomes `🐍 /opt/conda/envs/myenv`.

**3. A `%` in the env name breaks prompt rendering.** The neighbouring virtualenv line already escapes this; the conda line doesn't:

```console
$ zsh -f -c 'CONDA_DEFAULT_ENV="my%env"; print -P "${CONDA_DEFAULT_ENV}"'
my0nv
```

All three are fixed by making the conda branch behave like the virtualenv branch directly below it.

### Behavior change worth noting

Users running conda on default settings will stop seeing the `🐍` segment, because conda is already displaying the env itself. That is the duplication this removes, and it matches how `VIRTUAL_ENV_DISABLE_PROMPT` already gates the virtualenv segment — but it is a visible change for people who didn't opt in, so flagging it explicitly.

### Testing

```
1. conda active, changeps1 off   -> [seg |🐍 myenv|]
2. conda active, changeps1 on    -> (nothing)
3. env given as a full path      -> [seg |🐍 myenv|]
4. env name with a percent sign  -> [seg |🐍 my%env|]
5. no conda at all               -> (nothing)
```

`zsh -n themes/agnoster.zsh-theme` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

