### PR TITLE
fix(poetry-env): scope venv_dir to the activation function

### DIFF
--- a/plugins/poetry-env/poetry-env.plugin.zsh
+++ b/plugins/poetry-env/poetry-env.plugin.zsh
@@ -23,7 +23,7 @@ _togglePoetryShell() {
 
   # Activate the environment if in a Poetry directory and no environment is currently active
   if [[ $in_poetry_dir -eq 1 ]] && [[ $poetry_active -ne 1 ]]; then
-    venv_dir=$(poetry env info --path 2>/dev/null)
+    local venv_dir=$(poetry env info --path 2>/dev/null)
     # Handle case where poetry returns "." for in-project virtual environments
     if [[ "$venv_dir" == "." ]]; then
       venv_dir="$PWD/.venv"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (n/a, no new aliases)

## Changes:

Declare `venv_dir` as `local` in `_togglePoetryShell`.

It was assigned without `local`, so every activation left it behind in the caller's scope. The sibling `uv-env` plugin already declares the same variable `local`.

Follow-up to #13932, where I noticed this while reviewing. One line, no behavior change.

## Testing:

Sourced the plugin in `zsh -f` with a stubbed `poetry` and a fake `.venv/bin/activate`, in a directory with both marker files, and checked the caller's scope afterwards:

- `master`: `venv_dir` is set in the caller's scope after activation
- this branch: `venv_dir` is not set in the caller's scope

`zsh -n plugins/poetry-env/poetry-env.plugin.zsh` passes.

Activation behavior itself is unchanged: `venv_dir` is only ever read inside the function that assigns it, which I confirmed with a repo-wide grep.

## Other comments:

AI disclosure: found and fixed with Claude Code while reviewing #13932. I verified the leak and the fix myself with the `zsh -f` test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
