### PR TITLE
fix(symfony6): do not evaluate the typed command line

### DIFF
--- a/plugins/symfony6/symfony6.plugin.zsh
+++ b/plugins/symfony6/symfony6.plugin.zsh
@@ -15,8 +15,8 @@
 #   - https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Console/Resources/completion.bash
 #
 _sf_console() {
-    local lastParam flagPrefix requestComp out comp
-    local -a completions
+    local lastParam out comp sf_cmd
+    local -a completions flagPrefix requestComp inputs
 
     # The user could have moved the cursor backwards on the command-line.
     # We need to trigger completion from the $CURRENT location, so we need
@@ -29,11 +29,20 @@ _sf_console() {
     setopt local_options BASH_REMATCH
     if [[ "${lastParam}" =~ '-.*=' ]]; then
         # We are dealing with a flag with an =
-        flagPrefix="-P ${BASH_REMATCH}"
+        flagPrefix=(-P "${BASH_REMATCH}")
     fi
 
-    # Prepare the command to obtain completions
-    requestComp="${words[0]} ${words[1]} _complete --no-interaction -szsh -a1 -c$((CURRENT-1))" i=""
+    # Prepare the command to obtain completions. An alias is resolved here,
+    # because the request is no longer read again by the shell.
+    sf_cmd="${words[1]}"
+    if [[ -n "${aliases[$sf_cmd]}" ]]; then
+        requestComp=(${(z)aliases[$sf_cmd]})
+    else
+        requestComp=(${~sf_cmd})
+    fi
+
+    requestComp+=(_complete --no-interaction -szsh -a1 "-c$((CURRENT-1))")
+
     for w in ${words[@]}; do
         w=$(printf -- '%b' "$w")
         # remove quotes from typed values
@@ -47,19 +56,18 @@ _sf_console() {
         fi
         # empty values are ignored
         if [ ! -z "$w" ]; then
-            i="${i}-i${w} "
+            inputs+=("-i$w")
         fi
     done
 
     # Ensure at least 1 input
-    if [ "${i}" = "" ]; then
-        requestComp="${requestComp} -i\" \""
-    else
-        requestComp="${requestComp} ${i}"
+    if (( ! $#inputs )); then
+        inputs=(-i' ')
     fi
 
-    # Use eval to handle any environment variables and such
-    out=$(eval ${requestComp} 2>/dev/null)
+    # The request is run without being read again by the shell, so that a
+    # "$(...)" or a backtick typed on the command line is not executed
+    out=$(SHELL_VERBOSITY=0 "${requestComp[@]}" "${inputs[@]}" 2>/dev/null)
 
     while IFS='\n' read -r comp; do
         if [ -n "$comp" ]; then
@@ -75,7 +83,7 @@ _sf_console() {
     done < <(printf "%s\n" "${out[@]}")
 
     # Let inbuilt _describe handle completions
-    eval _describe "completions" completions $flagPrefix
+    _describe "completions" completions "${flagPrefix[@]}"
     return $?
 }
 


### PR DESCRIPTION
The `symfony6` plugin is a copy of the completion script shipped by `symfony/console`, and it has not been updated since it was added in June 2024. Two fixes made upstream since then are missing, one of them with a security impact.

### The completion runs what you type

The completion request is assembled as a string from the raw words of the command line, then passed to `eval`. Any command substitution present in a word is therefore executed by the completion, before the user validates the line.

Reproducer, with the plugin loaded and a `bin/console` in the current directory:

```
$ bin/console $(id>/tmp/pwned) ca<TAB>
$ cat /tmp/pwned
uid=501(jerome) gid=20(staff) ...
```

The file is created without the line ever being run. Pressing Tab is enough.

The request is now run as an array of arguments, without being read again by the shell, and `_describe` is called directly instead of through `eval`. The alias of the command is resolved explicitly with `${aliases[$sf_cmd]}`, since that was the only useful effect of the `eval`.

### Completion broken when SHELL_VERBOSITY=-1

The request now runs with `SHELL_VERBOSITY=0`, so completion keeps working for users who exported `SHELL_VERBOSITY=-1`.

### About this change

Both fixes are ported verbatim from Symfony, they are not written for this plugin:

- symfony/symfony#65818, do not evaluate the command line in the zsh completion
- symfony/symfony#63859, fix shell completion when `SHELL_VERBOSITY=-1`

The resulting file is byte for byte the current `src/Symfony/Component/Console/Resources/completion.zsh` of the Symfony 6.4 branch, with the two template placeholders substituted as the plugin already does:

```
git show 6.4:src/Symfony/Component/Console/Resources/completion.zsh \
  | sed 's/{{ COMMAND_NAME }}/console/g; s/{{ VERSION }}/1/' \
  | diff - plugins/symfony6/symfony6.plugin.zsh
```

The plugin already carries symfony/symfony#47464 and symfony/symfony#50110, so those needed no porting.

### How it was tested

`zsh -n` on the file, then in a real shell driven through `zpty`, against symfony-demo running `symfony/console` 8.1: `bin/console cache:cl<TAB>` completes, `bin/console cache:clear --env=<TAB>` still gets the `-P` flag prefix, and the same runs fine with `SHELL_VERBOSITY=-1` exported. The reproducer above creates the file before the change and no longer creates it after.

### Note on #13177

#13177 proposes to merge the three symfony plugins into one. It is untouched since June 2025 and it rewrites the same file, so it would need to carry these fixes over. This PR is independent of it and does not depend on its outcome.

AI-assisted: Claude Code helped port the upstream diff and build the `zpty` test harness. I reviewed and ran everything myself.