### PR TITLE
feat(kubectl): add kcrc alias for config rename-context

### DIFF
--- a/plugins/kubectl/README.md
+++ b/plugins/kubectl/README.md
@@ -23,6 +23,7 @@ plugins=(... kubectl)
 | kcsc     | `kubectl config set-context`                            | Set a context entry in kubeconfig                                                                |
 | kcdc     | `kubectl config delete-context`                         | Delete the specified context from the kubeconfig                                                 |
 | kccc     | `kubectl config current-context`                        | Display the current-context                                                                      |
+| kcrc     | `kubectl config rename-context`                         | Rename a context from the kubeconfig file                                                        |
 | kcgc     | `kubectl config get-contexts`                           | List of contexts available                                                                       |
 |          |                                                         | **General aliases**                                                                              |
 | kdel     | `kubectl delete`                                        | Delete resources by filenames, stdin, resources and names, or by resources and label selector    |

--- a/plugins/kubectl/kubectl.plugin.zsh
+++ b/plugins/kubectl/kubectl.plugin.zsh
@@ -36,6 +36,7 @@ alias kcuc='kubectl config use-context'
 alias kcsc='kubectl config set-context'
 alias kcdc='kubectl config delete-context'
 alias kccc='kubectl config current-context'
+alias kcrc='kubectl config rename-context'
 
 # List all contexts
 alias kcgc='kubectl config get-contexts'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Adds `kcrc` for `kubectl config rename-context`, plus the matching README row.

Use case: the plugin already ships aliases for five of the six `kubectl config *-context` subcommands (`kcuc`, `kcsc`, `kcdc`, `kccc`, `kcgc`). `rename-context` was the only one missing, so anyone who has learned the `kc*c` pattern currently has to break out of it for one command. The name follows the same convention and shadows nothing.

## Other comments:

This reapplies #10758 by @sarathsom, open since March 2022 and credited in the commit trailer. That PR did not include the README row; this one does.

Testing: sourced `plugins/kubectl/kubectl.plugin.zsh` in zsh and confirmed `kcrc` expands to `kubectl config rename-context` and collides with no existing alias or command. No other code paths touched.

Drafted with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
