### PR TITLE
docs(kubectl): fix krsss description to say statefulset

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -130,7 +130,7 @@ plugins=(... kubectl)
 | kdss     | `kubectl describe statefulset`                          | Describe statefulset resource in detail                                                          |
 | kdelss   | `kubectl delete statefulset`                            | Delete the statefulset                                                                           |
 | ksss     | `kubectl scale statefulset`                             | Scale a statefulset                                                                              |
-| krsss    | `kubectl rollout status statefulset`                    | Check the rollout status of a deployment                                                         |
+| krsss    | `kubectl rollout status statefulset`                    | Check the rollout status of a statefulset                                                        |
 | krrss    | `kubectl rollout restart statefulset`                   | Rollout restart a statefulset                                                                    |
 |          |                                                         | **Service Accounts management**                                                                  |
 | kdsa     | `kubectl describe sa`                                   | Describe a service account in details                                                            |


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- The README row for `krsss` said "Check the rollout status of a deployment". The alias runs `kubectl rollout status statefulset`, so the description now says statefulset.

## Other comments:

This was originally caught by @EvyBongers in #10003, alongside the `krrd`/`krrss` aliases that later landed separately in #12883. That PR is now closed, so the typo fix is carried over here with credit in the commit trailer.

Testing: documentation only, no code paths touched. Verified the alias definition in `plugins/kubectl/kubectl.plugin.zsh` matches the corrected description.

Drafted with Claude Code assistance.
