### PR TITLE
perf(update): check the update epoch before forking git

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -23,12 +23,32 @@ zstyle -s ':omz:update' mode update_mode || {
 # - the automatic update is disabled
 # - the current user doesn't have write permissions nor owns the $ZSH directory
 # - is not run from a tty
-# - git is unavailable on the system
-# - $ZSH is not a git repository
 if [[ "$update_mode" = disabled ]] \
    || [[ ! -w "$ZSH" || ! -O "$ZSH" ]] \
-   || [[ ! -t 1 && ${POWERLEVEL9K_INSTANT_PROMPT:-off} == off ]] \
-   || ! command git --version >/dev/null 2>&1 \
+   || [[ ! -t 1 && ${POWERLEVEL9K_INSTANT_PROMPT:-off} == off ]]; then
+  unset update_mode
+  return
+fi
+
+# Cancel update if it's not time to check yet. This runs before the git checks
+# below because those fork on every startup. Skipped when a background update
+# left a result that still needs to be reported (EXIT_STATUS is set).
+() {
+  local LAST_EPOCH EXIT_STATUS ERROR epoch_target
+  zmodload zsh/datetime
+  source "${ZSH_CACHE_DIR}/.zsh-update" 2>/dev/null || return 1
+  [[ -n "$LAST_EPOCH" && -z "$EXIT_STATUS" ]] || return 1
+  zstyle -s ':omz:update' frequency epoch_target || epoch_target=${UPDATE_ZSH_DAYS:-13}
+  (( ( EPOCHSECONDS / 60 / 60 / 24 - LAST_EPOCH ) < epoch_target ))
+} && {
+  unset update_mode
+  return
+}
+
+# Cancel update if:
+# - git is unavailable on the system
+# - $ZSH is not a git repository
+if ! command git --version >/dev/null 2>&1 \
    || (builtin cd -q "$ZSH"; ! command git rev-parse --is-inside-work-tree &>/dev/null); then
   unset update_mode
   return


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- With the default `prompt` update mode, every interactive shell on a tty ran `git --version`, `git rev-parse --is-inside-work-tree`, `mkdir` for the lock directory and `rm -rf` to remove it, only to find out that the update frequency hadn't elapsed yet.
- Read `.zsh-update` and compare the epoch first, and only fall through to the git and lock handling when a check is actually due.
- The shortcut is skipped when a background update left an `EXIT_STATUS` to report, so `background-alpha` mode still shows its result on the next prompt.

## Other comments:

Part of a series of small startup-time PRs. Measured on macOS arm64, zsh 5.9, on a pty with a fresh `LAST_EPOCH`: `check_for_upgrade.sh` goes from 27 ms to 1.6 ms, 4 forks to 0.

Verified on a pty: fresh `LAST_EPOCH` returns early with no forks; a `LAST_EPOCH` 100 days old takes the full path and rewrites the file; `background-alpha` with a pending `EXIT_STATUS` still registers its precmd hook; a missing or malformed `.zsh-update` is recreated as before. No globals leak from the early check.

🤖 Co-authored with Claude Code
