### PR TITLE
feat(composer): ask composer for completions

### DIFF
--- a/plugins/composer/README.md
+++ b/plugins/composer/README.md
@@ -4,6 +4,18 @@ This plugin provides completion for [composer](https://getcomposer.org/), as wel
 for frequent composer commands. It also adds Composer's global binaries to the PATH, using
 Composer if available.
 
+Completion asks composer itself, so it reports the commands of the installed version,
+including those added by composer plugins, the scripts declared in `composer.json`, and
+the options and arguments of each command. Composer 2.2, which cannot describe itself,
+falls back to the previous completion of this plugin.
+
+To opt out of the native completion and use zsh's builtin `_composer` instead (faster for
+package names thanks to its disk cache), add this to your zshrc before `compinit`:
+
+```zsh
+zstyle ':completion:*:composer:*' native-completion no
+```
+
 To use it add `composer` to the plugins array in your zshrc file.
 
 ```zsh

--- a/plugins/composer/composer.plugin.zsh
+++ b/plugins/composer/composer.plugin.zsh
@@ -1,34 +1,138 @@
-## Basic Composer command completion
-# Since Zsh 5.7, an improved composer command completion is provided
-if ! is-at-least 5.7; then
-  _composer () {
-    local curcontext="$curcontext" state line
-    typeset -A opt_args
-    _arguments '*:: :->subcmds'
+## Composer command completion
+#
+# Composer is a Symfony Console application, so since composer 2.4 it answers
+# the "_complete" protocol and can describe its own commands, options and
+# arguments. This is the frontend for it, adapted from the script shipped by
+# symfony/console:
+# https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Console/Resources/completion.zsh
+#
+# Composer 2.2, the LTS line maintained until at least 2026-12-31, has no
+# "_complete" command. _composer_legacy below is the previous completion of
+# this plugin, kept as a fallback for it.
+# Completion for composer older than 2.4, which cannot describe itself.
+# It parses the human readable output and only knows about command names and
+# the packages already required.
+_composer_legacy() {
+  local curcontext="$curcontext" state line
+  typeset -A opt_args
+  _arguments '*:: :->subcmds'
 
-    if (( CURRENT == 1 )) || ( (( CURRENT == 2 )) && [[ "$words[1]" = "global" ]] ); then
-      # Command list
-      local -a subcmds
-      subcmds=("${(@f)"$($_comp_command1 --no-ansi 2>/dev/null | awk '
-        /Available commands/{ r=1 }
-        r == 1 && /^[ \t]*[a-z]+/{
-          gsub(/^[ \t]+/, "")
-          gsub(/  +/, ":")
-          print $0
-        }
-      ')"}")
-      _describe -t commands 'composer command' subcmds
-    else
-      # Required list
-      compadd $($_comp_command1 show -s --no-ansi 2>/dev/null \
-        | sed '1,/requires/d' \
-        | awk 'NF > 0 && !/^requires \(dev\)/{ print $1 }')
+  if (( CURRENT == 1 )) || ( (( CURRENT == 2 )) && [[ "$words[1]" = "global" ]] ); then
+    # Command list
+    local -a subcmds
+    subcmds=("${(@f)"$($_comp_command1 --no-ansi 2>/dev/null | awk '
+      /Available commands/{ r=1 }
+      r == 1 && /^[ \t]*[a-z]+/{
+        gsub(/^[ \t]+/, "")
+        gsub(/  +/, ":")
+        print $0
+      }
+    ')"}")
+    _describe -t commands 'composer command' subcmds
+  else
+    # Required list
+    compadd $($_comp_command1 show -s --no-ansi 2>/dev/null \
+      | sed '1,/requires/d' \
+      | awk 'NF > 0 && !/^requires \(dev\)/{ print $1 }')
+  fi
+}
+
+_composer() {
+  local lastParam out comp composer_cmd
+  local -a completions flagPrefix requestComp inputs
+
+  # The user could have moved the cursor backwards on the command-line.
+  # We need to trigger completion from the $CURRENT location, so we need
+  # to truncate the command-line ($words) up to the $CURRENT location.
+  # (We cannot use $CURSOR as its value does not work when a command is an alias.)
+  words=("${=words[1,CURRENT]}") lastParam=${words[-1]}
+
+  # When completing a flag with an = (e.g., composer -n=<TAB>)
+  # completions must be prefixed with the flag
+  setopt local_options BASH_REMATCH
+  if [[ "${lastParam}" =~ '-.*=' ]]; then
+    flagPrefix=(-P "${BASH_REMATCH}")
+  fi
+
+  # Prepare the command to obtain completions. An alias is resolved here,
+  # because the request is not read again by the shell.
+  composer_cmd="${words[1]}"
+  if [[ -n "${aliases[$composer_cmd]}" ]]; then
+    requestComp=(${(z)aliases[$composer_cmd]})
+  else
+    requestComp=(${~composer_cmd})
+  fi
+
+  # Users who prefer zsh's builtin composer completion, which is faster for
+  # package names thanks to its disk cache, can opt out of the native one:
+  #   zstyle ':completion:*:composer:*' native-completion no
+  # The builtin only exists since zsh 5.7. When it is not available the autoload
+  # fails, and the native completion below runs as before.
+  if [[ "${composer_cmd:t}" == composer(|.phar) ]] \
+    && zstyle -t ":completion:*:composer:*" native-completion no \
+    && autoload +X -Uz _composer 2>/dev/null; then
+    _composer
+    return $?
+  fi
+
+  # Composer bundles symfony/console 5.4, which only knows the bash output and
+  # names the version option "--symfony" (-S), not "--api-version" (-a). The
+  # bash output is a plain list that the loop below reads just as well.
+  requestComp+=(_complete --no-interaction -sbash -S1 "-c$((CURRENT-1))")
+
+  for w in ${words[@]}; do
+    w=$(printf -- '%b' "$w")
+    # remove quotes from typed values
+    quote="${w:0:1}"
+    if [ "$quote" = \' ]; then
+      w="${w%\'}"
+      w="${w#\'}"
+    elif [ "$quote" = \" ]; then
+      w="${w%\"}"
+      w="${w#\"}"
     fi
-  }
+    # empty values are ignored
+    if [ ! -z "$w" ]; then
+      inputs+=("-i$w")
+    fi
+  done
 
-  compdef _composer composer
-  compdef _composer composer.phar
-fi
+  # Ensure at least 1 input
+  if (( ! $#inputs )); then
+    inputs=(-i' ')
+  fi
+
+  # The request is run without being read again by the shell, so that a
+  # "$(...)" or a backtick typed on the command line is not executed
+  out=$(SHELL_VERBOSITY=0 "${requestComp[@]}" "${inputs[@]}" 2>/dev/null)
+
+  # Composer older than 2.4 exits with an error, "_complete" is not defined.
+  # An installed composer with nothing to offer exits with 0 and no output.
+  if (( $? )); then
+    _composer_legacy
+    return $?
+  fi
+
+  while IFS='\n' read -r comp; do
+    if [ -n "$comp" ]; then
+      # If requested, completions are returned with a description.
+      # The description is preceded by a TAB character.
+      # For zsh's _describe, we need to use a : instead of a TAB.
+      # We first need to escape any : as part of the completion itself.
+      comp=${comp//:/\\:}
+      local tab=$(printf '\t')
+      comp=${comp//$tab/:}
+      completions+=${comp}
+    fi
+  done < <(printf "%s\n" "${out[@]}")
+
+  # Let inbuilt _describe handle completions
+  _describe "completions" completions "${flagPrefix[@]}"
+  return $?
+}
+
+compdef _composer composer
+compdef _composer composer.phar
 
 
 ## Aliases


### PR DESCRIPTION
Composer is a Symfony Console application. Since composer 2.4 it answers the `_complete` protocol, so it can describe its own commands, options and arguments. This plugin now asks it, using the frontend shipped by `symfony/console`.

### What it replaces

Two partial sources were covering composer, depending on the zsh version:

- The completion in this plugin, only active on zsh older than 5.7. It parsed the output of `composer` and `composer show -s` with awk and sed, and offered nothing beyond command names and the packages already required.
- The `_composer` zsh ships since 5.7, which is why this plugin steps aside on those versions. It is a hand written description of composer's interface, and its header says it does not complete custom commands, including script aliases.

Asking composer covers both and more:

```
$ cat composer.json
{"scripts":{"my-custom-task":"echo hi"}}
$ composer my<TAB>
$ composer my-custom-task

