### PR TITLE
fix(emacs): create a frame for empty launcher invocations

### DIFF
--- a/plugins/emacs/emacsclient.sh
+++ b/plugins/emacs/emacsclient.sh
@@ -32,8 +32,9 @@ emacsfun() {
   # Check if there are suitable frames
   frames="$(emacsclient -a '' -n -e "$cmd" 2>/dev/null |sed 's/.*\x07//g' )"
 
-  # Only create another X frame if there isn't one present
-  if [ -z "$frames" -o "$frames" = nil ]; then
+  # A bare emacs/e passes only --no-wait, so it still needs --create-frame.
+  if [ -z "$frames" ] || [ "$frames" = nil ] || [ "$#" -eq 0 ] \
+    || { [ "$#" -eq 1 ] && [ "$1" = --no-wait ]; }; then
     emacsclient --alternate-editor="" --create-frame "$@"
     return $?
   fi

--- a/plugins/emacs/tests/emacsclient.sh
+++ b/plugins/emacs/tests/emacsclient.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+set -eu
+
+launcher="${1:-$(dirname "$0")/../emacsclient.sh}"
+launcher="$(cd "$(dirname "$launcher")" && pwd)/$(basename "$launcher")"
+test_shell="${TEST_SHELL:-/bin/sh}"
+fixture_dir="$(mktemp -d "${TMPDIR:-/tmp}/omz-emacs-test.XXXXXX")"
+trap 'rm -r -- "$fixture_dir"' EXIT
+export EMACS_TEST_LOG="$fixture_dir/args"
+export PATH="$fixture_dir:$PATH"
+
+cat > "$fixture_dir/emacsclient" <<'STUB'
+#!/bin/sh
+if [ "$#" -eq 5 ] && [ "$1" = -a ] && [ "$3" = -n ] && [ "$4" = -e ]; then
+  printf '%s\n' "$EMACS_TEST_FRAMES"
+  exit 0
+fi
+printf '<%s>\n' "$@" > "$EMACS_TEST_LOG"
+exit "${EMACS_TEST_EXIT:-0}"
+STUB
+chmod +x "$fixture_dir/emacsclient"
+
+check() {
+  description="$1"
+  export EMACS_TEST_FRAMES="$2"
+  expected="$3"
+  shift 3
+  "$test_shell" "$launcher" "$@"
+  actual="$(cat "$EMACS_TEST_LOG")"
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL: %s\nexpected:\n%s\nactual:\n%s\n' \
+      "$description" "$expected" "$actual" >&2
+    exit 1
+  fi
+  printf 'PASS: %s\n' "$description"
+}
+
+create_frame='<--alternate-editor=>
+<--create-frame>'
+reuse_frame='<--alternate-editor=>'
+
+check 'bare emacs/e alias with a GUI frame' '(x)' "$create_frame
+<--no-wait>" --no-wait
+check 'empty launcher with a GUI frame' '(x)' "$create_frame"
+check 'empty launcher without a frame' nil "$create_frame"
+check 'bare emacs/e alias without a frame' nil "$create_frame
+<--no-wait>" --no-wait
+check 'file arguments reuse an existing GUI frame' '(x)' "$reuse_frame
+<--no-wait>
+<path with spaces [1].txt>
+<second.txt>" --no-wait 'path with spaces [1].txt' second.txt
+check 'file arguments create a missing GUI frame' nil "$create_frame
+<--no-wait>
+<file.txt>" --no-wait file.txt
+check 'eeval reuses an existing frame' '(x)' "$reuse_frame
+<--eval>
+<(+ 1 2)>" --eval '(+ 1 2)'
+check 'empty file operand stays unchanged' '(x)' "$reuse_frame
+<--no-wait>
+<>" --no-wait ''
+check 'explicit terminal frame drops no-wait' '(t)' "$reuse_frame
+<-nw>
+<file.txt>" --no-wait -nw file.txt
+check 'terminal alias without files stays unchanged' '(t)' "$reuse_frame
+<-nw>" -nw
+check 'tty flag drops no-wait' '(t)' "$reuse_frame
+<-t>
+<file.txt>" --no-wait -t file.txt
+check 'missing terminal frame is created' nil "$create_frame
+<--tty>
+<file.txt>" --no-wait --tty file.txt
+
+export EMACS_TEST_FRAMES='(x)'
+export EMACS_TEST_EXIT=23
+if "$test_shell" "$launcher" --no-wait; then
+  printf 'FAIL: client exit status was lost\n' >&2
+  exit 1
+else
+  result=$?
+  [ "$result" -eq 23 ] || exit 1
+fi
+printf 'PASS: client exit status is preserved\n'


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or from somewhere with an MIT-compatible license.
- [x] Meaningful AI assistance is disclosed below.
- [x] The code is efficient and does not waste computer resources.
- [x] The code was tested as described below.
- [x] No new aliases are introduced.

## Changes:

Fixes #13157, following @robbyrussell's diagnosis in the issue.

With a GUI frame already open, bare `emacs`/`e` passes only `--no-wait` to emacsclient and fails with “file name or argument required”. Route an empty invocation, or the single `--no-wait` argument added by those aliases, through the existing `--create-frame` branch.

Add a standalone regression script covering those calls, existing/missing frames, quoted file arguments, Lisp evaluation, terminal options from #14055, and client exit status.

## Other comments:

Validation:
- The new regression fails on unmodified master because `--create-frame` is missing.
- All 13 checks pass with sh, bash, dash, and zsh as the launcher shell (52 checks). Run `sh plugins/emacs/tests/emacsclient.sh`; set `TEST_SHELL` to choose another shell.
- The actual `emacs` and `e` aliases were also tested in isolated `zsh -df` processes.
- The upstream CI syntax check passes for all 585 files; both changed scripts parse in all four shells; `git diff --check` passes.

Tests use an emacsclient stub that returns an existing frame and records arguments; no real Emacs GUI was launched.

AI-assisted: OpenAI Codex (GPT-6) implemented the change and regression tests and ran the validation above.
