### PR TITLE
perf(appearance): cache the diff and ls capability probes

### DIFF
--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -20,9 +20,9 @@ __omz_probe_cache="$ZSH_CACHE_DIR/appearance-probes"
 __omz_probe_cached=("$__omz_probe_cache"(Nm-1))
 [[ -z "$__omz_probe_cached" ]] || source "$__omz_probe_cache"
 
-function test-cmd-args {
-  # Usage: test-cmd-args cmd args...
-  # e.g. test-cmd-args gls --color
+function __omz_test_cmd_args {
+  # Usage: __omz_test_cmd_args cmd args...
+  # e.g. __omz_test_cmd_args gls --color
   # Runs `cmd args... /dev/null` and remembers whether it succeeded
   local key="$*"
   if (( ! ${+__omz_probes[$key]} )); then
@@ -36,7 +36,7 @@ function test-cmd-args {
 }
 
 # Use diff --color if available
-if test-cmd-args diff --color /dev/null; then
+if __omz_test_cmd_args diff --color /dev/null; then
   function diff {
     command diff --color "$@"
   }
@@ -69,34 +69,34 @@ fi
     netbsd*)
       # On NetBSD, test if `gls` (GNU ls) is installed (this one supports colors);
       # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
-      test-cmd-args gls --color && alias ls='gls --color=tty'
+      __omz_test_cmd_args gls --color && alias ls='gls --color=tty'
       ;;
     openbsd*)
       # On OpenBSD, `gls` (ls from GNU coreutils) and `colorls` (ls from base,
       # with color and multibyte support) are available from ports.
       # `colorls` will be installed on purpose and can't be pulled in by installing
       # coreutils (which might be installed for ), so prefer it to `gls`.
-      test-cmd-args gls --color && alias ls='gls --color=tty'
-      test-cmd-args colorls -G && alias ls='colorls -G'
+      __omz_test_cmd_args gls --color && alias ls='gls --color=tty'
+      __omz_test_cmd_args colorls -G && alias ls='colorls -G'
       ;;
     (darwin|freebsd)*)
       # This alias works by default just using $LSCOLORS
-      test-cmd-args ls -G && alias ls='ls -G'
+      __omz_test_cmd_args ls -G && alias ls='ls -G'
       # Only use GNU ls if installed and there are user defaults for $LS_COLORS,
       # as the default coloring scheme is not very pretty
       zstyle -t ':omz:lib:theme-and-appearance' gnu-ls \
-        && test-cmd-args gls --color \
+        && __omz_test_cmd_args gls --color \
         && alias ls='gls --color=tty'
       ;;
     *)
-      if test-cmd-args ls --color; then
+      if __omz_test_cmd_args ls --color; then
         alias ls='ls --color=tty'
-      elif test-cmd-args ls -G; then
+      elif __omz_test_cmd_args ls -G; then
         alias ls='ls -G'
       fi
       ;;
   esac
 }
 
-unfunction test-cmd-args
+unfunction __omz_test_cmd_args
 unset __omz_probes __omz_probe_cache __omz_probe_cached

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -13,69 +13,90 @@ ZSH_THEME_RUBY_PROMPT_PREFIX="("
 ZSH_THEME_RUBY_PROMPT_SUFFIX=")"
 
 
+# The command probes below fork a process each, and their result doesn't change
+# from one shell to the next, so they're cached for a day (like lib/grep.zsh).
+typeset -A __omz_probes
+__omz_probe_cache="$ZSH_CACHE_DIR/appearance-probes"
+__omz_probe_cached=("$__omz_probe_cache"(Nm-1))
+[[ -z "$__omz_probe_cached" ]] || source "$__omz_probe_cache"
+
+function test-cmd-args {
+  # Usage: test-cmd-args cmd args...
+  # e.g. test-cmd-args gls --color
+  # Runs `cmd args... /dev/null` and remembers whether it succeeded
+  local key="$*"
+  if (( ! ${+__omz_probes[$key]} )); then
+    command "$@" /dev/null &>/dev/null
+    __omz_probes[$key]=$?
+    if [[ -w "$ZSH_CACHE_DIR" ]]; then
+      print -r -- "__omz_probes=(" "${(@qqkv)__omz_probes}" ")" >| "$__omz_probe_cache"
+    fi
+  fi
+  return $__omz_probes[$key]
+}
+
 # Use diff --color if available
