### PR TITLE
refactor(github)!: deprecate legacy hub plugin

### DIFF
--- a/plugins/gh/README.md
+++ b/plugins/gh/README.md
@@ -15,9 +15,6 @@ This plugin does not add any aliases.
 This plugin caches the completion script and is automatically updated when the
 plugin is loaded, which is usually when you start up a new terminal emulator.
 
-The cache is stored at:
-
-- `$ZSH/plugins/gh/_gh` completions script
-
-- `$ZSH_CACHE_DIR/gh_version` version of GitHub CLI, used to invalidate
-  the cache.
+The completion script is stored at `$ZSH_CACHE_DIR/completions/_gh`. If an
+update fails, the plugin keeps the last successfully generated completion
+script.

--- a/plugins/gh/gh.plugin.zsh
+++ b/plugins/gh/gh.plugin.zsh
@@ -13,6 +13,12 @@ fi
 
 zmodload -F zsh/files b:zf_mv
 () {
-  local TMPPREFIX="$ZSH_CACHE_DIR/completions/_gh"
-  zf_mv -f -- =( gh completion --shell zsh ) "$TMPPREFIX"
+  local completion_file="$ZSH_CACHE_DIR/completions/_gh"
+  local completion_tmp="${completion_file}.$$.${RANDOM}"
+
+  if gh completion --shell zsh >| "$completion_tmp" && [[ -s "$completion_tmp" ]]; then
+    zf_mv -f -- "$completion_tmp" "$completion_file"
+  fi
+
+  command rm -f -- "$completion_tmp"
 } &|

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -1,45 +1,43 @@
 # github plugin
 
