### PR TITLE
perf(vcs_info): apply the %-quoting patch on first use

### DIFF
--- a/lib/vcs_info.zsh
+++ b/lib/vcs_info.zsh
@@ -60,8 +60,14 @@ if (( $+functions[VCS_INFO_formats] )); then
   }
 else
   function VCS_INFO_formats {
+    functions -c VCS_INFO_formats _omz_vcs_info_formats_wrapper
     unfunction VCS_INFO_formats
-    autoload -Uz +X regexp-replace VCS_INFO_formats 2>/dev/null || return 1
+    autoload -Uz +X regexp-replace VCS_INFO_formats 2>/dev/null || {
+      functions -c _omz_vcs_info_formats_wrapper VCS_INFO_formats
+      unfunction _omz_vcs_info_formats_wrapper
+      return 1
+    }
+    unfunction _omz_vcs_info_formats_wrapper
 
     # We use $tmp here because it's already a local variable in VCS_INFO_formats
     local PATCH='for tmp (base base-name branch misc revision subdir) hook_com[$tmp]="${hook_com[$tmp]//\%/%%}"'

--- a/lib/vcs_info.zsh
+++ b/lib/vcs_info.zsh
@@ -43,20 +43,37 @@
 # vcs_info. `autoload` doesn't replace an already defined function, so this
 # wrapper survives a later `autoload -Uz vcs_info` in a theme or .zshrc, and
 # vcs_info's own `autoload -Uz VCS_INFO_formats`.
-function VCS_INFO_formats {
-  unfunction VCS_INFO_formats
-  autoload -Uz +X regexp-replace VCS_INFO_formats 2>/dev/null || return 1
+if (( $+functions[VCS_INFO_formats] )); then
+  () {
+    autoload -Uz +X regexp-replace 2>/dev/null || return 1
 
-  # We use $tmp here because it's already a local variable in VCS_INFO_formats
-  local PATCH='for tmp (base base-name branch misc revision subdir) hook_com[$tmp]="${hook_com[$tmp]//\%/%%}"'
-  # Unique string to avoid reapplying the patch if this code gets called twice
-  local PATCH_ID=vcs_info-patch-9b9840f2-91e5-4471-af84-9e9a0dc68c1b
-  # Only patch the VCS_INFO_formats function if not already patched
-  if [[ "$functions[VCS_INFO_formats]" != *$PATCH_ID* ]]; then
-    regexp-replace 'functions[VCS_INFO_formats]' \
-      "VCS_INFO_hook 'post-backend'" \
-      ': ${PATCH_ID}; ${PATCH}; ${MATCH}'
-  fi
+    # We use $tmp here because it's already a local variable in VCS_INFO_formats
+    local PATCH='for tmp (base base-name branch misc revision subdir) hook_com[$tmp]="${hook_com[$tmp]//\%/%%}"'
+    # Unique string to avoid reapplying the patch if this code gets called twice
+    local PATCH_ID=vcs_info-patch-9b9840f2-91e5-4471-af84-9e9a0dc68c1b
+    # Only patch the VCS_INFO_formats function if not already patched
+    if [[ "$functions[VCS_INFO_formats]" != *$PATCH_ID* ]]; then
+      regexp-replace 'functions[VCS_INFO_formats]' \
+        "VCS_INFO_hook 'post-backend'" \
+        ': ${PATCH_ID}; ${PATCH}; ${MATCH}'
+    fi
+  }
+else
+  function VCS_INFO_formats {
+    unfunction VCS_INFO_formats
+    autoload -Uz +X regexp-replace VCS_INFO_formats 2>/dev/null || return 1
 
-  VCS_INFO_formats "$@"
-}
+    # We use $tmp here because it's already a local variable in VCS_INFO_formats
+    local PATCH='for tmp (base base-name branch misc revision subdir) hook_com[$tmp]="${hook_com[$tmp]//\%/%%}"'
+    # Unique string to avoid reapplying the patch if this code gets called twice
+    local PATCH_ID=vcs_info-patch-9b9840f2-91e5-4471-af84-9e9a0dc68c1b
+    # Only patch the VCS_INFO_formats function if not already patched
+    if [[ "$functions[VCS_INFO_formats]" != *$PATCH_ID* ]]; then
+      regexp-replace 'functions[VCS_INFO_formats]' \
+        "VCS_INFO_hook 'post-backend'" \
+        ': ${PATCH_ID}; ${PATCH}; ${MATCH}'
+    fi
+
+    VCS_INFO_formats "$@"
+  }
+fi

--- a/lib/vcs_info.zsh
+++ b/lib/vcs_info.zsh
@@ -38,16 +38,25 @@
 # due to malicious input as a consequence of CVE-2021-45444, which affects
 # zsh versions from 5.0.3 to 5.8.
 #
-autoload -Uz +X regexp-replace VCS_INFO_formats 2>/dev/null || return 0
+# The patch is applied when VCS_INFO_formats is first called, since loading
+# and patching it on every startup costs time in shells that never use
+# vcs_info. `autoload` doesn't replace an already defined function, so this
+# wrapper survives a later `autoload -Uz vcs_info` in a theme or .zshrc, and
+# vcs_info's own `autoload -Uz VCS_INFO_formats`.
+function VCS_INFO_formats {
+  unfunction VCS_INFO_formats
+  autoload -Uz +X regexp-replace VCS_INFO_formats 2>/dev/null || return 1
 
-# We use $tmp here because it's already a local variable in VCS_INFO_formats
-typeset PATCH='for tmp (base base-name branch misc revision subdir) hook_com[$tmp]="${hook_com[$tmp]//\%/%%}"'
-# Unique string to avoid reapplying the patch if this code gets called twice
-typeset PATCH_ID=vcs_info-patch-9b9840f2-91e5-4471-af84-9e9a0dc68c1b
-# Only patch the VCS_INFO_formats function if not already patched
-if [[ "$functions[VCS_INFO_formats]" != *$PATCH_ID* ]]; then
-  regexp-replace 'functions[VCS_INFO_formats]' \
-    "VCS_INFO_hook 'post-backend'" \
-    ': ${PATCH_ID}; ${PATCH}; ${MATCH}'
-fi
-unset PATCH PATCH_ID
+  # We use $tmp here because it's already a local variable in VCS_INFO_formats
+  local PATCH='for tmp (base base-name branch misc revision subdir) hook_com[$tmp]="${hook_com[$tmp]//\%/%%}"'
+  # Unique string to avoid reapplying the patch if this code gets called twice
+  local PATCH_ID=vcs_info-patch-9b9840f2-91e5-4471-af84-9e9a0dc68c1b
+  # Only patch the VCS_INFO_formats function if not already patched
+  if [[ "$functions[VCS_INFO_formats]" != *$PATCH_ID* ]]; then
+    regexp-replace 'functions[VCS_INFO_formats]' \
+      "VCS_INFO_hook 'post-backend'" \
+      ': ${PATCH_ID}; ${PATCH}; ${MATCH}'
+  fi
+
+  VCS_INFO_formats "$@"
+}

--- a/lib/vcs_info.zsh
+++ b/lib/vcs_info.zsh
@@ -60,14 +60,13 @@ if (( $+functions[VCS_INFO_formats] )); then
   }
 else
   function VCS_INFO_formats {
-    functions -c VCS_INFO_formats _omz_vcs_info_formats_wrapper
-    unfunction VCS_INFO_formats
-    autoload -Uz +X regexp-replace VCS_INFO_formats 2>/dev/null || {
-      functions -c _omz_vcs_info_formats_wrapper VCS_INFO_formats
-      unfunction _omz_vcs_info_formats_wrapper
-      return 1
-    }
-    unfunction _omz_vcs_info_formats_wrapper
+    local loaded_function="$(
+      unfunction VCS_INFO_formats 2>/dev/null
+      autoload -Uz +X VCS_INFO_formats 2>/dev/null || return 1
+      print -r -- "$functions[VCS_INFO_formats]"
+    )" || return 1
+    functions[VCS_INFO_formats]="$loaded_function"
+    autoload -Uz +X regexp-replace 2>/dev/null || return 1
 
     # We use $tmp here because it's already a local variable in VCS_INFO_formats
     local PATCH='for tmp (base base-name branch misc revision subdir) hook_com[$tmp]="${hook_com[$tmp]//\%/%%}"'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- `lib/vcs_info.zsh` loaded `VCS_INFO_formats` and `regexp-replace` and patched the function body on every startup, although only themes that call `vcs_info` ever need it.
- Define a `VCS_INFO_formats` wrapper that loads and patches the real function the first time it's called, then replaces itself with it. The patch itself is unchanged.
- `autoload` doesn't override an existing function, so the wrapper survives a theme's `autoload -Uz vcs_info` (before or after Oh My Zsh loads) and vcs_info's own `autoload -Uz VCS_INFO_*`.

## Other comments:

Part of a series of small startup-time PRs. Measured on macOS arm64, zsh 5.9: 1.6 ms to 0.1 ms per interactive start.

Since this is the CVE-2021-45444 mitigation, verified through a full Oh My Zsh startup with `autoload -Uz vcs_info` in the zshrc: the wrapper is in place at startup, the first `vcs_info` call applies the patch and the wrapper is gone afterwards, a branch named `evil%n%m` renders literally after prompt expansion (same as with the eager patch), and re-running `autoload -Uz vcs_info` afterwards keeps the patched function.

🤖 Co-authored with Claude Code