-if command diff --color /dev/null{,} &>/dev/null; then
+if test-cmd-args diff --color /dev/null; then
   function diff {
     command diff --color "$@"
   }
 fi
 
-# Don't set ls coloring if disabled
-[[ "$DISABLE_LS_COLORS" != true ]] || return 0
+# Set up ls coloring. Done in a function so the early return below still
+# reaches the cleanup at the end of this file.
+() {
+  # Don't set ls coloring if disabled
+  [[ "$DISABLE_LS_COLORS" != true ]] || return 0
 
-# Default coloring for BSD-based ls
-export LSCOLORS="Gxfxcxdxbxegedabagacad"
+  # Default coloring for BSD-based ls
+  export LSCOLORS="Gxfxcxdxbxegedabagacad"
 
-# Default coloring for GNU-based ls
-if [[ -z "$LS_COLORS" ]]; then
-  # Define LS_COLORS via dircolors if available. Otherwise, set a default
-  # equivalent to LSCOLORS (generated via https://geoff.greer.fm/lscolors)
-  if (( $+commands[dircolors] )); then
-    [[ -f "$HOME/.dircolors" ]] \
-      && source <(dircolors -b "$HOME/.dircolors") \
-      || source <(dircolors -b)
-  else
-    export LS_COLORS="di=1;36:ln=35:so=32:pi=33:ex=31:bd=34;46:cd=34;43:su=30;41:sg=30;46:tw=30;42:ow=30;43"
+  # Default coloring for GNU-based ls
+  if [[ -z "$LS_COLORS" ]]; then
+    # Define LS_COLORS via dircolors if available. Otherwise, set a default
+    # equivalent to LSCOLORS (generated via https://geoff.greer.fm/lscolors)
+    if (( $+commands[dircolors] )); then
+      [[ -f "$HOME/.dircolors" ]] \
+        && source <(dircolors -b "$HOME/.dircolors") \
+        || source <(dircolors -b)
+    else
+      export LS_COLORS="di=1;36:ln=35:so=32:pi=33:ex=31:bd=34;46:cd=34;43:su=30;41:sg=30;46:tw=30;42:ow=30;43"
+    fi
   fi
-fi
 
-function test-ls-args {
-  # Usage: test-ls-args cmd args...
-  # e.g. test-ls-args gls --color
-  command "$@" /dev/null &>/dev/null
+  # Find the option for using colors in ls, depending on the version
+  case "$OSTYPE" in
+    netbsd*)
+      # On NetBSD, test if `gls` (GNU ls) is installed (this one supports colors);
+      # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
+      test-cmd-args gls --color && alias ls='gls --color=tty'
+      ;;
+    openbsd*)
+      # On OpenBSD, `gls` (ls from GNU coreutils) and `colorls` (ls from base,
+      # with color and multibyte support) are available from ports.
+      # `colorls` will be installed on purpose and can't be pulled in by installing
+      # coreutils (which might be installed for ), so prefer it to `gls`.
+      test-cmd-args gls --color && alias ls='gls --color=tty'
+      test-cmd-args colorls -G && alias ls='colorls -G'
+      ;;
+    (darwin|freebsd)*)
+      # This alias works by default just using $LSCOLORS
+      test-cmd-args ls -G && alias ls='ls -G'
+      # Only use GNU ls if installed and there are user defaults for $LS_COLORS,
+      # as the default coloring scheme is not very pretty
+      zstyle -t ':omz:lib:theme-and-appearance' gnu-ls \
+        && test-cmd-args gls --color \
+        && alias ls='gls --color=tty'
+      ;;
+    *)
+      if test-cmd-args ls --color; then
+        alias ls='ls --color=tty'
+      elif test-cmd-args ls -G; then
+        alias ls='ls -G'
+      fi
+      ;;
+  esac
 }
 
