### PR TITLE
fix(updater): detect pending terminal input on macOS

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -185,7 +185,7 @@ function has_typed_input() {
   # Consider that no input can be typed if stty fails
   # (this might happen if stdin is not a terminal)
   local termios
-  termios=$(stty --save 2>/dev/null) || return 1
+  termios=$(stty -g 2>/dev/null) || return 1
   {
     # Disable canonical mode so that typed input counts
     # regardless of whether Enter was pressed


### PR DESCRIPTION
## Standards checklist:

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] If I used AI tools (ChatGPT, Claude, Gemini, etc.) to assist with this contribution, I've disclosed it below.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [ ] If the code introduces new aliases, I provide a valid use case for all plugin users down below. (Not applicable.)

## Changes:

`has_typed_input` currently returns false on macOS even when input is already queued: Apple's `/bin/stty` rejects `--save`, and the error is suppressed. The update prompt then consumes the first character of that input. For example, `source venv/bin/activate` becomes `ource venv/bin/activate`.

Use `stty -g` to save the terminal settings. This is supported by macOS/BSD and is also the [GNU short spelling of `--save`](https://www.gnu.org/software/coreutils/manual/html_node/stty-invocation.html). The existing detection and restoration logic can then run on macOS.

Related to #12307: this fixes the case where input has arrived **before** the update check. It does not address input arriving after the confirmation prompt is displayed.

## Other comments:

Tested the complete `tools/check_for_upgrade.sh` in a real macOS PTY with Zsh 5.9. Each case used a temporary HOME, cache, and Git repository without a remote, so no update was downloaded or executed:

| Input queued before sourcing | Before | After |
| --- | --- | --- |
| `source venv/bin/activate` plus newline | Prompt consumes `s` | Reminder; entire line preserved |
| Same input without newline | Prompt consumes `s` | Reminder; entire input preserved |
| No input | Confirmation prompt | Confirmation prompt |

Terminal settings were restored in all three cases (excluding macOS's transient `PENDIN` flag). `zsh -n tools/check_for_upgrade.sh` also passed.

To reproduce the complete-line case manually, run the following from the repository root in Zsh on macOS. During the three-second pause, type `source venv/bin/activate` and press Enter. The final `read` prints the remaining input without executing it:

```zsh
updater=$PWD/tools/check_for_upgrade.sh
test_dir=$(mktemp -d)
git init -q "$test_dir"
mkdir "$test_dir/log" "$test_dir/cache"
print 'LAST_EPOCH=0' > "$test_dir/cache/.zsh-update"
env HOME="$test_dir" ZSH="$test_dir" ZSH_CACHE_DIR="$test_dir/cache" \
  zsh -dfc 'zstyle ":omz:update" mode prompt
    sleep 3
    source "$1"
    IFS= read -r line
    print -r -- "Remaining input: $line"' zsh "$updater"
rm -rf -- "$test_dir"
```

AI-assisted: OpenAI Codex assisted with diagnosis, the change, and PTY validation.
