### PR TITLE
perf(spectrum): build the FG and BG tables without a 256-iteration loop

### DIFF
--- a/lib/spectrum.zsh
+++ b/lib/spectrum.zsh
@@ -16,6 +16,7 @@ FX=(
 
 # Build the tables with array operations instead of a 256-iteration loop
 () {
+  setopt localoptions noksharrays
   local -a codes fg bg
   codes=({000..255})
   fg=( "%{"$'\e'"[38;5;"${^codes}"m%}" )

--- a/lib/spectrum.zsh
+++ b/lib/spectrum.zsh
@@ -14,10 +14,15 @@ FX=(
   reverse   "%{[07m%}" no-reverse   "%{[27m%}"
 )
 
-for color in {000..255}; do
-  FG[$color]="%{[38;5;${color}m%}"
-  BG[$color]="%{[48;5;${color}m%}"
-done
+# Build the tables with array operations instead of a 256-iteration loop
+() {
+  local -a codes fg bg
+  codes=({000..255})
+  fg=( "%{"$'\e'"[38;5;"${^codes}"m%}" )
+  bg=( "%{"$'\e'"[48;5;"${^codes}"m%}" )
+  FG=( ${codes:^fg} )
+  BG=( ${codes:^bg} )
+}
 
 # Show all 256 colors with color number
 function spectrum_ls() {


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Fill the `$FG` and `$BG` colour tables with a brace expansion zipped against the code list instead of looping over the 256 codes with two subscript assignments each.
- The escape character is written as `$'\e'` instead of a literal control byte in the source.
- The resulting arrays are byte-identical (all 256 keys of each, plus `$FX`, compared against the current file), and `spectrum_ls` / `spectrum_bls` output is unchanged.

## Other comments:

Part of a series of small startup-time PRs, and the smallest of them. Measured on macOS arm64, zsh 5.9: 0.85 ms to 0.35 ms per interactive start.

🤖 Co-authored with Claude Code