-# Find the option for using colors in ls, depending on the version
-case "$OSTYPE" in
-  netbsd*)
-    # On NetBSD, test if `gls` (GNU ls) is installed (this one supports colors);
-    # otherwise, leave ls as is, because NetBSD's ls doesn't support -G
-    test-ls-args gls --color && alias ls='gls --color=tty'
-    ;;
-  openbsd*)
-    # On OpenBSD, `gls` (ls from GNU coreutils) and `colorls` (ls from base,
-    # with color and multibyte support) are available from ports.
-    # `colorls` will be installed on purpose and can't be pulled in by installing
-    # coreutils (which might be installed for ), so prefer it to `gls`.
-    test-ls-args gls --color && alias ls='gls --color=tty'
-    test-ls-args colorls -G && alias ls='colorls -G'
-    ;;
-  (darwin|freebsd)*)
-    # This alias works by default just using $LSCOLORS
-    test-ls-args ls -G && alias ls='ls -G'
-    # Only use GNU ls if installed and there are user defaults for $LS_COLORS,
-    # as the default coloring scheme is not very pretty
-    zstyle -t ':omz:lib:theme-and-appearance' gnu-ls \
-      && test-ls-args gls --color \
-      && alias ls='gls --color=tty'
-    ;;
-  *)
-    if test-ls-args ls --color; then
-      alias ls='ls --color=tty'
-    elif test-ls-args ls -G; then
-      alias ls='ls -G'
-    fi
-    ;;
-esac
-
-unfunction test-ls-args
+unfunction test-cmd-args
+unset __omz_probes __omz_probe_cache __omz_probe_cached

--- a/lib/theme-and-appearance.zsh
+++ b/lib/theme-and-appearance.zsh
@@ -22,8 +22,10 @@ __omz_probe_cached=("$__omz_probe_cache"(Nm-1))
 
 function __omz_test_cmd_args {
   # Usage: __omz_test_cmd_args cmd args...
-  # e.g. __omz_test_cmd_args gls --color
-  # Runs `cmd args... /dev/null` and remembers whether it succeeded
+  # Runs `cmd args... /dev/null` and remembers whether it succeeded, so a
+  # command needing two operands passes the first one itself:
+  # e.g. __omz_test_cmd_args gls --color  ->  gls --color /dev/null
+  #      __omz_test_cmd_args diff --color /dev/null  ->  diff --color /dev/null /dev/null
   local key="$*"
   if (( ! ${+__omz_probes[$key]} )); then
     command "$@" /dev/null &>/dev/null


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- `diff --color` and `ls -G` (or `--color`, `gls`, `colorls` depending on the OS) were probed with a fork each on every startup.
- Remember the probe results in `$ZSH_CACHE_DIR/appearance-probes` for a day, the same way `lib/grep.zsh` caches its flag probe. `test-ls-args` becomes `test-cmd-args` and is used for the `diff` probe too.
- The ls section is wrapped in an anonymous function so the early return for `DISABLE_LS_COLORS` still runs the cleanup at the end of the file. Behaviour is otherwise unchanged.

## Other comments:

Part of a series of small startup-time PRs. Measured on macOS arm64, zsh 5.9: `lib/theme-and-appearance.zsh` goes from 5.7 ms to 0.7 ms per interactive start.

Verified: first run writes the cache and sets `ls='ls -G'` plus the `diff` function; second run forks neither `diff` nor `ls` and gives the same result; a cache older than a day is re-probed; `DISABLE_LS_COLORS=true` sets no ls alias and no `LSCOLORS`, still wraps `diff`, and leaves no helper function or variable behind; the `gnu-ls` zstyle path probes `gls` and caches its absence.

🤖 Co-authored with Claude Code
