### PR TITLE
feat(kubectl): add kesec alias for editing secrets

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -71,6 +71,7 @@ plugins=(... kubectl)
 |          |                                                         | **Secret management**                                                                            |
 | kgsec    | `kubectl get secret`                                    | Get secret for decoding                                                                          |
 | kgseca   | `kubectl get secret --all-namespaces`                   | List secrets across all namespaces                                                               |
+| kesec    | `kubectl edit secret`                                   | Edit secret resource                                                                             |
 | kdsec    | `kubectl describe secret`                               | Describe secret resource in detail                                                               |
 | kdelsec  | `kubectl delete secret`                                 | Delete the secret                                                                                |
 |          |                                                         | **Deployment management**                                                                        |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -93,6 +93,7 @@ alias kdelcm='kubectl delete configmap'
 # Secret management
 alias kgsec='kubectl get secret'
 alias kgseca='kubectl get secret --all-namespaces'
+alias kesec='kubectl edit secret'
 alias kdsec='kubectl describe secret'
 alias kdelsec='kubectl delete secret'
 


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `kesec` (`kubectl edit secret`) to the kubectl plugin, in the Secret management block.
- Add the matching README row.

Closes #8309.

## Other comments:

**Use case.** The plugin defines an edit alias for thirteen resource types (`kep`, `kes`, `kei`, `kens`, `kecm`, `ked`, `kers`, `kess`, `keno`, `kepvc`, `keds`, `kecj`, `kej`). Secret is the only resource that has `kgsec`, `kdsec` and `kdelsec` but no edit counterpart, so this fills a gap in a convention the plugin already applies everywhere else. `kesec` does not shadow any existing command or alias.

**Credit.** This reapplies @Moulick's #8309, open since October 2019, and he is credited with a `Co-Authored-By` trailer. Two changes from his original: the alias is placed after `kgseca` to match the get / get-all / edit / describe / delete ordering used by the ConfigMap and Deployment blocks, and the README row was added.

**Testing.** Sourced the plugin in `zsh -f` and confirmed `kesec`, `kgseca` and `kdsec` all expand as expected. No cluster was involved; `kubectl edit secret` itself is unchanged upstream behavior.

**AI assistance.** Found during backlog triage and prepared with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
