### PR TITLE
feat(opencode): add completion and opc aliases

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -1,0 +1,105 @@
+# opencode plugin
+
+This plugin adds completion and aliases for the [OpenCode](https://opencode.ai) CLI.
+Install OpenCode using its [installation instructions](https://opencode.ai/docs/#install),
+and make sure `opencode` is available on your `$PATH`.
+
+To enable it, add `opencode` to the plugins array in your `.zshrc`:
+
+```zsh
+plugins=(... opencode)
+```
+
+## Learning OpenCode from the terminal
+
+Use tab completion to explore commands and their descriptions without leaving the
+shell. For example, these are some of the candidates shown by the CLI:
+
+```text
+$ opencode <TAB>
+agent         -- manage agents
+models        -- list all available models
+run           -- run opencode with a message
+session       -- manage sessions
+stats         -- show token usage and cost statistics
+...
+
+$ opencode session <TAB>
+delete        -- delete a session
+list          -- list sessions
+
+$ opencode run --<TAB>
+--agent       -- agent to use
+--continue    -- continue the last session
+--file        -- file(s) to attach to message
+--model       -- model to use in the format of provider/model
+...
+```
+
+Completion works through the aliases too. Type a partial command or option and
+press Tab to finish it:
+
+```text
+$ opc session li<TAB>
+$ opc session list
+
+$ opcr --att<TAB>
+$ opcr --attach
+
+$ opcc --log-l<TAB>
+$ opcc --log-level
+```
+
+Candidates depend on your installed OpenCode version. In OpenCode 1.18.29, the
+CLI's completion output omits top-level TUI flags such as `--model` and `--fork`,
+even though those flags work when typed. Use `opencode --help` or
+`opencode run --help` for the full options, and see the
+[CLI reference](https://opencode.ai/docs/cli/) for more workflows.
+
+## Aliases
+
+| Alias  | Command               | Description                         |
+| ------ | --------------------- | ----------------------------------- |
+| `opc`  | `opencode`            | Launch the terminal UI              |
+| `opcc` | `opencode --continue` | Continue the last session           |
+| `opcr` | `opencode run`        | Run a prompt without opening the UI |
+
+To keep completion but disable aliases, add this before sourcing Oh My Zsh:
+
+```zsh
+zstyle ':omz:plugins:opencode' aliases no
+```
+
+## Common workflows
+
+All aliases accept additional arguments:
+
+```zsh
+# Open a project
+opc ~/projects/my-app
+
+# Explore a different approach by forking the last session
+opcc --fork
+
+# Ask a question without entering the terminal UI
+opcr "Explain the test setup in this project"
+
+# Reuse an already running backend to avoid MCP server cold starts
+opcr --attach http://localhost:4096 "Explain this project's architecture"
+```
+
+## Completion
+
+Completion queries the installed OpenCode CLI on demand for commands and options,
+including through the aliases above. It falls back to Zsh's default completion when
+the CLI returns no candidates. No OpenCode process is started at shell startup,
+and no generated completion cache is needed.
+
+## Credits
+
+Based on the OpenCode plugin proposals by
+[pranavavva](https://github.com/pranavavva) in
+[#13545](https://github.com/ohmyzsh/ohmyzsh/pull/13545) and
+[mskadu](https://github.com/mskadu) in
+[#13794](https://github.com/ohmyzsh/ohmyzsh/pull/13794).
+The completion adapter is derived from OpenCode's `opencode completion` output.

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -64,10 +64,16 @@ even though those flags work when typed. Use `opencode --help` or
 | `opcc` | `opencode --continue` | Continue the last session           |
 | `opcr` | `opencode run`        | Run a prompt without opening the UI |
 
-To keep completion but disable aliases, add this before sourcing Oh My Zsh:
+To keep completion but skip the aliases, set this in your `.zshrc`, above the line
+that sources Oh My Zsh:
 
 ```zsh
+# ~/.zshrc
 zstyle ':omz:plugins:opencode' aliases no
+
+plugins=(... opencode)
+
+source $ZSH/oh-my-zsh.sh
 ```
 
 ## Common workflows

--- a/plugins/opencode/_opencode
+++ b/plugins/opencode/_opencode
@@ -1,0 +1,12 @@
+#compdef opencode
+
+# Adapted from `opencode completion`, using the CLI's live Yargs completions.
+local -a reply
+reply=("${(@f)$(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" \
+  command opencode --get-yargs-completions "${words[@]}" < /dev/null 2> /dev/null)}")
+
+if [[ -n "${reply[1]}" ]]; then
+  _describe 'values' reply
+else
+  _default
+fi

--- a/plugins/opencode/opencode.plugin.zsh
+++ b/plugins/opencode/opencode.plugin.zsh
@@ -1,0 +1,7 @@
+if (( ! $+commands[opencode] )); then
+  return
+fi
+
+alias opc='opencode'
+alias opcc='opencode --continue'
+alias opcr='opencode run'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [ ] The PR doesn’t replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it’s from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I’ve disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

Add a small plugin for the [OpenCode CLI](https://opencode.ai) with on-demand completion and three everyday aliases:

| Alias | Command | Workflow |
| --- | --- | --- |
| `opc` | `opencode` | Open the terminal UI in the current or specified project |
| `opcc` | `opencode --continue` | Pick up the last session, optionally adding `--fork` |
| `opcr` | `opencode run` | Send a prompt without entering the UI, optionally attaching to an existing backend |

The autoloaded completion function adapts the CLI-generated Yargs adapter and queries the installed CLI only when completing. No OpenCode process runs at shell startup and no generated completion cache is needed. Aliases are skipped silently when the CLI is absent and support the standard OMZ alias-disable style.

The README emphasizes learning from tab completion, with command descriptions, partial-completion examples, and practical workflows.

## Other comments:

### Related contributions

This is a proposed consolidation of #13545 by @pranavavva and #13794 by @mskadu. Thank you both for the initial completion integration and alias/workflow proposals. Both contributions are also credited in the README.

This version uses the `opc` prefix, keeps the initial alias set small, and uses a separate autoloaded completion function instead of startup-time generation. Intended to supersede those proposals once reviewed and ready; neither is automatically closed by this PR. Feedback and testing from both authors would be welcome.

The non-duplication checkbox is intentionally unchecked because this consolidates existing open proposals. Full contribution-guide compliance and wiki-style confirmation are left for maintainer review; contributor coordination and additional community testing remain outstanding.

### Verification

Tested with Zsh 5.9 and OpenCode 1.18.29:

- Zsh syntax checks and Git whitespace checks pass.
- Real interactive Tab completion works for subcommands, nested session commands, global options, and run options through `opencode`, `opc`, `opcc`, and `opcr`.
- Alias expansion includes inserted `--continue` and `run` arguments in the completion context.
- Quoted arguments are forwarded through aliases.
- Missing CLI skips aliases silently and completion falls back to the default handler.
- Full Oh My Zsh loading with aliases disabled retains completion.
- No AI prompts or backend servers were launched during testing.

### Known upstream limitations

OpenCode 1.18.29 does not include default/TUI flags such as `--model` and `--fork` in its top-level completion output. Direct calls to its completion endpoint show the same limitation; the README documents it. The CLI also exposes a literal `$0` candidate and double-dash forms of short options. This adapter retains the upstream candidate list rather than maintaining a separate command schema.

Additional community testing is welcome before merging.

### AI assistance

AI-assisted implementation, documentation, and testing using OpenCode. Attribution to the existing community proposals is preserved above and in the README.