### PR TITLE
fix(common-aliases): open documents with the platform's opener

### DIFF
--- a/plugins/common-aliases/README.md
+++ b/plugins/common-aliases/README.md
@@ -99,18 +99,21 @@ $ find . -type f 2>/dev/null
 ## File extension aliases
 
 These are special aliases that are triggered when a file name is passed as the command. For example,
-if the pdf file extension is aliased to `acroread` (a popular Linux pdf reader), when running `file.pdf`
-that file will be open with `acroread`.
+if the pdf file extension is aliased to `open_command`, running `file.pdf` opens that file with
+whatever application your system uses for PDFs.
 
 ### Reading Docs
 
-| Alias | Command    | Description                        |
-| ----- | ---------- | ---------------------------------- |
-| pdf   | `acroread` | Opens up a document using acroread |
-| ps    | `gv`       | Opens up a .ps file using gv       |
-| dvi   | `xdvi`     | Opens up a .dvi file using xdvi    |
-| chm   | `xchm`     | Opens up a .chm file using xchm    |
-| djvu  | `djview`   | Opens up a .djvu file using djview |
+These use `open_command`, which picks the right opener for your platform: `open` on macOS,
+`xdg-open` on Linux, `cygstart` on Cygwin.
+
+| Alias | Command        | Description                                     |
+| ----- | -------------- | ----------------------------------------------- |
+| pdf   | `open_command` | Opens up a .pdf file in your default viewer     |
+| ps    | `open_command` | Opens up a .ps file in your default viewer      |
+| dvi   | `open_command` | Opens up a .dvi file in your default viewer     |
+| chm   | `open_command` | Opens up a .chm file in your default viewer     |
+| djvu  | `open_command` | Opens up a .djvu file in your default viewer    |
 
 ### Listing files inside a packed file
 

--- a/plugins/common-aliases/common-aliases.plugin.zsh
+++ b/plugins/common-aliases/common-aliases.plugin.zsh
@@ -71,12 +71,9 @@ if is-at-least 4.2.0; then
   _media_fts=(ape avi flv m4a mkv mov mp3 mpeg mpg ogg ogm rm wav webm)
   for ft in $_media_fts; do alias -s $ft=mplayer; done
 
-  #read documents
-  alias -s pdf=acroread
-  alias -s ps=gv
-  alias -s dvi=xdvi
-  alias -s chm=xchm
-  alias -s djvu=djview
+  # read documents with the platform's default application
+  _doc_fts=(pdf ps dvi chm djvu)
+  for ft in $_doc_fts; do alias -s $ft=open_command; done
 
   #list what's inside packed file
   alias -s zip="unzip -l"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (No new aliases; five existing ones change target.)

## Changes:

Closes #11177.

The document suffix aliases in `common-aliases` point at Linux/X11 binaries:

```zsh
alias -s pdf=acroread
alias -s ps=gv
alias -s dvi=xdvi
alias -s chm=xchm
alias -s djvu=djview
```

So on macOS, typing `report.pdf` gives `zsh: command not found: acroread`. Adobe also stopped shipping `acroread` for Linux a long time ago, so that one is mostly broken everywhere.

The reporter suggested `xdg-open`, which would fix Linux and leave macOS broken in the same way. We already have the right tool for this: `open_command` in `lib/functions.zsh` dispatches on `$OSTYPE` — `open` on macOS, `nohup xdg-open` on Linux (with a WSL branch), `cygstart` on Cygwin, `start` on MSYS. It is always loaded, and six other plugins already use it.

- Five suffix aliases now use `open_command`, following the `_*_fts` loop style used by the browser/editor/image/media aliases just above.
- README table and the surrounding explanation updated.

## Other comments:

This changes behaviour for Linux users who actually had `acroread`, `gv`, `xdvi`, `xchm` or `djview` installed: they now get their desktop's default handler instead. That seems right — it is what the rest of the plugin already does via `$BROWSER`, `$EDITOR` and `$XIVIEWER` — but it is a behaviour change, not purely a fix, so worth a second opinion. `common-aliases` is opt-in.

Tested on zsh 5.9 by sourcing `lib/functions.zsh` and the plugin under `zsh -f` with `open` stubbed to log its arguments:

```
/tmp/omz-t.pdf   ->  open /tmp/omz-t.pdf
/tmp/omz-t.djvu  ->  open /tmp/omz-t.djvu
```

Before the change the same aliases resolved to `acroread` and `djview`. Also confirmed a zsh suffix alias accepts a function as its target, and ran `zsh -n`.

One pre-existing wart worth knowing about, unchanged here: `open_command` ends in `&>/dev/null`, so if the platform opener is missing the failure is silent rather than a `command not found`.

AI disclosure: written and tested with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
