### PR TITLE
fix(emacs): drop `--no-wait` when opening a terminal frame

### DIFF
--- a/plugins/emacs/emacsclient.sh
+++ b/plugins/emacs/emacsclient.sh
@@ -5,10 +5,17 @@ emacsfun() {
 
   # Build the Emacs Lisp command to check for suitable frames
   # See https://www.gnu.org/software/emacs/manual/html_node/elisp/Frames.html#index-framep
-  case "$*" in
-  *-t*|*--tty*|*-nw*) tty=1; cmd="(memq 't (mapcar 'framep (frame-list)))" ;; # if != nil, there are tty frames
-  *) cmd="(delete 't (mapcar 'framep (frame-list)))" ;; # if != nil, there are graphical terminals (x, w32, ns)
-  esac
+  for arg in "$@"; do
+    case "$arg" in
+    -t|--tty|-nw) tty=1; break ;;
+    esac
+  done
+
+  if [ -n "$tty" ]; then
+    cmd="(memq 't (mapcar 'framep (frame-list)))" # if != nil, there are tty frames
+  else
+    cmd="(delete 't (mapcar 'framep (frame-list)))" # if != nil, there are graphical terminals (x, w32, ns)
+  fi
 
   # A tty frame needs the client to stay attached, so drop the --no-wait the
   # `emacs` alias adds. Otherwise emacsclient returns at once and nothing opens.

--- a/plugins/emacs/emacsclient.sh
+++ b/plugins/emacs/emacsclient.sh
@@ -1,14 +1,26 @@
 #!/bin/sh
 
 emacsfun() {
-  local cmd frames
+  local cmd frames arg tty
 
   # Build the Emacs Lisp command to check for suitable frames
   # See https://www.gnu.org/software/emacs/manual/html_node/elisp/Frames.html#index-framep
   case "$*" in
-  *-t*|*--tty*|*-nw*) cmd="(memq 't (mapcar 'framep (frame-list)))" ;; # if != nil, there are tty frames
+  *-t*|*--tty*|*-nw*) tty=1; cmd="(memq 't (mapcar 'framep (frame-list)))" ;; # if != nil, there are tty frames
   *) cmd="(delete 't (mapcar 'framep (frame-list)))" ;; # if != nil, there are graphical terminals (x, w32, ns)
   esac
+
+  # A tty frame needs the client to stay attached, so drop the --no-wait the
+  # `emacs` alias adds. Otherwise emacsclient returns at once and nothing opens.
+  if [ -n "$tty" ]; then
+    for arg do
+      shift
+      case "$arg" in
+      --no-wait) continue ;;
+      esac
+      set -- "$@" "$arg"
+    done
+  fi
 
   # Check if there are suitable frames
   frames="$(emacsclient -a '' -n -e "$cmd" 2>/dev/null |sed 's/.*\x07//g' )"


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (No aliases.)

## Changes:

Closes #10940.

The plugin's `emacs` alias always adds `--no-wait`, so `emacs -nw file` arrives at emacsclient as:

```
emacsclient --alternate-editor= --create-frame --no-wait -nw file
```

`--no-wait` asks emacsclient to return immediately, which cannot work for a terminal frame — the client has to stay attached to the tty. It exits straight away and nothing opens, so the shell looks like it ignored the command. The plugin's own `te` alias avoids this because it never passes `--no-wait`.

`emacsclient.sh` already inspects the arguments for `-t`/`--tty`/`-nw` to decide which frames to look for; this reuses that to strip `--no-wait` on those paths.

## Other comments:

Tested with `emacsclient` stubbed to log its arguments (no real emacs launched), running the script directly with each argument list:

| invocation | master | this PR |
| --- | --- | --- |
| `emacs --no-wait -nw file.txt` | `--create-frame --no-wait -nw file.txt` | `--create-frame -nw file.txt` |
| `emacs --no-wait -t file.txt` | `--create-frame --no-wait -t file.txt` | `--create-frame -t file.txt` |
| `emacs --no-wait file.txt` | `--create-frame --no-wait file.txt` | unchanged |
| `emacs -nw file.txt` | `--create-frame -nw file.txt` | unchanged |

So the GUI path is untouched. Also ran `sh -n` on the script.

The argument rebuild uses the portable `for arg do shift; …; set -- "$@" "$arg"; done` idiom, since this file is `#!/bin/sh`; I checked it behaves the same under dash, bash and zsh.

AI disclosure: diagnosed and fixed with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
