### PR TITLE
fix(jonathan): use a literal dash in the UTF-8 fill bar

### DIFF
--- a/themes/jonathan.zsh-theme
+++ b/themes/jonathan.zsh-theme
@@ -14,7 +14,7 @@ function theme_precmd {
   if (( promptsize + rubypromptsize + pwdsize + venvpromptsize + condapromptsize > TERMWIDTH )); then
     (( PR_PWDLEN = TERMWIDTH - promptsize ))
   elif [[ "${langinfo[CODESET]}" = UTF-8 ]]; then
-    PR_FILLBAR="\${(l:$(( TERMWIDTH - (promptsize + rubypromptsize + pwdsize + venvpromptsize + condapromptsize ) ))::${PR_HBAR}:)}"
+    PR_FILLBAR="\${(l:$(( TERMWIDTH - (promptsize + rubypromptsize + pwdsize + venvpromptsize + condapromptsize ) ))::─:)}"
   else
     PR_FILLBAR="${PR_SHIFT_IN}\${(l:$(( TERMWIDTH - (promptsize + rubypromptsize + pwdsize + venvpromptsize + condapromptsize ) ))::${altchar[q]:--}:)}${PR_SHIFT_OUT}"
   fi


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (No aliases.)

## Changes:

Closes #11039.

`PR_HBAR` is chosen once, when the theme loads. In a non-UTF-8 locale it becomes the terminfo form:

```
%{^[(0%}q%{^[(B%}
```

If the locale is UTF-8 by the time `theme_precmd` runs, that value gets interpolated into the padding string of `${(l:N::...:)}`, and the `%}` inside it closes the parameter expansion early. zsh then prints

```
zsh: closing brace expected
```

on every prompt, and again on every window resize. JetBrains terminals start without a UTF-8 locale, which is why the reports come from IntelliJ users — but the defect is ours, and the reporters' own workaround (moving `export LANG` above the `oh-my-zsh.sh` line) is consistent with that.

That branch has already established the codeset is UTF-8, so it can use the character directly. The `else` branch below does the equivalent with `${altchar[q]:--}`.

## Other comments:

Reproduced on zsh 5.9. Sourcing the theme with `PR_HBAR` holding the terminfo form and `COLUMNS=500`, then calling `theme_precmd` and expanding the result:

| | `PR_FILLBAR` | expanding it |
| --- | --- | --- |
| master | `${(l:340::%{^[(0%}q%{^[(B%}:)}` | `zsh: closing brace expected` |
| this PR | `${(l:340::─:)}` | 340 `─` characters |

Also confirmed the minimal case independently: `${(l:5::%{a%}:)}` errors, `${(l:5::─:)}` does not.

AI disclosure: diagnosed and fixed with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
