### PR TITLE
fix(termsupport): set title correctly on terminals with parameterized tsl

### DIFF
--- a/lib/termsupport.zsh
+++ b/lib/termsupport.zsh
@@ -31,7 +31,12 @@ function title {
       else
         # Try to use terminfo to set the title if the feature is available
         if (( ${+terminfo[fsl]} && ${+terminfo[tsl]} )); then
-          print -Pn "${terminfo[tsl]}$1${terminfo[fsl]}"
+          # Emit the capabilities with echoti so terminfo does its own parameter
+          # substitution: some terminals (vt320) take a column argument, and
+          # running prompt expansion over the capability string mangles it.
+          echoti tsl 0
+          print -Pn "$1"
+          echoti fsl
         fi
       fi
       ;;


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below. *(no new aliases)*

## Changes:

- `lib/termsupport.zsh`: in the terminfo fallback branch of `title()`, emit `tsl` and `fsl` with `echoti` instead of interpolating them into a `print -Pn` string.

Closes #8519.

## Other comments:

**The bug.** The branch did:

```zsh
print -Pn "${terminfo[tsl]}$1${terminfo[fsl]}"
```

`$1` needs prompt expansion — callers pass things like `%15<..<%~%<<` — but the capability string must not get it. A parameterized `tsl` is then read as prompt escapes. On vt320, `tsl` is `\E[2$~\E[1$}\E[%i%p1%d\``, so `%d` expanded to the working directory and the sequence went out malformed, with the cwd embedded in it.

**The fix.** `echoti` asks terminfo to do its own parameter substitution, which is what these capabilities expect. Prompt expansion still applies to the title text, and only to that.

**Testing.** Compared emitted bytes before and after, in `/tmp`, with `zsh -f`:

```
TERM=vt320
  before  ^[[2$~^[[1$}^[[41/tmp`/tmp^[[0$}
  after   ^[[2$~^[[1$}^[[1`/tmp^[[0$}

TERM=ghostty
  before  ^[]2;/tmp^G
  after   ^[]2;/tmp^G          (unchanged)

TERM=xterm-256color, TERM=screen
  take the earlier case branches; untouched by this change
```

Terminals whose `tsl` takes no parameters are byte-identical. `linux` and `xterm-kitty` do not define `tsl`/`fsl` at all and never reach this branch.

**Credit.** @franrogers diagnosed this in #8519 in January 2020 and is credited with a `Co-Authored-By` trailer. His patch also added an unconditional `echoti dl1`, which is left out here: Ghostty reaches this same branch, and `dl1` would inject `\E[M` into the middle of its OSC sequence.

**AI assistance.** Found during backlog triage and prepared with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
