### PR TITLE
fix(ssh-agent): add honor-existing to reuse a running agent

### DIFF
--- a/plugins/ssh-agent/README.md
+++ b/plugins/ssh-agent/README.md
@@ -21,6 +21,18 @@ To enable **agent forwarding support** add the following to your zshrc file:
 zstyle :omz:plugins:ssh-agent agent-forwarding yes
 ```
 
+### `honor-existing`
+
+If your session already provides an ssh-agent — a desktop keyring, `gpg-agent`,
+KeePassXC, or an agent forwarded over SSH — the plugin normally ignores it and
+starts one of its own, which leaves you with two agents. Set this to reuse the
+running agent instead, and only start a new one when `$SSH_AUTH_SOCK` is empty
+or does not answer:
+
+```zsh
+zstyle :omz:plugins:ssh-agent honor-existing yes
+```
+
 ### `helper`
 
 To set an **external helper** to ask for the passwords and possibly store

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -1,16 +1,27 @@
 # Get the filename to store/lookup the environment from
 ssh_env_cache="$HOME/.ssh/environment-$SHORT_HOST"
 
+# Test if $SSH_AUTH_SOCK points at a listening agent
+function _is_agent_running() {
+  [[ -n "$SSH_AUTH_SOCK" && -S "$SSH_AUTH_SOCK" ]] || return 1
+  zmodload zsh/net/socket
+  zsocket "$SSH_AUTH_SOCK" 2>/dev/null || return 1
+  exec {REPLY}>&- # close the probe connection
+  return 0
+}
+
 function _start_agent() {
+  # Reuse an agent the session already provides, if enabled
+  if zstyle -t :omz:plugins:ssh-agent honor-existing && _is_agent_running; then
+    return 0
+  fi
+
   # Check if ssh-agent is already running
   if [[ -f "$ssh_env_cache" ]]; then
     . "$ssh_env_cache" > /dev/null
 
     # Test if $SSH_AUTH_SOCK is visible
-    zmodload zsh/net/socket
-    if [[ -S "$SSH_AUTH_SOCK" ]] && zsocket "$SSH_AUTH_SOCK" 2>/dev/null; then
-      return 0
-    fi
+    _is_agent_running && return 0
   fi
 
   if [[ ! -d "$HOME/.ssh" ]]; then
@@ -124,4 +135,4 @@ if ! zstyle -t :omz:plugins:ssh-agent lazy; then
 fi
 
 unset agent_forwarding ssh_env_cache
-unfunction _start_agent _add_identities
+unfunction _start_agent _add_identities _is_agent_running

--- a/plugins/ssh-agent/ssh-agent.plugin.zsh
+++ b/plugins/ssh-agent/ssh-agent.plugin.zsh
@@ -3,8 +3,9 @@ ssh_env_cache="$HOME/.ssh/environment-$SHORT_HOST"
 
 # Test if $SSH_AUTH_SOCK points at a listening agent
 function _is_agent_running() {
+  local REPLY
   [[ -n "$SSH_AUTH_SOCK" && -S "$SSH_AUTH_SOCK" ]] || return 1
-  zmodload zsh/net/socket
+  zmodload zsh/net/socket 2>/dev/null || return 1
   zsocket "$SSH_AUTH_SOCK" 2>/dev/null || return 1
   exec {REPLY}>&- # close the probe connection
   return 0


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (No new aliases.)

## Changes:

Fixes #11067.

`_start_agent` sources `$HOME/.ssh/environment-$SHORT_HOST` before anything ever reads an inherited `SSH_AUTH_SOCK`, so an agent the session already provides — a desktop keyring, `gpg-agent`, KeePassXC, or one forwarded over SSH — gets overwritten and a second agent is started. Until now the only way to defer to an existing agent was to set `agent-forwarding yes`, which both people on that issue pointed out is a different feature being borrowed for the job.

- Add an opt-in `honor-existing` style. When set, the plugin probes the inherited `SSH_AUTH_SOCK` and reuses that agent if it answers, only starting its own when there is nothing there.
- Move the socket probe into a small `_is_agent_running` helper shared with the existing cached-agent path.
- Document the new style in the plugin README.

## Other comments:

**Default behaviour is unchanged.** The new style is off unless you set it.

Tested on zsh 5.9 by sourcing the plugin under `zsh -f` with `SSH_AUTH_SOCK` pointed at a real listening socket (created with `zsocket -l`) and a stale cache file on disk, with `ssh-agent` stubbed so no real agent was ever started:

| | master | this PR |
|---|---|---|
| style unset | starts its own agent, discards the inherited socket | same |
| `honor-existing yes` | starts its own agent, discards the inherited socket | keeps the inherited agent |

Also ran `zsh -n` on the plugin.

One incidental fix: `zsocket` leaves the connection it opens in `$REPLY`, and the existing code never closed it, so master leaks a file descriptor on every shell start where the cached agent is live. The shared helper closes it.

AI disclosure: written with Claude Code, reviewed and tested by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
