### PR TITLE
fix(installer): back up the history file when replacing .zshrc

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -414,17 +414,14 @@ setup_zshrc() {
       case " $hist_backed_up " in
         *" $hist "*) continue ;;
       esac
-      hist_backup="${hist}.pre-oh-my-zsh"
+      hist_backup_base="${hist}.pre-oh-my-zsh"
+      hist_backup="$hist_backup_base"
       if [ -e "$hist_backup" ]; then
-        hist_backup="${hist_backup}-$(date +%Y-%m-%d_%H-%M-%S)"
-        if [ -e "$hist_backup" ]; then
-          fmt_error "$hist_backup exists. Can't back up $hist"
-          fmt_error "re-run the installer again in a couple of seconds"
-          if ! mv "$OLD_ZSHRC" "$zdot/.zshrc"; then
-            fmt_error "could not restore $zdot/.zshrc from backup"
-          fi
-          exit 1
-        fi
+        hist_backup_i=0
+        while [ -e "$hist_backup" ]; do
+          hist_backup_i=$((hist_backup_i + 1))
+          hist_backup="${hist_backup_base}-$(date +%Y-%m-%d_%H-%M-%S)-${hist_backup_i}"
+        done
       fi
       if cp -p "$hist" "$hist_backup"; then
         echo "${FMT_GREEN}Backing up your command history to ${hist_backup}${FMT_RESET}"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -417,6 +417,14 @@ setup_zshrc() {
       hist_backup="${hist}.pre-oh-my-zsh"
       if [ -e "$hist_backup" ]; then
         hist_backup="${hist_backup}-$(date +%Y-%m-%d_%H-%M-%S)"
+        if [ -e "$hist_backup" ]; then
+          fmt_error "$hist_backup exists. Can't back up $hist"
+          fmt_error "re-run the installer again in a couple of seconds"
+          if ! mv "$OLD_ZSHRC" "$zdot/.zshrc"; then
+            fmt_error "could not restore $zdot/.zshrc from backup"
+          fi
+          exit 1
+        fi
       fi
       if cp "$hist" "$hist_backup"; then
         echo "${FMT_GREEN}Backing up your command history to ${hist_backup}${FMT_RESET}"
@@ -425,6 +433,10 @@ setup_zshrc() {
         # a half-written file would look like a usable backup
         rm -f "$hist_backup"
         fmt_error "could not back up $hist"
+        if ! mv "$OLD_ZSHRC" "$zdot/.zshrc"; then
+          fmt_error "could not restore $zdot/.zshrc from backup"
+        fi
+        exit 1
       fi
     done
   fi

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -426,7 +426,7 @@ setup_zshrc() {
           exit 1
         fi
       fi
-      if cp "$hist" "$hist_backup"; then
+      if cp -p "$hist" "$hist_backup"; then
         echo "${FMT_GREEN}Backing up your command history to ${hist_backup}${FMT_RESET}"
         hist_backed_up="$hist_backed_up $hist"
       else

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -370,6 +370,7 @@ setup_zshrc() {
       # Ask user for confirmation before backing up and overwriting
       echo "${FMT_YELLOW}Found ${zdot}/.zshrc."
       echo "The existing .zshrc will be backed up to .zshrc.pre-oh-my-zsh if overwritten."
+      echo "Your command history will be backed up too, since replacing .zshrc drops any SAVEHIST you had set."
       echo "Make sure your .zshrc contains the following minimal configuration if you choose not to overwrite it:${FMT_RESET}"
       echo "----------------------------------------"
       cat "$ZSH/templates/minimal.zshrc"
@@ -398,6 +399,34 @@ setup_zshrc() {
     fi
     echo "${FMT_GREEN}Backing up to ${OLD_ZSHRC}${FMT_RESET}"
     mv "$zdot/.zshrc" "$OLD_ZSHRC"
+
+    # The .zshrc we just moved aside is where the user's SAVEHIST lived. Without
+    # it zsh trims $HISTFILE the next time a shell exits, so copy the history
+    # while it is still intact. $HISTFILE is a zsh variable we cannot read from
+    # here, so cover both locations it is commonly given: /etc/zshrc on macOS
+    # sets ${ZDOTDIR:-$HOME}/.zsh_history, and lib/history.zsh falls back to
+    # $HOME/.zsh_history.
+    hist_backed_up=""
+    for hist in "$zdot/.zsh_history" "$HOME/.zsh_history"; do
+      if [ ! -f "$hist" ]; then
+        continue
+      fi
+      case " $hist_backed_up " in
+        *" $hist "*) continue ;;
+      esac
+      hist_backup="${hist}.pre-oh-my-zsh"
+      if [ -e "$hist_backup" ]; then
+        hist_backup="${hist_backup}-$(date +%Y-%m-%d_%H-%M-%S)"
+      fi
+      if cp "$hist" "$hist_backup"; then
+        echo "${FMT_GREEN}Backing up your command history to ${hist_backup}${FMT_RESET}"
+        hist_backed_up="$hist_backed_up $hist"
+      else
+        # a half-written file would look like a usable backup
+        rm -f "$hist_backup"
+        fmt_error "could not back up $hist"
+      fi
+    done
   fi
 
   echo "${FMT_GREEN}Using the Oh My Zsh template file and adding it to $zdot/.zshrc.${FMT_RESET}"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -417,10 +417,11 @@ setup_zshrc() {
       hist_backup_base="${hist}.pre-oh-my-zsh"
       hist_backup="$hist_backup_base"
       if [ -e "$hist_backup" ]; then
+        hist_backup_ts="$(date +%Y-%m-%d_%H-%M-%S)"
         hist_backup_i=0
         while [ -e "$hist_backup" ]; do
           hist_backup_i=$((hist_backup_i + 1))
-          hist_backup="${hist_backup_base}-$(date +%Y-%m-%d_%H-%M-%S)-${hist_backup_i}"
+          hist_backup="${hist_backup_base}-${hist_backup_ts}-${hist_backup_i}"
         done
       fi
       if cp -p "$hist" "$hist_backup"; then


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (No aliases.)

## Changes:

Closes #10908.

The `.zshrc` the installer moves aside is where the user's `SAVEHIST` lives. Once it's gone, zsh falls back to a much smaller value, `lib/history.zsh` raises that to 10000, and the next clean shell exit rewrites `$HISTFILE` with only the most recent 10000 entries. We back up the `.zshrc`; we have never backed up the history.

This copies the history file next to `.zshrc.pre-oh-my-zsh` at the moment the config is replaced, and says so in the overwrite prompt.

`$HISTFILE` is a zsh variable the installer can't read, so it covers both locations it's commonly given:

- macOS `/etc/zshrc` sets `HISTFILE=${ZDOTDIR:-$HOME}/.zsh_history` for every interactive shell
- `lib/history.zsh` falls back to `$HOME/.zsh_history`

**This does not stop the trim**, which is governed by `SAVEHIST`. It makes the lost history recoverable.

## Other comments:

Tested on zsh 5.9 by extracting `setup_zshrc` and running it against a sandboxed `HOME` (real `~` untouched, no network, no `chsh`), then starting one interactive shell with Oh My Zsh's history defaults and letting it exit:

| | after first exit | backup |
| --- | --- | --- |
| master, no ZDOTDIR | 10000 of 20000 | none |
| master, with ZDOTDIR | 10000 of 20000 | none |
| this PR, no ZDOTDIR | 10000 of 20000 | 20000 |
| this PR, with ZDOTDIR | 10000 of 20000 | 20000 |

Two things worth flagging for review:

- A `cp` that fails partway leaves a truncated file that would look like a usable backup — I measured 2 MB of a 5 MB copy surviving an interruption — so the failure path removes it.
- A custom `HISTFILE` set inside the replaced `.zshrc` isn't covered. In that case Oh My Zsh doesn't truncate that file either, it just starts a new one at the default path, so it's orphaned history rather than lost history.

Also worth knowing while reviewing: macOS `/etc/zshrc` sets `SAVEHIST=1000`, so for a default macOS user our floor of 10000 is a tenfold improvement. The people affected are specifically those who set a large `SAVEHIST` themselves.

I didn't run the real `curl | sh` installer end to end, and I couldn't stage a genuine disk-full `cp`.

AI disclosure: written and tested with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
