### PR TITLE
feat(systemd): add `sc-edit-full`

### DIFF
--- a/plugins/systemd/README.md
+++ b/plugins/systemd/README.md
@@ -45,6 +45,7 @@ plugins=(... systemd)
 | `sc-set-environment`   | `sudo systemctl set-environment`   | Set one or more systemd manager environment variables            |
 | `sc-unset-environment` | `sudo systemctl unset-environment` | Unset one or more systemd manager environment variables          |
 | `sc-edit`              | `sudo systemctl edit`              | Edit a drop-in snippet or a whole replacement file with `--full` |
+| `sc-edit-full`         | `sudo systemctl edit --full`       | Edit the whole unit file instead of a drop-in snippet            |
 | `sc-enable-now`        | `sudo systemctl enable --now`      | Enable and start unit(s)                                         |
 | `sc-disable-now`       | `sudo systemctl disable --now`     | Disable and stop unit(s)                                         |
 | `sc-mask-now`          | `sudo systemctl mask --now`        | Mask and stop unit(s)                                            |

--- a/plugins/systemd/systemd.plugin.zsh
+++ b/plugins/systemd/systemd.plugin.zsh
@@ -97,6 +97,10 @@ alias scu-mask-now="scu-mask --now"
 alias scu-failed='systemctl --user --failed'
 alias sc-failed='systemctl --failed'
 
+# --full commands
+alias sc-edit-full="sc-edit --full"
+alias scu-edit-full="scu-edit --full"
+
 function systemd_prompt_info {
   local unit
   for unit in "$@"; do


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Closes #11194. This reapplies @galenguyer's #11217, which had gone stale against master — the change is his, the rebase is mine.

`systemctl edit` writes a drop-in override under `/etc/systemd/system/<unit>.d/`. `systemctl edit --full` copies the whole unit file and edits that instead. They are different operations, and there was no alias for the second one.

- `sc-edit-full` → `sudo systemctl edit --full`
- `scu-edit-full` → `systemctl --user edit --full`
- One README row, next to the existing `sc-edit` entry.

### Use case for the new aliases

`--full` is the standard way to change something the drop-in mechanism cannot express — reordering or clearing an existing directive, or editing `ExecStart` when the unit sets it once. Anyone maintaining units on a Linux box reaches for it regularly, and the plugin already ships the analogous `--now` variants (`sc-enable-now`, `sc-disable-now`, `sc-mask-now`) built exactly this way, so this adds no new pattern.

Note this **adds** an alias rather than changing `sc-edit`. @carlosala made that call on the issue in 2022: changing the default would be a breaking change for anyone with it in muscle memory.

## Other comments:

Tested on zsh 5.9 by sourcing the plugin under `zsh -f` with `sudo` and `systemctl` stubbed, and checking the aliases resolve all the way through:

```
sc-edit-full nginx   ->  sudo systemctl edit --full nginx
scu-edit-full nginx  ->  systemctl --user edit --full nginx
```

Also ran `zsh -n` on the plugin.

AI disclosure: reapplied and tested with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