$ composer install --no-de<TAB>
$ composer install --no-dev

$ composer require symfony/http-f<TAB>
$ composer require symfony/http-foundation
```

The commands reported are those of the installed version, so commands added by composer plugins show up too, and the list does not need updating when composer changes.

### Opting out

Users who prefer zsh's builtin composer completion, which is faster for package names thanks to its disk cache, can opt out of the native one:

```zsh
zstyle ':completion:*:composer:*' native-completion no
```

The builtin only exists since zsh 5.7. When it is not available the autoload fails, and the native completion runs as before.

### Composer 2.2 keeps what it has

Composer 2.2 is the LTS line, maintained until at least 2026-12-31, and it has no `_complete` command:

```
$ composer2.2 _complete --no-interaction -sbash -S1 -c1 -icomposer -i' '
  [Symfony\Component\Console\Exception\CommandNotFoundException]
  Command "_complete" is not defined.
$ echo $?
1
```

An installed composer with nothing to offer exits with 0 and no output, so the exit status tells the two apart. The previous completion of this plugin is kept as `_composer_legacy` and used when the request fails. Composer 2.2 users therefore keep exactly what they have today, on any zsh version, instead of only on zsh older than 5.7.

### Why the request uses `-sbash` and `-S1`

Composer bundles `symfony/console` 5.4, which only ships the bash completion output and names the version option `--symfony` (`-S`), the option later renamed to `--api-version` (`-a`). Checked against composer 2.10.3:

```
$ composer _complete --no-interaction -szsh -a1 -c1 -icomposer -i' '
  The "-a" option does not exist.
$ composer _complete --no-interaction -szsh -S1 -c1 -icomposer -i' '
                     # empty, no zsh output in symfony/console 5.4
$ composer _complete --no-interaction -sbash -S1 -c1 -icomposer -i' '
help
list
completion
```

The bash output is a plain newline separated list, which the zsh frontend reads just as well.

### On the frontend itself

It is adapted from `src/Symfony/Component/Console/Resources/completion.zsh` of the Symfony 6.4 branch, so it already carries the upstream fixes: the request is run as an array of arguments rather than through `eval`, and it runs with `SHELL_VERBOSITY=0`. The `symfony6` plugin still has the version from before those fixes, #14058 ports them there. The two PRs are independent and touch different files.

### How it was tested

`zsh -n` on the file, then in a real shell driven through `zpty`, against composer 2.10.3: the four cases above, plus `composer global req<TAB>` and the `cr symfony/http-f<TAB>` alias from this plugin, which exercises the alias resolution path. Against composer 2.2.25 put first in `PATH`, the fallback kicks in and `composer inst<TAB>` and `composer diag<TAB>` still complete. With `native-completion no` set, the builtin takes over and `composer require symfony/http-f<TAB>` completes from the disk cache.

AI-assisted: Claude Code helped write the plugin change and the `zpty` test harness, and ran the comparisons against zsh's builtin completion and composer 2.2. I reviewed and ran everything myself.