### PR TITLE
fix(globalias): preserve quoted words and assignment values

### DIFF
--- a/plugins/globalias/globalias.plugin.zsh
+++ b/plugins/globalias/globalias.plugin.zsh
@@ -4,7 +4,11 @@ globalias() {
    # (A) makes it an array even if there's only one element
    local word=${${(Az)LBUFFER}[-1]}
    if [[ $GLOBALIAS_FILTER_VALUES[(Ie)$word] -eq 0 ]]; then
-      zle _expand_alias
+      # Completion also considers quoted strings and assignment values as aliases.
+      # Only expand when the complete shell word is an alias name.
+      if (( ${+aliases[$word]} || ${+galiases[$word]} )); then
+         zle _expand_alias
+      fi
       zle expand-word
    fi
    zle self-insert

--- a/plugins/globalias/tests/globalias.test.zsh
+++ b/plugins/globalias/tests/globalias.test.zsh
@@ -1,0 +1,81 @@
+#!/usr/bin/env zsh
+
+# Exercise the actual ZLE widgets in an isolated interactive shell.
+emulate -L zsh
+setopt err_return
+zmodload zsh/zpty
+zmodload zsh/zselect
+
+local test_dir=$(mktemp -d)
+export GLOBALIAS_TEST_PLUGIN=${0:A:h:h}/globalias.plugin.zsh
+export GLOBALIAS_TEST_RESULT=$test_dir/result
+
+wait_for_marker() {
+  local marker=$1 output received
+  local -i deadline=$(( SECONDS + 5 ))
+  while (( SECONDS < deadline )); do
+    if zpty -r globalias-test output; then
+      received+=$output
+      [[ $received == *$marker* ]] && return 0
+    else
+      zselect -t 1 || true
+    fi
+  done
+  print -u2 -r -- "Timed out waiting for ZLE: $received"
+  return 1
+}
+
+check_expansion() {
+  local input=$1 expected=$2 actual
+  zpty -w -n globalias-test "$input"$' \x18'
+  wait_for_marker GLOBALIAS_TEST_CAPTURED
+  actual=$(< "$GLOBALIAS_TEST_RESULT")
+  if [[ $actual != "$expected" ]]; then
+    print -u2 -r -- "Input: ${(qqq)input}"
+    print -u2 -r -- "Expected: ${(qqq)expected}; got: ${(qqq)actual}"
+    return 1
+  fi
+}
+
+{
+  cat > "$test_dir/setup.zsh" <<'SETUP'
+autoload -Uz compinit
+compinit -D
+source "$GLOBALIAS_TEST_PLUGIN"
+alias 1='cd -1'
+alias ll='ls -l'
+alias -g G='| grep'
+GLOBALIAS_FILTER_VALUES=(ll)
+_globalias_test_capture() {
+  print -rn -- "$BUFFER" > "$GLOBALIAS_TEST_RESULT"
+  print -r -- $'\nGLOBALIAS_TEST_CAPTURED'
+  BUFFER=
+  zle .accept-line
+}
+zle -N _globalias_test_capture
+bindkey '^X' _globalias_test_capture
+PS1='GLOBALIAS_TEST_READY> '
+RPROMPT=
+SETUP
+  zpty -b globalias-test zsh -dfi
+  zpty -w globalias-test "source ${(q)test_dir}/setup.zsh"
+  wait_for_marker GLOBALIAS_TEST_READY
+
+  check_expansion 'DEBUG=1' 'DEBUG=1 '
+  check_expansion 'DEBUG="1"' 'DEBUG="1" '
+  check_expansion "DEBUG='1'" "DEBUG='1' "
+  check_expansion '1' 'cd -1 '
+  check_expansion '"1"' '"1" '
+  check_expansion "'1'" "'1' "
+  check_expansion '\1' '\1 '
+  check_expansion 'echo G' 'echo | grep '
+  check_expansion 'DEBUG=1 1' 'DEBUG=1 cd -1 '
+  check_expansion 'll' 'll '
+  check_expansion 'echo $((1+2))' 'echo 3 '
+  check_expansion 'echo {a,b}' 'echo a b  '
+  check_expansion '' ' '
+  print 'All globalias expansion tests passed.'
+} always {
+  zpty -d globalias-test 2>/dev/null || true
+  rm -rf -- "$test_dir"
+}


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (No new aliases.)

## Changes:

With `alias 1='cd -1'`, typing `DEBUG=1` and pressing space changes the buffer to `DEBUG=cd -1 `. Quoting the value doesn't prevent it. `_expand_alias` sees the assignment value as a completion word, so the existing shell-word parsing alone doesn't protect it.

Only call `_expand_alias` when the complete, unmodified shell word is present in `aliases` or `galiases`. Assignment values and quoted words are then left to the existing `expand-word` widget. Ordinary/global aliases, filtered values, arithmetic and glob expansion continue to work.

Fixes #12047.

## Other comments:

Added a standalone regression test using zsh's `zpty` and the real ZLE widgets, without external test dependencies:

```sh
zsh plugins/globalias/tests/globalias.test.zsh
```

On macOS with zsh 5.9, the unmodified plugin fails the first `DEBUG=1` assertion; the patch passes all 13 cases. Syntax checks and `git diff --check` also pass.

Related: #13708 addresses a backslash-prefixed word by skipping all expansion. This also preserves escaped aliases, but addresses the reported assignment and quoted-word corruption while retaining the separate word-expansion step.

AI-assisted: OpenAI Codex helped implement the fix and regression tests and ran the checks above.