-This plugin supports working with GitHub from the command line. It provides a few things:
+> [!WARNING]
+> This plugin is deprecated and will be removed in a future release. It supports
+> the legacy [`hub`](https://github.com/mislav/hub) CLI, not the current GitHub
+> CLI. For `gh` completion, use the [`gh` plugin](../gh) instead.
 
-* Sets up the `hub` wrapper and completions for the `git` command if you have [`hub`](https://github.com/github/hub) installed.
-* Completion for the [`github` Ruby gem](https://github.com/defunkt/github-gem).
-* Convenience functions for working with repos and URLs.
+The plugin provides compatibility for existing `hub` users by:
 
-### Functions
+- aliasing `git` to `hub` when `hub` is installed;
+- adding completion for `hub`; and
+- defining convenience functions for creating repositories.
 
-* `empty_gh` - Creates a new empty repo (with a `README.md`) and pushes it to GitHub
-* `new_gh` - Initializes an existing directory as a repo and pushes it to GitHub
-* `exist_gh` - Takes an existing repo and pushes it to GitHub
+## Migrating to GitHub CLI
 
-
-## Installation
-
-[Hub](https://github.com/github/hub) needs to be installed if you want to use it. On OS X with Homebrew, this can be done with `brew install hub`. The `hub` completion definition needs to be added to your `$FPATH` before initializing OMZ.
-
-The [`github` Ruby gem](https://github.com/defunkt/github-gem) needs to be installed if you want to use it.
-
-### Configuration
-
-These settings affect `github`'s behavior.
-
-#### Environment variables
-
-* `$GITHUB_USER`
-* `$GITHUB_PASSWORD`
-
-#### Git configuration options
-
-* `github.user` - GitHub username for repo operations
-
-See `man hub` for more details.
-
-### Homebrew installation note
-
-If you have installed `hub` using Homebrew, its completions may not be on your `$FPATH` if you are using the system `zsh`. Homebrew installs `zsh` completion definitions to `/usr/local/share/zsh/site-functions`, which will be on `$FPATH` for the Homebrew-installed `zsh`, but not for the system `zsh`. If you want it to work with the system `zsh`, add this to your `~/.zshrc` before it sources `oh-my-zsh.sh`.
+Install [GitHub CLI](https://cli.github.com/), replace `github` with `gh` in
+your plugin list, and restart your shell:
 
 ```zsh
-if (( ! ${fpath[(I)/usr/local/share/zsh/site-functions]} )); then
-  FPATH=/usr/local/share/zsh/site-functions:$FPATH
-fi
+plugins=(... gh)
 ```
+
+The `gh` plugin supplies completion for the installed GitHub CLI. It does not
+alias `git`, because `gh` is not a Git wrapper.
+
+The closest replacement for creating a GitHub repository from an existing
+local repository is:
+
+```zsh
+gh repo create --source=. --push
+```
+
+## Deprecated functions
+
+- `empty_gh` - creates a new repository with a `README.md` and pushes it to GitHub
+- `new_gh` - initializes an existing directory and pushes it to GitHub
+- `exist_gh` - pushes an existing Git repository to GitHub
+
+These functions remain available during the deprecation period and require
+`hub`. They will be removed with the plugin.
+
+If you continue using `hub`, see its documentation for authentication and
+configuration details.

--- a/plugins/github/github.plugin.zsh
+++ b/plugins/github/github.plugin.zsh
@@ -1,3 +1,6 @@
+print -Pru2 -- "%F{yellow}[oh-my-zsh] The \`github\` plugin is deprecated and will be removed in a future release."
+print -Pru2 -- "It supports the legacy \`hub\` CLI. Use the \`gh\` plugin for GitHub CLI completion.%f"
+
 # Set up hub wrapper for git, if it is available; https://github.com/github/hub
 if (( $+commands[hub] )); then
   alias git=hub
@@ -26,7 +29,7 @@ empty_gh() { # [NAME_OF_REPO]
 # This function will add all non-hidden files to git.
 new_gh() { # [DIRECTORY]
   emulate -L zsh
-  local repo="$1"
+  local repo="${1:-.}"
   cd "$repo" \
     || return
 
@@ -42,7 +45,7 @@ new_gh() { # [DIRECTORY]
     || return
   hub create \
     || return
-  git push -u origin master \
+  git push -u origin HEAD \
     || return
 }
 
@@ -52,18 +55,19 @@ new_gh() { # [DIRECTORY]
 # to your GitHub.
 exist_gh() { # [DIRECTORY]
   emulate -L zsh
-  local repo=$1
-  cd "$repo"
+  local repo="${1:-.}"
+  cd "$repo" \
+    || return
 
   hub create \
     || return
-  git push -u origin master
+  git push -u origin HEAD
 }
 
 # git.io "GitHub URL"
 #
 # Shorten GitHub url, example:
-#   https://github.com/nvogel/dotzsh    >   https://git.io/8nU25w
+#   https://github.com/nvogel/dotzsh    > https://git.io/8nU25w
 # source: https://github.com/nvogel/dotzsh
 # documentation: https://github.com/blog/985-git-io-github-url-shortener
 #
@@ -74,4 +78,3 @@ git.io() {
 }
 
 # End Functions #############################################################
-

--- a/plugins/github/github.plugin.zsh
+++ b/plugins/github/github.plugin.zsh
@@ -1,5 +1,5 @@
-print -Pru2 -- "%F{yellow}[oh-my-zsh] The \`github\` plugin is deprecated and will be removed in a future release."
-print -Pru2 -- "It supports the legacy \`hub\` CLI. Use the \`gh\` plugin for GitHub CLI completion.%f"
+print -Pru2 -- '%F{yellow}[oh-my-zsh] The %Bgithub%b plugin is deprecated and will be removed in a future release.'
+print -Pru2 -- 'It supports the legacy %Bhub%b CLI. Use the %Bgh%b plugin for GitHub CLI completion.%f'
 
 # Set up hub wrapper for git, if it is available; https://github.com/github/hub
 if (( $+commands[hub] )); then


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] This change does not introduce new aliases.

## Changes:

- Deprecate the `github` plugin, which supports the legacy `hub` CLI, and direct GitHub CLI users to the `gh` plugin.
- Keep existing `hub` behavior during the deprecation period while making the repository helpers use the current branch and stop after a failed directory change.
- Replace stale `github` documentation with migration guidance for `gh repo create`.
- Preserve the last valid `gh` completion cache when completion generation fails.
- Correct the documented `gh` completion cache location.

## Testing:

- Ran `zsh -n` against both plugin files.
- Ran `git diff --check`.
- Loaded both plugins through `oh-my-zsh.sh`.
- Generated and loaded completion using GitHub CLI v2.100.0.
- Simulated failed completion generation and verified the existing cache remained unchanged.
- Verified `exist_gh` does not call `hub` after a failed `cd` and pushes `HEAD` for a valid directory.

## Other comments:

GitHub CLI is not a drop-in Git wrapper, so this intentionally does not replace `alias git=hub` with `gh`. Existing `hub` users retain the old behavior until the deprecated plugin is removed.

AI-assisted: OpenCode assisted with research, implementation, and test setup; the resulting changes were reviewed and tested manually.