### PR TITLE
fix: remove shadowed alias definitions and two related defects

### DIFF
--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -241,7 +241,7 @@ function aws_regions() {
 function aws_profiles() {
   aws --no-cli-pager configure list-profiles 2> /dev/null && return
   [[ -r "${AWS_CONFIG_FILE:-$HOME/.aws/config}" ]] || return 1
-  grep --color=never -Eo '\[.*\]' "${AWS_CONFIG_FILE:-$HOME/.aws/config}" | sed -E 's/^[[:space:]]*\[(profile)?[[:space:]]*([^[:space:]]+)\][[:space:]]*$/\2/g'
+  grep --color=never -Eo '^\[[[:space:]]*(profile[[:space:]]+)?[^][:space:]]+[[:space:]]*\]' "${AWS_CONFIG_FILE:-$HOME/.aws/config}" | sed -E 's/^\[[[:space:]]*(profile[[:space:]]+)?([^][:space:]]+)[[:space:]]*\]$/\2/'
 }
 
 function _aws_regions() {

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -241,7 +241,7 @@ function aws_regions() {
 function aws_profiles() {
   aws --no-cli-pager configure list-profiles 2> /dev/null && return
   [[ -r "${AWS_CONFIG_FILE:-$HOME/.aws/config}" ]] || return 1
-  grep --color=never -Eo '^\[[[:space:]]*(profile[[:space:]]+)?[^][:space:]]+[[:space:]]*\]' "${AWS_CONFIG_FILE:-$HOME/.aws/config}" | sed -E 's/^\[[[:space:]]*(profile[[:space:]]+)?([^][:space:]]+)[[:space:]]*\]$/\2/'
+  grep --color=never -Eo '^[[:space:]]*\[[[:space:]]*(profile[[:space:]]+)?[^][:space:]]+[[:space:]]*\]' "${AWS_CONFIG_FILE:-$HOME/.aws/config}" | sed -E 's/^[[:space:]]*\[[[:space:]]*(profile[[:space:]]+)?([^][:space:]]+)[[:space:]]*\]$/\2/'
 }
 
 function _aws_regions() {

--- a/plugins/aws/aws.plugin.zsh
+++ b/plugins/aws/aws.plugin.zsh
@@ -241,7 +241,7 @@ function aws_regions() {
 function aws_profiles() {
   aws --no-cli-pager configure list-profiles 2> /dev/null && return
   [[ -r "${AWS_CONFIG_FILE:-$HOME/.aws/config}" ]] || return 1
-  grep --color=never -Eo '^[[:space:]]*\[[[:space:]]*(profile[[:space:]]+)?[^][:space:]]+[[:space:]]*\]' "${AWS_CONFIG_FILE:-$HOME/.aws/config}" | sed -E 's/^[[:space:]]*\[[[:space:]]*(profile[[:space:]]+)?([^][:space:]]+)[[:space:]]*\]$/\2/'
+  command grep -Eo '^[[:space:]]*\[[[:space:]]*(profile[[:space:]]+)?[^][:space:]]+[[:space:]]*\]' "${AWS_CONFIG_FILE:-$HOME/.aws/config}" | command sed -E 's/^[[:space:]]*\[[[:space:]]*(profile[[:space:]]+)?([^][:space:]]+)[[:space:]]*\]$/\2/'
 }
 
 function _aws_regions() {

--- a/plugins/rails/rails.plugin.zsh
+++ b/plugins/rails/rails.plugin.zsh
@@ -139,7 +139,6 @@ function rdsl() { _rails_db_command db:schema:load "$@" }
 
 # legacy stuff
 alias sc='ruby script/console'
-alias sd='ruby script/destroy'
 alias sd='ruby script/server --debugger'
 alias sg='ruby script/generate'
 alias sp='ruby script/plugin'

--- a/plugins/safe-paste/safe-paste.plugin.zsh
+++ b/plugins/safe-paste/safe-paste.plugin.zsh
@@ -11,7 +11,6 @@
 # Load bracketed-paste-magic if zsh version is >= 5.1
 autoload -Uz is-at-least
 if is-at-least 5.1; then
-  set zle_bracketed_paste  # Explicitly restore this zsh default
   autoload -Uz bracketed-paste-magic
   zle -N bracketed-paste bracketed-paste-magic
   return  ### The rest of this file is NOT executed on zsh version >= 5.1 ###

--- a/plugins/suse/README.md
+++ b/plugins/suse/README.md
@@ -71,7 +71,6 @@ Related: [#9798](https://github.com/ohmyzsh/ohmyzsh/pull/9798).
 | Alias | Commands            | Description                              |
 | ----- | ------------------- | ---------------------------------------- |
 | zar   | `sudo zypper ar`    | add a repository                         |
-| zcl   | `sudo zypper clean` | clean cache                              |
 | zlr   | `zypper lr`         | list repositories                        |
 | zmr   | `sudo zypper mr`    | modify repositories                      |
 | znr   | `sudo zypper nr`    | rename repositories (for the alias only) |

--- a/plugins/suse/suse.plugin.zsh
+++ b/plugins/suse/suse.plugin.zsh
@@ -38,7 +38,6 @@ alias zwp='zypper --no-refresh wp'
 
 #Repositories commands
 alias zar='sudo zypper ar'
-alias zcl='sudo zypper clean'
 alias zlr='zypper lr'
 alias zmr='sudo zypper mr'
 alias znr='sudo zypper nr'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (No new aliases; two dead ones removed.)

## Changes:

Four small defects found while sweeping the issue backlog. Each is one commit, and **none of them changes what any alias does today.**

### `fix(suse)` — `zcl` was defined twice, with different meanings

```zsh
alias zcl='sudo zypper clean'   # repositories section  — dead
alias zcl='sudo zypper cl'      # package locks section — wins
```

These are different commands: `zypper clean` empties the package cache, `zypper cl` is `cleanlocks`. The README documented `zcl` **twice**, once as "clean cache" and once as "remove unused locks", so anyone who read the first row and ran `zcl` was removing package locks instead. Present since 2018.

Removed the dead definition and the README row describing behaviour the plugin does not have. `zcl` still runs `sudo zypper cl`, unchanged — fixing that instead would be a breaking change, so this only makes the docs honest. Worth noting there is now no alias for `zypper clean`; happy to add one if wanted, but that is a separate decision.

### `fix(rails)` — `sd` was defined twice, one line apart

`alias sd='ruby script/destroy'` sits directly above `alias sd='ruby script/server --debugger'`. The first has had no effect since the second was added in 2021. Removed the dead line.

### `fix(safe-paste)` — a `set` line that clobbered `$@`

```zsh
set zle_bracketed_paste  # Explicitly restore this zsh default
```

There is no shell option called `zle_bracketed_paste` (`setopt` lists none), and `set` with a bare word assigns positional parameters. Sourcing the plugin replaced `$1` with the literal string `zle_bracketed_paste`:

```
before: $1=[alpha] $#=2
after:  $1=[zle_bracketed_paste] $#=1
```

`zle_bracketed_paste` is an array parameter, so the line was not setting that either. Removing it does not change paste behaviour.

### `fix(aws)` — `aws_profiles` listed `[sso-session ...]` as a profile

The fallback used when the `aws` binary is missing matched every bracketed header. Against a config with an `[sso-session]` and a `[services]` block:

```
before:  default, foo, spaced-out, [sso-session my-sso], [services my-services]
after:   default, foo, spaced-out
```

Real profiles are still found, including ones with irregular spacing after `profile`.

## Other comments:

Tested on zsh 5.9. Each plugin passes `zsh -n`, and I checked the two surviving aliases resolve exactly as before (`zcl='sudo zypper cl'`, `sd='ruby script/server --debugger'`), that `$@` survives sourcing safe-paste, and the `aws_profiles` fallback against a synthetic `AWS_CONFIG_FILE` — no real credentials or network involved.

They are four separate commits with their own scopes, so a rebase merge keeps the changelog entries per-plugin. Happy to split into four PRs if that suits better.

AI disclosure: found and fixed with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
