### PR TITLE
chore(core): refresh links in install and upgrade

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -528,9 +528,10 @@ print_success() {
     "$(fmt_code "$(fmt_link ".zshrc" "file://$zdot/.zshrc" --text)")" \
     "file to select plugins, themes, and options."
   printf '\n'
-  printf '%s\n' "• Follow us on X: $(fmt_link @ohmyzsh https://x.com/ohmyzsh)"
-  printf '%s\n' "• Join our Discord community: $(fmt_link "Discord server" https://discord.gg/ohmyzsh)"
-  printf '%s\n' "• Get stickers, t-shirts, coffee mugs and more: $(fmt_link "CommitGoods Shop" https://commitgoods.com/collections/oh-my-zsh)"
+  printf '%s\n' "• Follow along on X ($(fmt_link @ohmyzsh https://x.com/ohmyzsh)) or Bluesky ($(fmt_link @ohmyz.sh https://bsky.app/profile/ohmyz.sh))"
+  printf '%s\n' "• Questions or ideas? Join the community on $(fmt_link Discord https://discord.gg/ohmyzsh)"
+  printf '%s\n' "• Help support the project: sponsor us on $(fmt_link "Open Collective" https://opencollective.com/ohmyzsh),"
+  printf '%s\n' "  or grab stickers, shirts, and swag from $(fmt_link CommitGoods https://commitgoods.com/ohmyzsh)"
   printf '%s\n' $FMT_RESET
 }
 

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -271,9 +271,18 @@ if LANG= git pull --quiet --rebase $remote $branch; then
     printf '%s    %s        %s           %s /____/ %s       %s     %s          %s\n'      $RAINBOW $RESET
     printf '\n'
     printf "${BLUE}%s${RESET}\n\n" "$message"
-    printf "${BLUE}${BOLD}%s %s${RESET}\n" "To keep up with the latest news and updates, follow us on X:" "$(fmt_link @ohmyzsh https://x.com/ohmyzsh)"
-    printf "${BLUE}${BOLD}%s %s${RESET}\n" "Want to get involved in the community? Join our Discord:" "$(fmt_link "Discord server" https://discord.gg/ohmyzsh)"
-    printf "${BLUE}${BOLD}%s %s${RESET}\n" "Get your Oh My Zsh swag at:" "$(fmt_link "CommitGoods Shop" https://commitgoods.com/collections/oh-my-zsh)"
+    printf "${BLUE}${BOLD}%s %s %s %s${RESET}\n" \
+      "Follow along on X" "($(fmt_link @ohmyzsh https://x.com/ohmyzsh))" \
+      "or Bluesky" "($(fmt_link @ohmyz.sh https://bsky.app/profile/ohmyz.sh))"
+    printf "${BLUE}${BOLD}%s %s${RESET}\n" \
+      "Questions or ideas? Join the community on" \
+      "$(fmt_link Discord https://discord.gg/ohmyzsh)"
+    printf "${BLUE}${BOLD}%s %s,${RESET}\n" \
+      "Help support the project: sponsor us on" \
+      "$(fmt_link "Open Collective" https://opencollective.com/ohmyzsh)"
+    printf "${BLUE}${BOLD}%s %s${RESET}\n" \
+      "or grab stickers, shirts, and swag from" \
+      "$(fmt_link CommitGoods https://commitgoods.com/ohmyzsh)"
   elif [[ $verbose_mode == minimal ]]; then
     printf "${BLUE}%s${RESET}\n" "$message"
   fi


### PR DESCRIPTION
## Summary

The post-install and post-upgrade messages drifted apart and both had some awkward wording ("Join our Discord: Discord server"). This makes them say the same thing, styled to match their surroundings: bullets in `install.sh`, bold blue lines in `upgrade.sh`.

- Drops the redundant "Discord: Discord server" wording
- Adds the Bluesky account (`@ohmyz.sh`)
- Reframes the shop line as "help support the project" and adds an Open Collective sponsor link
- Mentions stickers, shirts, and swag instead of listing products
- Keeps the block to four short lines so it is easy to skim

No changes to the ASCII logo, `fmt_link`, `supports_hyperlinks`, or anything else in either file.

## Before / after

### `tools/install.sh` (after "Before you scream Oh My Zsh!...")

Before (hyperlinks off):
```
• Follow us on X: https://x.com/ohmyzsh
• Join our Discord community: https://discord.gg/ohmyzsh
• Get stickers, t-shirts, coffee mugs and more: https://commitgoods.com/collections/oh-my-zsh
```

After (hyperlinks off):
```
• Follow along on X (https://x.com/ohmyzsh) or Bluesky (https://bsky.app/profile/ohmyz.sh)
• Questions or ideas? Join the community on https://discord.gg/ohmyzsh
• Help support the project: sponsor us on https://opencollective.com/ohmyzsh,
  or grab stickers, shirts, and swag from https://commitgoods.com/ohmyzsh
```

After (hyperlinks on, link text shown; each name is a clickable OSC 8 link):
```
• Follow along on X (@ohmyzsh) or Bluesky (@ohmyz.sh)
• Questions or ideas? Join the community on Discord
• Help support the project: sponsor us on Open Collective,
  or grab stickers, shirts, and swag from CommitGoods
```

### `tools/upgrade.sh` (after the update message, bold blue)

Before (hyperlinks off):
```
To keep up with the latest news and updates, follow us on X: https://x.com/ohmyzsh
Want to get involved in the community? Join our Discord: https://discord.gg/ohmyzsh
Get your Oh My Zsh swag at: https://commitgoods.com/collections/oh-my-zsh
```

After (hyperlinks off):
```
Follow along on X (https://x.com/ohmyzsh) or Bluesky (https://bsky.app/profile/ohmyz.sh)
Questions or ideas? Join the community on https://discord.gg/ohmyzsh
Help support the project: sponsor us on https://opencollective.com/ohmyzsh,
or grab stickers, shirts, and swag from https://commitgoods.com/ohmyzsh
```

After (hyperlinks on, link text shown):
```
Follow along on X (@ohmyzsh) or Bluesky (@ohmyz.sh)
Questions or ideas? Join the community on Discord
Help support the project: sponsor us on Open Collective,
or grab stickers, shirts, and swag from CommitGoods
```

## Fallback behavior

`fmt_link` prints the raw URL (underlined on a tty) when `supports_hyperlinks` is false, so the link text in each line was chosen to read well either way. In the fallback the parenthesized handles become parenthesized URLs, and "sponsor us on Open Collective" becomes "sponsor us on https://opencollective.com/ohmyzsh". Both files were rendered with `FORCE_HYPERLINK=1` and `FORCE_HYPERLINK=0` to confirm the output above.

## Checks

- `https://commitgoods.com/ohmyzsh` returns a 301 to `/collections/oh-my-zsh`, which returns 200, so the short URL is used in both files.
- `ohmyz.sh` resolves as a Bluesky handle via the public API and the profile page loads.
- `https://opencollective.com/ohmyzsh` returns 200.
- shellcheck output on both files is unchanged from `master` (only pre-existing findings; it cannot parse the zsh `case` glob in `upgrade.sh`, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
