### PR TITLE
feat(laravel): add pammig alias for php artisan make:migration and update README.md

### DIFF
--- a/plugins/laravel/README.md
+++ b/plugins/laravel/README.md
@@ -43,6 +43,7 @@ plugins=(... laravel)
 | `pami`  | `php artisan make:interface` |
 | `pamtr` | `php artisan make:trait` |
 | `pamv` | `php artisan make:view` |
+| `pammig` | `php artisan make:migration` |
 
 ## Clears
 

--- a/plugins/laravel/laravel.plugin.zsh
+++ b/plugins/laravel/laravel.plugin.zsh
@@ -32,6 +32,7 @@ alias pamen='php artisan make:enum'
 alias pami='php artisan make:interface'
 alias pamtr='php artisan make:trait'
 alias pamv='php artisan make:view'
+alias pammig='php artisan make:migration'
 
 
 # Clears


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ x] The PR title is descriptive.
- [x ] The PR doesn't replicate another PR which is already open.
- [ x] I have read the contribution guide and followed all the instructions.
- [ x] The code follows the code style guide detailed in the wiki.
- [ x] The code is mine or it's from somewhere with an MIT-compatible license.
- [ x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [ x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ x] The code is stable and I have tested it myself, to the best of my abilities.
- [ x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `pammig` alias to quickly create Laravel migration files.

## Other comments:
pammig is intended as a shorthand for the commonly used Laravel migration creation command, reducing the amount of typing required when creating migrations.
